### PR TITLE
[build] fix branding of `Xamarin.Android.Tools.AndroidSdk`

### DIFF
--- a/external/xamarin-android-tools.override.props
+++ b/external/xamarin-android-tools.override.props
@@ -16,7 +16,8 @@
       BeforeTargets="SetVersion"
       DependsOnTargets="GetXAVersionInfo">
     <PropertyGroup>
-      <PackageVersionSuffix>-preview.$(PackVersionCommitCount)</PackageVersionSuffix>
+      <PackageVersionSuffix Condition="$(XAVersionBranch.StartsWith('release/'))">-preview.$(PackVersionCommitCount)</PackageVersionSuffix>
+      <PackageVersionSuffix Condition="!$(XAVersionBranch.StartsWith('release/'))">-ci.$(_AndroidPackBranch).$(PackVersionCommitCount)</PackageVersionSuffix>
     </PropertyGroup>
   </Target>
 </Project>


### PR DESCRIPTION
We are seeing the error pushing to maestro:

    D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25415.5\tools\SdkTasks\PublishArtifactsInManifest.proj(124,5): error : Package 'D:\a\_work\1\a\86b5ccfa-76bb-4ef4-8116-e2e3a1e113de\Xamarin.Android.Tools.AndroidSdk.1.0.106-preview.277.nupkg' already exists on 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json' with different content.
    ##[error].packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25415.5\tools\SdkTasks\PublishArtifactsInManifest.proj(124,5): error : Package 'D:\a\_work\1\a\86b5ccfa-76bb-4ef4-8116-e2e3a1e113de\Xamarin.Android.Tools.AndroidSdk.1.0.106-preview.277.nupkg' already exists on 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json' with different content.
    D:\a\_work\1\s\.packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25415.5\tools\SdkTasks\PublishArtifactsInManifest.proj(124,5): error : Failed to publish package 'Xamarin.Android.Tools.AndroidSdk@1.0.106-preview.277' to 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json' after 5 attempts. (Final status: ExistsAndDifferent)
    ##[error].packages\microsoft.dotnet.arcade.sdk\10.0.0-beta.25415.5\tools\SdkTasks\PublishArtifactsInManifest.proj(124,5): error : Failed to publish package 'Xamarin.Android.Tools.AndroidSdk@1.0.106-preview.277' to 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet10/nuget/v3/index.json' after 5 attempts. (Final status: ExistsAndDifferent)

This is because `main` and the `release/10.0.1xx-rc1` branch are both producing packages with the same version...

Let's fix this by introducing the `-ci.<branch>.<commitcount>` suffix for non-release branches.