### PR TITLE
Remove Enhanced Fast Deployment

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:rminstantrun@a59662b944fe04b90ddb3131f8f704314bab5bb0
+xamarin/monodroid:main@272999f3bc26c8f708d9e26ed2246c2249e5b546

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@272999f3bc26c8f708d9e26ed2246c2249e5b546
+xamarin/monodroid:main@93ab95e18077d56d9d55ce7b4069a534e2dea35e

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@9ca6d9f64fce11f04d668ece50ada36de1d7efce
+xamarin/monodroid:rminstantrun@a59662b944fe04b90ddb3131f8f704314bab5bb0

--- a/Documentation/docs-mobile/building-apps/build-properties.md
+++ b/Documentation/docs-mobile/building-apps/build-properties.md
@@ -549,6 +549,8 @@ Support for Fast Deploying resources and assets via that system was
 removed in commit [f0d565fe](https://github.com/xamarin/xamarin-android/commit/f0d565fe4833f16df31378c77bbb492ffd2904b9). This was becuase it required the use of
 deprecated API's to work.
 
+**Support for this feature was removed in .NET 9
+
 **Experimental**.
 
 ## AndroidFragmentType

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -220,16 +220,6 @@ extends:
             artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Xamarin.Android.JcwGen_Tests-Signed.apk
             artifactFolder: $(DotNetTargetFramework)-Default
 
-        - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml@self
-          parameters:
-            configuration: $(XA.Build.Configuration)
-            testName: Xamarin.Android.JcwGen_Tests_FastDev
-            project: tests/CodeGen-Binding/Xamarin.Android.JcwGen-Tests/Xamarin.Android.JcwGen-Tests.csproj
-            testResultsFiles: TestResult-Xamarin.Android.JcwGen_Tests-$(XA.Build.Configuration).xml
-            artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Xamarin.Android.JcwGen_Tests-Signed.apk
-            artifactFolder: $(DotNetTargetFramework)-FastDev_Assemblies_Dexes
-            extraBuildArgs: /p:AndroidFastDeploymentType=Assemblies:Dexes
-
         - template: /build-tools/automation/yaml-templates/run-nunit-tests.yaml@self
           parameters:
             testRunTitle: Xamarin.Android.Tools.Aidl-Tests - macOS

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Android.Tasks
 		static ITaskItem? GetOrCreateSymbolItem (Dictionary<string, ITaskItem> symbols, ITaskItem assembly)
 		{
 			var symbolPath = Path.ChangeExtension (assembly.ItemSpec, ".pdb");
-			if (!symbols.TryGetValue (symbolPath, out var symbol)) {
+			if (!symbols.TryGetValue (symbolPath, out var symbol) || !string.IsNullOrEmpty (symbol.GetMetadata ("DestinationSubDirectory"))) {
 				// Sometimes .pdb files are not included in @(ResolvedFileToPublish), so add them if they exist
 				if (File.Exists (symbolPath)) {
 					symbols [symbolPath] = symbol = new TaskItem (symbolPath);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -275,7 +275,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCase ("_AndroidUseJavaLegacyResolver", "true", true, true)]
 		[TestCase ("_AndroidEmitLegacyInterfaceInvokers", "true", false, true)]
 		[TestCase ("_AndroidEmitLegacyInterfaceInvokers", "true", true, true)]
-		public void PropertyDeprecatedWarning (string property, string value, bool isRelease, bool isBindingProject)
+		public void XA1037PropertyDeprecatedWarning (string property, string value, bool isRelease, bool isBindingProject)
 		{
 			XamarinAndroidProject proj = isBindingProject ? new XamarinAndroidBindingProject () : new XamarinAndroidApplicationProject ();
 			proj.IsRelease = isRelease;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -269,15 +269,19 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		[TestCase ("AndroidFastDeploymentType", "Assemblies", true)]
-		[TestCase ("AndroidFastDeploymentType", "Assemblies", false)]
-		public void PropertyDeprecatedWarning (string property, string value, bool isRelease)
+		[TestCase ("AndroidFastDeploymentType", "Assemblies", true, false)]
+		[TestCase ("AndroidFastDeploymentType", "Assemblies", false, false)]
+		[TestCase ("_AndroidUseJavaLegacyResolver", "true", false, true)]
+		[TestCase ("_AndroidUseJavaLegacyResolver", "true", true, true)]
+		[TestCase ("_AndroidEmitLegacyInterfaceInvokers", "true", false, true)]
+		[TestCase ("_AndroidEmitLegacyInterfaceInvokers", "true", true, true)]
+		public void PropertyDeprecatedWarning (string property, string value, bool isRelease, bool isBindingProject)
 		{
-			var proj = new XamarinAndroidApplicationProject ();
+			XamarinAndroidProject proj = isBindingProject ? new XamarinAndroidBindingProject () : new XamarinAndroidApplicationProject ();
 			proj.IsRelease = isRelease;
 			proj.SetProperty (property, value);
 			
-			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+			using (ProjectBuilder b = isBindingProject ? CreateDllBuilder (Path.Combine ("temp", TestName)) : CreateApkBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, $"The '{property}' MSBuild property is deprecated and will be removed"),
 					$"Should not get a warning about the {property} property");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -269,6 +269,22 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		[TestCase ("AndroidFastDeploymentType", "Assemblies", true)]
+		[TestCase ("AndroidFastDeploymentType", "Assemblies", false)]
+		public void PropertyDeprecatedWarning (string property, string value, bool isRelease)
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.IsRelease = isRelease;
+			proj.SetProperty (property, value);
+			
+			using (var b = CreateApkBuilder (Path.Combine ("temp", TestName))) {
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, $"The '{property}' MSBuild property is deprecated and will be removed"),
+					$"Should not get a warning about the {property} property");
+			}
+		}
+
+		[Test]
 		public void ClassLibraryHasNoWarnings ()
 		{
 			var proj = new XamarinAndroidLibraryProject ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -601,7 +601,7 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidLibraryProject ();
 			using (var b = CreateDllBuilder (Path.Combine ("temp", TestName))) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+				Assert.IsTrue (b.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"`{target}` should be skipped!");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/KnownProperties.cs
@@ -32,7 +32,6 @@ namespace Xamarin.ProjectTools
 		public const string OutputPath = "OutputPath";
 		public const string IntermediateOutputPath = "IntermediateOutputPath";
 		public const string OutputType = "OutputType";
-		public const string AndroidFastDeploymentType = "AndroidFastDeploymentType";
 		public const string AndroidClassParser = "AndroidClassParser";
 		public const string _AndroidAllowDeltaInstall = "_AndroidAllowDeltaInstall";
 		public const string Nullable = "Nullable";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -129,11 +129,6 @@ namespace Xamarin.ProjectTools
 			set { SetProperty (KnownProperties.AndroidLinkTool, value); }
 		}
 
-		public string AndroidFastDeploymentType {
-			get { return GetProperty (KnownProperties.AndroidFastDeploymentType); }
-			set { SetProperty (KnownProperties.AndroidFastDeploymentType, value); }
-		}
-
 		public bool UseJackAndJill {
 			get { return string.Equals (GetProperty (KnownProperties.UseJackAndJill), "True", StringComparison.OrdinalIgnoreCase); }
 			set { SetProperty (KnownProperties.UseJackAndJill, value.ToString ()); }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -535,6 +535,11 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       ResourceName="XA1035"
       Condition=" '$(BundleAssemblies)' == 'true' "
   />
+  <AndroidWarning Code="XA1037"
+      ResourceName="XA1037"
+      FormatArguments="AndroidFastDeploymentType;9"
+      Condition=" '$(AndroidFastDeploymentType)' == '' "
+  />
 </Target>
 
 <!--

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -538,7 +538,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <AndroidWarning Code="XA1037"
       ResourceName="XA1037"
       FormatArguments="AndroidFastDeploymentType;9"
-      Condition=" '$(AndroidFastDeploymentType)' == '' "
+      Condition=" '$(AndroidFastDeploymentType)' != '' "
   />
 </Target>
 

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -137,37 +137,16 @@ namespace Xamarin.Android.Build.Tests
 		static object [] DebuggerCustomAppTestCases = new object [] {
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* activityStarts */     true,
 				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* activityStarts */     true,
 				/* packageFormat */      "apk",
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies:Dexes",
-				/* activityStarts */     true,
-				/* packageFormat */      "apk",
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies:Dexes",
-				/* activityStarts */     false,
-				/* packageFormat */      "apk",
-			},
-			new object[] {
-				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
-				/* activityStarts */     true,
-				/* packageFormat */      "aab",
-			},
-			new object[] {
-				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies:Dexes",
 				/* activityStarts */     true,
 				/* packageFormat */      "aab",
 			},
@@ -177,7 +156,7 @@ namespace Xamarin.Android.Build.Tests
 		[Test, Category ("Debugger")]
 		[TestCaseSource (nameof (DebuggerCustomAppTestCases))]
 		[Retry(5)]
-		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool activityStarts, string packageFormat)
+		public void CustomApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, bool activityStarts, string packageFormat)
 		{
 			AssertCommercialBuild ();
 			SwitchUser ();
@@ -190,7 +169,6 @@ namespace Xamarin.Android.Build.Tests
 
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
-				AndroidFastDeploymentType = fastDevType,
 			};
 			proj.SetAndroidSupportedAbis (DeviceAbi);
 			proj.SetProperty ("EmbedAssembliesIntoApk", embedAssemblies.ToString ());
@@ -299,7 +277,6 @@ namespace ${ROOT_NAMESPACE} {
 		static object [] DebuggerTestCases = new object [] {
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
 				/* packageFormat */      "apk",
@@ -307,7 +284,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
 				/* packageFormat */      "apk",
@@ -315,7 +291,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
 				/* packageFormat */      "apk",
@@ -323,23 +298,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
-				/* allowDeltaInstall */  true,
-				/* user */		 null,
-				/* packageFormat */      "apk",
-				/* useLatestSdk */       true,
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies:Dexes",
-				/* allowDeltaInstall */  false,
-				/* user */		 null,
-				/* packageFormat */      "apk",
-				/* useLatestSdk */       true,
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies:Dexes",
 				/* allowDeltaInstall */  true,
 				/* user */		 null,
 				/* packageFormat */      "apk",
@@ -347,7 +305,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
 				/* packageFormat */      "apk",
@@ -355,7 +312,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
 				/* packageFormat */      "apk",
@@ -363,7 +319,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
 				/* packageFormat */      "aab",
@@ -371,7 +326,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
 				/* packageFormat */      "aab",
@@ -383,7 +337,7 @@ namespace ${ROOT_NAMESPACE} {
 		[Test, Category ("Debugger"), Category ("WearOS")]
 		[TestCaseSource (nameof(DebuggerTestCases))]
 		[Retry (5)]
-		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, string fastDevType, bool allowDeltaInstall, string username, string packageFormat, bool useLatestSdk)
+		public void ApplicationRunsWithDebuggerAndBreaks (bool embedAssemblies, bool allowDeltaInstall, string username, string packageFormat, bool useLatestSdk)
 		{
 			AssertCommercialBuild ();
 			SwitchUser ();
@@ -424,7 +378,6 @@ namespace ${ROOT_NAMESPACE} {
 				ProjectName = "App",
 				IsRelease = false,
 				EmbedAssembliesIntoApk = embedAssemblies,
-				AndroidFastDeploymentType = fastDevType
 			};
 			if (!useLatestSdk) {
 				lib.TargetFramework = "net8.0-android";

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -19,27 +19,18 @@ namespace Xamarin.Android.Build.Tests
 		static object [] MonoAndroidExportTestCases = new object [] {
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies",
 				/* isRelease */          false,
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* isRelease */          false,
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "Assemblies:Dexes",
-				/* isRelease */          false,
-			},
-			new object[] {
-				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies:Dexes",
 				/* isRelease */          false,
 			},
 			new object[] {
 				/* embedAssemblies */    true,
-				/* fastDevType */        "",
 				/* isRelease */          true,
 			},
 		};
@@ -47,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (MonoAndroidExportTestCases))]
-		public void MonoAndroidExportReferencedAppStarts (bool embedAssemblies, string fastDevType, bool isRelease)
+		public void MonoAndroidExportReferencedAppStarts (bool embedAssemblies, bool isRelease)
 		{
 			AssertCommercialBuild ();
 			var proj = new XamarinAndroidApplicationProject () {
@@ -56,8 +47,6 @@ namespace Xamarin.Android.Build.Tests
 					new BuildItem.Reference ("Mono.Android.Export"),
 				},
 			};
-			if (!string.IsNullOrEmpty (fastDevType))
-				proj.AndroidFastDeploymentType = fastDevType;
 			proj.Sources.Add (new BuildItem.Source ("ContainsExportedMethods.cs") {
 				TextContent = () => @"using System;
 using Java.Interop;


### PR DESCRIPTION
Context https://github.com/xamarin/monodroid/pull/1481
Context https://github.com/xamarin/xamarin-android/issues/2730

Bump monodroid to bring in the following changes. 

Changes https://github.com/xamarin/monodroid/compare/9ca6d9f64fce11f04d668ece50ada36de1d7efce...93ab95e18077d56d9d55ce7b4069a534e2dea35e.

The biggest of these changes is the removal of Enhanced Fast Deplyment. This change removes the ability to side load `.dex`, `.so` and resources in the same directory as we sideload assemblies. This feature was always hard to maintain as it used a bunch of android API's which are deprecated or have very little documentation. It also did not work for `Application` subcalsses. This restriction alone makes it impossible to use this feature with Maui. 

Given its maintainance issues and the lack of use among our customer base it is best is we remove this feature. 
The default Fast Deployment of assemblies will still function as it currently does now. Only the side loading of `.dex`, `.so` and resources is being removed.

Add a `XA1037` warning to tell users that the `AndroidFastDeploymentType` is no longer supported.
Add a new test `XA1037PropertyDeprecatedWarning` which makes sure that the areas using the generic `XA1037` warning are producing a correct message.