### PR TITLE
[xabt] fix incremental design-time builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
+++ b/src/Xamarin.Android.Build.Tasks/MSBuild/Xamarin/Android/Xamarin.Android.Resource.Designer.targets
@@ -62,7 +62,7 @@ Copyright (C) 2016 Xamarin. All rights reserved.
   <ItemGroup>
     <_ProjectReferenceResourceDirectory Include="$(MSBuildProjectDirectory)\$(MonoAndroidResourcePrefix)"
         Condition=" !Exists('$(OutputPath)$(TargetName).aar') "
-        StampFile="$(MSBuildProjectFile)"
+        StampFile="$(MSBuildProjectFullPath)"
     />
   </ItemGroup>
 </Target>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/issues/10528
Context: https://github.com/dotnet/android/issues/10563

There is a report in .NET 10 of *something* going wrong with incremental builds (and possibly design-time builds)...

The app crashes with an error such as:

    android.content.res.Resources$NotFoundException: String resource ID #0x7f1000be at
    android.content.res.Resources.getText(Resources.java:466) at android.content.Context.getText(Context.java:933) at
    androidx.appcompat.widget.Toolbar.setNavigationContentDescription(Toolbar.java:1001) at
    crc64e02730b4d0e10e64.CustomShellRenderer_SectionRenderer.n_onCreateView(Native Method) at
    crc64e02730b4d0e10e64.CustomShellRenderer_SectionRenderer.onCreateView(CustomShellRenderer_SectionRenderer.java:36) ...

Where the resource ID is invalid.

After some debugging, after watching the video:

* https://github.com/dotnet/android/issues/10528#issuecomment-3409831027

I was able to reproduce the issue, when I did:

1. Open emulator
2. Open project in VS
3. Ctrl+F5 (see app running)
4. Close VS (make sure emulator stays open)
5. Reopen VS
6. Ctrl+F5 again
7. App crashes

Reviewing builds logs, I saw this oddity on the design-time build on step 5:

    Target _GenerateRtxt
    Building target "_GenerateRtxt" completely.
    Input file "Bug.Dependency.csproj" does not exist.

That is a referenced project file, it definitely should exist!

However, I noticed the path is wrong:

    Target _CollectProjectReferenceResources
        Task MSBuild
            OutputItems
                LibraryResourceDirectories
                    D:\src\dotnet-android-bug-10528\src\Bug.Dependency\Resources
                        StampFile = Bug.Dependency.csproj

`%(StampFile)` is a relative path, which can be fixed via:

```diff
--StampFile="$(MSBuildProjectFile)"
++StampFile="$(MSBuildProjectFullPath)"
```

This problem was introduced in .NET 10 via:

* https://github.com/dotnet/android/commit/9ed1469303b9c842cfd76cfb8d2b04dd1fd7255f

The target also uses `$(MSBuildProjectDirectory)`, which is a full path, see:

* https://learn.microsoft.com/visualstudio/msbuild/msbuild-reserved-and-well-known-properties

I was also able to reproduce this issue by adding a class library to the existing `BuildInDesignTimeMode()` test.