### PR TITLE
[trimming] preserve custom views and `$(AndroidHttpClientHandlerType)`

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -336,9 +336,7 @@ namespace Android.Runtime {
 		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof (Xamarin.Android.Net.AndroidMessageHandler))]
 		static object GetHttpMessageHandler ()
 		{
-			// FIXME: https://github.com/xamarin/xamarin-android/issues/8797
-			// Note that this is a problem for custom $(AndroidHttpClientHandlerType) or $XA_HTTP_CLIENT_HANDLER_TYPE
-			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "DynamicDependency should preserve AndroidMessageHandler.")]
+			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Rooted by the <GenerateILLinkXml/> MSBuild task.")]
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			static Type TypeGetType (string typeName) =>
 				Type.GetType (typeName, throwOnError: false);

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -81,7 +81,8 @@ _ResolveAssemblies MSBuild target.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveAssemblies">
+  <Target Name="_ResolveAssemblies"
+      DependsOnTargets="_GenerateILLinkXml">
     <ItemGroup>
       <_RIDs Include="$(RuntimeIdentifier)"  Condition=" '$(RuntimeIdentifiers)' == '' " />
       <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
@@ -96,6 +97,7 @@ _ResolveAssemblies MSBuild target.
         ;_OuterIntermediateAssembly=@(IntermediateAssembly)
         ;_OuterOutputPath=$(OutputPath)
         ;_OuterIntermediateOutputPath=$(IntermediateOutputPath)
+        ;_AndroidGeneratedRootDescriptor=$(_AndroidGeneratedRootDescriptor)
       </_AdditionalProperties>
       <_AndroidBuildRuntimeIdentifiersInParallel Condition=" '$(_AndroidBuildRuntimeIdentifiersInParallel)' == '' ">true</_AndroidBuildRuntimeIdentifiersInParallel>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -55,6 +55,7 @@ properties that determine build ordering.
       _SetLatestTargetFrameworkVersion;
       _GetLibraryImports;
       _RemoveRegisterAttribute;
+      _GenerateILLinkXml;
       _ResolveAssemblies;
       _ResolveSatellitePaths;
       _CreatePackageWorkspace;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -9,6 +9,8 @@ This file contains the .NET 5-specific targets to customize ILLink
 
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <UsingTask TaskName="Xamarin.Android.Tasks.GenerateILLinkXml" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
+
   <Target Name="_PrepareLinking"
       Condition=" '$(PublishTrimmed)' == 'true' "
       AfterTargets="ComputeResolvedFilesToPublishList"
@@ -94,6 +96,25 @@ This file contains the .NET 5-specific targets to customize ILLink
           Condition=" '@(ResolvedFileToPublish->Count())' != '0' and '%(Filename)' != '' "
           Include="@(_PreserveLists)" />
       <TrimmerRootDescriptor Include="@(LinkDescription)" />
+      <TrimmerRootDescriptor
+          Condition=" Exists('$(_AndroidGeneratedRootDescriptor)') "
+          Include="$(_AndroidGeneratedRootDescriptor)"
+      />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateILLinkXml"
+      Condition=" '$(PublishTrimmed)' == 'true' ">
+    <PropertyGroup>
+      <_AndroidGeneratedRootDescriptor>$(IntermediateOutputPath)net-android-trimmer.xml</_AndroidGeneratedRootDescriptor>
+    </PropertyGroup>
+    <GenerateILLinkXml
+        AndroidHttpClientHandlerType="$(AndroidHttpClientHandlerType)"
+        CustomViewMapFile="$(_CustomViewMapFile)"
+        OutputFile="$(_AndroidGeneratedRootDescriptor)"
+    />
+    <ItemGroup>
+      <FileWrites Include="$(_AndroidGeneratedRootDescriptor)" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateILLinkXml.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateILLinkXml.cs
@@ -1,0 +1,70 @@
+using System.Xml.Linq;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks;
+
+public class GenerateILLinkXml : AndroidTask
+{
+	public override string TaskPrefix => "GILX";
+
+	[Required]
+	public string AndroidHttpClientHandlerType { get; set; }
+
+	[Required]
+	public string CustomViewMapFile { get; set; }
+
+	[Required]
+	public string OutputFile { get; set; }
+
+	public override bool RunTask ()
+	{
+		string assemblyName, typeName;
+
+		var index = AndroidHttpClientHandlerType.IndexOf (',');
+		if (index != -1) {
+			typeName = AndroidHttpClientHandlerType.Substring (0, index).Trim ();
+			assemblyName = AndroidHttpClientHandlerType.Substring (index + 1).Trim ();
+		} else {
+			typeName = AndroidHttpClientHandlerType;
+			assemblyName = "Mono.Android";
+		}
+
+		// public parameterless constructors
+		// example: https://github.com/dotnet/runtime/blob/039d2ecb46687e89337d6d629c295687cfe226be/src/mono/System.Private.CoreLib/src/ILLink/ILLink.Descriptors.xml
+		var ctor = new XElement ("method", new XAttribute("signature", "System.Void .ctor()"));
+
+		XElement linker;
+		var doc = new XDocument (
+			linker = new XElement ("linker",
+				new XElement ("assembly",
+					new XAttribute ("fullname", assemblyName),
+					new XElement ("type", new XAttribute ("fullname", typeName), ctor)
+				)
+			)
+		);
+
+		var customViewMap = MonoAndroidHelper.LoadCustomViewMapFile (BuildEngine4, CustomViewMapFile);
+		foreach (var pair in customViewMap) {
+			index = pair.Key.IndexOf (',');
+			if (index == -1)
+				continue;
+
+			typeName = pair.Key.Substring (0, index).Trim ();
+			assemblyName = pair.Key.Substring (index + 1).Trim ();
+
+			linker.Add (new XElement ("assembly",
+				new XAttribute ("fullname", assemblyName),
+				new XElement ("type", new XAttribute ("fullname", typeName), ctor)
+			));
+		}
+
+		if (doc.SaveIfChanged (OutputFile)) {
+			Log.LogDebugMessage ($"Saving {OutputFile}");
+		} else {
+			Log.LogDebugMessage ($"{OutputFile} is unchanged. Skipping.");
+		}
+
+		return !Log.HasLoggedErrors;
+	}
+}

--- a/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -1,11 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
 using NUnit.Framework;
-using Mono.Android_Test.Library;
 
 namespace Xamarin.Android.RuntimeTests
 {
@@ -14,7 +12,6 @@ namespace Xamarin.Android.RuntimeTests
 	{
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=23880
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -24,7 +21,6 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void LowerCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -34,7 +30,6 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperAndLowerCaseCustomWidget_FromLibrary_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8797
Context: https://github.com/dotnet/runtime/blob/714a4420805ed53c311b05381c83c88894100fa9/docs/tools/illink/data-formats.md

Here are two cases `TrimMode=full` can break applications:

* `AndroidHttpClientHandlerType` set to a custom type

* Custom views (Android `.xml`) that are not referenced in C# code

For either of these cases, the traditional approach in Xamarin.Android would have been to author a trimmer step to preserve these types.

However, thinking about NativeAOT in the future, it is more "future-proof" to write an MSBuild task that generates trimmer `.xml` to preserve these types. This same XML file could be passed to the NativeAOT trimmer (`Ilc`). If we had a custom trimmer step, we would have to reimplement the same logic for the NativeAOT trimmer.

This is WIP as custom views are not yet preserved.