### PR TITLE
[GitHub] Keep GH issue templates up to date.

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -10,12 +10,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid13.0, etc.)
-      - .NET Android (net7.0-android, net8.0-android, etc.)
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -23,7 +24,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.8.0, VSMac 17.6.7, .NET 8.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea
@@ -54,7 +55,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This is likely a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or attach a [MSBuild binlog](https://docs.microsoft.com/en-us/visualstudio/msbuild/obtaining-build-logs-with-msbuild?view=vs-2022#save-a-binary-log).
+      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This is likely a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or attach a [MSBuild binlog](https://aka.ms/binlog).
       render: shell
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/01-building-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/01-building-an-application.yml
@@ -55,7 +55,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This is likely a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or attach a [MSBuild binlog](https://aka.ms/binlog).
+      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This is likely a [diagnostic MSBuild log](https://learn.microsoft.com/previous-versions/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or attach a [MSBuild binlog](https://aka.ms/binlog).
       render: shell
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/02-running-an-application.yml
+++ b/.github/ISSUE_TEMPLATE/02-running-an-application.yml
@@ -10,12 +10,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid13.0, etc.)
-      - .NET Android (net7.0-android, net8.0-android, etc.)
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -23,7 +24,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.8.0, VSMac 17.6.7, .NET 8.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -15,12 +15,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid13.0, etc.)
-      - .NET Android (net7.0-android, net8.0-android, etc.)
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -28,7 +29,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.8.0, VSMac 17.6.7, .NET 8.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
+++ b/.github/ISSUE_TEMPLATE/03-mono-android-api.yml
@@ -8,9 +8,9 @@ body:
       value: |
         Issues with missing Android API or the API not working as documented are tracked here.
 
-        If you are not sure how to use an API or how to accomplish your task, better support is available from our community of application writers, available in several forms:
+        If you are not sure how to use an API or how to accomplish your task, better support is available from the community of application writers, available in several forms:
 
-        [Microsoft Q&A](https://docs.microsoft.com/en-us/answers/topics/dotnet-android.html)
+        [Microsoft Q&A](https://learn.microsoft.com/answers/products/97/dotnet/)
         [Stack Overflow](https://stackoverflow.com)
   - type: dropdown
     id: android-type

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -57,7 +57,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files. This is likely a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output).  Please capture a log where you "Rebuild" the project, as some diagnostic info is only available on clean builds.
+      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files. This is likely a [diagnostic MSBuild log](https://learn.microsoft.com/previous-versions/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output).  Please capture a log where you "Rebuild" the project, as some diagnostic info is only available on clean builds.
       render: shell
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
+++ b/.github/ISSUE_TEMPLATE/04-binding-a-java-library.yml
@@ -12,12 +12,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid13.0, etc.)
-      - .NET Android (net7.0-android, net8.0-android, etc.)
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -25,7 +26,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.8.0, VSMac 17.6.7, .NET 8.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -10,12 +10,13 @@ body:
   - type: dropdown
     id: android-type
     attributes:
-      label: Android application type
-      description: In what type(s) of Android application(s) do you see this issue?
+      label: Android framework version
+      description: In what target framework(s) of Android application(s) do you see this issue?
       multiple: true
       options:
-      - Classic Xamarin.Android (MonoAndroid13.0, etc.)
-      - .NET Android (net7.0-android, net8.0-android, etc.)
+      - net8.0-android
+      - net9.0-android
+      - Other
     validations:
       required: true
   - type: input
@@ -23,7 +24,7 @@ body:
     attributes:
       label: Affected platform version
       description: Please provide the version number of the platform you see this issue on.
-      placeholder: E.g. VS 2022 17.8.0, VSMac 17.6.7, .NET 8.0.100, etc.
+      placeholder: E.g. VS 2022 17.9.0, .NET 8.0.100, etc.
     validations:
       required: true
   - type: textarea
@@ -54,7 +55,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This could be a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or a [MSBuild binlog](https://docs.microsoft.com/en-us/visualstudio/msbuild/obtaining-build-logs-with-msbuild?view=vs-2022#save-a-binary-log).
+      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This could be a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or a [MSBuild binlog](https://aka.ms/binlog).
       render: shell
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/05-other.yml
+++ b/.github/ISSUE_TEMPLATE/05-other.yml
@@ -55,7 +55,7 @@ body:
     id: logs
     attributes:
       label: Relevant log output
-      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This could be a [diagnostic MSBuild log](https://docs.microsoft.com/en-us/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or a [MSBuild binlog](https://aka.ms/binlog).
+      description: Please copy and paste any (short!) relevant log output.  Longer logs can be attached as .txt files.  This could be a [diagnostic MSBuild log](https://learn.microsoft.com/previous-versions/xamarin/android/troubleshooting/troubleshooting#diagnostic-msbuild-output) or a [MSBuild binlog](https://aka.ms/binlog).
       render: shell
   - type: markdown
     attributes:


### PR DESCRIPTION
Update GH issue templates, removing EOL Classic and .NET 7.