### PR TITLE
Enable more tests to run on all 3 runtimes, part 4

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -1093,8 +1093,13 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 		}
 
 		[Test]
-		public void AndroidMavenLibrary_AllDependenciesAreVerified ()
+		public void AndroidMavenLibrary_AllDependenciesAreVerified ([Values] AndroidRuntime runtime)
 		{
+			bool isRelease = runtime == AndroidRuntime.NativeAOT;
+			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+				return;
+			}
+
 			// Test that <AndroidMavenLibrary> triggers Java dependency verification and that
 			// all dependencies are verified via various supported mechanisms
 
@@ -1126,10 +1131,12 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 			var parcelable = new BuildItem ("AndroidIgnoredJavaDependency", "androidx.versionedparcelable:versionedparcelable:1.2.0");
 
 			var proj = new XamarinAndroidBindingProject {
+				IsRelease = isRelease,
 				Jars = { item, annotations_experimental_androidlib },
 				PackageReferences = { annotations_nuget },
 				OtherBuildItems = { concurrent, lifecycle, parcelable },
 			};
+			proj.SetRuntime (runtime);
 
 			proj.AddReference (collection);
 			var collection_proj = proj.References.First ();


### PR DESCRIPTION
This pull request expands the test coverage in `BindingBuildTest.cs` to run binding and application tests across multiple Android runtimes by parameterizing tests with the `AndroidRuntime` enum. It also updates test setup logic to properly configure projects for each runtime and ensures unsupported configurations are skipped.

**Test parameterization and runtime support:**

* All major test methods in `BindingBuildTest.cs` now accept an `AndroidRuntime runtime` parameter (using `[Values]` or `[TestCaseSource]`), allowing tests to run against all supported runtimes.

* Test projects are now configured per-runtime by setting `IsRelease` according to the runtime (NativeAOT uses Release), and calling `SetRuntime(runtime)` on each project.

**Test data generation improvements:**

* The static `ClassParseOptions` array is replaced with a `Get_ClassParseOptions()` method, which dynamically generates test cases for each `AndroidRuntime` value, ensuring all relevant runtime combinations are tested.

**Test execution control:**

* All tests now call `IgnoreUnsupportedConfiguration(runtime, release: isRelease)` at the start, and skip execution if the configuration is not supported. This prevents failures on unsupported runtime/build type combinations.

**Test path consistency and cleanup:**

* Several test methods now use `TestName` and `Path.Combine` to generate unique temporary directories for builds, improving test isolation and consistency.

These changes make the test suite more robust, comprehensive, and maintainable by ensuring all supported Android runtimes are covered and by improving test configuration and isolation.