### PR TITLE
[build] fix code-flow from dotnet/installer, .NET 9.0.100-preview.5.24262.2

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,24 +1,24 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.Dotnet.Sdk.Internal" Version="9.0.100-preview.5.24253.16">
+    <Dependency Name="VS.Tools.Net.Core.SDK.Resolver" Version="9.0.100-preview.5.24262.2">
       <Uri>https://github.com/dotnet/installer</Uri>
-      <Sha>fa261b952d702c6bd604728fcbdb58ac071a22b1</Sha>
+      <Sha>1741345c6399ae203d8f259fb12fb873dac5129d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.4.24251.3" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4326eb7ed4d03f30ce4a4de1eb028ee76fdaaa3c</Sha>
+      <Sha>84b33395057737db3ea342a5151feb6b90c1b6f6</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.4.24251.3" CoherentParentDependency="Microsoft.Dotnet.Sdk.Internal">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="9.0.0-preview.5.24256.1" CoherentParentDependency="VS.Tools.Net.Core.SDK.Resolver">
       <Uri>https://github.com/dotnet/runtime</Uri>
-      <Sha>4326eb7ed4d03f30ce4a4de1eb028ee76fdaaa3c</Sha>
+      <Sha>84b33395057737db3ea342a5151feb6b90c1b6f6</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Emscripten.Current.Manifest-9.0.100.Transport" Version="9.0.0-preview.5.24223.2" CoherentParentDependency="Microsoft.NETCore.App.Ref">
       <Uri>https://github.com/dotnet/emsdk</Uri>
       <Sha>53288f87c588907e8ff01f129786820fe998573c</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.24222.1" CoherentParentDependency="Microsoft.NET.ILLink.Tasks">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.4-alpha.24230.1" CoherentParentDependency="Microsoft.NET.ILLink.Tasks">
       <Uri>https://github.com/dotnet/cecil</Uri>
-      <Sha>4abe3e63a5d4653ca098c633644432c1395411c1</Sha>
+      <Sha>7a4a59f9f66baf6711a6ce2de01d3b2c62ed72d8</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,15 +1,17 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftDotnetSdkInternalPackageVersion>9.0.100-preview.5.24253.16</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETILLinkTasksPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.4.24251.3</MicrosoftNETCoreAppRefPackageVersion>
+    <!-- NOTE: $(VSToolsNetCoreSDKResolverPackageVersion) may be temporary -->
+    <VSToolsNetCoreSDKResolverPackageVersion>9.0.100-preview.5.24262.2</VSToolsNetCoreSDKResolverPackageVersion>
+    <MicrosoftDotnetSdkInternalPackageVersion>$(VSToolsNetCoreSDKResolverPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
+    <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.5.24256.1</MicrosoftNETILLinkTasksPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.5.24256.1</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.5.24223.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.24222.1</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.4-alpha.24230.1</MicrosoftDotNetCecilPackageVersion>
     <SystemIOHashingPackageVersion>$(MicrosoftNETCoreAppRefPackageVersion)</SystemIOHashingPackageVersion>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/installer/pull/19707
Changes: https://github.com/dotnet/installer/compare/fa261b95...1741345c
Changes: https://github.com/dotnet/runtime/compare/4326eb7e...84b33395
Changes: https://github.com/dotnet/cecil/compare/4abe3e63...7a4a59f9

dotnet/installer is no longer producing a `Microsoft.Dotnet.Sdk.Internal` "package" for the SDK. This is causing the maestro code-flow to fail, such as:

    > darc update-dependencies --id 225276
    Looking up build with BAR id 225276
    Checking for coherency updates...
    Using 'Strict' coherency mode. If this fails, a second attempt utilizing 'Legacy' Coherency mode will be made.
    Found no dependencies to update.

We use `Microsoft.Dotnet.Sdk.Internal` to provision the .NET SDK, similar to:

    ./dotnet-install.sh --version $(MicrosoftDotnetSdkInternalPackageVersion)

Where `eng/Versions.props` is updated by the Maestro bot for the version number.

Looking for the `Microsoft.Dotnet.Sdk.Internal` dependency, such as:

    > darc gather-drop --id 225276 -o drop --dry-run | grep Microsoft.Dotnet.Sdk.Internal
    Root build - Build number 20240512.2 of
    https://dev.azure.com/dnceng/internal/_git/dotnet-installer
    @ 1741345c6399ae203d8f259fb12fb873dac5129d

But we can find the package for .NET 9 Preview 4:

    > darc gather-drop --id 225611 -o drop --dry-run | grep Microsoft.Dotnet.Sdk.Internal
    Root build - Build number 20240515.4 of
    https://dev.azure.com/dnceng/internal/_git/dotnet-installer
    @ df80b5eb607242b1d8ded158ec97a25e5d5e5e05
    Skipping non-shipping asset Microsoft.Dotnet.Sdk.Internal@9.0.100-preview.4.24265.4

For now, we can use `VS.Tools.Net.Core.SDK.Resolver` instead, as this is a component inserted into Visual Studio that contains the same version number.

We may have to change this again in the future, as dotnet/installer is in the process of merging and/or moving to dotnet/sdk.

MS employees can see more details in the [MS Teams thread][0].

[0]: https://teams.microsoft.com/l/message/19:afba3d1545dd45d7b79f34c1821f6055@thread.skype/1715789991637?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=4d73664c-9f2f-450d-82a5-c2f02756606d&parentMessageId=1715789991637&teamName=.NET%20Core%20Eng%20Services%20Partners&channelName=First%20Responders&createdTime=1715789991637