### PR TITLE
[Mono.Android] AndroidMessageHandler should follow 308: permanent redirect

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -827,6 +827,7 @@ namespace Xamarin.Android.Net
 						     // what to do with the response
 
 				case HttpStatusCode.TemporaryRedirect: // 307
+				case HttpStatusCode.PermanentRedirect: // 308
 					break;
 
 				default:

--- a/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -234,6 +234,20 @@ namespace Xamarin.Android.NetTests
 			Assert.IsTrue (result.IsSuccessStatusCode);
 		}
 
+		[Test]
+		public async Task AndroidMessageHandlerFollows308PermanentRedirect ()
+		{
+			int callbackCounter = 0;
+
+			var handler = new AndroidMessageHandler ();
+
+			var client = new HttpClient (handler);
+			var result = await client.GetAsync ("https://httpbin.org/redirect-to?url=https://www.microsoft.com/&status_code=308");
+
+			Assert.IsTrue (result.IsSuccessStatusCode);
+			Assert.AreEqual ("https://www.microsoft.com/", result.RequestMessage.RequestUri.ToString ());
+		}
+
 		private async Task AssertRejectsRemoteCertificate (Func<Task> makeRequest)
 		{
 			// there is a difference between the exception that's thrown in the .NET build and the legacy Xamarin


### PR DESCRIPTION
For some reason we skipped 308 (https://learn.microsoft.com/en-us/dotnet/api/system.net.httpstatuscode?view=net-8.0#system-net-httpstatuscode-permanentredirect) in AndroidMessageHandler. This PR adds support for this redirect status code.

Fixes #8946 

/cc @grendello 