### PR TITLE
Correctly handle file path that contains spaces

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -118,11 +118,13 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <!-- Satellite assemblies -->
       <IlcSatelliteAssembly Include="$(_OuterIntermediateSatelliteAssembliesWithTargetPath)" />
 
-      <LinkerArg Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.$(Configuration.ToLower())-static-$(Configuration.ToLower())'))" />
+      <_NdkLibs Include="@(RuntimePackAsset->WithMetadataValue('Filename', 'libnaot-android.$(Configuration.ToLower())-static-$(Configuration.ToLower())'))" />
 
       <!-- Include libc++ -->
-      <LinkerArg Include="$(_NdkSysrootDir)libc++_static.a" />
-      <LinkerArg Include="$(_NdkSysrootDir)libc++abi.a" />
+      <_NdkLibs Include="$(_NdkSysrootDir)libc++_static.a" />
+      <_NdkLibs Include="$(_NdkSysrootDir)libc++abi.a" />
+      
+      <LinkerArg Include="&quot;%(_NdkLibs.Identity)&quot;" />
 
       <!-- This library conflicts with static libc++ -->
       <NativeLibrary Remove="$(IlcSdkPath)libstdc++compat.a" />


### PR DESCRIPTION
Otherwise the linker step will fail because path can contain spaces, for example:

```
C:\Program Files\dotnet\packs\Microsoft.Android.Runtime.NativeAOT.36.android-x64\36.0.0-rc.2.332\runtimes\android-x64\native\libnaot-android.debug-static-debug.a
```