### PR TITLE
[Xamarin.Android.Build.Tasks] Remove "Xamarin" from messages

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/Properties/Resources.resx
+++ b/src/Microsoft.Android.Sdk.ILLink/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="XA2000" xml:space="preserve">
-    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will is no longer be available.</value>
+    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher only supports a single AppDomain, so this API is no longer available.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</comment>
   </data>

--- a/src/Microsoft.Android.Sdk.ILLink/Properties/Resources.resx
+++ b/src/Microsoft.Android.Sdk.ILLink/Properties/Resources.resx
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="XA2000" xml:space="preserve">
-    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will no longer be available in Xamarin.Android once .NET 6 is released.</value>
+    <value>Use of AppDomain.CreateDomain() detected in assembly: {0}. .NET 6 and higher will only support a single AppDomain, so this API will is no longer be available.</value>
     <comment>The following are literal names and should not be translated: AppDomain.CreateDomain(), AppDomain
 {0} - The name of the assembly</comment>
   </data>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -562,11 +562,11 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 {0} - The assembly name</comment>
   </data>
   <data name="APT2264" xml:space="preserve">
-    <value>This could be caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2264 for details.</value>
+    <value>This could be caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/en-us/dotnet/android/messages/apt2264 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="APT2265" xml:space="preserve">
-    <value>This could be caused by the project having non-ASCII characters in its filename or path. See https://learn.microsoft.com/xamarin/android/errors-and-warnings/apt2265 for details.</value>
+    <value>This could be caused by the project having non-ASCII characters in its filename or path. See https://learn.microsoft.com/en-us/dotnet/android/messages/apt2265 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="XA3001" xml:space="preserve">
@@ -1010,7 +1010,7 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The numeric version of .NET</comment>
   </data>
   <data name="XA1039" xml:space="preserve">
-    <value>The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/xamarin/androidx for more details.</value>
+    <value>The Android Support libraries are not supported in .NET 9 and later, please migrate to AndroidX. See https://aka.ms/net-android/androidx for more details.</value>
     <comment>The following are literal names and should not be translated: Android Support, AndroidX, .NET.</comment>
   </data>
   <data name="XA4241" xml:space="preserve">

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -562,11 +562,11 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 {0} - The assembly name</comment>
   </data>
   <data name="APT2264" xml:space="preserve">
-    <value>This could be caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/en-us/dotnet/android/messages/apt2264 for details.</value>
+    <value>This could be caused by the project exceeding the Windows maximum path length limitation. See https://learn.microsoft.com/dotnet/android/messages/apt2264 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="APT2265" xml:space="preserve">
-    <value>This could be caused by the project having non-ASCII characters in its filename or path. See https://learn.microsoft.com/en-us/dotnet/android/messages/apt2265 for details.</value>
+    <value>This could be caused by the project having non-ASCII characters in its filename or path. See https://learn.microsoft.com/dotnet/android/messages/apt2265 for details.</value>
     <comment>The following are literal names and should not be translated:</comment>
   </data>
   <data name="XA3001" xml:space="preserve">


### PR DESCRIPTION
Context: https://dotnet.microsoft.com/platform/support/policy/xamarin
Context: ab3773cf439ab620934b04e1bd01f0d9cf61a6ae

Support for Xamarin.Android ends on 2024-May-1.

Update error and warning messages to minimize use of "Xamarin".

Remaining messages which contain "xamarin" are:

  * XA0030: Building with JDK version `{0}` is not supported. Please install JDK version `{1}`. See https://aka.ms/xamarin/jdk9-errors

  * XA1005: If basic type name matching fails, please add a `xamarin:managedType` attribute to the element to specify the fully qualified managed type name of the element

XA0030 Should Not Happen with .NET 6+, as JDK 11+ is required. XA0030 is thus moot.

XA1005 is related to Layout Code Behind (ab3773cf), and replacing `xamarin` would (1) be a source breaking change (so we can't *remove* support for `xamarin`), and (2) while we could add an alternate XML namespace to use for layout code behind, that's a larger change.