### PR TITLE
[build] set `$DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT`

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -72,3 +72,5 @@ variables:
   value: 'cat != SystemApplication & cat != TimeZoneInfo & cat != Localization'
 - name: RunMAUITestJob
   value: true
+- name: DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT
+  value: true


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/commit/d89d82ac6c821ee712da8881476bb87d739cc4a0
Context: https://github.com/dotnet/runtime/blob/1fb517811e25a96a92ce377d51bf693461ae4f75/src/libraries/System.Net.Security/src/System/Net/Security/SslAuthenticationOptions.cs#L16-L20

Our CI is randomly failing on the `dotnet restore` step with:

    Determining projects to restore...
    Retrying 'FindPackagesByIdAsync' for source 'https://pkgs.dev.azure.com/dnceng/9ee6d478-d288-47f7-aacc-f6e6d082ae6d/_packaging/d6432872-d676-4a5e-aaa1-e455c44fa8ac/nuget/v3/flat2/netstandard.library/index.json'.
    The SSL connection could not be established, see inner exception.
        The remote certificate is invalid because of errors in the certificate chain: RevocationStatusUnknown

They've been fighting this issue in dotnet/maui, so going to try the same thing to set `$DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT=true`.