### PR TITLE
[ci] revert changes to NuGet push to dotnet9 feed

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -537,15 +537,6 @@ extends:
         variables:
         - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
           - group: Publish-Build-Assets
-        templateContext:
-          outputs:
-          - output: nuget
-            condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
-            useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
-            packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
-            packageParentPath: $(Build.StagingDirectory)\nuget-signed
-            nuGetFeedType: external
-            publishFeedCredentials: $(DotNetFeedCredential)
         steps:
         - checkout: self
 

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -537,6 +537,15 @@ extends:
         variables:
         - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
           - group: Publish-Build-Assets
+        templateContext:
+          outputs:
+          - output: nuget
+            condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+            useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
+            packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
+            packageParentPath: $(Build.StagingDirectory)\nuget-signed
+            nuGetFeedType: external
+            publishFeedCredentials: $(DotNetFeedCredential)
         steps:
         - checkout: self
 
@@ -608,11 +617,11 @@ extends:
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - powershell: |
-            $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
+            $versionEndpoint = 'https://maestro-prod.westus2.cloudapp.azure.com/api/assets/darc-version?api-version=2019-01-16'
             $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
             $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
             & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
-            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
+            & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --publishing-infra-version 3 --skip-assets-publishing --password $(MaestroAccessToken) --azdev-pat $(publishing-dnceng-devdiv-code-r-build-re)
           displayName: add build to default darc channel
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -10,6 +10,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
 
   <UsingTask TaskName="CreateFrameworkListFile" AssemblyFile="$(DotNetSharedFrameworkTaskFile)"/>
+  <UsingTask TaskName="GenerateBuildManifest" AssemblyFile="$(_MicrosoftDotNetBuildTasksFeedTaskDir)Microsoft.DotNet.Build.Tasks.Feed.dll" />
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.ReplaceFileContents" AssemblyFile="$(PrepTasksAssembly)" />
 
   <!-- https://github.com/dotnet/runtime/blob/0647ec314948904319da5eb15e9931f7c85ed1e2/src/installer/pkg/projects/Directory.Build.targets#L281 -->
@@ -163,26 +164,15 @@
     <RemoveDir Directories="@(_PackFoldersToDelete)" />
   </Target>
 
-  <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
   <Target Name="PushManifestToBuildAssetRegistry" >
-    <PropertyGroup>
-      <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
-      <AssetManifestFileName>Assets.xml</AssetManifestFileName>
-      <AssetManifestPath>$(ArtifactsLogDir)AssetManifest\$(AssetManifestFileName)</AssetManifestPath>
-    </PropertyGroup>
-
-    <Error Condition="Exists($(AssetManifestPath))" Text="The manifest file '$(AssetManifestPath)' already exists." />
-
     <ItemGroup>
-      <ItemsToPush Include="$(OutputPath)*.nupkg" />
+      <BuildArtifacts Include="$(OutputPath)*.nupkg" />
     </ItemGroup>
 
-    <Error Condition="'@(ItemsToPush)' == ''" Text="No packages to push." />
-
-    <Message Text="Publishing %(ItemsToPush.Identity)" Importance="normal" />
+    <Error Condition="'@(BuildArtifacts)' == ''" Text="No packages to create manifest from." />
 
     <ItemGroup>
-      <ManifestBuildData Include="InitialAssetsLocation=" />
+      <ManifestBuildData Include="InitialAssetsLocation=https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
       <ManifestBuildData Include="AzureDevOpsBuildId=$(BUILD_BUILDID)" />
       <ManifestBuildData Include="AzureDevOpsBuildDefinitionId=$(SYSTEM_DEFINITIONID)" />
       <ManifestBuildData Include="AzureDevOpsProject=$(SYSTEM_TEAMPROJECT)" />
@@ -191,14 +181,14 @@
       <ManifestBuildData Include="AzureDevOpsBranch=$(BUILD_SOURCEBRANCH)" />
     </ItemGroup>
 
-    <PushToAzureDevOpsArtifacts
-        ItemsToPush="@(ItemsToPush)"
-        ManifestBuildData="@(ManifestBuildData)"
-        ManifestRepoUri="$(BUILD_REPOSITORY_NAME)"
-        ManifestBranch="$(BUILD_SOURCEBRANCH)"
-        ManifestBuildId="$(BUILD_BUILDNUMBER)"
-        ManifestCommit="$(BUILD_SOURCEVERSION)"
-        AssetManifestPath="$(AssetManifestPath)"
+    <GenerateBuildManifest
+        Artifacts="@(BuildArtifacts)"
+        OutputPath="$(OutputPath)bar-manifests\AssetManifest.xml"
+        BuildId="$(BUILD_BUILDNUMBER)"
+        BuildData="@(ManifestBuildData)"
+        RepoUri="$(BUILD_REPOSITORY_URI)"
+        RepoBranch="$(BUILD_SOURCEBRANCH)"
+        RepoCommit="$(BUILD_SOURCEVERSION)"
         PublishingVersion="3" />
 
     <MSBuild
@@ -209,7 +199,7 @@
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(OutputPath)bar-manifests;MaestroApiEndpoint=https://maestro-prod.westus2.cloudapp.azure.com"
     />
   </Target>
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -26,9 +26,9 @@
       <Uri>https://github.com/dotnet/arcade</Uri>
       <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="8.0.0-beta.24225.1">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="7.0.0-beta.22103.1">
       <Uri>https://github.com/dotnet/arcade</Uri>
-      <Sha>67d23f4ba1813b315e7e33c71d18b63475f5c5f8</Sha>
+      <Sha>70831f0d126fe88b81d7dc8de11358e17a5ce364</Sha>
     </Dependency>
     <Dependency Name="Microsoft.TemplateEngine.Tasks" Version="7.0.100-rc.1.22410.7">
       <Uri>https://github.com/dotnet/templating</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,7 +7,7 @@
     <MicrosoftNETILLinkTasksPackageVersion>9.0.0-preview.5.24256.1</MicrosoftNETILLinkTasksPackageVersion>
     <MicrosoftNETCoreAppRefPackageVersion>9.0.0-preview.5.24256.1</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>8.0.0-beta.24225.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>9.0.0-preview.5.24223.2</MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest90100TransportVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineTasksPackageVersion>7.0.100-rc.1.22410.7</MicrosoftTemplateEngineTasksPackageVersion>


### PR DESCRIPTION
CI is failing with:

```
Response status code does not indicate success: 401 (Unauthorized).
Pushing Microsoft.Android.Ref.34.34.99.0-preview.5.290.nupkg to 'https://dnceng.pkgs.visualstudio.com/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/a54510f9-4b2c-4e69-b96a-6096683aaa1f/nuget/v2/'...
  PUT https://dnceng.pkgs.visualstudio.com/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/a54510f9-4b2c-4e69-b96a-6096683aaa1f/nuget/v2/
Using credentials from config. UserName: CustomToken
  Unauthorized https://dnceng.pkgs.visualstudio.com/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/a54510f9-4b2c-4e69-b96a-6096683aaa1f/nuget/v2/ 4958ms
```

* This reverts commit a0b7aadec4fbcc6e7d6463f8a3982963db03ed17
* This reverts commit bbac9fe4ce1014f02c6f9933a13485dc20089a9d

@pjcollins will revisit these later.

We were trying to use a feature of darc/maestro, where it can manage pushing NuGet packages.

This will simplify the credentials to these feeds, when we get it working.