### PR TITLE
Bump $(AndroidNetPreviousVersion) to 34.0.95

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -43,7 +43,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.79</AndroidNetPreviousVersion>
+    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.95</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/releases/tag/34.0.95

Changes: https://github.com/xamarin/xamarin-android/compare/87e4a6d890397c13b2572ce01d4b57874ecef9b0...0d97e20b84d8e87c3502469ee395805907905fe3