### PR TITLE
[workload-dependencies] fix blank `$(DotNetStableTargetFramework)`

### DIFF
--- a/tools/workload-dependencies/Directory.Build.props
+++ b/tools/workload-dependencies/Directory.Build.props
@@ -6,6 +6,7 @@
     Xamarin.Android.Common.props from WorkloadDependencies.proj.
     -->
   <PropertyGroup>
+    <DotNetStableTargetFramework Condition=" '$(DotNetStableTargetFramework)' == '' ">net9.0</DotNetStableTargetFramework>
     <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
   </PropertyGroup>


### PR DESCRIPTION
Local builds can fail with:

    > ./dotnet-local.cmd build build-tools/create-packs/Microsoft.Android.Sdk.proj -t:ConfigureLocalWorkload
    Restore complete (2.2s)
    WorkloadDependencies failed with 2 error(s) (1.0s)
        D:\src\android\bin\Debug\dotnet\sdk\9.0.305\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(96,5): error NETSDK1013: The TargetFramework value '' was not recognized. It may be misspelled. If not, then the TargetFrameworkIdentifier and/or TargetFrameworkVersion properties must be specified explicitly. [D:\src\android\tools\workload-dependencies\workload-dependencies.csproj]
        D:\src\android\tools\workload-dependencies\WorkloadDependencies.proj(83,5): error MSB3073: The command "dotnet run --project "D:\src\android\tools\workload-dependencies\workload-dependencies.csproj" -p:MonoOptionsVersion=6.12.0.148 -p:NewtonsoftJsonPackageVersion=13.0.3 -- "--feed=https://aka.ms/AndroidManifestFeed/d17-12" -o "D:\src\android\bin\BuildDebug\nuget-unsigned\workload-manifest\WorkloadDependencies.json" --build-tools-version=35.0.0 --cmdline-tools-version=12.0 --jdk-version=17.0.14 --jdk-max-version=21.0.99 --ndk-version=26.3.11579264 --platform-tools-version=34.0.5 --platform-version=android-35 --preview-platform-version=36 --workload-version=35.0.2" exited with code 1.
    Build failed with 2 error(s) in 9.5s

Because `tools\workload-dependencies\Directory.Build.props` exists, we don't get the value from the root `Directory.Build.props`.

I think we should simply set `$(DotNetStableTargetFramework)` if blank, and we'll have one more place to update when moving to .NET 11, etc.