### PR TITLE
Bump to binutils based on LLVM 18.1.4

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "L_18.1.3-8.0.0";
+		const string BinutilsVersion                = "L_18.1.4-8.0.0";
 
 		const string MicrosoftOpenJDK17Version      = "17.0.8";
 		const string MicrosoftOpenJDK17Release      = "17.0.8.7";


### PR DESCRIPTION
Changes: https://discourse.llvm.org/t/18-1-4-released/78430

There isn't anything directly interesting for us in this release. 
Simply tracking the current version of the toolchain.