### PR TITLE
[Testing] Change the dotnet/maui repository branch to net11.0

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -22,6 +22,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
+    ref: net11.0
     endpoint: xamarin
 
 parameters:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -25,7 +25,7 @@ resources:
   - repository: maui
     type: github
     name: dotnet/maui
-    ref: refs/heads/main
+    ref: net11.0
     endpoint: xamarin
 
 parameters:


### PR DESCRIPTION
Closes #10660 

The `main` of this repository is currently using the .NET 11 SDK, while in the dotnet/maui repo our main is the .NET 10 servicing branch and `net11.0` is the .NET 11 working branch. This PR attempts to align these two repos.