### PR TITLE
Update build-items.md -  fix AndroidLibrary documentation

### DIFF
--- a/Documentation/docs-mobile/building-apps/build-items.md
+++ b/Documentation/docs-mobile/building-apps/build-items.md
@@ -180,8 +180,8 @@ Any project can specify:
 
 ```xml
 <ItemGroup>
-  <AndroidLibrary Include="foo.jar" />
-  <AndroidLibrary Include="bar.aar" />
+  <AndroidLibrary Update="foo.jar" />
+  <AndroidLibrary Update="bar.aar" />
 </ItemGroup>
 ```
 
@@ -194,7 +194,7 @@ The result of the above code snippet has a different effect for each
 * Java binding projects:
   * `foo.jar` maps to [**EmbeddedJar**](#embeddedjar).
   * `foo.jar` maps to [**EmbeddedReferenceJar**](#embeddedreferencejar)
-    if `Bind="false"` metadata is added.
+    if `Bind="false"` metadata (attribute) is added.
   * `bar.aar` maps to [**LibraryProjectZip**](#libraryprojectzip).
 
 This simplification means you can use **AndroidLibrary** everywhere.


### PR DESCRIPTION
The `AndroidLibrary` documentation is somewhat incorrect; to get the desired functionality, you need to use `Update` and not `Include`.

It's also confusing what "metadata" means in this context. It means an attribute on  the `<AndroidLibrary>` XML node.