### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17928: Build ID 9698338

### DIFF
--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.cs.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.cs.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Aplikace Android Wear",
-  "description": "Projekt pro vytvoření aplikace .NET Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Přepíše název balíčku v souboru AndroidManifest.xml.",
   "symbols/supportedOSVersion/description": "Přepíše $(SupportedOSPlatformVersion) v projektu."
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.de.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.de.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear-Anwendung",
-  "description": "Ein Projekt zum Erstellen einer .NET für Android Wear-Anwendung",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Überschreibt den Paketnamen in der Datei „AndroidManifest.xml“.",
   "symbols/supportedOSVersion/description": "Überschreibt $(SupportedOSPlatformVersion) im Projekt"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.es.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.es.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Aplicación Android Wear",
-  "description": "Proyecto para crear una aplicación .NET para Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Invalida el nombre del paquete en AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Invalida $(SupportedOSPlatformVersion) en el proyecto"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.fr.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.fr.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear Application",
-  "description": "Projet de création d’une application .NET pour Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Remplace le nom du package dans le AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Remplace $(SupportedOSPlatformVersion) dans le projet"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.it.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.it.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Applicazione Android Wear",
-  "description": "Progetto per la creazione di un'applicazione per Android Wear .NET",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Esegue l'override del nome del pacchetto nel file AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Esegue l'override di $(SupportedOSPlatformVersion) nel progetto"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ja.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ja.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear アプリケーション",
-  "description": ".NET for Android Wear アプリケーションを作成するためのプロジェクト",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "AndroidManifest.xml のパッケージ名をオーバーライドします",
   "symbols/supportedOSVersion/description": "プロジェクト ファイルの $(SupportedOSPlatformVersion) をオーバーライドします"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ko.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ko.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android 웨어 애플리케이션",
-  "description": "Android용 .NET Wear 애플리케이션을 만들기 위한 프로젝트",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "AndroidManifest.xml의 패키지 이름을 재정의합니다.",
   "symbols/supportedOSVersion/description": "프로젝트에서 $(SupportedOSPlatformVersion) 재정의"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pl.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pl.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Aplikacja systemu Android Wear",
-  "description": "Projekt służący do tworzenia aplikacji platformy .NET dla systemu Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Przesłania nazwę pakietu w pliku AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Nadpisuje element $(SupportedOSPlatformVersion) w projekcie"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pt-BR.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.pt-BR.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Aplicativo Android Wear",
-  "description": "Um projeto para a criação de um aplicativo .NET para Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Substitui o nome do pacote no AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Substitui a $(SupportedOSPlatformVersion) no projeto"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ru.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.ru.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Приложение Android Wear",
-  "description": "Проект создания приложения .NET для Android Wear",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "Переопределяет имя пакета в AndroidManifest.xml",
   "symbols/supportedOSVersion/description": "Переопределяет $(SupportedOSPlatformVersion) в файле проекта"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.tr.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.tr.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear Uygulaması",
-  "description": "Android için .NET Wear uygulaması oluşturmak için proje",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "AndroidManifest.xm öğesindeki paket adını geçersiz kılar",
   "symbols/supportedOSVersion/description": "Projedeki $(SupportedOSPlatformVersion) öğesini geçersiz kılar"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hans.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hans.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear 应用程序",
-  "description": "用于创建 .NET for Android Wear 应用程序的项目",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "重写 AndroidManifest.xml 中的包名称",
   "symbols/supportedOSVersion/description": "替代项目中的 $(SupportedOSPlatformVersion)"
 }

--- a/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hant.json
+++ b/src/Microsoft.Android.Templates/android-wear/.template.config/localize/templatestrings.zh-Hant.json
@@ -1,7 +1,7 @@
 ﻿{
   "author": "Microsoft",
   "name": "Android Wear 應用程式",
-  "description": "用於建立 Android 版 .NET Wear 應用程式的專案",
+  "description": "A project for creating a Wear OS app using .NET for Android",
   "symbols/packageName/description": "覆寫 AndroidManifest.xml 中的套件名稱",
   "symbols/supportedOSVersion/description": "覆寫專案中的 $(SupportedOSPlatformVersion)"
 }


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.