### PR TITLE
$(AndroidPackVersionSuffix)=preview.5; net9 is 34.99.0.preview.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/9.0.1xx-preview4

We branched for .NET 9 Preview 4 from b30285f2 into release/9.0.1xx-preview4; the main branch is now .NET 9 Preview 5.

Update xamarin-android/main's version number to 34.99.0-preview.5.