### PR TITLE
Make fast deployment work with aab files

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:allowaabfastdev@a52595ad5c9b3bf85e13ec1268f0a2eb532014b4
+xamarin/monodroid:allowaabfastdev@ab08fd9d3c53d4ecb797c74e4bcf8dbcbe25b90d

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:allowaabfastdev@ab08fd9d3c53d4ecb797c74e4bcf8dbcbe25b90d
+xamarin/monodroid:main@c6aae9e5a154cfbf2c3a94e046fa2c747c3b82e2

--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-xamarin/monodroid:main@93ab95e18077d56d9d55ce7b4069a534e2dea35e
+xamarin/monodroid:allowaabfastdev@a52595ad5c9b3bf85e13ec1268f0a2eb532014b4

--- a/Xamarin.Android.code-workspace
+++ b/Xamarin.Android.code-workspace
@@ -5,6 +5,7 @@
 		}
 	],
 	"settings": {
-		"nxunitExplorer.logpanel": true
+		"nxunitExplorer.logpanel": true,
+		"java.compile.nullAnalysis.mode": "disabled"
 	}
 }

--- a/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-emulator-tests.yaml
@@ -4,7 +4,7 @@ parameters:
   stageName: msbuilddevice_tests
   job_name: 'mac_dotnetdevice_tests'
   dependsOn: mac_build
-  agent_count: 8
+  agent_count: 12
   stageCondition: succeeded()
   stagePrefix: ''
   xaSourcePath: $(System.DefaultWorkingDirectory)

--- a/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-msbuild-tests.yaml
@@ -22,7 +22,7 @@ stages:
       testOS: macOS
       jobName: mac_msbuild_tests
       jobDisplayName: macOS > Tests > MSBuild
-      agentCount: 8
+      agentCount: 14
       xaSourcePath: ${{ parameters.xaSourcePath }}
       repositoryAlias: ${{ parameters.repositoryAlias }}
       commit: ${{ parameters.commit }}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -112,9 +112,7 @@ namespace Xamarin.Android.Tasks
 
 		void SetMetadataForAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
 		{
-			Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: Start of Loop");
 			foreach (ITaskItem assembly in InputAssemblies) {
-				Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: {assembly.ItemSpec}");
 				if (DesignTimeBuild && !File.Exists (assembly.ItemSpec)) {
 					// Designer builds don't produce assemblies, so library and main application DLLs might not
 					// be there and would later cause an error when the `_CopyAssembliesForDesigner` task runs
@@ -132,7 +130,6 @@ namespace Xamarin.Android.Tasks
 				}
 				output.Add (assembly);
 			}
-			Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: End of Loop");
 		}
 
 		static bool IsFromAKnownRuntimePack (ITaskItem assembly)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -112,7 +112,9 @@ namespace Xamarin.Android.Tasks
 
 		void SetMetadataForAssemblies (List<ITaskItem> output, Dictionary<string, ITaskItem> symbols)
 		{
+			Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: Start of Loop");
 			foreach (ITaskItem assembly in InputAssemblies) {
+				Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: {assembly.ItemSpec}");
 				if (DesignTimeBuild && !File.Exists (assembly.ItemSpec)) {
 					// Designer builds don't produce assemblies, so library and main application DLLs might not
 					// be there and would later cause an error when the `_CopyAssembliesForDesigner` task runs
@@ -130,6 +132,7 @@ namespace Xamarin.Android.Tasks
 				}
 				output.Add (assembly);
 			}
+			Log.LogDebugMessage ($"DEBUG!SetMetadataForAssemblies: End of Loop");
 		}
 
 		static bool IsFromAKnownRuntimePack (ITaskItem assembly)
@@ -146,6 +149,7 @@ namespace Xamarin.Android.Tasks
 				// Sometimes .pdb files are not included in @(ResolvedFileToPublish), so add them if they exist
 				if (File.Exists (symbolPath)) {
 					symbols [symbolPath] = symbol = new TaskItem (symbolPath);
+					return symbol;
 				}
 			}
 			return symbol;
@@ -185,6 +189,7 @@ namespace Xamarin.Android.Tasks
 				}
 
 				string destination = Path.Combine (abi, item.GetMetadata ("DestinationSubDirectory"));
+				//Log.LogDebugMessage ($"DEBUG!!!'{item.ItemSpec}' '{rid}' = '{abi}'. DestinationSubDirectory='{destination}'");
 				item.SetMetadata ("DestinationSubDirectory", destination + Path.DirectorySeparatorChar);
 				item.SetMetadata ("DestinationSubPath", Path.Combine (destination, Path.GetFileName (item.ItemSpec)));
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -11,6 +11,7 @@ using System.Threading.Tasks;
 using System.Xml.Linq;
 using System.Xml.XPath;
 using Xamarin.ProjectTools;
+using System.Runtime.InteropServices;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -77,7 +78,10 @@ namespace Xamarin.Android.Build.Tests
 				}
 				SetAdbLogcatBufferSize (128);
 				CreateGuestUser (GuestUserName);
+				return;
 			}
+			TestContext.Out.WriteLine ($"LOG DeviceSetup: No Device!!!!");
+			DeviceAbi = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "arm64-v8a" : "x86_64";
 		}
 
 		[OneTimeTearDown]

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -497,10 +497,6 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AndroidLinkTool)' != '' "
   />
   <AndroidWarning Code="XA0119"
-      ResourceName="XA0119_AAB"
-      Condition=" '$(EmbedAssembliesIntoApk)' != 'True' And '$(AndroidPackageFormat)' == 'aab' "
-  />
-  <AndroidWarning Code="XA0119"
       ResourceName="XA0119_Interpreter"
       Condition=" '$(AndroidUseInterpreter)' == 'True' And '$(AotAssemblies)' == 'True' "
   />

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -151,6 +151,11 @@ namespace Xamarin.Android.Build.Tests
 				/* activityStarts */     true,
 				/* packageFormat */      "aab",
 			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* activityStarts */     true,
+				/* packageFormat */      "aab",
+			},
 		};
 #pragma warning restore 414
 
@@ -326,7 +331,23 @@ namespace ${ROOT_NAMESPACE} {
 				/* useLatestSdk */       true,
 			},
 			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
+				/* allowDeltaInstall */  false,
+				/* user */		 null,
+				/* packageFormat */      "aab",
+				/* useLatestSdk */       true,
+			},
+			new object[] {
 				/* embedAssemblies */    true,
+				/* allowDeltaInstall */  false,
+				/* user */		 DeviceTest.GuestUserName,
+				/* packageFormat */      "aab",
+				/* useLatestSdk */       true,
+			},
+			new object[] {
+				/* embedAssemblies */    false,
+				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
 				/* packageFormat */      "aab",
@@ -388,7 +409,9 @@ namespace ${ROOT_NAMESPACE} {
 			app.SetProperty ("AndroidPackageFormat", packageFormat);
 			app.MainPage = app.MainPage.Replace ("InitializeComponent ();", "InitializeComponent (); new Foo ();");
 			app.AddReference (lib);
-			app.SetAndroidSupportedAbis (DeviceAbi);
+			var abis = new [] { "x86", DeviceAbi };
+			app.SetRuntimeIdentifiers (abis);
+			//app.SetAndroidSupportedAbis (DeviceAbi);
 			app.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
 			app.SetDefaultTargetDevice ();
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -407,9 +407,8 @@ namespace ${ROOT_NAMESPACE} {
 			app.SetProperty ("AndroidPackageFormat", packageFormat);
 			app.MainPage = app.MainPage.Replace ("InitializeComponent ();", "InitializeComponent (); new Foo ();");
 			app.AddReference (lib);
-			var abis = new [] { "x86", DeviceAbi };
+			var abis = new [] { DeviceAbi };
 			app.SetRuntimeIdentifiers (abis);
-			//app.SetAndroidSupportedAbis (DeviceAbi);
 			app.SetProperty (KnownProperties._AndroidAllowDeltaInstall, allowDeltaInstall.ToString ());
 			app.SetDefaultTargetDevice ();
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -332,7 +332,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 null,
 				/* packageFormat */      "aab",
@@ -347,7 +346,6 @@ namespace ${ROOT_NAMESPACE} {
 			},
 			new object[] {
 				/* embedAssemblies */    false,
-				/* fastDevType */        "Assemblies",
 				/* allowDeltaInstall */  false,
 				/* user */		 DeviceTest.GuestUserName,
 				/* packageFormat */      "aab",

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -455,7 +455,9 @@ namespace Xamarin.Android.Build.Tests
 
 		// https://xamarin.github.io/bugzilla-archives/31/31705/bug.html
 		[Test]
-		public void LocalizedAssemblies_ShouldBeFastDeployed ()
+		[TestCase ("apk")]
+		[TestCase ("aab")]
+		public void LocalizedAssemblies_ShouldBeFastDeployed (string packageFormat)
 		{
 			AssertCommercialBuild ();
 
@@ -469,6 +471,7 @@ namespace Xamarin.Android.Build.Tests
 				EmbedAssembliesIntoApk = false,
 			};
 			InlineData.AddCultureResourcesToProject (app, "Foo", "CancelButton");
+			app.SetProperty ("AndroidPackageFormat", packageFormat);
 			app.References.Add (new BuildItem.ProjectReference ($"..\\{lib.ProjectName}\\{lib.ProjectName}.csproj", lib.ProjectName, lib.ProjectGuid));
 
 			using (var libBuilder = CreateDllBuilder (Path.Combine (path, lib.ProjectName)))
@@ -494,12 +497,14 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void IncrementalFastDeployment ()
+		[TestCase ("apk")]
+		[TestCase ("aab")]
+		public void IncrementalFastDeployment (string packageFormat)
 		{
 			AssertCommercialBuild ();
 
 			var class1src = new BuildItem.Source ("Class1.cs") {
-				TextContent = () => "namespace Library1 { public class Class1 { public static int foo = 0; } }"
+				TextContent = () => "namespace Library1 { public class Class1 { public static int foo = 500; } }"
 			};
 			var lib1 = new XamarinAndroidLibraryProject () {
 				ProjectName = "Library1",
@@ -509,7 +514,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 
 			var class2src = new BuildItem.Source ("Class2.cs") {
-				TextContent = () => "namespace Library2 { public class Class2 { public static int foo = 0; } }"
+				TextContent = () => "namespace Library2 { public class Class2 { public static int foo = 40; } }"
 			};
 			var lib2 = new DotNetStandard {
 				ProjectName = "Library2",
@@ -527,16 +532,21 @@ namespace Xamarin.Android.Build.Tests
 					new BuildItem ("ProjectReference", "..\\Library2\\Library2.csproj"),
 				},
 			};
+			app.SetProperty ("AndroidPackageFormat", packageFormat);
 
 			// Set up library projects
 			var rootPath = Path.Combine (Root, "temp", TestName);
-			using (var lb1 = CreateDllBuilder (Path.Combine (rootPath, lib1.ProjectName)))
+			using (var lb1 = CreateDllBuilder (Path.Combine (rootPath, lib1.ProjectName))) {
+				lb1.BuildLogFile = "build.log";
 				Assert.IsTrue (lb1.Build (lib1), "First library build should have succeeded.");
-			using (var lb2 = CreateDllBuilder (Path.Combine (rootPath, lib2.ProjectName)))
+			}
+			using (var lb2 = CreateDllBuilder (Path.Combine (rootPath, lib2.ProjectName))) {
+				lb2.BuildLogFile = "build.log";
 				Assert.IsTrue (lb2.Build (lib2), "Second library build should have succeeded.");
+			}
 
 			long lib1FirstBuildSize = new FileInfo (Path.Combine (rootPath, lib1.ProjectName, lib1.OutputPath, "Library1.dll")).Length;
-
+			
 			using (var builder = CreateApkBuilder (Path.Combine (rootPath, app.ProjectName))) {
 				builder.Verbosity = LoggerVerbosity.Detailed;
 				builder.ThrowOnBuildFailure = false;
@@ -560,13 +570,15 @@ namespace Xamarin.Android.Build.Tests
 					File.SetLastWriteTimeUtc (file, DateTime.UtcNow);
 				}
 
-				class1src.TextContent = () => "namespace Library1 { public class Class1 { public static int foo = 100; } }";
+				class1src.TextContent = () => "namespace Library1 { public class Class1 { public static int foo = 1; } }";
 				class1src.Timestamp = DateTime.UtcNow.AddSeconds(1);
-				using (var lb1 = CreateDllBuilder (Path.Combine (rootPath, lib1.ProjectName)))
+				using (var lb1 = CreateDllBuilder (Path.Combine (rootPath, lib1.ProjectName))) {
+					lb1.BuildLogFile = "build2.log";
 					Assert.IsTrue (lb1.Build (lib1), "Second library build should have succeeded.");
+				}
 
 				long lib1SecondBuildSize = new FileInfo (Path.Combine (rootPath, lib1.ProjectName, lib1.OutputPath, "Library1.dll")).Length;
-				Assert.AreEqual (lib1FirstBuildSize, lib1SecondBuildSize, "Library2.dll was not the same size.");
+				Assert.AreEqual (lib1FirstBuildSize, lib1SecondBuildSize, "Library1.dll was not the same size.");
 
 				builder.BuildLogFile = "install3.log";
 				Assert.IsTrue (builder.Install (app, doNotCleanupOnUpdate: true, saveProject: false), "Third install should have succeeded.");


### PR DESCRIPTION
Commit https://github.com/xamarin/monodroid/commit/c6aae9e5a154cfbf2c3a94e046fa2c747c3b82e2 removed the restriction for using .aab files during fast deployment. 
While using an .aab will still be slower that using an .apk it should still speed up the development process for those using things like asset packs. 
The reason it is slower is becasue the .aab file has to go through `bundle-tool` to be packaged and installed. This is a slow process. The .apk is much faster as we work with it directly. 

Numerous unit tests have been updated to test fast deployment when using .aab files. As a result we have had to increase the number of CI bots we use so we can spread out the new tests amonst more machines.
