### PR TITLE
[xabt] Implement `DeployToDevice` target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -94,6 +94,48 @@ properties that determine build ordering.
     </_PrepareBuildApkDependsOnTargets>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <InstallDependsOnTargets>
+      SignAndroidPackage;
+      _DeployApk;
+      _DeployAppBundle;
+    </InstallDependsOnTargets>
+    <UninstallDependsOnTargets>
+      AndroidPrepareForBuild;
+      _Uninstall
+    </UninstallDependsOnTargets>
+    <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
+    <_MinimalSignAndroidPackageDependsOn>
+      BuildOnlySettings;
+      _CreatePropertiesCache;
+      ResolveReferences;
+      PrepareResources;
+      CreateSatelliteAssemblies;
+      _CopyPackage;
+      _Sign;
+      _CreateUniversalApkFromBundle;
+    </_MinimalSignAndroidPackageDependsOn>
+    <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'true' ">
+      Build;
+      Package;
+      _Sign;
+      _CreateUniversalApkFromBundle;
+    </SignAndroidPackageDependsOn>
+    <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'true' ">
+      $(_MinimalSignAndroidPackageDependsOn);
+    </SignAndroidPackageDependsOn>
+    <!-- This should function similar to SignAndroidPackage inside VS plus also deploy -->
+    <DeployToDeviceDependsOnTargets Condition=" '$(_XASupportsFastDev)' == 'true' ">
+      $(_MinimalSignAndroidPackageDependsOn);
+      _Upload;
+    </DeployToDeviceDependsOnTargets>
+    <DeployToDeviceDependsOnTargets Condition=" '$(_XASupportsFastDev)' != 'true' ">
+      $(_MinimalSignAndroidPackageDependsOn);
+      _DeployApk;
+      _DeployAppBundle;
+    </DeployToDeviceDependsOnTargets>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(AndroidApplication)' != 'True' ">
     <BuildDependsOn>
       $(_AndroidBuildDependsOn);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2800,28 +2800,10 @@ because xbuild doesn't support framework reference assemblies.
   <UnzipToFolder Sources="$(_UniversalApkSetIntermediate)" DestinationDirectories="$(OutDir)" Files="@(_FilestoExtract)" />
 </Target>
 
-<PropertyGroup>
-  <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' != 'True' ">
-    Build;
-    Package;
-    _Sign;
-    _CreateUniversalApkFromBundle;
-  </SignAndroidPackageDependsOn>
-  <!-- When inside an IDE, Build has just been run. This is a minimal list of targets for SignAndroidPackage. -->
-  <SignAndroidPackageDependsOn Condition=" '$(BuildingInsideVisualStudio)' == 'True' ">
-    BuildOnlySettings;
-    _CreatePropertiesCache;
-    ResolveReferences;
-    PrepareResources;
-    CreateSatelliteAssemblies;
-    _CopyPackage;
-    _Sign;
-    _CreateUniversalApkFromBundle;
-  </SignAndroidPackageDependsOn>
-</PropertyGroup>
 <Target Name="SignAndroidPackage" DependsOnTargets="$(SignAndroidPackageDependsOn)">
 </Target>
 
+<Target Name="DeployToDevice" DependsOnTargets="$(DeployToDeviceDependsOnTargets)" />
 
 <!-- Callable targets -->
 <PropertyGroup>
@@ -2937,18 +2919,6 @@ because xbuild doesn't support framework reference assemblies.
   <WriteLinesToFile File="$(_LldbConfigFile)" Lines="PKG=$(_AndroidPackage)" Overwrite="true"/>
   <WriteLinesToFile File="$(_LldbConfigFile)" Lines="MANIFEST=$(IntermediateOutputPath)android\AndroidManifest.xml"/>
 </Target>
-
-<PropertyGroup>
-  <InstallDependsOnTargets>
-    SignAndroidPackage;
-    _DeployApk;
-    _DeployAppBundle;
-  </InstallDependsOnTargets>
-  <UninstallDependsOnTargets>
-    AndroidPrepareForBuild;
-    _Uninstall
-  </UninstallDependsOnTargets>
-</PropertyGroup>
 
 <Target Name="_DeployApk"
     Condition=" '$(AndroidPackageFormat)' != 'aab' ">


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/blob/c164a9bc1246c48191fb780992530f0fe975141b/documentation/specs/dotnet-run-for-maui.md

Implements the `DeployToDevice` MSBuild target per the `dotnet run` spec for .NET MAUI scenarios. This target allows deploying an already-built app to a device without rebuilding, supporting the `dotnet run` workflow.

The target reuses existing deployment logic but skips the full build, enabling faster iteration when only deployment is needed e.g. `--no-build`.

Also consolidates `$(SignAndroidPackageDependsOn)`, `$(InstallDependsOnTargets)`, and `$(UninstallDependsOnTargets)` properties into `BuildOrder.targets` to keep all target dependency ordering in one place.

Adds test coverage to verify the target deploys successfully and the app can be launched via adb commands.