### PR TITLE
[release/8.0.2xx] [build] use new Mono archive URL

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Android.Prepare
 
 			public static readonly Uri NugetUri = new Uri ("https://dist.nuget.org/win-x86-commandline/v6.0.0/nuget.exe");
 
-			public static Uri MonoArchive_BaseUri = new Uri ("https://xamjenkinsartifact.blob.core.windows.net/mono-sdks/");
+			public static Uri MonoArchive_BaseUri = new Uri ("https://download.mono-project.com/mono-sdks/");
 
 			public static Uri BinutilsArchive = new Uri ($"https://github.com/xamarin/xamarin-android-binutils/releases/download/{BinutilsVersion}/xamarin-android-toolchain-{BinutilsVersion}.7z");
 		}


### PR DESCRIPTION
Context: https://download.mono-project.com/mono-sdks/

`xamjenkinsartifact.blob.core.windows.net` has been decomissioned.