### PR TITLE
[trimming] preserve custom views and `$(AndroidHttpClientHandlerType)`

### DIFF
--- a/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs
+++ b/src/Microsoft.Android.Sdk.ILLink/MarkJavaObjects.cs
@@ -5,6 +5,7 @@ using Mono.Cecil;
 using Mono.Linker;
 using Mono.Linker.Steps;
 using Mono.Tuner;
+using Java.Interop.Tools.Cecil;
 using Xamarin.Android.Tasks;
 
 namespace MonoDroid.Tuner {
@@ -16,7 +17,42 @@ namespace MonoDroid.Tuner {
 		public override void Initialize (LinkContext context, MarkContext markContext)
 		{
 			base.Initialize (context, markContext);
+			context.TryGetCustomData ("AndroidHttpClientHandlerType", out string androidHttpClientHandlerType);
+			context.TryGetCustomData ("AndroidCustomViewMapFile", out string androidCustomViewMapFile);
+			var customViewMap = MonoAndroidHelper.LoadCustomViewMapFile (androidCustomViewMapFile);
+
+			markContext.RegisterMarkAssemblyAction (assembly => ProcessAssembly (assembly, androidHttpClientHandlerType, customViewMap));
 			markContext.RegisterMarkTypeAction (type => ProcessType (type));
+		}
+
+		bool IsActiveFor (AssemblyDefinition assembly)
+		{
+			return assembly.MainModule.HasTypeReference ("System.Net.Http.HttpMessageHandler") || assembly.MainModule.HasTypeReference ("Android.Runtime.IJavaObject");
+		}
+
+		public void ProcessAssembly (AssemblyDefinition assembly, string androidHttpClientHandlerType, Dictionary<string, HashSet<string>> customViewMap)
+		{
+			if (!IsActiveFor (assembly))
+				return;
+
+			foreach (var type in assembly.MainModule.Types) {
+				// Custom HttpMessageHandler
+				if (!string.IsNullOrEmpty (androidHttpClientHandlerType) &&
+					androidHttpClientHandlerType.StartsWith (type.Name, StringComparison.Ordinal)) {
+					var assemblyQualifiedName = type.GetPartialAssemblyQualifiedName (Context);
+					if (assemblyQualifiedName == androidHttpClientHandlerType) {
+						Annotations.Mark (type);
+						PreservePublicParameterlessConstructors (type);
+						continue;
+					}
+				}
+
+				// Custom views in Android .xml files
+				if (customViewMap.ContainsKey (type.FullName)) {
+					Annotations.Mark (type);
+					PreserveJavaObjectImplementation (type);
+				}
+			}
 		}
 
 		public void ProcessType (TypeDefinition type)
@@ -46,6 +82,21 @@ namespace MonoDroid.Tuner {
 			PreserveAttributeSetConstructor (type);
 			PreserveInvoker (type);
 			PreserveInterfaces (type);
+		}
+
+		void PreservePublicParameterlessConstructors (TypeDefinition type)
+		{
+			if (!type.HasMethods)
+				return;
+
+			foreach (var constructor in type.Methods)
+			{
+				if (!constructor.IsConstructor || constructor.IsStatic || !constructor.IsPublic || constructor.HasParameters)
+					continue;
+
+				PreserveMethod (type, constructor);
+				break; // We can stop when found
+			}
 		}
 
 		void PreserveAttributeSetConstructor (TypeDefinition type)

--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -336,9 +336,7 @@ namespace Android.Runtime {
 		[DynamicDependency (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor, typeof (Xamarin.Android.Net.AndroidMessageHandler))]
 		static object GetHttpMessageHandler ()
 		{
-			// FIXME: https://github.com/xamarin/xamarin-android/issues/8797
-			// Note that this is a problem for custom $(AndroidHttpClientHandlerType) or $XA_HTTP_CLIENT_HANDLER_TYPE
-			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "DynamicDependency should preserve AndroidMessageHandler.")]
+			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Preserved by the MarkJavaObjects trimmer step.")]
 			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]
 			static Type TypeGetType (string typeName) =>
 				Type.GetType (typeName, throwOnError: false);

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -96,6 +96,7 @@ _ResolveAssemblies MSBuild target.
         ;_OuterIntermediateAssembly=@(IntermediateAssembly)
         ;_OuterOutputPath=$(OutputPath)
         ;_OuterIntermediateOutputPath=$(IntermediateOutputPath)
+        ;_OuterCustomViewMapFile=$(_CustomViewMapFile)
       </_AdditionalProperties>
       <_AndroidBuildRuntimeIdentifiersInParallel Condition=" '$(_AndroidBuildRuntimeIdentifiersInParallel)' == '' ">true</_AndroidBuildRuntimeIdentifiersInParallel>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -34,6 +34,8 @@ This file contains the .NET 5-specific targets to customize ILLink
         Used for the <ILLink CustomData="@(_TrimmerCustomData)" /> value:
         https://github.com/dotnet/sdk/blob/a5393731b5b7b225692fff121f747fbbc9e8b140/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.ILLink.targets#L147
         -->
+      <_TrimmerCustomData Include="AndroidHttpClientHandlerType" Value="$(AndroidHttpClientHandlerType)" />
+      <_TrimmerCustomData Include="AndroidCustomViewMapFile" Value="$(_OuterCustomViewMapFile)" />
       <_TrimmerCustomData Include="XATargetFrameworkDirectories" Value="$(_XATargetFrameworkDirectories)" />
       <_TrimmerCustomData
           Condition=" '$(_ProguardProjectConfiguration)' != '' "

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -156,14 +156,53 @@ namespace Xamarin.Android.Build.Tests
 			return assm;
 		}
 
-		private void PreserveCustomHttpClientHandler (string handlerType, string handlerAssembly, string testProjectName, string assemblyPath)
+		private void PreserveCustomHttpClientHandler (
+				string handlerType,
+				string handlerAssembly,
+				string testProjectName,
+				string assemblyPath,
+				TrimMode trimMode)
 		{
-			var proj = new XamarinAndroidApplicationProject () { IsRelease = true };
+			testProjectName += trimMode.ToString ();
+
+			var class_library = new XamarinAndroidLibraryProject {
+				IsRelease = true,
+				ProjectName = "MyClassLibrary",
+				Sources = {
+					new BuildItem.Source ("MyCustomHandler.cs") {
+						TextContent = () => """
+							class MyCustomHandler : System.Net.Http.HttpMessageHandler
+							{
+								protected override Task <HttpResponseMessage> SendAsync (HttpRequestMessage request, CancellationToken cancellationToken) =>
+									throw new NotImplementedException ();
+							}
+						"""
+					},
+					new BuildItem.Source ("Bar.cs") {
+						TextContent = () => "public class Bar { }",
+					}
+				}
+			};
+			using (var libBuilder = CreateDllBuilder ($"{testProjectName}/{class_library.ProjectName}")) {
+				Assert.IsTrue (libBuilder.Build (class_library), $"Build for {class_library.ProjectName} should have succeeded.");
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				IsRelease = true,
+				TrimModeRelease = trimMode,
+				Sources = {
+					new BuildItem.Source ("Foo.cs") {
+						TextContent = () => "public class Foo : Bar { }",
+					}
+				}
+			};
+			proj.AddReference (class_library);
 			proj.AddReferences ("System.Net.Http");
 			string handlerTypeFullName = string.IsNullOrEmpty(handlerAssembly) ? handlerType : handlerType + ", " + handlerAssembly;
 			proj.SetProperty (proj.ActiveConfigurationProperties, "AndroidHttpClientHandlerType", handlerTypeFullName);
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("base.OnCreate (bundle);", "base.OnCreate (bundle);\nvar client = new System.Net.Http.HttpClient ();");
-			using (var b = CreateApkBuilder (testProjectName)) {
+			using (var b = CreateApkBuilder ($"{testProjectName}/{proj.ProjectName}")) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				using (var assembly = AssemblyDefinition.ReadAssembly (Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, assemblyPath))) {
@@ -173,12 +212,14 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void PreserveCustomHttpClientHandlers ()
+		public void PreserveCustomHttpClientHandlers ([Values (TrimMode.Partial, TrimMode.Full)] TrimMode trimMode)
 		{
 			PreserveCustomHttpClientHandler ("Xamarin.Android.Net.AndroidMessageHandler", "",
-				"temp/PreserveAndroidMessageHandler", "android-arm64/linked/Mono.Android.dll");
+				"temp/PreserveAndroidMessageHandler", "android-arm64/linked/Mono.Android.dll", trimMode);
 			PreserveCustomHttpClientHandler ("System.Net.Http.SocketsHttpHandler", "System.Net.Http",
-				"temp/PreserveSocketsHttpHandler", "android-arm64/linked/System.Net.Http.dll");
+				"temp/PreserveSocketsHttpHandler", "android-arm64/linked/System.Net.Http.dll", trimMode);
+			PreserveCustomHttpClientHandler ("MyCustomHandler", "MyClassLibrary",
+				"temp/MyCustomHandler", "android-arm64/linked/MyClassLibrary.dll", trimMode);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.Linker.cs
@@ -60,5 +60,24 @@ namespace Xamarin.Android.Tasks
 					.Select (p => Path.GetDirectoryName (p.TrimEnd (Path.DirectorySeparatorChar)))
 					.Any (p => assembly.StartsWith (p, StringComparison.OrdinalIgnoreCase));
 		}
+
+		static readonly char [] CustomViewMapSeparator = [';'];
+
+		public static Dictionary<string, HashSet<string>> LoadCustomViewMapFile (string mapFile)
+		{
+			var map = new Dictionary<string, HashSet<string>> ();
+			if (!File.Exists (mapFile))
+				return map;
+			foreach (var s in File.ReadLines (mapFile)) {
+				var items = s.Split (CustomViewMapSeparator, count: 2);
+				var key = items [0];
+				var value = items [1];
+				HashSet<string> set;
+				if (!map.TryGetValue (key, out set))
+					map.Add (key, set = new HashSet<string> ());
+				set.Add (value);
+			}
+			return map;
+		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -408,19 +408,7 @@ namespace Xamarin.Android.Tasks
 			var cachedMap = engine?.GetRegisteredTaskObjectAssemblyLocal<Dictionary<string, HashSet<string>>> (mapFile, RegisteredTaskObjectLifetime.Build);
 			if (cachedMap != null)
 				return cachedMap;
-			var map = new Dictionary<string, HashSet<string>> ();
-			if (!File.Exists (mapFile))
-				return map;
-			foreach (var s in File.ReadLines (mapFile)) {
-				var items = s.Split (new char [] { ';' }, count: 2);
-				var key = items [0];
-				var value = items [1];
-				HashSet<string> set;
-				if (!map.TryGetValue (key, out set))
-					map.Add (key, set = new HashSet<string> ());
-				set.Add (value);
-			}
-			return map;
+			return LoadCustomViewMapFile (mapFile);
 		}
 
 		public static bool SaveCustomViewMapFile (IBuildEngine4 engine, string mapFile, Dictionary<string, HashSet<string>> map)

--- a/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -1,11 +1,9 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Android.App;
+﻿using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
 using NUnit.Framework;
-using Mono.Android_Test.Library;
 
 namespace Xamarin.Android.RuntimeTests
 {
@@ -14,7 +12,6 @@ namespace Xamarin.Android.RuntimeTests
 	{
 		// https://bugzilla.xamarin.com/show_bug.cgi?id=23880
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -24,7 +21,6 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void LowerCaseCustomWidget_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {
@@ -34,7 +30,6 @@ namespace Xamarin.Android.RuntimeTests
 		}
 
 		[Test]
-		[DynamicDependency (DynamicallyAccessedMemberTypes.All, typeof (CustomTextView))]
 		public void UpperAndLowerCaseCustomWidget_FromLibrary_ShouldNotThrowInflateException ()
 		{
 			Assert.DoesNotThrow (() => {


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8797

Here are two cases `TrimMode=full` can break applications:

* `$(AndroidHttpClientHandlerType)` set to a custom type

* Custom views (Android `.xml`) that are not referenced in C# code

In the `MarkJavaObjects` trimmer step we can preserve both of these cases by:

* Passing in `$(AndroidHttpClientHandlerType)`, preserve the public, parameterless constructor of the type

* Pass in `$(_CustomViewMapFile)`, preserve `IJavaObject` types if they are found in the map file