### PR TITLE
Make 7z able to handle symlinks in the NDK zip again

### DIFF
--- a/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
+++ b/build-tools/xaprepare/xaprepare/ToolRunners/SevenZipRunner.cs
@@ -14,6 +14,12 @@ namespace Xamarin.Android.Prepare
 		// Just an educated guess.  The official download page had versions 19 and then 23+ available
 		// and the 19 one didn't support the `-snld` switch
 		static readonly Version snldMinVersion = new Version (20, 0);
+
+		// New switch was added in v25.01 
+		//   https://sourceforge.net/p/sevenzip/discussion/45797/thread/da14cd780b/
+		//   https://github.com/ip7z/7zip/releases/tag/25.01
+		static readonly Version snld20MinVersion = new Version (25, 1);
+
 		Version version;
 
 		protected override string DefaultToolExecutableName => "7za";
@@ -126,8 +132,15 @@ namespace Xamarin.Android.Prepare
 			//
 			//   https://sourceforge.net/p/sevenzip/discussion/45798/thread/187ce54fb0/
 			//
-			if (version >= snldMinVersion) {
-				Log.DebugLine ("Adding option to ignore dangerous symlinks");
+			// A new switch was added in version 25.01:
+			//
+			//   https://sourceforge.net/p/sevenzip/discussion/45797/thread/da14cd780b/
+			//   https://github.com/ip7z/7zip/releases/tag/25.01
+			if (version >= snld20MinVersion) {
+				Log.DebugLine ("Adding -snld20 option to ignore dangerous symlinks");
+				runner.AddArgument ("-snld20");
+			} else if (version >= snldMinVersion) {
+				Log.DebugLine ("Adding -snld option to ignore dangerous symlinks");
 				runner.AddArgument ("-snld");
 			}
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10387
Context: https://sourceforge.net/p/sevenzip/discussion/45797/thread/da14cd780b/
Context: https://github.com/ip7z/7zip/releases/tag/25.01

With the release of 7z 25.01, the previously used `-snld` switch stopped working when
unpacking Android NDK archives:

```
stderr | ERROR: Dangerous link via another link was ignored : android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/lib/libc++.so.1 : x86_64-unknown-linux-gnu/libc++.so.1
stderr | ERROR: Dangerous link via another link was ignored : android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/lib/libc++abi.so.1 : x86_64-unknown-linux-gnu/libc++abi.so.1
stderr | ERROR: Dangerous link via another link was ignored : android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/ld : ld.lld
```

I've seen it only on my Linux PC which uses Debian/unstable, but the problem will show itself
on macOS and Windows as well with the new 7z version.

Instead of switching to `System.IO.Compression`, as suggested in the issue, this PR adds
support for the new `-snld20` switch added in 7z 25.01 and which makes 7z able to handle
NDK archives again.