### PR TITLE
[xaprepare] increase `ProcessRunner` timeout

### DIFF
--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -21,8 +21,8 @@ namespace Xamarin.Android.Prepare
 			ExitCodeNotZero,
 		};
 
-		static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes (5);
-		static readonly TimeSpan DefaultOutputTimeout = TimeSpan.FromSeconds (10);
+		static readonly TimeSpan DefaultProcessTimeout = TimeSpan.FromMinutes (10);
+		static readonly TimeSpan DefaultOutputTimeout = TimeSpan.FromSeconds (15);
 
 		sealed class WriterGuard
 		{


### PR DESCRIPTION
NuGet restore is randomly failing on the step:

    2025-12-16T19:20:47.0794510Z   Error: Process '/Users/builder/azdo/_work/4/s/android/bin/Release/dotnet/dotnet "restore" "\"/Users/builder/azdo/_work/4/s/android/build-tools/xaprepare/xaprepare/package-download.proj\"" "--configfile" "/Users/builder/azdo/_work/4/s/android/NuGet.config" "\"-bl:/Users/builder/azdo/_work/4/s/android/bin/BuildRelease/msbuild-20251216T111525-download-runtime-packs.binlog\""' timed out after 00:05:00
    2025-12-16T19:20:47.0818640Z   Error: Failed to restore runtime packs using '/Users/builder/azdo/_work/4/s/android/build-tools/xaprepare/xaprepare/package-download.proj'.
    2025-12-16T19:20:47.0854200Z
    2025-12-16T19:20:47.0856120Z Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
    2025-12-16T19:20:47.0867930Z System.InvalidOperationException: Step Xamarin.Android.Prepare.Step_InstallDotNetPreview failed
    2025-12-16T19:20:47.0869390Z    at Xamarin.Android.Prepare.Scenario.Run(Context context, Log log) in /Users/builder/azdo/_work/4/s/android/build-tools/xaprepare/xaprepare/Application/Scenario.cs:line 50
    2025-12-16T19:20:47.0870820Z    at Xamarin.Android.Prepare.Context.Execute() in /Users/builder/azdo/_work/4/s/android/build-tools/xaprepare/xaprepare/Application/Context.cs:line 488
    2025-12-16T19:20:47.0872110Z    at Xamarin.Android.Prepare.App.Run(String[] args) in /Users/builder/azdo/_work/4/s/android/build-tools/xaprepare/xaprepare/Main.cs:line 155

Let's try increasing the timeout to see if that helps.