### PR TITLE
[build] Do not provision JDK 8

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -137,9 +137,6 @@
   <PropertyGroup>
     <JavacSourceVersion>1.8</JavacSourceVersion>
     <JavacTargetVersion>1.8</JavacTargetVersion>
-    <Java8SdkDirectory Condition=" '$(Java8SdkDirectory)' == '' and Exists($(JAVA_HOME_8_X64)) ">$(JAVA_HOME_8_X64)</Java8SdkDirectory>
-    <Java8SdkDirectory Condition=" '$(Java8SdkDirectory)' == '' and Exists('$(JavaSdkDirectory)\..\jdk-1.8') ">$([System.IO.Path]::GetFullPath ('$(JavaSdkDirectory)\..\jdk-1.8'))</Java8SdkDirectory>
-    <Java8SdkDirectory Condition=" '$(Java8SdkDirectory)' == '' ">$(JavaSdkDirectory)</Java8SdkDirectory>
   </PropertyGroup>
   <PropertyGroup>
     <AndroidNdkFullPath>$([System.IO.Path]::GetFullPath ('$(AndroidNdkDirectory)'))</AndroidNdkFullPath>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.MacOS.cs
@@ -1,15 +1,11 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Xamarin.Android.Prepare
 {
 	partial class Configurables
 	{
-		const string AdoptOpenJDKUpdate = "332";
-		const string AdoptOpenJDKBuild = "b09";
-
-		const string JetBrainsOpenJDKOperatingSystem = "osx-x64";
-		const string MicrosoftOpenJDKOperatingSystem = "macOS-x64";
-		const string AdoptOpenJDKOperatingSystem = "x64_mac";
+		static string MicrosoftOpenJDKOperatingSystem = RuntimeInformation.OSArchitecture == Architecture.Arm64 ? "macos-aarch64": "macos-x64";
 
 		partial class Defaults
 		{

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -21,20 +21,10 @@ namespace Xamarin.Android.Prepare
 		const string MicrosoftOpenJDK17Release      = "17.0.8.7";
 		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.8+7";
 
-		const string AdoptOpenJDKRelease = "8.0"; // build_number.0
-		static readonly string AdoptOpenJDKUrlVersion = $"8u{AdoptOpenJDKUpdate}{AdoptOpenJDKBuild}";
-		static readonly string AdoptOpenJDKTag = $"jdk8u{AdoptOpenJDKUpdate}-{AdoptOpenJDKBuild}";
-		static readonly string AdoptOpenJDKVersion = $"1.8.0.{AdoptOpenJDKUpdate}";
-
 		static Context ctx => Context.Instance;
 
 		public static partial class Urls
 		{
-			// https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_linux_hotspot_8u345b01.tar.gz
-			// https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u332-b09/OpenJDK8U-jdk_x64_mac_hotspot_8u332b09.tar.gz
-			// https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u345-b01/OpenJDK8U-jdk_x64_windows_hotspot_8u345b01.zip
-			public static readonly Uri AdoptOpenJDK8 = new Uri ($"https://github.com/adoptium/temurin8-binaries/releases/download/{AdoptOpenJDKTag}/OpenJDK8U-jdk_{AdoptOpenJDKOperatingSystem}_hotspot_{AdoptOpenJDKUrlVersion}.{AdoptOpenJDKArchiveExtension}");
-
 			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-linux-x64.tar.gz
 			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-macOS-x64.tar.gz
 			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.zip
@@ -58,10 +48,6 @@ namespace Xamarin.Android.Prepare
 			public static readonly Version MicrosoftOpenJDK17Version       = new Version (Configurables.MicrosoftOpenJDK17Version);
 			public static readonly Version MicrosoftOpenJDK17Release       = new Version (Configurables.MicrosoftOpenJDK17Release);
 			public static readonly string  MicrosoftOpenJDK17RootDirName   = Configurables.MicrosoftOpenJDK17RootDirName;
-
-			public static readonly Version AdoptOpenJDK8Version     = new Version (Configurables.AdoptOpenJDKVersion);
-			public static readonly Version AdoptOpenJDK8Release     = new Version (Configurables.AdoptOpenJDKRelease);
-			public static readonly string  AdoptOpenJDK8RootDirName = Configurables.AdoptOpenJDKTag;
 
 			public const string DotNetTestRuntimeVersion                   = "3.1.11";
 
@@ -216,11 +202,8 @@ namespace Xamarin.Android.Prepare
 			public static string MonoAndroidFrameworksRootDir        => GetCachedPath (ref monoAndroidFrameworksRootDir, ()        => Path.Combine (XAInstallPrefix, MonoAndroidFrameworksSubDir));
 			public static string InstallMSBuildDir                   => GetCachedPath (ref installMSBuildDir, ()                   => ctx.Properties.GetRequiredValue (KnownProperties.MicrosoftAndroidSdkOutDir));
 
-			// AdoptOpenJDK
-			public static string OldOpenJDKInstallDir                => GetCachedPath (ref oldOpenJDKInstallDir, ()                => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk"));
-			public static string OpenJDK8InstallDir                  => GetCachedPath (ref openJDK8InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-1.8"));
-			public static string OpenJDK8CacheDir                    => GetCachedPath (ref openJDK8CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
-
+			// OpenJDK
+			public static string OldOpenJDKInstallDir                => GetCachedPath (ref oldOpenJDKInstallDir, ()                => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-1.8"));
 			public static string OpenJDK17InstallDir                 => GetCachedPath (ref openJDK17InstallDir, ()                   => Path.Combine (ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainDirectory), "jdk-17"));
 			public static string OpenJDK17CacheDir                   => GetCachedPath (ref openJDK17CacheDir, ()                     => ctx.Properties.GetRequiredValue (KnownProperties.AndroidToolchainCacheDirectory));
 
@@ -302,8 +285,8 @@ namespace Xamarin.Android.Prepare
 			static string? installMSBuildDir;
 			static string? monoAndroidFrameworksRootDir;
 			static string? externalJavaInteropDir;
-			static string? openJDK8InstallDir,  openJDK17InstallDir;
-			static string? openJDK8CacheDir,    openJDK17CacheDir;
+			static string? openJDK17InstallDir;
+			static string? openJDK17CacheDir;
 			static string? oldOpenJDKInstallDir;
 			static string? configurationPropsGeneratedPath;
 			static string? windowsBinutilsInstallDir;

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -17,17 +17,17 @@ namespace Xamarin.Android.Prepare
 	{
 		const string BinutilsVersion                = "L_18.1.6-8.0.0";
 
-		const string MicrosoftOpenJDK17Version      = "17.0.8";
-		const string MicrosoftOpenJDK17Release      = "17.0.8.7";
-		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.8+7";
+		const string MicrosoftOpenJDK17Version      = "17.0.11";
+		const string MicrosoftOpenJDK17Release      = "17.0.11.9";
+		const string MicrosoftOpenJDK17RootDirName  = "jdk-17.0.11+9";
 
 		static Context ctx => Context.Instance;
 
 		public static partial class Urls
 		{
-			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-linux-x64.tar.gz
-			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-macOS-x64.tar.gz
-			// https://aka.ms/download-jdk/microsoft-jdk-17.0.8-windows-x64.zip
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.11-linux-x64.tar.gz
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.11-macOS-x64.tar.gz or https://aka.ms/download-jdk/microsoft-jdk-17.0.11-macos-aarch64.pkg
+			// https://aka.ms/download-jdk/microsoft-jdk-17.0.11-windows-x64.zip
 			public static readonly Uri MicrosoftOpenJDK17 = new Uri ($"https://aka.ms/download-jdk/microsoft-jdk-{MicrosoftOpenJDK17Version}-{MicrosoftOpenJDKOperatingSystem}.{MicrosoftOpenJDKFileExtension}");
 
 			/// <summary>

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_AndroidTestDependencies.cs
@@ -18,8 +18,7 @@ namespace Xamarin.Android.Prepare
 		protected override void AddSteps (Context context)
 		{
 			Steps.Add (new Step_InstallDotNetPreview ());
-			Steps.Add (new Step_InstallAdoptOpenJDK8 ());
-			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
+			Steps.Add (new Step_InstallMicrosoftOpenJDK ());
 			Steps.Add (new Step_Android_SDK_NDK (AndroidSdkNdkType));
 
 			// disable installation of missing programs...

--- a/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
+++ b/build-tools/xaprepare/xaprepare/Scenarios/Scenario_Standard.cs
@@ -19,8 +19,7 @@ namespace Xamarin.Android.Prepare
 				throw new ArgumentNullException (nameof (context));
 
 			Steps.Add (new Step_InstallDotNetPreview ());
-			Steps.Add (new Step_InstallAdoptOpenJDK8 ());
-			Steps.Add (new Step_InstallMicrosoftOpenJDK11 ());
+			Steps.Add (new Step_InstallMicrosoftOpenJDK ());
 			Steps.Add (new Step_Android_SDK_NDK ());
 			Steps.Add (new Step_GenerateFiles (atBuildStart: true));
 			Steps.Add (new Step_PrepareProps ());

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallAdoptOpenJDK.cs
@@ -267,30 +267,12 @@ namespace Xamarin.Android.Prepare
 		}
 	}
 
-	class Step_InstallAdoptOpenJDK8 : Step_InstallOpenJDK {
-
-		const string _ProductName = "AdoptOpenJDK";
-
-		public Step_InstallAdoptOpenJDK8 ()
-			: base ($"Installing {_ProductName} 1.8")
-		{
-		}
-
-		protected   override    string  ProductName      => _ProductName;
-		protected   override    string  JdkInstallDir    => Configurables.Paths.OpenJDK8InstallDir;
-		protected   override    Version JdkVersion       => Configurables.Defaults.AdoptOpenJDK8Version;
-		protected   override    Version JdkRelease       => Configurables.Defaults.AdoptOpenJDK8Release;
-		protected   override    Uri     JdkUrl           => Configurables.Urls.AdoptOpenJDK8;
-		protected   override    string  JdkCacheDir      => Configurables.Paths.OpenJDK8CacheDir;
-		protected   override    string  RootDirName      => Configurables.Defaults.AdoptOpenJDK8RootDirName;
-	}
-
-	class Step_InstallMicrosoftOpenJDK11 : Step_InstallOpenJDK {
+	class Step_InstallMicrosoftOpenJDK : Step_InstallOpenJDK {
 
 		const string _ProductName = "Microsoft OpenJDK";
 
-		public Step_InstallMicrosoftOpenJDK11 ()
-			: base ($"Installing {_ProductName} 11")
+		public Step_InstallMicrosoftOpenJDK ()
+			: base ($"Installing {_ProductName}")
 		{
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Directory.Build.targets
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Directory.Build.targets
@@ -37,7 +37,7 @@
       Inputs="@(JavaSourceJarTest)"
       Outputs="Resources/javasourcejartest-javadoc.jar">
     <PropertyGroup>
-      <_Javadoc>"$(Java8SdkDirectory)/bin/javadoc"</_Javadoc>
+      <_Javadoc>"$(JavaSdkDirectory)/bin/javadoc"</_Javadoc>
       <_Outdir>$(IntermediateOutputPath)/javadoc</_Outdir>
     </PropertyGroup>
     <MakeDir Directories="$(_Outdir)" />

--- a/src/manifestmerger/manifestmerger.targets
+++ b/src/manifestmerger/manifestmerger.targets
@@ -9,12 +9,12 @@
       Outputs="$(_Destination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; build $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Copy
@@ -28,7 +28,7 @@
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>

--- a/src/r8/r8.targets
+++ b/src/r8/r8.targets
@@ -10,7 +10,7 @@
       Outputs="$(_Destination)">
     <Exec
         Command="&quot;$(GradleWPath)&quot; jar $(GradleArgs) -PjavaSourceVer=$(JavacSourceVersion) -PjavaTargetVer=$(JavacTargetVersion)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
     <Copy
@@ -24,7 +24,7 @@
     <Delete Files="$(_Destination)" />
     <Exec
         Command="&quot;$(GradleWPath)&quot; clean $(GradleArgs)"
-        EnvironmentVariables="JAVA_HOME=$(Java8SdkDirectory);APP_HOME=$(GradleHome)"
+        EnvironmentVariables="JAVA_HOME=$(JavaSdkDirectory);APP_HOME=$(GradleHome)"
         WorkingDirectory="$(MSBuildThisFileDirectory)"
     />
   </Target>


### PR DESCRIPTION
Removes JDK 8 provisioning logic as it appears to not be needed.

The version of JDK 17 that is installed has been bumped to 17.0.11, and
aarch64 packages will now be used on macOS when applicable. 