### PR TITLE
$(AndroidPackVersionSuffix)=preview.6; net9 is 34.99.0.preview.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>34.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
   </PropertyGroup>
 
   <!-- Common <PackageReference/> versions -->


### PR DESCRIPTION
Context: https://github.com/xamarin/xamarin-android/tree/release/9.0.1xx-preview5

We branched for .NET 9 Preview 5 from https://github.com/xamarin/xamarin-android/commit/c61174316fcb69959fc8731964edbf2e7df7d726 into release/9.0.1xx-preview5;
the main branch is now .NET 9 Preview 6.

Update xamarin-android/main's version number to 34.99.0-preview.6.