### PR TITLE
[Xamarin.Android.Build.Tests] Fix ActionBarSherlock URL

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -436,7 +436,7 @@ namespace Foo {
 				IsRelease = true,
 				Jars = {
 					new AndroidItem.LibraryProjectZip ("Jars\\ActionBarSherlock-4.3.1.zip") {
-						WebContent = "https://github.com/xamarin/monodroid-samples/blob/main/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true"
+						WebContent = "https://github.com/xamarin/monodroid-samples/blob/archived-xamarin/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true"
 					}
 				},
 				AndroidClassParser = "class-parse",


### PR DESCRIPTION
On 2024-May-01, xamarin/monodroid-samples was updated so that the `main` branch no longer contained samples for Classic Xamarin.Android. This in turn meant the removal of the ActionBarSherlock sample.

This change in turn broke xamarin-android unit tests, which attempt to download this URL, which no longer exists:

  * <https://github.com/xamarin/monodroid-samples/blob/main/ActionBarSherlock/ActionBarSherlock/Jars/ActionBarSherlock-4.3.1.zip?raw=true>

Oops.

As part of the removal of Classic Xamarin.Android samples, a new `monodroid-samples/archived-xamarin` branch was created, which is the state of the `main` branch before all old samples were removed.

Update the `BindingBuildTest.RemoveEventHandlerResolution()` integration test to use the correct URL for ActionBarSherlock.