### PR TITLE
Bump LLVM to 18.1.6

### DIFF
--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string BinutilsVersion                = "L_18.1.4-8.0.0";
+		const string BinutilsVersion                = "L_18.1.6-8.0.0";
 
 		const string MicrosoftOpenJDK17Version      = "17.0.8";
 		const string MicrosoftOpenJDK17Release      = "17.0.8.7";


### PR DESCRIPTION
Changes: https://discourse.llvm.org/t/18-1-5-released/78740
Changes: https://discourse.llvm.org/t/18-1-6-released/79068

There are no changes in the above announcements that are important to us. Simply tracking the latest LLVM 18 version.

There are no more planned 18.1.x releases, but there could be one if a critical issue is found.