### PR TITLE
[Xamarin.Android.Build.Tasks] fix detection of "Android libraries"

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -277,8 +277,13 @@ namespace Xamarin.Android.Tasks
 #if MSBUILD
 		public static bool IsMonoAndroidAssembly (ITaskItem assembly)
 		{
+			// NOTE: look for both MonoAndroid and Android
 			var tfi = assembly.GetMetadata ("TargetFrameworkIdentifier");
-			if (string.Compare (tfi, "MonoAndroid", StringComparison.OrdinalIgnoreCase) == 0)
+			if (tfi.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1)
+				return true;
+
+			var tpi = assembly.GetMetadata ("TargetPlatformIdentifier");
+			if (tpi.IndexOf ("Android", StringComparison.OrdinalIgnoreCase) != -1)
 				return true;
 
 			var hasReference = assembly.GetMetadata ("HasMonoAndroidReference");


### PR DESCRIPTION
Fixes: https://github.com/dotnet/maui/issues/18819

The sample creates a problem such as:

* Create a .NET Maui 8 class library with a base class inheriting from Java.Lang.Object: `MauiLib1`
  * `BaseClass` * `DerivedClass1` : No error when creating an instance

* Create a .NET Maui 8 mobile app with a derived class of the base class in step 1: `MauiApp1`
    * `DerivedClass2` : No error when creating an instance

* Create a .Net Maui 8 class library with a derived class of the base class in step 1: `MauiLib2` * `DerivedClass3` * Create an instance of all 3 derived class in mobile app in step 2. * `NotSupportedException` creating `DerivedClass3`

```
    Only System.NotSupportedException Message=Cannot create instance of type 'MauiLib2.DerivedClass3': no Java peer type found.
    at Java.Interop.JniPeerMembers.JniInstanceMethods..ctor(Type declaringType) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 22
    at Java.Interop.JniPeerMembers.JniInstanceMethods.GetConstructorsForType(Type declaringType) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 77
    at Java.Interop.JniPeerMembers.JniInstanceMethods.StartCreateInstance(String constructorSignature, Type declaringType, JniArgumentValue* parameters) in /Users/runner/work/1/s/xamarin-android/external/Java.Interop/src/Java.Interop/Java.Interop/JniPeerMembers.JniInstanceMethods.cs:line 139
    at Java.Lang.Object..ctor() in /Users/runner/work/1/s/xamarin-android/src/Mono.Android/obj/Release/net8.0/android-34/mcw/Java.Lang.Object.cs:line 37
    at MauiLib1.BaseClass..ctor()
    at MauiLib2.DerivedClass..ctor() in C:\Project\Maui\MauiApp1\MauiLib2\Platforms\Android\DerivedClass.cs:line 7
    at MauiApp1.App..ctor(IServiceProvider serviceProvider) in C:\Project\Maui\MauiApp1\MauiApp1\App.xaml.cs:line 18
```
I could reproduce this problem in an existing `ProjectDependencies()` test, by making some existing classes `Java.Lang.Object` and asserting their JCWs are in the final `classes.dex` file.

The fix here appears to be our detection of "Android libraries" in:

    var tfi = assembly.GetMetadata ("TargetFrameworkIdentifier");
    if (string.Compare (tfi, "MonoAndroid", StringComparison.OrdinalIgnoreCase) == 0)
        return true;

This looks like it would only support Xamarin.Android class libraries, as the metadata says:

    TargetPlatformIdentifier = Android

The only reason this works *at all*, is because we also look for `Mono.Android.dll` assembly references: which is more of a fallback.

Update the code to look for `Android` in the `TargetPlatformIdentifier`, and use `string.IndexOf()` for both checks.