### PR TITLE
[build] bump to `$(AndroidNetPreviousVersion)` 34.0.113

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -43,7 +43,7 @@
     <DebugType Condition=" '$(DebugType)' == '' ">portable</DebugType>
     <Deterministic Condition=" '$(Deterministic)' == '' ">True</Deterministic>
     <LangVersion Condition=" '$(LangVersion)' == '' ">latest</LangVersion>
-    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.95</AndroidNetPreviousVersion>
+    <AndroidNetPreviousVersion Condition=" '$(AndroidNetPreviousVersion)' == '' ">34.0.113</AndroidNetPreviousVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(HostOS)' == '' ">
     <HostOS Condition="$([MSBuild]::IsOSPlatform('windows'))">Windows</HostOS>


### PR DESCRIPTION
Changes: https://github.com/xamarin/xamarin-android/compare/34.0.95...96b6bb65e8736e45180905177aa343f0e1854ea3

* Bump to dotnet/runtime@fd8f5b5af7 8.0.4

* Bump to dotnet/installer@5b9983e91a 8.0.204-servicing.24169.39

* [ci] Migrate to the 1ES template

* [Xamarin.Android.Build.Tasks] Remove "Xamarin" from messages

* [Xamarin.Android.Build.Tasks] fix detection of "Android libraries"

* [Mono.Android] fix potential leak of RunnableImplementors

* Bump binutils to 17.0.6-7.2.2

* [Xamarin.Android.Build.Tasks] set %(DefineConstantsOnly) for older API levels