### PR TITLE
Make sure `_GenerateJavaStubs` always generates native assembly files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1510,6 +1510,7 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 
   <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
+  <Touch Files="@(_TypeMapAssemblySource)" />
 </Target>
 
 <Target Name="_ManifestMerger"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1509,8 +1509,8 @@ because xbuild doesn't support framework reference assemblies.
     <FileWrites Include="$(_ManifestOutput)" />
   </ItemGroup>
 
-  <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
   <Touch Files="@(_TypeMapAssemblySource)" />
+  <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
 </Target>
 
 <Target Name="_ManifestMerger"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1445,7 +1445,7 @@ because xbuild doesn't support framework reference assemblies.
 <Target Name="_GenerateJavaStubs"
     DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
     Inputs="@(_AndroidMSBuildAllProjects);@(_ResolvedUserMonoAndroidAssemblies);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache);@(AndroidEnvironment);@(LibraryEnvironments)"
-    Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
+    Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp;@(_TypeMapAssemblySource)">
 
   <PropertyGroup>
     <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(IntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>


### PR DESCRIPTION
Fixes: https://github.com/xamarin/xamarin-android/issues/8967

For some reason, sometimes the `typemap*.ll` files are sometimes removed from the `obj/` directory which leads to build errors similar to:

    typemaps.x86_64.ll: error: Could not open input file: no such file or directory

Files are generated by the `GenerateJavaStubs` tasks, which is invoked by the `_GenerateJavaStubs` target.  However, the target doesn't specify the `*.ll` files in its `Outputs` parameter and, therefore, whenever the files are removed but the `_GenerateJavaStubs.stamp` file is newer than the items/files specified in the target's `Inputs` parameter, the native assembly files aren't regenerated leading to the above error.

To fix this, we need to add the `typemap*.ll` files to the target's `Outputs` set, thus forcing their regeneration should they be no longer where they are expected to be.