### PR TITLE
[ci] Re-enable to push to dotnet9 feed

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -537,6 +537,15 @@ extends:
         variables:
         - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
           - group: Publish-Build-Assets
+        templateContext:
+          outputs:
+          - output: nuget
+            condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+            useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
+            packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
+            packageParentPath: $(Build.StagingDirectory)\nuget-signed
+            nuGetFeedType: external
+            publishFeedCredentials: $(DotNetFeedCredential)
         steps:
         - checkout: self
 


### PR DESCRIPTION
Commit bbac9fe4ce hit some issues when attempting to publish to maestro via the [Build Promotion Pipeline][0]:

    error : Asset 'D:\a\_work\1\a\7dc04dfe-406a-4fa3-aea0-199acc2763fa\MergedManifest.xml' already exists with different contents

We can continue to push to the dotnet feeds ourselves for now while this issue is fixed.

[0]: https://dev.azure.com/devdiv/DevDiv/_build?definitionId=12603&_a=summary