### PR TITLE
[xabt] default `$(AndroidEnableMarshalMethods)=false` for CoreCLR

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -194,7 +194,7 @@ stages:
         testName: Mono.Android.NET_Tests-CoreCLR
         project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)CoreCLR.xml
-        extraBuildArgs: -p:TestsFlavor=CoreCLR -p:UseMonoRuntime=false -p:AndroidEnableMarshalMethods=false
+        extraBuildArgs: -p:TestsFlavor=CoreCLR -p:UseMonoRuntime=false
         artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
         artifactFolder: $(DotNetTargetFramework)-CoreCLR
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -48,9 +48,9 @@ namespace Xamarin.Android.Build.Tests
 				AndroidTargetArch.X86,
 			};
 			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = isRelease
+				IsRelease = isRelease,
+				EnableMarshalMethods = marshalMethodsEnabled,
 			};
-			proj.SetProperty (KnownProperties.AndroidEnableMarshalMethods, marshalMethodsEnabled.ToString ());
 			proj.SetRuntimeIdentifiers (abis);
 			bool shouldMarshalMethodsBeEnabled = isRelease && marshalMethodsEnabled;
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -251,8 +251,8 @@ namespace Xamarin.Android.Build.Tests
 					PackageName = $"com.companyname.App{i}",
 					AotAssemblies = true,
 					IsRelease = true,
+					EnableMarshalMethods = true,
 				};
-				app1.SetProperty ("AndroidEnableMarshalMethods", "True");
 				sb.Projects.Add (app1);
 			}
 			sb.BuildingInsideVisualStudio = false;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -655,7 +655,7 @@ public abstract class MyRunner {
 				"base.OnCreate (bundle);",
 				"base.OnCreate (bundle);\n" +
 				"if (Lib1.Library1.Is64 ()) Console.WriteLine (\"Hello World!\");");
-			proj.SetProperty ("AndroidEnableMarshalMethods", enableMarshalMethods.ToString ());
+			proj.EnableMarshalMethods = enableMarshalMethods;
 
 
 			using var lb = CreateDllBuilder (Path.Combine (path, "Lib1"));

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -340,9 +340,9 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   <_AndroidAotStripLibraries Condition=" '$(_AndroidAotStripLibraries)' == '' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</_AndroidAotStripLibraries>
   <AndroidAotEnableLazyLoad Condition=" '$(AndroidAotEnableLazyLoad)' == '' And '$(AotAssemblies)' == 'true' And '$(AndroidIncludeDebugSymbols)' != 'true' ">True</AndroidAotEnableLazyLoad>
   <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(UsingMicrosoftNETSdkRazor)' == 'true') ">False</AndroidEnableMarshalMethods>
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' and '$(PublishReadyToRun)' != 'true' ">True</AndroidEnableMarshalMethods>
-  <!-- NOTE: temporarily disable for NativeAOT for now, to get build passing -->
-  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(_AndroidRuntime)' == 'NativeAOT' or '$(PublishReadyToRun)' == 'true') ">False</AndroidEnableMarshalMethods>
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and '$(_AndroidRuntime)' == 'MonoVM' and '$(PublishReadyToRun)' != 'true' ">True</AndroidEnableMarshalMethods>
+  <!-- NOTE: temporarily disable for NativeAOT and CoreCLR for now -->
+  <AndroidEnableMarshalMethods Condition=" '$(AndroidEnableMarshalMethods)' == '' and ('$(_AndroidRuntime)' != 'MonoVM' or '$(PublishReadyToRun)' == 'true') ">False</AndroidEnableMarshalMethods>
 
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' == 'True' ">False</_AndroidUseMarshalMethods>
   <_AndroidUseMarshalMethods Condition=" '$(AndroidIncludeDebugSymbols)' != 'True' ">$(AndroidEnableMarshalMethods)</_AndroidUseMarshalMethods>


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10491
Context: https://github.com/dotnet/android/pull/10245

In 9861b570, We enabled `$(PublishReadyToRun)` by default in `Release` mode, and so we also need to disable `$(AndroidEnableMarshalMethods)` as it does not work in combination with R2R yet. This is really a build ordering issue, that we'll need to significantly rework in the future.

We didn't notice this issue, because we were explicitly passing `-p:AndroidEnableMarshalMethods=false` to the CoreCLR on-device tests.

I also cleaned up a few MSBuild tests to use the `EnableMarshalMethods` property.