### PR TITLE
[ci] Update .NET version installed for MAUI tests

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -342,6 +342,8 @@ extends:
           parameters:
             xaSourcePath: $(Build.SourcesDirectory)/xamarin-android
             androidSdkPlatforms: $(DefaultTestSdkPlatforms)
+            dotnetVersion: 9.0.100-preview.4.24267.66
+            dotnetQuality: preview
 
         - task: NuGetAuthenticate@1
           displayName: authenticate with azure artifacts

--- a/build-tools/automation/yaml-templates/setup-test-environment.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment.yaml
@@ -3,9 +3,10 @@ parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)
   jdkTestFolder: $(JAVA_HOME_17_X64)
   remove_dotnet: false
+  dotnetVersion: $(DotNetSdkVersion)
+  dotnetQuality: $(DotNetSdkQuality)
   installTestSlicer: false
   installApkDiff: true
-  installLegacyDotNet: false
   installLegacyXamarinAndroid: false
   updateMono: false
   androidSdkPlatforms: $(DefaultTestSdkPlatforms)
@@ -33,16 +34,12 @@ steps:
   displayName: set JI_JAVA_HOME to ${{ parameters.jdkTestFolder }}
   condition: and(succeeded(), eq(variables['agent.os'], 'Windows_NT'))
 
-# Install .NET 6 for legacy tests
-- ${{ if eq(parameters.installLegacyDotNet, true) }}:
-  - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
-    parameters:
-      version: 6.0
-      quality: GA
-      remove_dotnet: ${{ parameters.remove_dotnet }}
-
 # Install latest .NET
 - template: /build-tools/automation/yaml-templates/use-dot-net.yaml
+  parameters:
+    version: ${{ parameters.dotnetVersion }}
+    quality: ${{ parameters.dotnetQuality }}
+    remove_dotnet: ${{ parameters.remove_dotnet }}
 
 - task: DotNetCoreCLI@2
   displayName: shut down existing build daemons


### PR DESCRIPTION
The MAUI integration job started failing recently seemingly due to some
of the arcade integration changes they are making:

    C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24274.1\tools\RepositoryValidation.proj(33,5): error MSB4018: The "Microsoft.DotNet.Arcade.Sdk.GetLicenseFilePath" task failed unexpectedly.
    C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24274.1\tools\RepositoryValidation.proj(33,5): error MSB4018: System.IO.FileNotFoundException: Could not load file or assembly 'System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'. The system cannot find the file specified.
    C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.arcade.sdk\9.0.0-beta.24274.1\tools\RepositoryValidation.proj(33,5): error MSB4018: File name: 'System.Runtime, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'

Attempt to fix this by installing a .NET 9 preview that will be used to
run their build tasks that provision a local .NET install.

The `installLegacyDotNet` setup-test-environment parameter did not seem
to be in use anywhere and has also been removed.