### PR TITLE
[marshal methods] Make AndroidEnvironmentInternal.UnhandledException …

### DIFF
--- a/src/Mono.Android.Runtime/Android.Runtime/AndroidEnvironmentInternal.cs
+++ b/src/Mono.Android.Runtime/Android.Runtime/AndroidEnvironmentInternal.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace Android.Runtime
 {
-	internal static class AndroidEnvironmentInternal
+	public static class AndroidEnvironmentInternal
 	{
 		internal static Action<Exception>? UnhandledExceptionHandler;
 
-		internal static void UnhandledException (Exception e)
+		public static void UnhandledException (Exception e)
 		{
 			if (UnhandledExceptionHandler == null) {
 				return;

--- a/src/Mono.Android.Runtime/Android.Runtime/AndroidEnvironmentInternal.cs
+++ b/src/Mono.Android.Runtime/Android.Runtime/AndroidEnvironmentInternal.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Android.Runtime
 {
-	public static class AndroidEnvironmentInternal
+	internal static class AndroidEnvironmentInternal
 	{
 		internal static Action<Exception>? UnhandledExceptionHandler;
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FixUpMonoAndroidRuntime.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FixUpMonoAndroidRuntime.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+
+namespace Xamarin.Android.Tasks;
+
+public class FixUpMonoAndroidRuntime : AndroidTask
+{
+	public override string TaskPrefix => "FUMAR";
+
+	[Required]
+	public string IntermediateOutputDirectory { get; set; } = String.Empty;
+
+	[Required]
+	public ITaskItem[] ResolvedAssemblies { get; set; } = [];
+
+	public override bool RunTask ()
+	{
+		List<ITaskItem> monoAndroidRuntimeItems = new ();
+		foreach (ITaskItem item in ResolvedAssemblies) {
+
+			if (!MonoAndroidHelper.StringEquals (Path.GetFileName (item.ItemSpec), "Mono.Android.Runtime.dll", StringComparison.OrdinalIgnoreCase)) {
+				continue;
+			}
+			monoAndroidRuntimeItems.Add (item);
+		}
+
+		if (monoAndroidRuntimeItems.Count == 0) {
+			Log.LogDebugMessage ("No 'Mono.Android.Runtime.dll' items found");
+			return !Log.HasLoggedErrors;
+		}
+
+		return MonoAndroidRuntimeMarshalMethodsFixUp.Run (Log, monoAndroidRuntimeItems) && !Log.HasLoggedErrors;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/FixUpMonoAndroidRuntime.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/FixUpMonoAndroidRuntime.cs
@@ -11,16 +11,12 @@ public class FixUpMonoAndroidRuntime : AndroidTask
 	public override string TaskPrefix => "FUMAR";
 
 	[Required]
-	public string IntermediateOutputDirectory { get; set; } = String.Empty;
-
-	[Required]
 	public ITaskItem[] ResolvedAssemblies { get; set; } = [];
 
 	public override bool RunTask ()
 	{
 		List<ITaskItem> monoAndroidRuntimeItems = new ();
 		foreach (ITaskItem item in ResolvedAssemblies) {
-
 			if (!MonoAndroidHelper.StringEquals (Path.GetFileName (item.ItemSpec), "Mono.Android.Runtime.dll", StringComparison.OrdinalIgnoreCase)) {
 				continue;
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -2214,7 +2214,7 @@ namespace App1
 			}
 
 			Assert.NotNull (type, $"Failed to find the '{TypeName}' type in '{monoAndroidRuntimePath}'");
-			Assert.IsTrue (type.IsPublic, "Type '{typeName}' should be public");
+			Assert.IsTrue (type.IsPublic, $"Type '{TypeName}' should be public");
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidHelper.cs
@@ -884,16 +884,7 @@ namespace Xamarin.Android.Tasks
 			}
 
 			File.Copy (source, dest, true);
-
-			if (File.Exists (destBackup)) {
-				try {
-					File.Delete (destBackup);
-				} catch (Exception ex) {
-					// On Windows the deletion may fail, depending on lock state of the original `target` file before the move.
-					log.LogDebugMessage ($"While trying to delete '{destBackup}', exception was thrown: {ex}");
-					log.LogDebugMessage ($"Failed to delete backup file '{destBackup}', ignoring.");
-				}
-			}
+			TryRemoveFile (log, destBackup);
 		}
 
 		public static void TryRemoveFile (TaskLoggingHelper log, string? filePath)
@@ -906,7 +897,7 @@ namespace Xamarin.Android.Tasks
 				File.Delete (filePath);
 			} catch (Exception ex) {
 				log.LogWarning ($"Unable to delete source file '{filePath}'");
-				log.LogDebugMessage ($"{ex.ToString ()}");
+				log.LogDebugMessage (ex.ToString ());
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidRuntimeMarshalMethodsFixUp.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidRuntimeMarshalMethodsFixUp.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Android.Build.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using Mono.Cecil;
+
+namespace Xamarin.Android.Tasks;
+
+class MonoAndroidRuntimeMarshalMethodsFixUp
+{
+	const string RuntimeTypeName = "Android.Runtime.AndroidEnvironmentInternal";
+
+	public static bool Run (TaskLoggingHelper log, List<ITaskItem> items)
+	{
+		bool everythingWorked = true;
+		foreach (ITaskItem item in items) {
+			if (!ApplyFixUp (log, item)) {
+				everythingWorked = false;
+			}
+		}
+
+		return everythingWorked;
+	}
+
+	static bool ApplyFixUp (TaskLoggingHelper log, ITaskItem monoAndroidRuntime)
+	{
+		string newDirPath = Path.Combine (Path.GetDirectoryName (monoAndroidRuntime.ItemSpec), "new");
+		string newFilePath = Path.Combine (newDirPath, Path.GetFileName (monoAndroidRuntime.ItemSpec));
+		Directory.CreateDirectory (newDirPath);
+
+		string origPdbPath = Path.ChangeExtension (monoAndroidRuntime.ItemSpec, ".pdb");
+		bool havePdb = File.Exists (origPdbPath);
+
+		log.LogDebugMessage ($"Fixing up {monoAndroidRuntime.ItemSpec}");
+		var readerParams = new ReaderParameters () {
+			InMemory = true,
+			ReadSymbols = havePdb,
+		};
+		AssemblyDefinition asmdef = AssemblyDefinition.ReadAssembly (monoAndroidRuntime.ItemSpec, readerParams);
+		TypeDefinition? androidRuntimeInternal = null;
+		foreach (ModuleDefinition module in asmdef.Modules) {
+			androidRuntimeInternal = FindAndroidRuntimeInternal (module);
+			if (androidRuntimeInternal != null) {
+				break;
+			}
+		}
+
+		if (androidRuntimeInternal == null) {
+			log.LogDebugMessage ($"'{RuntimeTypeName}' not found in {monoAndroidRuntime.ItemSpec}");
+			return true; // Not an error, per se...
+		}
+		log.LogDebugMessage ($"Found '{RuntimeTypeName}', making it public");
+		androidRuntimeInternal.IsPublic = true;
+
+		var writerParams = new WriterParameters {
+			WriteSymbols = havePdb,
+		};
+		asmdef.Write (newFilePath, writerParams);
+
+		CopyFile (log, newFilePath, monoAndroidRuntime.ItemSpec);
+		RemoveFile (log, newFilePath);
+
+		if (!havePdb) {
+			return true;
+		}
+
+		string pdbPath = Path.ChangeExtension (newFilePath, ".pdb");
+		havePdb = File.Exists (pdbPath);
+		if (!havePdb) {
+			return true;
+		}
+
+		CopyFile (log, pdbPath, origPdbPath);
+		RemoveFile (log, pdbPath);
+
+		return true;
+	}
+
+	static void CopyFile (TaskLoggingHelper log, string source, string target)
+	{
+		log.LogDebugMessage ($"Copying rewritten assembly: {source} -> {target}");
+		MonoAndroidHelper.CopyFileAvoidSharingViolations (log, source, target);
+	}
+
+	static void RemoveFile (TaskLoggingHelper log, string? path)
+	{
+		log.LogDebugMessage ($"Deleting: {path}");
+		MonoAndroidHelper.TryRemoveFile (log, path);
+	}
+
+	static TypeDefinition? FindAndroidRuntimeInternal (ModuleDefinition module)
+	{
+		foreach (TypeDefinition t in module.Types) {
+			if (MonoAndroidHelper.StringEquals (RuntimeTypeName, t.FullName)) {
+				return t;
+			}
+		}
+
+		return null;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidRuntimeMarshalMethodsFixUp.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/MonoAndroidRuntimeMarshalMethodsFixUp.cs
@@ -25,7 +25,7 @@ class MonoAndroidRuntimeMarshalMethodsFixUp
 
 	static bool ApplyFixUp (TaskLoggingHelper log, ITaskItem monoAndroidRuntime)
 	{
-		string newDirPath = Path.Combine (Path.GetDirectoryName (monoAndroidRuntime.ItemSpec), "new");
+		string newDirPath = Path.Combine (Path.GetDirectoryName (monoAndroidRuntime.ItemSpec), "new")!;
 		string newFilePath = Path.Combine (newDirPath, Path.GetFileName (monoAndroidRuntime.ItemSpec));
 		Directory.CreateDirectory (newDirPath);
 
@@ -37,7 +37,7 @@ class MonoAndroidRuntimeMarshalMethodsFixUp
 			InMemory = true,
 			ReadSymbols = havePdb,
 		};
-		AssemblyDefinition asmdef = AssemblyDefinition.ReadAssembly (monoAndroidRuntime.ItemSpec, readerParams);
+		using AssemblyDefinition asmdef = AssemblyDefinition.ReadAssembly (monoAndroidRuntime.ItemSpec, readerParams);
 		TypeDefinition? androidRuntimeInternal = null;
 		foreach (ModuleDefinition module in asmdef.Modules) {
 			androidRuntimeInternal = FindAndroidRuntimeInternal (module);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -103,6 +103,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 <UsingTask TaskName="Xamarin.Android.Tasks.UnzipToFolder" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.GenerateJniRemappingNativeCode" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <UsingTask TaskName="Xamarin.Android.Tasks.PrepareSatelliteAssemblies" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
+<UsingTask TaskName="Xamarin.Android.Tasks.FixUpMonoAndroidRuntime" AssemblyFile="Xamarin.Android.Build.Tasks.dll" />
 <!--
 *******************************************
   Extensibility hook that allows VS to
@@ -1602,6 +1603,11 @@ because xbuild doesn't support framework reference assemblies.
       IntermediateOutputDirectory="$(IntermediateOutputPath)"
       EnableNativeRuntimeLinking="$(_AndroidEnableNativeRuntimeLinking)">
   </GenerateJavaStubs>
+
+  <FixUpMonoAndroidRuntime
+      Condition=" '$(_AndroidUseMarshalMethods)' == 'true' And '$(AndroidIncludeDebugSymbols)' == 'false' "
+      IntermediateOutputDirectory="$(IntermediateOutputPath)"
+      ResolvedAssemblies="@(_ResolvedAssemblies)" />
 
   <RewriteMarshalMethods
       Condition=" '$(_AndroidUseMarshalMethods)' == 'true' And '$(AndroidIncludeDebugSymbols)' == 'false' "

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1606,7 +1606,6 @@ because xbuild doesn't support framework reference assemblies.
 
   <FixUpMonoAndroidRuntime
       Condition=" '$(_AndroidUseMarshalMethods)' == 'true' And '$(AndroidIncludeDebugSymbols)' == 'false' "
-      IntermediateOutputDirectory="$(IntermediateOutputPath)"
       ResolvedAssemblies="@(_ResolvedAssemblies)" />
 
   <RewriteMarshalMethods


### PR DESCRIPTION
…public

Fixes: https://github.com/dotnet/android/issues/10602
Context: https://github.com/dotnet/android/commit/8bc7a3e84f95e70fe12790ac31ecd97957771cb2

This is in the category of "how the hell has it worked before?", as every time the `AndroidEnvironmentInternal.UnhandledException` method living in `Mono.Android.Runtime.dll` would be called, the runtime would respond with a method not accessible exception, rightly so as both the type and the method were internal and visible only to `Mono.Android.dll`.

I guess we haven't had many unhandled exceptions in marshal method wrappers over the years?

This PR fixes the problem by making both the type and the method public. This is the simplest way to fix the issue.