### PR TITLE
[release/9.0.1xx] Bump to DevDiv/android-platform-support/release/9.01xx@0ec8d44d

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:release/9.0.1xx@41f8660f009f6efe6c440100ecf13ce1e276177b
+DevDiv/android-platform-support:release/9.0.1xx@0ec8d44d5d90dd2b8ab69cc9791e22da4ff16a52


### PR DESCRIPTION
Backport of: https://github.com/dotnet/android/pull/10174
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC41f8660f009f6efe6c440100ecf13ce1e276177b&targetVersion=GC0ec8d44d5d90dd2b8ab69cc9791e22da4ff16a52
Fixes: https://github.com/dotnet/android/issues/10167

FastDev binary utilities are rebuilt with 16k page alignment for arm64, which causes them not to segfault on devices or emulators which enabled 16k page support.

At the same time, the 16k-aligned binaries work fine on 4k-page devices/emulators. Tested both on Android 16.