### PR TITLE
[ci] Use long version for maestro publishing

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -57,11 +57,10 @@ variables:
   - name: DotNetFeedCredential
     value: dnceng-dotnet9
 - name: MicroBuildSignType
-  value: Test
-  #${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
-  #  value: Real
-  #${{ else }}:
-  #  value: Test
+  ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
+    value: Real
+  ${{ else }}:
+    value: Test
 
 extends:
   ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
@@ -471,7 +470,7 @@ extends:
       dependsOn:
       - mac_build
       - linux_build
-      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Test'))
+      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
       jobs:
       # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
       - template: sign-artifacts/jobs/v2.yml@yaml-templates
@@ -536,9 +535,8 @@ extends:
         workspace:
           clean: all
         variables:
-        - group: Publish-Build-Assets
-        #- ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-        #  - group: Publish-Build-Assets
+        - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+          - group: Publish-Build-Assets
         steps:
         - checkout: self
           clean: true

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -537,15 +537,6 @@ extends:
         variables:
         - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
           - group: Publish-Build-Assets
-        templateContext:
-          outputs:
-          - output: nuget
-            condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
-            useDotNetTask: false # The default is false to use the NuGetCommand task. Set to true to use the DotNetCoreCLI task to publish packages.
-            packagesToPush: $(Build.StagingDirectory)\nuget-signed\*.nupkg
-            packageParentPath: $(Build.StagingDirectory)\nuget-signed
-            nuGetFeedType: external
-            publishFeedCredentials: $(DotNetFeedCredential)
         steps:
         - checkout: self
 
@@ -606,14 +597,22 @@ extends:
                 artifactName: vsdrop-multitarget-signed
                 downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
-        - powershell: >-
-            & dotnet build -v:n -c $(XA.Build.Configuration)
-            -t:PushManifestToBuildAssetRegistry
-            -p:BuildAssetRegistryToken=$(MaestroAccessToken)
-            -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
-            $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
-            -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
+        - task: DotNetCoreCLI@2
+          displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
+          inputs:
+            projects: $(System.DefaultWorkingDirectory)\Xamarin.Android.BootstrapTasks.sln
+            arguments: -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\bootstrap.binlog
+          condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
+
+        - task: DotNetCoreCLI@2
           displayName: generate and publish BAR manifest
+          inputs:
+            projects: $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
+            arguments: >-
+              -t:PushManifestToBuildAssetRegistry
+              -p:BuildAssetRegistryToken=$(MaestroAccessToken)
+              -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
+              -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
           condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 
         - powershell: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -57,10 +57,11 @@ variables:
   - name: DotNetFeedCredential
     value: dnceng-dotnet9
 - name: MicroBuildSignType
-  ${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
-    value: Real
-  ${{ else }}:
-    value: Test
+  value: Test
+  #${{ if and(or(eq(variables['Build.DefinitionName'], 'Xamarin.Android'), eq(variables['Build.DefinitionName'], 'Xamarin.Android-Private')), ne(variables['Build.Reason'], 'PullRequest')) }}:
+  #  value: Real
+  #${{ else }}:
+  #  value: Test
 
 extends:
   ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
@@ -470,7 +471,7 @@ extends:
       dependsOn:
       - mac_build
       - linux_build
-      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Real'))
+      condition: and(eq(dependencies.mac_build.result, 'Succeeded'), eq(dependencies.linux_build.result, 'Succeeded'), eq(variables['MicroBuildSignType'], 'Test'))
       jobs:
       # Check - "Xamarin.Android (Prepare .NET Release Sign Archives)"
       - template: sign-artifacts/jobs/v2.yml@yaml-templates
@@ -535,10 +536,13 @@ extends:
         workspace:
           clean: all
         variables:
-        - ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
-          - group: Publish-Build-Assets
+        - group: Publish-Build-Assets
+        #- ${{ if eq(variables['MicroBuildSignType'], 'Real') }}:
+        #  - group: Publish-Build-Assets
         steps:
         - checkout: self
+          clean: true
+          submodules: recursive
 
         - task: DownloadPipelineArtifact@2
           inputs:
@@ -598,7 +602,7 @@ extends:
                 downloadPath: $(Build.StagingDirectory)\$(MultiTargetVSDropCommitStatusName)
 
         - task: DotNetCoreCLI@2
-          displayName: build Xamarin.Android.Tools.BootstrapTasks.csproj
+          displayName: build Xamarin.Android.Tools.BootstrapTasks.sln
           inputs:
             projects: $(System.DefaultWorkingDirectory)\Xamarin.Android.BootstrapTasks.sln
             arguments: -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\bootstrap.binlog

--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -164,7 +164,8 @@
   </Target>
 
   <!-- https://github.com/dotnet/arcade/blob/efc3da96e5ac110513e92ebd9ef87c73f44d8540/Documentation/DependencyFlowOnboardingWithoutArcade.md -->
-  <Target Name="PushManifestToBuildAssetRegistry" >
+  <Target Name="PushManifestToBuildAssetRegistry" 
+      DependsOnTargets="GetXAVersionInfo" >
     <PropertyGroup>
       <ArtifactsLogDir>$(OutputPath)</ArtifactsLogDir>
       <AssetManifestFileName>Assets.xml</AssetManifestFileName>
@@ -204,12 +205,12 @@
     <MSBuild
         Targets="Restore"
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion)"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersionLong)"
     />
 
     <MSBuild
         Projects="$(PkgMicrosoft_DotNet_Arcade_Sdk)\tools\SdkTasks\PublishBuildAssets.proj"
-        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersion);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
+        Properties="Configuration=$(Configuration);RepoRoot=$(XamarinAndroidSourcePath);VersionPrefix=$(AndroidPackVersionLong);ManifestsPath=$(ArtifactsLogDir)AssetManifest;MaestroApiEndpoint=https://maestro.dot.net"
     />
   </Target>
 


### PR DESCRIPTION
Commit bbac9fe hit some issues when attempting to publish to maestro:

    error : Asset 'D:\a\_work\1\a\7dc04dfe-406a-4fa3-aea0-199acc2763fa\MergedManifest.xml' already exists with different contents at assets/manifests/xamarin-xamarin-android/34.99.0-dev/MergedManifest.xml

We should be able to fix this by using the long package version which optionally includes pre-release labeling and commit distance info.