### PR TITLE
[build] Disable debug spew from the localizer

### DIFF
--- a/Documentation/workflow/Localization.md
+++ b/Documentation/workflow/Localization.md
@@ -39,12 +39,22 @@ so when adding a new message, follow these steps:
 
  6. The [OneLocBuild][oneloc] task will manage handoff and handback for string translations.
 
-### Templates
+## Templates
 
 All updates to `src/Microsoft.Android.Templates` should be built locally to update the
 `templatestrings.*.json` used for localization.  The [OneLocBuild][oneloc] task
 will manage handoff and handback for string translations after the
 `templatestrings.*.json` changes are committed.
+
+Templates localization files are *NOT* rebuilt by default. In order to rebuild them it is
+necessary to build the templates project in one of the following ways:
+
+   * On Unix systems run `make LOCALIZE_TEMPLATES=true prepare all` (the `prepare` parameter
+     can be omitted if it was ran previously)
+   * On all systems run `dotnet-local.sh -p:LocalizeTemplates=true -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj`
+
+This will generate all the changed localization files, which then need to be comitted and pushed
+to the repository.
 
 ## Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ PREPARE_SCENARIO =
 PREPARE_CI_PR ?= 0
 PREPARE_CI ?= 0
 PREPARE_AUTOPROVISION ?= 0
+LOCALIZE_TEMPLATES ?= 0
 
 _PREPARE_CI_MODE_PR_ARGS = --no-emoji --run-mode=CI
 _PREPARE_CI_MODE_ARGS = $(_PREPARE_CI_MODE_PR_ARGS) -a
@@ -22,7 +23,7 @@ _PREPARE_ARGS =
 
 all:
 	$(call DOTNET_BINLOG,all) $(MSBUILD_FLAGS) $(SOLUTION)
-	$(call DOTNET_BINLOG,setup-workload) -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj
+	$(call DOTNET_BINLOG,setup-workload) $(MSBUILD_FLAGS) -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj
 
 
 ifeq ($(OS_NAME),)
@@ -72,6 +73,10 @@ include build-tools/scripts/msbuild.mk
 ifeq ($(USE_MSBUILD),1)
 _SLN_BUILD  = $(MSBUILD)
 endif   # $(USE_MSBUILD) == 1
+
+ifneq ($(LOCALIZE_TEMPLATES),0)
+MSBUILD_FLAGS += -p:LocalizeTemplates=true
+endif
 
 ifneq ($(API_LEVEL),)
 MSBUILD_FLAGS += /p:AndroidApiLevel=$(API_LEVEL) /p:AndroidFrameworkVersion=$(word $(API_LEVEL), $(ALL_FRAMEWORKS)) /p:AndroidPlatformId=$(word $(a), $(ALL_PLATFORM_IDS))

--- a/build-tools/create-packs/ConfigureLocalWorkload.targets
+++ b/build-tools/create-packs/ConfigureLocalWorkload.targets
@@ -39,6 +39,7 @@
       Outputs="@(_TemplatesOutputs)">
     <ItemGroup>
       <_PackProps Include="-v:n -c $(Configuration)" />
+      <_PackProps Condition=" '$(LocalizeTemplates)' != '' " Include="-p:LocalizeTemplates=$(LocalizeTemplates)" />
       <_PackProps Include="-p:IncludeSymbols=False" />
       <_PackProps Include="-p:OutputPath=$(BuildOutputDirectory)lib\template-packs" />
       <_PackProps Include="-p:TemplatePackVersion=$(AndroidPackVersion)" />

--- a/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
+++ b/src/Microsoft.Android.Templates/Microsoft.Android.Templates.csproj
@@ -8,8 +8,9 @@
     <Description>Templates for Android platforms.</Description>
     <IncludeContentInPack>true</IncludeContentInPack>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!-- Only localize templates on CI builds to avoid verbose template localizer output during local development -->
-    <LocalizeTemplates Condition=" '$(RunningOnCI)' == 'true' ">true</LocalizeTemplates>
+    <!-- Only localize templates on demand avoid verbose template localizer output during local development -->
+    <!-- Set this property to `true` on command line, or uncomment it below, to enable localization -->
+    <!-- LocalizeTemplates>true</LocalizeTemplates -->
     <ContentTargetFolders>content</ContentTargetFolders>
     <OutputPath>..\..\bin\Build$(Configuration)\nuget-unsigned\</OutputPath>
     <!-- Remove the `<group targetFramework=".NETStandard2.0" />` entry from the .nuspec. -->
@@ -25,7 +26,7 @@
     <Compile Remove="**\*" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(RunningOnCI)' == 'true' ">
+  <ItemGroup Condition=" '$(LocalizeTemplates)' == 'true' ">
     <PackageReference Include="Microsoft.TemplateEngine.Authoring.Tasks" Version="$(MicrosoftTemplateEngineAuthoringTasksPackageVersion)" PrivateAssets="all" IsImplicitlyDefined="true" />
   </ItemGroup>
 


### PR DESCRIPTION
Local builds would generate hundreds (nearly 700) of messages similar to these:

    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //$schema
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //classifications
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //classifications
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //classifications
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //identity
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //author
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //name
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //classifications
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: The following element in the template.json will not be included in the localizations because it does not match any of the rules for localizable elements: //classifications
    Microsoft.TemplateEngine.TemplateLocalizer.Core.TemplateStringExtractor: Adding into localizable strings: //description

Disable the localizer for local builds by default.

In order to rebuild them it is necessary to build the templates project in 
one of the following ways:

   * On Unix systems run `make LOCALIZE_TEMPLATES=true prepare all` (the `prepare` parameter
     can be omitted if it was ran previously)
   * On all systems run `dotnet-local.sh -p:LocalizeTemplates=true -t:ConfigureLocalWorkload build-tools/create-packs/Microsoft.Android.Sdk.proj`
