### PR TITLE
[nativeaot] Log location of the actual p/invoke stub called

### DIFF
--- a/src/native/nativeaot/host/internal-pinvoke-stubs.cc
+++ b/src/native/nativeaot/host/internal-pinvoke-stubs.cc
@@ -5,9 +5,14 @@ using namespace xamarin::android;
 
 namespace {
 	[[gnu::noreturn]]
-	void pinvoke_unreachable ()
+	void pinvoke_unreachable (std::source_location sloc = std::source_location::current ())
 	{
-		Helpers::abort_application (LOG_DEFAULT, "The method is not implemented. This is a stub and should not be called."sv);
+		Helpers::abort_application (
+			LOG_DEFAULT,
+			"The p/invoke is not implemented. This is a stub and should not be called."sv,
+			true, // log_location
+			sloc
+		);
 	}
 }
 


### PR DESCRIPTION
Context: 869b0e03937e0c17a4cf3fbc85f50d80350b2576

The `pinvoke_unreachable` function, when invoked, would log
its own source location instead of that of the call site.
That's a bit useless in diagnosing issues, so let's improve
it by logging the call site location... :)