### PR TITLE
Bump to xamarin/monodroid/release/8.0.1xx@21aed734

### DIFF
--- a/.external
+++ b/.external
@@ -1,2 +1,2 @@
-xamarin/monodroid:release/8.0.1xx@d627218f1e1d0c1e501e2cc36609deb0b09d30aa
+xamarin/monodroid:release/8.0.1xx@21aed734165ab0ea8bcaa1f4151bf13654153327
 mono/mono:2020-02@6dd9def57ce969ca04a0ecd9ef72c0a8f069112d


### PR DESCRIPTION
Changes: https://github.com/xamarin/monodroid/compare/d627218f1e1d0c1e501e2cc36609deb0b09d30aa...21aed734165ab0ea8bcaa1f4151bf13654153327

  * xamarin/monodroid@21aed7341: Bump to xamarin/androidtools/release/8.0.1xx@5b93b9e7 (xamarin/monodroid#1470)
  * xamarin/monodroid@cb085d420: Bump to xamarin-android/release/8.0.2xx@183b7f76 (xamarin/monodroid#1471)
  * xamarin/monodroid@792168d45: Remove "Xamarin" from messages (#1468) (xamarin/monodroid#1469)