### PR TITLE
[xabt] `ComputeRunArguments` target no longer needs to deploy

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -22,12 +22,9 @@ This file contains targets specific for Android application projects.
       Install;
       StartAndroidActivity;
     </_RunDependsOn>
-    <_AndroidComputeRunArgumentsDependsOn Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NetCoreSdkVersion), 10.0.200))">
+    <_AndroidComputeRunArgumentsDependsOn Condition=" '$(_AndroidComputeRunArgumentsDependsOn)' == '' ">
       _ResolveMonoAndroidSdks;
       _GetAndroidPackageName;
-    </_AndroidComputeRunArgumentsDependsOn>
-    <_AndroidComputeRunArgumentsDependsOn Condition="$([MSBuild]::VersionLessThan($(NetCoreSdkVersion), 10.0.200))">
-      Install;
     </_AndroidComputeRunArgumentsDependsOn>
   </PropertyGroup>
 


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/52046
Context: https://github.com/dotnet/sdk/blob/c164a9bc1246c48191fb780992530f0fe975141b/documentation/specs/dotnet-run-for-maui.md

When the `DeployToDevice` target is run by the `dotnet run` pipeline, we will no longer need to make the `ComputeRunArguments` target deploy anything.

We are thinking this feature can ship in future .NET 11 and 10.0.200 SDKs.

This is draft until this one is merged:
* https://github.com/dotnet/sdk/pull/52046