### PR TITLE
[release/10.0.1xx] test unwanted `CA1416` warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -443,6 +443,17 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True"); // Disables API 29 warning in Xamarin.Build.Download
 			proj.SetProperty ("AndroidPackageFormat", packageFormat);
 			proj.SetProperty ("TrimmerSingleWarn", "false");
+			
+			// Add test code for: https://github.com/dotnet/android/issues/10509
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
+				"""
+					// These should not cause warnings
+					new FrameLayout (this).Foreground = null;
+					new ListView (this).Adapter = null;
+					Console.WriteLine (Android.Provider.MediaStore.Video.IVideoColumns.DateTaken);
+					Console.WriteLine (Android.Provider.MediaStore.Images.IImageColumns.DateTaken);
+				""");
+
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				b.AssertHasNoWarnings ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Forms/MainActivity.cs
@@ -22,7 +22,7 @@ namespace ${ROOT_NAMESPACE}
 			global::Xamarin.Forms.Forms.Init (this, savedInstanceState);
 			//${AFTER_FORMS_INIT}
 			LoadApplication (new App ());
+			//${AFTER_ONCREATE}
 		}
-		//${AFTER_ONCREATE}
 	}
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/10509

These should already be working on `release/10.0.1xx`, due to changes already reverted.

Update an existing test for #10509.