### PR TITLE
[ci] Improve maestro artifact publishing

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -504,9 +504,9 @@ extends:
             buildType: specific
             project: DevDiv
             definition: 11410
-            buildVersionToDownload: latestFromBranch
+            pipelineId: 9568160
+            buildVersionToDownload: specific
             allowPartiallySucceededBuilds: true
-            branchName: refs/heads/main
             artifactName: nuget-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -526,10 +526,10 @@ extends:
       # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
       - job: push_signed_nugets
         displayName: Push Internal
-        dependsOn:
-        - nuget_convert
-        - sign_net_linux
-        condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
+        #dependsOn:
+        #- nuget_convert
+        #- sign_net_linux
+        #condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
         timeoutInMinutes: 60
         pool: $(VSEngMicroBuildPool)
         workspace:
@@ -551,79 +551,92 @@ extends:
 
         - task: DownloadPipelineArtifact@2
           inputs:
+            buildType: specific
+            project: DevDiv
+            definition: 11410
+            buildVersionToDownload: latestFromBranch
+            allowPartiallySucceededBuilds: true
+            branchName: refs/heads/main
             artifactName: nuget-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: nuget-linux-signed
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: nuget-signed
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: vs-msi-nugets
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: nuget-linux-signed
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - task: DownloadPipelineArtifact@2
-          inputs:
-            artifactName: $(WindowsToolchainPdbArtifactName)
-            downloadPath: $(Build.StagingDirectory)\nuget-signed
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: vs-msi-nugets
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(NupkgCommitStatusName)
-            blobName: $(NupkgCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\nuget-signed
-            yamlResourceName: yaml-templates
+        #- task: DownloadPipelineArtifact@2
+        #  inputs:
+        #    artifactName: $(WindowsToolchainPdbArtifactName)
+        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(VSDropCommitStatusName)
-            blobName: $(VSDropCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-            yamlResourceName: yaml-templates
-            downloadSteps:
-            - task: DownloadPipelineArtifact@2
-              inputs:
-                artifactName: vsdrop-signed
-                downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(NupkgCommitStatusName)
+        #    blobName: $(NupkgCommitStatusName)
+        #    packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\nuget-signed
+        #    yamlResourceName: yaml-templates
 
-        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-          parameters:
-            githubToken: $(GitHub.Token)
-            githubContext: $(MultiTargetVSDropCommitStatusName)
-            blobName: $(MultiTargetVSDropCommitStatusName)
-            packagePrefix: xamarin-android
-            artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-            yamlResourceName: yaml-templates
-            downloadSteps:
-            - task: DownloadPipelineArtifact@2
-              inputs:
-                artifactName: vsdrop-multitarget-signed
-                downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(VSDropCommitStatusName)
+        #    blobName: $(VSDropCommitStatusName)
+        #    packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+        #    yamlResourceName: yaml-templates
+        #    downloadSteps:
+        #    - task: DownloadPipelineArtifact@2
+        #      inputs:
+        #        artifactName: vsdrop-signed
+        #        downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+
+        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+        #  parameters:
+        #    githubToken: $(GitHub.Token)
+        #    githubContext: $(MultiTargetVSDropCommitStatusName)
+        #    blobName: $(MultiTargetVSDropCommitStatusName)
+        #    packagePrefix: xamarin-android
+        #    artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        #    yamlResourceName: yaml-templates
+        #    downloadSteps:
+        #    - task: DownloadPipelineArtifact@2
+        #      inputs:
+        #        artifactName: vsdrop-multitarget-signed
+        #        downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - powershell: >-
             & dotnet build -v:n -c $(XA.Build.Configuration)
-            -t:PushManifestToBuildAssetRegistry
+            -t:PublishToBuildAssetRegistry
+            -p:ManifestsPath=$(Build.StagingDirectory)\nuget-signed\AssetManifest
             -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+            -p:MaestroApiEndpoint=https://maestro.dot.net
             -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
             $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
             -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
           displayName: generate and publish BAR manifest
-          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+          #condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        - powershell: |
-            $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
-            $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-            $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-            & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-          displayName: add build to default darc channel
-          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+        #- powershell: |
+        #    $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+        #    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+        #    $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+        #    & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+        #    & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+        #  displayName: add build to default darc channel
+        #  condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - template: build-tools\automation\yaml-templates\upload-results.yaml@self
           parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -608,7 +608,7 @@ extends:
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - powershell: |
-            $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+            $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
             $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
             $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
             & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -467,19 +467,69 @@ extends:
 
     - stage: dotnet_prepare_release
       displayName: Prepare .NET Release
-      dependsOn: []
-      #dependsOn:
-      #- mac_build
-      #- linux_build
-      #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+      dependsOn:
+      - mac_build
+      - linux_build
+      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
       jobs:
+      # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
+      - template: sign-artifacts/jobs/v2.yml@yaml-templates
+        parameters:
+          name: sign_net_mac_win
+          poolName: $(VSEngMicroBuildPool)
+          artifactName: $(NuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          signedArtifactName: nuget-signed
+          usePipelineArtifactTasks: true
+          use1ESTemplate: true
+
+      # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
+      - template: sign-artifacts/jobs/v2.yml@yaml-templates
+        parameters:
+          name: sign_net_linux
+          displayName: Sign Linux Archive
+          poolName: $(VSEngMicroBuildPool)
+          artifactName: $(LinuxNuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          signedArtifactName: nuget-linux-signed
+          usePipelineArtifactTasks: true
+          use1ESTemplate: true
+
+      # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
+      - template: nuget-msi-convert/job/v3.yml@yaml-templates
+        parameters:
+          yamlResourceName: yaml-templates
+          dependsOn: sign_net_mac_win
+          artifactName: nuget-signed
+          artifactPatterns: |
+            !*Darwin*
+          propsArtifactName: $(NuGetArtifactName)
+          signType: $(MicroBuildSignType)
+          use1ESTemplate: true
+          postConvertSteps:
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifactName: $(NuGetArtifactName)
+              downloadPath: $(Build.StagingDirectory)\sign-verify
+              patterns: |
+                **/SignVerifyIgnore.txt
+
+          - task: MicroBuildCodesignVerify@3
+            displayName: verify signed msi content
+            inputs:
+              TargetFolders: |
+                $(Build.ArtifactStagingDirectory)\bin\manifests
+                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
+              ExcludeSNVerify: true
+              ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
+
       # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
       - job: push_signed_nugets
         displayName: Push Internal
-        #dependsOn:
-        #- nuget_convert
-        #- sign_net_linux
-        #condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
+        dependsOn:
+        - nuget_convert
+        - sign_net_linux
+        condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
         timeoutInMinutes: 60
         pool: $(VSEngMicroBuildPool)
         workspace:
@@ -487,85 +537,65 @@ extends:
         variables:
         - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
           - group: Publish-Build-Assets
-        templateContext:
-          outputs:
-          - output: nuget
-            condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
-            useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
-            packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
-            packageParentPath: $(Build.StagingDirectory)\nuget-signed
-            nuGetFeedType: external
-            publishFeedCredentials: $(DotNetFeedCredential)
         steps:
         - checkout: self
 
         - task: DownloadPipelineArtifact@2
           inputs:
-            buildType: specific
-            project: DevDiv
-            definition: 11410
-            pipelineId: 9568160
-            buildVersionToDownload: specific
-            allowPartiallySucceededBuilds: true
             artifactName: nuget-signed
             downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: nuget-signed
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: nuget-linux-signed
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: nuget-linux-signed
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: vs-msi-nugets
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: vs-msi-nugets
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: $(WindowsToolchainPdbArtifactName)
+            downloadPath: $(Build.StagingDirectory)\nuget-signed
 
-        #- task: DownloadPipelineArtifact@2
-        #  inputs:
-        #    artifactName: $(WindowsToolchainPdbArtifactName)
-        #    downloadPath: $(Build.StagingDirectory)\nuget-signed
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(NupkgCommitStatusName)
+            blobName: $(NupkgCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\nuget-signed
+            yamlResourceName: yaml-templates
 
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(NupkgCommitStatusName)
-        #    blobName: $(NupkgCommitStatusName)
-        #    packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\nuget-signed
-        #    yamlResourceName: yaml-templates
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(VSDropCommitStatusName)
+            blobName: $(VSDropCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
+            yamlResourceName: yaml-templates
+            downloadSteps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifactName: vsdrop-signed
+                downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
 
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(VSDropCommitStatusName)
-        #    blobName: $(VSDropCommitStatusName)
-        #    packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-        #    yamlResourceName: yaml-templates
-        #    downloadSteps:
-        #    - task: DownloadPipelineArtifact@2
-        #      inputs:
-        #        artifactName: vsdrop-signed
-        #        downloadPath: $(Build.StagingDirectory)\$(VSDropCommitStatusName)
-
-        #- template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
-        #  parameters:
-        #    githubToken: $(GitHub.Token)
-        #    githubContext: $(MultiTargetVSDropCommitStatusName)
-        #    blobName: $(MultiTargetVSDropCommitStatusName)
-        #    packagePrefix: xamarin-android
-        #    artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
-        #    yamlResourceName: yaml-templates
-        #    downloadSteps:
-        #    - task: DownloadPipelineArtifact@2
-        #      inputs:
-        #        artifactName: vsdrop-multitarget-signed
-        #        downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+        - template: templates\common\upload-vs-insertion-artifacts.yml@sdk-insertions
+          parameters:
+            githubToken: $(GitHub.Token)
+            githubContext: $(MultiTargetVSDropCommitStatusName)
+            blobName: $(MultiTargetVSDropCommitStatusName)
+            packagePrefix: xamarin-android
+            artifactsPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
+            yamlResourceName: yaml-templates
+            downloadSteps:
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifactName: vsdrop-multitarget-signed
+                downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - powershell: >-
             & dotnet build -v:n -c $(XA.Build.Configuration)
@@ -575,16 +605,16 @@ extends:
             $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
             -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
           displayName: generate and publish assets
-          #condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
-        #- powershell: |
-        #    $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
-        #    $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
-        #    $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-        #    & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-        #    & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-        #  displayName: add build to default darc channel
-        #  condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+        - powershell: |
+            $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
+            $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
+            $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
+            & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+          displayName: add build to default darc channel and feed
+          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - template: build-tools\automation\yaml-templates\upload-results.yaml@self
           parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -570,9 +570,7 @@ extends:
         - powershell: >-
             & dotnet build -v:n -c $(XA.Build.Configuration)
             -t:PublishToBuildAssetRegistry
-            -p:ManifestsPath=$(Build.StagingDirectory)\nuget-signed\AssetManifest
             -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            -p:MaestroApiEndpoint=https://maestro.dot.net
             -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
             $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
             -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -467,62 +467,11 @@ extends:
 
     - stage: dotnet_prepare_release
       displayName: Prepare .NET Release
-      dependsOn:
-      - mac_build
-      - linux_build
-      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+      #dependsOn:
+      #- mac_build
+      #- linux_build
+      #condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
       jobs:
-      # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
-      - template: sign-artifacts/jobs/v2.yml@yaml-templates
-        parameters:
-          name: sign_net_mac_win
-          poolName: $(VSEngMicroBuildPool)
-          artifactName: $(NuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          signedArtifactName: nuget-signed
-          usePipelineArtifactTasks: true
-          use1ESTemplate: true
-
-      # Check - "Xamarin.Android (Prepare .NET Release Sign Linux Archive)"
-      - template: sign-artifacts/jobs/v2.yml@yaml-templates
-        parameters:
-          name: sign_net_linux
-          displayName: Sign Linux Archive
-          poolName: $(VSEngMicroBuildPool)
-          artifactName: $(LinuxNuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          signedArtifactName: nuget-linux-signed
-          usePipelineArtifactTasks: true
-          use1ESTemplate: true
-
-      # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-      - template: nuget-msi-convert/job/v3.yml@yaml-templates
-        parameters:
-          yamlResourceName: yaml-templates
-          dependsOn: sign_net_mac_win
-          artifactName: nuget-signed
-          artifactPatterns: |
-            !*Darwin*
-          propsArtifactName: $(NuGetArtifactName)
-          signType: $(MicroBuildSignType)
-          use1ESTemplate: true
-          postConvertSteps:
-          - task: DownloadPipelineArtifact@2
-            inputs:
-              artifactName: $(NuGetArtifactName)
-              downloadPath: $(Build.StagingDirectory)\sign-verify
-              patterns: |
-                **/SignVerifyIgnore.txt
-
-          - task: MicroBuildCodesignVerify@3
-            displayName: verify signed msi content
-            inputs:
-              TargetFolders: |
-                $(Build.ArtifactStagingDirectory)\bin\manifests
-                $(Build.ArtifactStagingDirectory)\bin\manifests-multitarget
-              ExcludeSNVerify: true
-              ApprovalListPathForCerts: $(Build.StagingDirectory)\sign-verify\SignVerifyIgnore.txt
-
       # Check - "Xamarin.Android (Prepare .NET Release Push Internal)"
       - job: push_signed_nugets
         displayName: Push Internal

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -467,6 +467,7 @@ extends:
 
     - stage: dotnet_prepare_release
       displayName: Prepare .NET Release
+      dependsOn: []
       #dependsOn:
       #- mac_build
       #- linux_build

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -576,7 +576,7 @@ extends:
             -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
             $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
             -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
-          displayName: generate and publish BAR manifest
+          displayName: generate and publish assets
           #condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         #- powershell: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -599,12 +599,12 @@ extends:
 
         - powershell: >-
             & dotnet build -v:n -c $(XA.Build.Configuration)
-            -t:PublishToBuildAssetRegistry
+            -t:PushManifestToBuildAssetRegistry
             -p:BuildAssetRegistryToken=$(MaestroAccessToken)
             -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
             $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
             -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
-          displayName: generate and publish assets
+          displayName: generate and publish BAR manifest
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - powershell: |
@@ -613,7 +613,7 @@ extends:
             $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
             & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
             & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
-          displayName: add build to default darc channel and feed
+          displayName: add build to default darc channel
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - template: build-tools\automation\yaml-templates\upload-results.yaml@self

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -164,7 +164,7 @@
     <RemoveDir Directories="@(_PackFoldersToDelete)" />
   </Target>
 
-  <!-- https://github.com/dotnet/arcade/blob/d8a997bd4a23c6d6fe7c785b3b440be7dd8463e9/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
+  <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
   <Target Name="PublishToBuildAssetRegistry">
     <PropertyGroup>
       <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
@@ -213,6 +213,17 @@
       ManifestCommit="$(BUILD_SOURCEVERSION)"
       AssetManifestPath="$(AssetManifestPath)"
       PublishingVersion="3" />
+
+    <MSBuild
+        Targets="Restore"
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
+    />
+
+    <MSBuild
+        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ManifestsPath);MaestroApiEndpoint=$(MaestroApiEndpoint)"
+    />
   </Target>
 
   <Target Name="PushManifestToBuildAssetRegistry" >

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,7 +10,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
-  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" AssemblyFile="$(PrepTasksAssembly)" />
 
   <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,7 +10,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" AssemblyFile="$(PrepTasksAssembly)" />
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,7 +10,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
-  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" AssemblyFile="$(PrepTasksAssembly)" />
 
@@ -205,7 +204,7 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
-    <PushToBuildStorage
+    <PushToAzureDevOpsArtifacts
       ItemsToPush="@(ItemsToPush)"
       ManifestBuildData="@(ManifestBuildData)"
       ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -168,8 +168,9 @@
   <!-- https://github.com/dotnet/arcade/blob/d8a997bd4a23c6d6fe7c785b3b440be7dd8463e9/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
   <Target Name="PublishToBuildAssetRegistry">
     <PropertyGroup>
+      <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
       <AssetManifestFileName>Assets.xml</AssetManifestFileName>
-      <AssetManifestPath>$(OutputPath)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
+      <AssetManifestPath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
     </PropertyGroup>
 
     <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
@@ -180,7 +181,7 @@
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
 
-    <Error Condition="'$(BUILD_BUILDNUMBER)' == ''" Text="The BUILD_BUILDNUMBER property is required." />
+    <!--Error Condition="'$(BUILD_BUILDNUMBER)' == ''" Text="The BUILD_BUILDNUMBER property is required." />
     <Error Condition="'$(ArtifactsLogDir)' == ''" Text="The ArtifactsLogDir property is required." />
     <Error Condition="'$(BUILD_SOURCEBRANCH)' == ''" Text="The BUILD_SOURCEBRANCH property is required." />
     <Error Condition="'$(BUILD_SOURCEVERSION)' == ''" Text="The BUILD_SOURCEVERSION property is required." />
@@ -190,7 +191,7 @@
     <Error Condition="'$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)' == ''" Text="The SYSTEM_TEAMFOUNDATIONCOLLECTIONURI property is required." />
     <Error Condition="'$(SYSTEM_TEAMPROJECT)' == ''" Text="The SYSTEM_TEAMPROJECT property is required." />
     <Error Condition="'$(BUILD_BUILDID)' == ''" Text="The BUILD_BUILDID property is required." />
-    <Error Condition="'$(SYSTEM_DEFINITIONID)' == ''" Text="The SYSTEM_DEFINITIONID property is required." />
+    <Error Condition="'$(SYSTEM_DEFINITIONID)' == ''" Text="The SYSTEM_DEFINITIONID property is required." /-->
 
     <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -165,7 +165,7 @@
   </Target>
 
   <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
-  <Target Name="PublishToBuildAssetRegistry">
+  <Target Name="PushManifestToBuildAssetRegistry">
     <PropertyGroup>
       <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
       <AssetManifestFileName>Assets.xml</AssetManifestFileName>
@@ -193,14 +193,14 @@
     </ItemGroup>
 
     <PushToAzureDevOpsArtifacts
-      ItemsToPush="@(ItemsToPush)"
-      ManifestBuildData="@(ManifestBuildData)"
-      ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
-      ManifestBranch="$(BUILD_SOURCEBRANCH)"
-      ManifestBuildId="$(BUILD_BUILDNUMBER)"
-      ManifestCommit="$(BUILD_SOURCEVERSION)"
-      AssetManifestPath="$(AssetManifestPath)"
-      PublishingVersion="3" />
+        ItemsToPush="@(ItemsToPush)"
+        ManifestBuildData="@(ManifestBuildData)"
+        ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
+        ManifestBranch="$(BUILD_SOURCEBRANCH)"
+        ManifestBuildId="$(BUILD_BUILDNUMBER)"
+        ManifestCommit="$(BUILD_SOURCEVERSION)"
+        AssetManifestPath="$(AssetManifestPath)"
+        PublishingVersion="3" />
 
     <MSBuild
         Targets="Restore"

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -165,7 +165,7 @@
   </Target>
 
   <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
-  <Target Name="PushManifestToBuildAssetRegistry">
+  <Target Name="PushManifestToBuildAssetRegistry" >
     <PropertyGroup>
       <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
       <AssetManifestFileName>Assets.xml</AssetManifestFileName>

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,6 +10,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
+  <UsingTask TaskName="Microsoft.DotNet.Build.Tasks.Feed.PushToBuildStorage" AssemblyFile="$(MicrosoftDotNetBuildTasksFeedFilePath)" />
   <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" AssemblyFile="$(PrepTasksAssembly)" />
 
@@ -162,6 +163,56 @@
       <_PackFoldersToDelete Include="$(DotNetPreviewPath)template-packs" />
     </ItemGroup>
     <RemoveDir Directories="@(_PackFoldersToDelete)" />
+  </Target>
+
+  <!-- https://github.com/dotnet/arcade/blob/d8a997bd4a23c6d6fe7c785b3b440be7dd8463e9/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
+  <Target Name="PublishToBuildAssetRegistry">
+    <PropertyGroup>
+      <AssetManifestFileName>Assets.xml</AssetManifestFileName>
+      <AssetManifestPath>$(OutputPath)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
+    </PropertyGroup>
+
+    <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
+
+    <ItemGroup>
+      <ItemsToPush Include="$(OutputPath)*.nupkg" />
+    </ItemGroup>
+
+    <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
+
+    <Error Condition="'$(BUILD_BUILDNUMBER)' == ''" Text="The BUILD_BUILDNUMBER property is required." />
+    <Error Condition="'$(ArtifactsLogDir)' == ''" Text="The ArtifactsLogDir property is required." />
+    <Error Condition="'$(BUILD_SOURCEBRANCH)' == ''" Text="The BUILD_SOURCEBRANCH property is required." />
+    <Error Condition="'$(BUILD_SOURCEVERSION)' == ''" Text="The BUILD_SOURCEVERSION property is required." />
+    <Error Condition="'$(BUILD_REPOSITORY_URI)' == ''" Text="The BUILD_REPOSITORY_URI property is required." />
+    <Error Condition="'$(MaestroAccessToken)' == ''" Text="The MaestroAccessToken property is required." />
+    <Error Condition="'$(MaestroApiEndpoint)' == ''" Text="The MaestroApiEndpoint property is required." />
+    <Error Condition="'$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)' == ''" Text="The SYSTEM_TEAMFOUNDATIONCOLLECTIONURI property is required." />
+    <Error Condition="'$(SYSTEM_TEAMPROJECT)' == ''" Text="The SYSTEM_TEAMPROJECT property is required." />
+    <Error Condition="'$(BUILD_BUILDID)' == ''" Text="The BUILD_BUILDID property is required." />
+    <Error Condition="'$(SYSTEM_DEFINITIONID)' == ''" Text="The SYSTEM_DEFINITIONID property is required." />
+
+    <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
+
+    <ItemGroup>
+      <ManifestBuildData Include="InitialAssetsLocation=TODO" />
+      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
+      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
+      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
+      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
+      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
+      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
+    </ItemGroup>
+
+    <PushToBuildStorage
+      ItemsToPush="@(ItemsToPush)"
+      ManifestBuildData="@(ManifestBuildData)"
+      ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
+      ManifestBranch="$(BUILD_SOURCEBRANCH)"
+      ManifestBuildId="$(BUILD_BUILDNUMBER)"
+      ManifestCommit="$(BUILD_SOURCEVERSION)"
+      AssetManifestPath="$(AssetManifestPath)"
+      PublishingVersion="3" />
   </Target>
 
   <Target Name="PushManifestToBuildAssetRegistry" >

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -222,7 +222,7 @@
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(AssetManifestPath);MaestroApiEndpoint=https://maestro.dot.net"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
     />
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -180,22 +180,10 @@
 
     <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
 
-    <!--Error Condition="'$(BUILD_BUILDNUMBER)' == ''" Text="The BUILD_BUILDNUMBER property is required." />
-    <Error Condition="'$(ArtifactsLogDir)' == ''" Text="The ArtifactsLogDir property is required." />
-    <Error Condition="'$(BUILD_SOURCEBRANCH)' == ''" Text="The BUILD_SOURCEBRANCH property is required." />
-    <Error Condition="'$(BUILD_SOURCEVERSION)' == ''" Text="The BUILD_SOURCEVERSION property is required." />
-    <Error Condition="'$(BUILD_REPOSITORY_URI)' == ''" Text="The BUILD_REPOSITORY_URI property is required." />
-    <Error Condition="'$(MaestroAccessToken)' == ''" Text="The MaestroAccessToken property is required." />
-    <Error Condition="'$(MaestroApiEndpoint)' == ''" Text="The MaestroApiEndpoint property is required." />
-    <Error Condition="'$(SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)' == ''" Text="The SYSTEM_TEAMFOUNDATIONCOLLECTIONURI property is required." />
-    <Error Condition="'$(SYSTEM_TEAMPROJECT)' == ''" Text="The SYSTEM_TEAMPROJECT property is required." />
-    <Error Condition="'$(BUILD_BUILDID)' == ''" Text="The BUILD_BUILDID property is required." />
-    <Error Condition="'$(SYSTEM_DEFINITIONID)' == ''" Text="The SYSTEM_DEFINITIONID property is required." /-->
-
     <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=TODO" />
+      <ManifestBuildData Include="InitialAssetsLocation=" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
@@ -223,45 +211,6 @@
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
         Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
-    />
-  </Target>
-
-  <Target Name="PushManifestToBuildAssetRegistry" >
-    <ItemGroup>
-      <BuildArtifacts Include="$(OutputPath)*.nupkg" />
-    </ItemGroup>
-
-    <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
-
-    <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
-      <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
-      <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
-      <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
-      <ManifestBuildData Include="AzureDevOpsBuildNumber=$(BUILD_BUILDNUMBER)" />
-      <ManifestBuildData Include="AzureDevOpsRepository=$(BUILD_REPOSITORY_URI)" />
-      <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
-    </ItemGroup>
-
-    <GenerateBuildManifest
-        Artifacts="@(BuildArtifacts)"
-        OutputPath="$(OutputPath)bar-manifests\AssetManifest.xml"
-        BuildId="$(BUILD_BUILDNUMBER)"
-        BuildData="@(ManifestBuildData)"
-        RepoUri="$(BUILD_REPOSITORY_URI)"
-        RepoBranch="$(BUILD_SOURCEBRANCH)"
-        RepoCommit="$(BUILD_SOURCEVERSION)"
-        PublishingVersion="3" />
-
-    <MSBuild
-        Targets="Restore"
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
-    />
-
-    <MSBuild
-        Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
     />
   </Target>
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -222,7 +222,7 @@
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ManifestsPath);MaestroApiEndpoint=$(MaestroApiEndpoint)"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(AssetManifestPath);MaestroApiEndpoint=https://maestro.dot.net"
     />
   </Target>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,9 +22,9 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="8.0.0-beta.24225.1">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
+      <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24225.1">
       <Uri>https://github.com/dotnet/arcade</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,9 +26,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="7.0.0-beta.22103.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24260.2">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
+      <Sha>480401b003bfd2eb989c315da5d6b99ad13a968c</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22410.7">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -22,13 +22,13 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="7.0.0-beta.22103.1">
+    <Dependency Name="Microsoft.DotNet.ApiCompat" Version="8.0.0-beta.24225.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
+      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="9.0.0-beta.24260.2">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24225.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>480401b003bfd2eb989c315da5d6b99ad13a968c</Sha>
+      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22410.7">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -5,7 +5,7 @@
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>9.0.0-beta.24260.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.5.24223.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,7 +4,7 @@
     <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.5.24253.16</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftDotNetApiCompatPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.5.24223.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -4,8 +4,8 @@
     <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.5.24253.16</MicrosoftDotnetSdkInternalPackageVersion>
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETCoreAppRefPackageVersion>
-    <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>9.0.0-beta.24260.2</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetApiCompatPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetApiCompatPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.5.24223.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>


### PR DESCRIPTION
Context: https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md

The steps used to publish build asset information to maestro have been
updated.

With the new `PushToAzureDevOpsArtifacts` task the build pipeline should
now create all of the artifacts required for maestro artifact publishing.
The `add-build-to-channel` darc command will now trigger a
[Build Promotion Pipeline][0] that pushes build assets to the feed that
corresponds to the maestro channel that is being updated.  We should 
no longer need to push assets to various NuGet feeds in a separate step. 

[0]: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=9577012&view=logs&j=ba23343f-f710-5af9-782d-5bd26b102304&t=c7a8693b-2f9c-5ea8-c909-cde9405ac2e1&l=238
