### PR TITLE
[ci] Run "Push Internal" job on AzurePipelines-EO pool

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -521,7 +521,10 @@ extends:
         - sign_net_linux
         condition: and(eq(dependencies.nuget_convert.result, 'Succeeded'), eq(dependencies.sign_net_linux.result, 'Succeeded'))
         timeoutInMinutes: 60
-        pool: $(VSEngMicroBuildPool)
+        pool:
+          name: AzurePipelines-EO
+          image: $(WindowsPoolImage1ESPT)
+          os: windows
         workspace:
           clean: all
         variables:


### PR DESCRIPTION
We've been running into issues with the `AzureFileCopy` task on the
MicroBuild pool, which will hopefully be resolved by using a different
image:

    Failed to perform Auto-login: 'Get-AzAccessToken' command was found in the module 'Az.Accounts', but the module could not be loaded.