### PR TITLE
[xabt] pass in `$(SupportedOSPlatformVersion)` to `<Aapt2Link/>`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Aapt2.targets
@@ -166,6 +166,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
       JavaPlatformJarPath="$(JavaPlatformJarPath)"
       JavaDesignerOutputDirectory="$(ResgenTemporaryDirectory)"
       CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       AndroidManifestFile="$(_AndroidManifestAbs)"
       ManifestFiles="$(ResgenTemporaryDirectory)\AndroidManifest.xml"
       AdditionalAndroidResourcePaths="@(_LibraryResourceDirectories)"
@@ -213,6 +214,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
   </PropertyGroup>
   <MakeDir Directories="$(_OutputFileDir)" Condition=" !Exists ('$(_OutputFileDir)') " />
   <Aapt2Link
+      SupportedOSPlatformVersion="$(SupportedOSPlatformVersion)"
       AndroidManifestFile="$(_AndroidManifestAbs)"
       CompiledResourceFlatFiles="@(_CompiledFlatFiles)"
       DaemonMaxInstanceCount="$(Aapt2DaemonMaxInstanceCount)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/Aapt2.cs
@@ -36,7 +36,9 @@ namespace Xamarin.Android.Tasks {
 
 		public ITaskItem []? ResourceDirectories { get; set; }
 
-		public ITaskItem? AndroidManifestFile { get; set;}
+		public ITaskItem? AndroidManifestFile { get; set; }
+
+		public string? SupportedOSPlatformVersion { get; set; }
 
 		public string? ResourceSymbolsTextFile { get; set; }
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/AndroidResourceTests.cs
@@ -5,7 +5,6 @@ using Xamarin.ProjectTools;
 using System.IO;
 using System.Linq;
 using Microsoft.Build.Framework;
-using System.Text;
 using Xamarin.Android.Tasks;
 using Microsoft.Build.Utilities;
 
@@ -162,6 +161,22 @@ namespace Xamarin.Android.Build.Tests {
 			var proj = new XamarinAndroidApplicationProject {
 				SupportedOSPlatformVersion = "26",
 				AndroidResources = {
+					new AndroidItem.AndroidResource ("Resources\\values\\colors.xml") {
+						TextContent = () => """
+							<resources>
+								<color name="adaptive_icon_background">#2C3E50</color>
+								<color name="adaptive_icon_foreground">#FFFFFF</color>
+							</resources>
+						""",
+					},
+					new AndroidItem.AndroidResource ("Resources\\drawable\\ic_shortcut_add.xml") {
+						TextContent = () => """
+							<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+								<background android:drawable="@color/adaptive_icon_background"/>
+								<foreground android:drawable="@color/adaptive_icon_foreground"/>
+							</adaptive-icon>
+						""",
+					},
 					new AndroidItem.AndroidResource ("Resources\\mipmap-anydpi-v26\\adaptiveicon.xml") {
 						TextContent = () => """
 							<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -595,6 +595,20 @@ namespace Xamarin.Android.Tasks
 			return apiLevel;
 		}
 
+		public static bool TryParseApiLevel (string apiLevel, out Version version)
+		{
+			if (Version.TryParse (apiLevel, out var v)) {
+				version = v;
+				return true;
+			}
+			if (int.TryParse (apiLevel, out var major)) {
+				version = new Version (major, 0);
+				return true;
+			}
+			version = null;
+			return false;
+		}
+
 #if MSBUILD
 		public static string GetAssemblyAbi (ITaskItem asmItem)
 		{


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10194
Context: https://discord.com/channels/732297728826277939/732297837953679412/1427681737957441577
Fixes: https://github.com/dotnet/android/issues/6739

PR #10194 was originally meant to fix #6739, but did not when testing a sample project. The test written in #10194 passed even without the fixes, so we did not have a proper test case.

After reviewing the failing project, I noticed `<Aapt2Link/>` was passed:

    AndroidManifestFile = D:\Downloads\test_sdk26\AndroidManifest.xml

This is the developer's `AndroidManifest.xml` in their project, which should completely omit `<uses-sdk/>` in favor of the `$(SupportedOSPlatformVersion)` MSBuild property. I suspect the fix for #10194 would have worked if `<uses-sdk/>` was present.

`<Aapt2Link/>` can run quite early, before we have generated the final `AndroidManifest.xml` file. So, a solution here is to pass in `$(SupportedOSPlatformVersion)` to `<Aapt2Link/>`.

I also updated the test so it properly tests this scenario.