### PR TITLE
[build] use dotnet/maui/main for `MAUI Integration` lane

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,7 +25,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/net10.0
+    ref: refs/heads/main
     endpoint: xamarin
 
 parameters:


### PR DESCRIPTION
The net10.0 branch is failing with:

    dotnet-install : Downloading from "primary" link has failed with error :  [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    EXEC : error : Unable to download https://dotnetbuilds.blob.core.windows.net/public/Sdk/10.0.101-servicing.25562.108/dotnet-sdk-10.0.101-servicing.25562.108-win-x64.zip. Returned HTTP status code: 409 Downloading from "legacy" link has failed with error: [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    EXEC : error : Unable to download https://dotnetbuilds.blob.core.windows.net/public/Sdk/10.0.101-servicing.25562.108/dotnet-dev-win-x64.10.0.101-servicing.25562.108.zip. Returned HTTP status code: 409 [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    dotnet-install : Downloading from "primary" link has failed with error :  [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    EXEC : error : Unable to download https://dotnetbuilds.blob.core.windows.net/public/Sdk/10.0.101-servicing.25562.108/dotnet-sdk-10.0.101-servicing.25562.108-win-x64.zip. Returned HTTP status code: 409 Downloading from "legacy" link has failed with error: [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    EXEC : error : Unable to download https://dotnetbuilds.blob.core.windows.net/public/Sdk/10.0.101-servicing.25562.108/dotnet-dev-win-x64.10.0.101-servicing.25562.108.zip. Returned HTTP status code: 409 [C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj]
    C:\a\_work\1\s\maui\src\DotNet\DotNet.csproj(160,5): error MSB3073: The command "powershell -ExecutionPolicy ByPass -NoProfile -Command "& 'C:\a\_work\1\s\maui\temp/dotnet-install.ps1' -Version 10.0.101-servicing.25562.108 -InstallDir 'C:\a\_work\1\s\maui\.dotnet/' -Verbose -AzureFeed https://dotnetbuilds.blob.core.windows.net/public"" exited with code 1.
        0 Warning(s)
        7 Error(s)

Let's see if `main` is working instead, as they are now using .NET 10 on main.