### PR TITLE
[copilot] move NuGet cache to `/mnt`

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,6 +9,10 @@ jobs:
     env:
       AndroidToolchainCacheDirectory: /mnt/android-archives
       AndroidToolchainDirectory: /mnt/android-toolchain
+      NUGET_PACKAGES: /mnt/nuget/packages
+      NUGET_HTTP_CACHE_PATH: /mnt/nuget/v3-cache
+      NUGET_PLUGINS_CACHE_PATH: /mnt/nuget/plugins-cache
+      NUGET_SCRATCH: /mnt/nuget/scratch
     
     steps:
     - name: Checkout repository
@@ -28,7 +32,11 @@ jobs:
         sudo mkdir -p /mnt/android-toolchain
         sudo mkdir -p /mnt/bin
         sudo mkdir -p /mnt/gradle
-        sudo chown $USER:$USER /mnt/android-archives /mnt/android-toolchain /mnt/bin /mnt/gradle
+        sudo mkdir -p /mnt/nuget/packages
+        sudo mkdir -p /mnt/nuget/v3-cache
+        sudo mkdir -p /mnt/nuget/plugins-cache
+        sudo mkdir -p /mnt/nuget/scratch
+        sudo chown -R $USER:$USER /mnt/android-archives /mnt/android-toolchain /mnt/bin /mnt/gradle /mnt/nuget
         
         # Remove bin directory if it exists and create symlink to use the secondary disk
         rm -rf ./bin
@@ -38,10 +46,15 @@ jobs:
         mkdir -p /mnt/gradle
         ln -s /mnt/gradle $HOME/.gradle
         
-        echo "Android toolchain directories configured:"
+        echo "Build cache directories configured on /mnt (secondary disk):"
+        echo "  - Android toolchain: /mnt/android-toolchain"
+        echo "  - Build output: /mnt/bin"
+        echo "  - Gradle cache: /mnt/gradle"
+        echo "  - NuGet packages: /mnt/nuget/packages"
+        echo "  - NuGet HTTP cache: /mnt/nuget/v3-cache"
+        echo "  - NuGet plugins cache: /mnt/nuget/plugins-cache"
+        echo "  - NuGet scratch: /mnt/nuget/scratch"
         ls -la /mnt
-        ls -lah bin
-        ls -lah $HOME/.gradle
         df -h /mnt
 
     - name: Setup .NET


### PR DESCRIPTION
Context: https://learn.microsoft.com/nuget/consume-packages/managing-the-global-packages-and-cache-folders

Move build caches to secondary disk to prevent disk space issues

Redirects all NuGet caches to `/mnt` (secondary disk with 74GB) to avoid filling `/dev/root` during Copilot builds.

Environment variables configured:
- `NUGET_PACKAGES`, `NUGET_HTTP_CACHE_PATH`, `NUGET_PLUGINS_CACHE_PATH`, `NUGET_SCRATCH`