### PR TITLE
[api-merge] Add `removed-since` info.

### DIFF
--- a/build-tools/api-merge/ApiDescription.cs
+++ b/build-tools/api-merge/ApiDescription.cs
@@ -121,6 +121,13 @@ namespace Xamarin.Android.ApiMerge {
 						}
 					}
 #endif
+					foreach (var smember in stype.Elements ()) {
+						var nmember = GetMember (ntype, smember);
+
+						if (nmember is null)
+							SetRemovedSince (smember, platform);
+					}
+
 					foreach (var nmember in ntype.Elements ()) {
 						var smember = GetMember (stype, nmember);
 						if (smember == null) {
@@ -306,6 +313,16 @@ namespace Xamarin.Android.ApiMerge {
 				element.Add (new XAttribute ("deprecated-since", platform));
 			else
 				deprecatedSince.SetValue (platform);
+		}
+
+		void SetRemovedSince (XElement element, string platform)
+		{
+			if (element is null)
+				return;
+
+			// Don't replace an earlier removal, as we want to keep the earliest one.
+			if (!element.Attributes ("removed-since").Any ())
+				element.Add (new XAttribute ("removed-since", platform));
 		}
 
 		XElement AddWithLocation (XElement old, XElement child, string location)


### PR DESCRIPTION
Our process of building `Mono.Android.dll`'s `api.xml` using `api-merge` does not take into account that API could be removed from `android.jar`.

Track API removals by adding a `removed-since="XX"` attribute to API that no longer exists.

Note this information is not currently consumed anywhere, but having this data will allow us to determine if we want to make modifications to handle it in future PRs.  Potentially [`[UnsupportedOSPlatformAttribute]`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.versioning.unsupportedosplatformattribute?view=net-8.0) is a good solution for this.