### PR TITLE
Test fixlocalizationtests branch

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@a5742221b314864636f4356173a2535a539c7b2c
+xamarin/monodroid:fixlocalizationtests@548e099f4fe1ab0d3a9375f734ac69fce94fa36a

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:fixlocalizationtests@548e099f4fe1ab0d3a9375f734ac69fce94fa36a
+xamarin/monodroid:main@9ca6d9f64fce11f04d668ece50ada36de1d7efce

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -468,7 +468,7 @@ namespace Xamarin.Android.Build.Tests
 			var app = new XamarinAndroidApplicationProject {
 				EmbedAssembliesIntoApk = false,
 			};
-			InlineData.AddCultureResourcesToProject (lib, "Foo", "CancelButton");
+			InlineData.AddCultureResourcesToProject (app, "Foo", "CancelButton");
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
 
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))


### PR DESCRIPTION
Changes https://github.com/xamarin/monodroid/compare/a5742221b314864636f4356173a2535a539c7b2c...9ca6d9f64fce11f04d668ece50ada36de1d7efce.

Context: http://github.com/xamarin/xamarin-android/commit/86260ed36dfe1a90c8ed6a2bb1cd0607d637f403
Context: https://github.com/xamarin/xamarin-android/pull/8478
Context: https://github.com/xamarin/xamarin-android/pull/8895

Commit https://github.com/xamarin/xamarin-android/commit/86260ed3 altered packaging so that
*all* assemblies were considered to be ABI-specific, removing even
the *idea* of "CPU-agnostic assemblies".

This had unforeseen breakage: localization-specific `.resx` & related
files were no longer fast deployed to the correct location, breaking
*all* of our localization unit tests.

This wasn't found in https://github.com/xamarin/xamarin-android/pull/8478 because the
localization tests which broke were only run on *nightly* builds, and
not run as part of the normal PR process.

Oops.

The root cause of this is that the `%(TargetPath)` metadata on
Satellite assemblies is set to `%(Culture)\%(Filename)%(Extension)`
by default.  The code we had in place to set `%(TargetPath)` first
checked to see if it was empty.  In the case of `XX.resource.dll`
files, it was NOT empty, and as a result the `XX.resource.dll` files
would get deployed to `files/.__override__/%(Culture)` instead of
`files/.__override__/%(Abi)/%(Culture)`.

Because our assembly loader now *only* looks in the `%(Abi)` directory
for its files, the resources were never found.

Update the `_ComputeFastDevFiles` target to check the value of
`%(TargetPath)` to see if it is the default value, and if not then
update it to use the `%(DestinationSubDirectory)` value.

Update the `LocalizedAssemblies_ShouldBeFastDeployed` unit test to include application based resource.dll files, so that the failure can be caught during smoke testing.