### PR TITLE
[release/9.0.1xx] [xabt] fix `MONO_GC_PARAMS=bridge-implementation=new` env var

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:release/9.0.1xx@0ec8d44d5d90dd2b8ab69cc9791e22da4ff16a52
+DevDiv/android-platform-support:release/9.0.1xx@709210edd65a679cd5a7b36c8e3a3140fba1c512

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -961,14 +961,19 @@ namespace UnnamedProject
 				OtherBuildItems = {
 					new BuildItem("AndroidEnvironment", "env.txt") {
 						TextContent = () => @"Foo=Bar
-Bar34=Foo55",
+Bar34=Foo55
+Empty=
+MONO_GC_PARAMS=bridge-implementation=new",
 					}
 				}
 			};
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", @"
 		Console.WriteLine (""Foo="" + Environment.GetEnvironmentVariable(""Foo""));
 		Console.WriteLine (""Bar34="" + Environment.GetEnvironmentVariable(""Bar34""));
-		Console.WriteLine (""DOTNET_MODIFIABLE_ASSEMBLIES="" + Environment.GetEnvironmentVariable(""DOTNET_MODIFIABLE_ASSEMBLIES""));");
+		Console.WriteLine (""Empty="" + Environment.GetEnvironmentVariable(""Empty""));
+		Console.WriteLine (""MONO_GC_PARAMS="" + Environment.GetEnvironmentVariable(""MONO_GC_PARAMS""));
+		Console.WriteLine (""DOTNET_MODIFIABLE_ASSEMBLIES="" + Environment.GetEnvironmentVariable(""DOTNET_MODIFIABLE_ASSEMBLIES""));
+		");
 			var builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Build (proj), "`dotnet build` should succeed");
 			RunProjectAndAssert (proj, builder);
@@ -983,12 +988,23 @@ Bar34=Foo55",
 			StringAssert.Contains (
 					"Foo=Bar",
 					logcatOutput,
-					"The Environment variable \"Foo\" was not set."
+					"The Environment variable \"Foo\" was not set to expected value \"Bar\"."
 			);
 			StringAssert.Contains (
 					"Bar34=Foo55",
 					logcatOutput,
-					"The Environment variable \"Bar34\" was not set."
+					"The Environment variable \"Bar34\" was not set to expected value \"Foo55\"."
+			);
+			// NOTE: `Empty=` test case is to ensure a blank value doesn't cause a build error
+			StringAssert.Contains (
+					"Empty=",
+					logcatOutput,
+					"The Environment variable \"Empty\" was not set."
+			);
+			StringAssert.Contains (
+					"MONO_GC_PARAMS=bridge-implementation=new",
+					logcatOutput,
+					"The Environment variable \"MONO_GC_PARAMS\" was not set to expected value \"bridge-implementation=new\"."
 			);
 			// NOTE: set when $(UseInterpreter) is true, default for Debug mode
 			if (!isRelease) {


### PR DESCRIPTION
Backports: https://github.com/dotnet/android/pull/10275
Fixes: https://github.com/dotnet/android/issues/9701

A `=` symbol in the value of an environment variable does not appear to work in Debug mode with Fast Deployment enabled. This seems to be caused by the code in the `<FastDeploy/>` MSBuild task:

    var items = line.Split(new char[] { '=' });
    if (items.Length != 2)
        continue;

Introduce a test to verify a value such as:
`MONO_GC_PARAMS=bridge-implementation=new`.

Bump to DevDiv/android-platform-support/release/9.0.1xx@709210ed

Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC0ec8d44d5d90dd2b8ab69cc9791e22da4ff16a52&targetVersion=GC709210edd65a679cd5a7b36c8e3a3140fba1c512

* [xabdt] fix env vars containing `=` sign

* [Xamarin.Installer.AndroidSDK] sort components before installing