### PR TITLE
[build] fix broken incrementality of `Mono.Android.csproj`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.targets
@@ -266,11 +266,30 @@
     </PropertyGroup>
   </Target>
 
+  <Target Name="_WriteBundledVersionsCache"
+      DependsOnTargets="GetXAVersionInfo">
+    <ItemGroup>
+      <_BundledVersionsCacheLines Include="AndroidPackVersionLong=$(AndroidPackVersionLong)" />
+      <_BundledVersionsCacheLines Include="AndroidLatestStableApiLevel=$(AndroidLatestStableApiLevel)" />
+      <_BundledVersionsCacheLines Include="AndroidLatestUnstableApiLevel=$(AndroidLatestUnstableApiLevel)" />
+      <_BundledVersionsCacheLines Include="DotNetTargetFramework=$(DotNetTargetFramework)" />
+      <_BundledVersionsCacheLines Include="DotNetTargetFrameworkVersion=$(DotNetTargetFrameworkVersion)" />
+    </ItemGroup>
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)_GenerateBundledVersions.cache"
+        Lines="@(_BundledVersionsCacheLines)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+    />
+  </Target>
+
   <!-- Generate and include this file in our SDK for now, but we may eventually want to migrate to:
        https://github.com/dotnet/installer/blob/d98f5f18bce44014aeacd2f99923b4779d89459d/src/redist/targets/GenerateBundledVersions.targets
        -->
   <Target Name="_GenerateBundledVersions"
-      DependsOnTargets="GetXAVersionInfo">
+      DependsOnTargets="_WriteBundledVersionsCache"
+      Inputs="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\AutoImport.in.props;$(IntermediateOutputPath)_GenerateBundledVersions.cache"
+      Outputs="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.BundledVersions.targets;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\AutoImport.props">
     <ReplaceFileContents
         SourceFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\in\Microsoft.Android.Sdk.BundledVersions.in.targets"
         DestinationFile="$(MSBuildThisFileDirectory)\Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.BundledVersions.targets"
@@ -281,6 +300,9 @@
         DestinationFile="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\AutoImport.props"
         Replacements="@DOTNET_TARGET_FRAMEWORK_VERSION@=$(DotNetTargetFrameworkVersion)">
     </ReplaceFileContents>
+    <Touch
+        Files="$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\targets\Microsoft.Android.Sdk.BundledVersions.targets;$(MSBuildThisFileDirectory)Microsoft.Android.Sdk\Sdk\AutoImport.props"
+    />
   </Target>
 
   <Target Name="_CopyNetSdkTargets">


### PR DESCRIPTION
I noticed this was happening like for *every* build...

    > .\dotnet-local.cmd build .\src\Mono.Android\Mono.Android.csproj -bl
    ...
    Build succeeded with 78 warning(s) in 125.6s

Even with no changes!

I tracked this down to this chain of events:

    Mono.Android.csproj
    Target CoreCompile
    Building target "CoreCompile" completely.
    Input file "Android.Runtime\JNIEnv.g.cs" is newer than output file "obj\Debug\net10.0\android-36\Mono.Android.pdb".
    ...
    Target _BuildJNIEnv
    Building target "_BuildJNIEnv" completely.
    Input file "..\..\bin\BuildDebug\jnienv-gen.dll" is newer than output file "../../src/Mono.Android/Android.Runtime/JNIEnv.g.cs".
    ...
    Target CoreCompile
    Building target "CoreCompile" completely.
    Input file "D:\src\xamarin-android\bin\Debug\lib\packs\Microsoft.Android.Sdk.Windows\36.1.99\Sdk\AutoImport.props" is newer than output file "obj\Debug\net9.0\jnienv-gen.pdb".

Reviewing the `_GenerateBundledVersions` MSBuild target, it just runs every time! No `Inputs` or `Outputs` are defined, so it is always considered out-of-date.

I created a new `_WriteBundledVersionsCache` target that writes a cache file with all important properties, and then made `_GenerateBundledVersions` depend on that target, and added `Inputs` and `Outputs` to it.

This appears to speed up our builds significantly!

    > .\dotnet-local.cmd build .\src\Mono.Android\Mono.Android.csproj -bl
    ...
    Build succeeded in 2.1s