### PR TITLE
[build] set $(DisableTransitiveFrameworkReferenceDownloads) in another file

### DIFF
--- a/tools/workload-dependencies/Directory.Build.props
+++ b/tools/workload-dependencies/Directory.Build.props
@@ -5,4 +5,8 @@
     This is so that we can cleanly import Xamarin.Installer.Common.props and
     Xamarin.Android.Common.props from WorkloadDependencies.proj.
     -->
+  <PropertyGroup>
+    <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
+    <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=12288035&view=logs&j=96fd57f5-f69e-53c7-3d47-f67e6cf9b93e&t=b1c5529c-cb32-57d3-a3b4-ef8eebaa5024&l=356

Our .NET 10 RC 1 release branch failed on a .NET upgrade with:

    "build-tools/create-packs/Microsoft.Android.Sdk.proj" (CreateAllPacks target) (1:7) ->
    (CreateAllPacks target) ->
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: Unable to find package Microsoft.AspNetCore.App.Ref with version (= 9.0.9) [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 1356 version(s) in dotnet10 [ Nearest version: 10.0.0-alpha.1.24419.2 ] [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 154 version(s) in dotnet-public [ Nearest version: 10.0.0-preview.1.25120.3 ] [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 1 version(s) in dotnet-tools [ Nearest version: 5.0.0-rc.2.20513.11 ] [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-android-a618557-1 [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-android-a618557 [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-emsdk-3cddc1f [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-runtime-207cda3 [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-runtime-3b1cfdc [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in darc-pub-dotnet-runtime-6cd8ef8 [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in dotnet-eng [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/workload-dependencies.csproj : error NU1102: - Found 0 version(s) in dotnet10-transport [tools/workload-dependencies/WorkloadDependencies.proj]
        tools/workload-dependencies/WorkloadDependencies.proj(84,5): error MSB3073: The command "dotnet run --project "tools/workload-dependencies/workload-dependencies.csproj" -p:DotNetStableTargetFramework=net9.0 -p:MonoOptionsVersion=6.12.0.148 -p:NewtonsoftJsonPackageVersion=13.0.3 -- "--feed=tools/workload-dependencies//../../external/android-platform-support/Feeds/AndroidManifestFeed_d17.12.xml" -o "bin/BuildRelease/nuget-unsigned/workload-manifest/WorkloadDependencies.json" --build-tools-version=36.0.0 --cmdline-tools-version=19.0 --jdk-version=17.0.14 --jdk-max-version=21.0.99 --ndk-version=26.1.10909125 --platform-tools-version=36.0.0 --platform-version=android-36 --workload-version=36.0.0-ci.darc-release-10-0-1xx-rc1-2c23cc94-2130-4789-b290-6e1687150096.290" exited with code 1.
        build-tools/create-packs/Directory.Build.targets(61,5): error MSB3073: The command ""bin/Release/dotnet/dotnet" pack -p:Configuration=Release "-bl:bin/BuildRelease/msbuild-20250828T020302-Microsoft.NET.Sdk.Android.binlog" "build-tools/create-packs/Microsoft.NET.Sdk.Android.proj"" exited with code 1.

We normally have set `$(DisableTransitiveFrameworkReferenceDownloads)` to solve this problem, as it prevents the .NET SDK from restoring ASP.NET or Windows Desktop packs.

I noticed this specific project had its own `Directory.Build.props` file, but it did not set `$(DisableTransitiveFrameworkReferenceDownloads)`, so I added it.

Bringing this change to `main`, so this won't fail in future .NET 10 releases.