### PR TITLE
Bump to xamarin/xamarin-android-tools/release/8.0.1xx@d50747cb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -29,4 +29,4 @@
 [submodule "external/xamarin-android-tools"]
     path = external/xamarin-android-tools
     url = https://github.com/xamarin/xamarin-android-tools
-    branch = main
+    branch = release/8.0.1xx


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android-tools/compare/d3e7284851da69d0aef293614e7b2dfc5f43b3b8...d50747cbddf6ab3e2151fc2ae3e3af76edb4fd72

  * xamarin/xamarin-android-tools@d50747c: Check for ANDROID_HOME Sdk location on Windows. (xamarin/xamarin-android-tools#230)