### PR TITLE
[Mono.Android] fix potential leak in Java.Lang.Thread

### DIFF
--- a/src/Mono.Android/Java.Lang/Thread.cs
+++ b/src/Mono.Android/Java.Lang/Thread.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 using Android.Runtime;
@@ -27,7 +28,7 @@ namespace Java.Lang {
 				this.removable = removable;
 				if (removable)
 					lock (instances)
-						instances [handler] = this;
+						instances.AddOrUpdate (handler, this);
 			}
 
 			public void Run ()
@@ -41,7 +42,7 @@ namespace Java.Lang {
 				Dispose ();
 			}
 
-			static Dictionary<Action, RunnableImplementor> instances = new Dictionary<Action, RunnableImplementor> ();
+			static ConditionalWeakTable<Action, RunnableImplementor> instances = new ();
 
 			public static RunnableImplementor Remove (Action handler)
 			{


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/18757
Context: https://github.com/dotnet/maui/pull/22007
Context: https://cs.android.com/android/platform/superproject/+/main:frameworks/base/core/java/android/view/View.java;l=19612

If you do something like:

    new View(myContext).Post(() => {
        // do something
    });

If the `View` is never added to the `Window` (`IsAttachedToWindow` is false), the `Runnable` will never be executed, with data stored in this dictionary:

    static Dictionary<Action, RunnableImplementor> instances = new Dictionary<Action, RunnableImplementor> ();

This is a problem if the `Action`:

* Is an instance method, will cause the `Action.Target` to live forever

* Is an anonymous method with captured variables, will cause the captured variables to live forever

I could observe this behavior in a MAUI unit test that:

* Creates a `ListView`

* Creates the platform view that implements `ListView`

* Never adds any of these objects to the `Window`

* Makes sure none of the things leak -- *this fails*

This seems less likely to occur in a real application, but it is still a bug.