### PR TITLE
[Docs] Update JDK version in docs

### DIFF
--- a/Documentation/building/unix/dependencies.md
+++ b/Documentation/building/unix/dependencies.md
@@ -68,7 +68,7 @@ Alternatively, the Java Development Kit may be downloaded from the
 [openjdk]: https://openjdk.java.net
 [download-jdk]: http://www.oracle.com/technetwork/java/javase/downloads/
 
-For the JDK version that is currently used, see [`Configurables.cs`](/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs).
+For the JDK version that is currently used, see [`Configurables.cs`](../../../build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs).
 
 
 <a name="autotools" />


### PR DESCRIPTION
Use [Configurables.cs](https://github.com/dotnet/android/blob/cae9fcc053d541ac7bf1e353ef34d754a0043798/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs) to reference the current JDK version.