### PR TITLE
Fix JNI preload cache generation

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGenerator.cs
@@ -279,7 +279,7 @@ namespace Xamarin.Android.Tasks
 			module.AddGlobalVariable ("dso_jni_preloads_idx_stride", dsoState.NameMutationsCount);
 
 			// This variable MUST be written after `dso_cache` since it relies on sorting performed by HashAndSortDSOCache
-			var dso_jni_preloads_idx = new LlvmIrGlobalVariable (new List<uint> (), "dso_jni_preloads_idx", LlvmIrVariableOptions.GlobalConstant) {
+			var dso_jni_preloads_idx = new LlvmIrGlobalVariable (typeof(List<uint>), "dso_jni_preloads_idx", LlvmIrVariableOptions.GlobalConstant) {
 				Comment = " Indices into dso_cache[] of DSO libraries to preload because of JNI use",
 				ArrayItemCount = (uint)dsoState.JniPreloadDSOs.Count,
 				GetArrayItemCommentCallback = GetPreloadIndicesLibraryName,
@@ -369,11 +369,6 @@ namespace Xamarin.Android.Tasks
 
 		void PopulatePreloadIndices (LlvmIrVariable variable, LlvmIrModuleTarget target, object? state)
 		{
-			var indices = variable.Value as List<uint>;
-			if (indices == null) {
-				throw new InvalidOperationException ($"Internal error: DSO preload indices list instance not present.");
-			}
-
 			var dsoState = state as DsoCacheState;
 			if (dsoState == null) {
 				throw new InvalidOperationException ($"Internal error: DSO state not present.");
@@ -382,6 +377,8 @@ namespace Xamarin.Android.Tasks
 			var dsoNames = new List<string> ();
 
 			// Indices array MUST NOT be sorted, since it groups alias entries together with the main entry
+			var indices = new List<uint> ();
+			variable.Value = indices;
 			foreach (DSOCacheEntry preload in dsoState.JniPreloadDSOs) {
 				int dsoIdx = dsoState.DsoCache.FindIndex (entry => {
 					if (entry.Instance == null) {

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -383,7 +383,7 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		module.AddGlobalVariable ("dso_jni_preloads_idx_stride", dsoState.NameMutationsCount);
 
 		// This variable MUST be written after `dso_cache` since it relies on sorting performed by HashAndSortDSOCache
-		var dso_jni_preloads_idx = new LlvmIrGlobalVariable (new List<uint> (), "dso_jni_preloads_idx", LlvmIrVariableOptions.GlobalConstant) {
+		var dso_jni_preloads_idx = new LlvmIrGlobalVariable (typeof (List<uint>), "dso_jni_preloads_idx", LlvmIrVariableOptions.GlobalConstant) {
 			Comment = " Indices into dso_cache[] of DSO libraries to preload because of JNI use",
 			ArrayItemCount = (uint)dsoState.JniPreloadDSOs.Count,
 			GetArrayItemCommentCallback = GetPreloadIndicesLibraryName,
@@ -601,11 +601,6 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 
 	void PopulatePreloadIndices (LlvmIrVariable variable, LlvmIrModuleTarget target, object? state)
 	{
-		var indices = variable.Value as List<uint>;
-		if (indices == null) {
-			throw new InvalidOperationException ("Internal error: DSO preload indices list instance not present.");
-		}
-
 		var dsoState = state as DsoCacheState;
 		if (dsoState == null) {
 			throw new InvalidOperationException ("Internal error: DSO state not present.");
@@ -614,6 +609,8 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 		var dsoNames = new List<string> ();
 
 		// Indices array MUST NOT be sorted, since it groups alias entries together with the main entry
+		var indices = new List<uint> ();
+		variable.Value = indices;
 		foreach (DSOCacheEntry preload in dsoState.JniPreloadDSOs) {
 			int dsoIdx = dsoState.DsoCache.FindIndex (entry => {
 				if (entry.Instance == null) {

--- a/src/native/clr/include/host/pinvoke-override-impl.hh
+++ b/src/native/clr/include/host/pinvoke-override-impl.hh
@@ -57,7 +57,7 @@ namespace xamarin::android {
 
 		void *entry_handle = MonodroidDl::monodroid_dlsym (lib_handle, symbol_name);
 		if (entry_handle == nullptr) {
-			log_warn (LOG_ASSEMBLY, "Symbol '{}' not found in shared library '{}', p/invoke may fail", library_name, symbol_name);
+			log_warn (LOG_ASSEMBLY, "Symbol '{}' not found in shared library '{}', p/invoke may fail", symbol_name, library_name);
 			return nullptr;
 		}
 

--- a/src/native/mono/pinvoke-override/pinvoke-override-api-impl.hh
+++ b/src/native/mono/pinvoke-override/pinvoke-override-api-impl.hh
@@ -37,7 +37,7 @@ namespace xamarin::android {
 
 		void *entry_handle = internal::MonodroidDl::monodroid_dlsym (lib_handle, symbol_name, nullptr, nullptr);
 		if (entry_handle == nullptr) {
-			log_warn (LOG_ASSEMBLY, "Symbol '{}' not found in shared library '{}', p/invoke may fail", optional_string (library_name), optional_string (symbol_name));
+			log_warn (LOG_ASSEMBLY, "Symbol '{}' not found in shared library '{}', p/invoke may fail", optional_string (symbol_name), optional_string (library_name));
 			return nullptr;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10544
Context: 1a62af3814beddb63759ebd9918d63d1014182a5
Context: cba39dcf723b0b0311a050533bd7e2d45facdff5

cba39dcf introduced code to preload at startup native libraries which use JNI, 
to work around an issue in Android which prevents such libraries from being 
properly loaded at the later time of application life.

Part of the workaround was support for updating handle of such a library in
our shared library cache. Since every library has different entries in the 
cache (because we search the array using xxHash generated from various forms
of the library name), after preloading it we had to update every entry in the
DSO cache with the correct handle, so that the library is never loaded again.

The code which generates the caches and indexes at application build time worked
fine in my testing (using `dotnet build`) but it turns out that using `dotnet publish`
instead breaks the code in a subtle, but nasty way. 

The issue is that the code which generated the index of shared libraries to preload
reused an array which stored the indexes, while generating code for different RIDs.
This resulted in the very first RID to process to contain valid indexes, the
second one would **append** its own indexes to the preceding RID's data, the third
RID would further append its own data etc.

This would result in the following index code generated for the subsequend RIDs:

```
; android-arm
; Indices into dso_cache[] of DSO libraries to preload because of JNI use
@dso_jni_preloads_idx = dso_local local_unnamed_addr constant [4 x i32] [
        i32 15, ; libSystem.Security.Cryptography.Native.Android.so
        i32 0, ; libSystem.Security.Cryptography.Native.Android
        i32 7, ; System.Security.Cryptography.Native.Android.so
        i32 8 ; System.Security.Cryptography.Native.Android
], align 4
```

```
; android-arm64
; Indices into dso_cache[] of DSO libraries to preload because of JNI use
@dso_jni_preloads_idx = dso_local local_unnamed_addr constant [8 x i32] [
        i32 15, ; libSystem.Security.Cryptography.Native.Android.so
        i32 0, ; libSystem.Security.Cryptography.Native.Android
        i32 7, ; System.Security.Cryptography.Native.Android.so
        i32 8, ; System.Security.Cryptography.Native.Android
        i32 10, ; Invalid index 4
        i32 0, ; Invalid index 5
        i32 1, ; Invalid index 6
        i32 14 ; Invalid index 7
], align 4
```

```
; android-x64
; Indices into dso_cache[] of DSO libraries to preload because of JNI use
@dso_jni_preloads_idx = dso_local local_unnamed_addr constant [12 x i32] [
        i32 15, ; libSystem.Security.Cryptography.Native.Android.so
        i32 0, ; libSystem.Security.Cryptography.Native.Android
        i32 7, ; System.Security.Cryptography.Native.Android.so
        i32 8, ; System.Security.Cryptography.Native.Android
        i32 10, ; Invalid index 4
        i32 0, ; Invalid index 5
        i32 1, ; Invalid index 6
        i32 14, ; Invalid index 7
        i32 10, ; Invalid index 8
        i32 0, ; Invalid index 9
        i32 1, ; Invalid index 10
        i32 14 ; Invalid index 11
], align 16
```

In effect, when running on an arm64 device, we would try to load, and cache the
handle, of an entirely different shared library, leading to further problems to
find a requested symbol:

```
10-17 11:25:18.062 27900 27900 F monodroid-assembly: Failed to load symbol 'AndroidCryptoNative_EcKeyCreateByKeyParameters' from shared library 'libSystem.Security.Cryptography.Native.Android'
10-17 11:25:18.110  1444  4298 I ActivityManager: Process com.companyname.test_jwt (pid 27900) has died: fg  TOP 
10-17 11:25:18.110  1444  1712 I libprocessgroup: Removed cgroup /sys/fs/cgroup/apps/uid_10361/pid_27900
10-17 11:25:18.111   913   913 I Zygote  : Process 27900 exited cleanly (0)
```

Native code attempted to load the symbol from a library that happened to be
stored at the index valid for `android-arm` but not for e.g. `android-arm64`,
which was not `libSystem.Security.Cryptography.Native.Android`, leading to
the above red herring error.

Note: if **all** of RIDs enabled for the application are 32-bit or **all**
of them are 64-bit, things would work even though the generated code would
be technically incorrect. This is because all of the hashes and, thus, sort
order of the `dso_cache` entries would be the same.

Fix this by making sure that the index array is not shared between different
RIDs when generating the DSO cache code.