### PR TITLE
[build] fix `generate and publish BAR manifest` step

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -407,7 +407,6 @@ extends:
                 dotnet build $(System.DefaultWorkingDirectory)\build-tools\create-packs\Microsoft.Android.Sdk.proj
                 -t:PushManifestToBuildAssetRegistry
                 -p:OutputPath=$(Build.StagingDirectory)\nuget-signed\
-                -p:TargetFramework=$(DotNetStableTargetFramework)
                 -c $(XA.Build.Configuration) -bl:$(System.DefaultWorkingDirectory)\bin\Build$(XA.Build.Configuration)\push-bar-manifest.binlog
             condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))
 

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -12,6 +12,11 @@ core workload SDK packs imported by WorkloadManifest.targets.
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateUnixFilePermissions" />
 
   <PropertyGroup>
+    <!-- Use stable TFM since CI only has the stable .NET SDK installed -->
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <PackageId>Microsoft.Android.Sdk.$(HostOS)</PackageId>
     <OverridePackageId>$(PackageId)</OverridePackageId>
     <PlatformPackageType>ToolPack</PlatformPackageType>


### PR DESCRIPTION
This failed with:

    Microsoft.NET.TargetFrameworkInference.targets(188,5): error NETSDK1045:
    The current .NET SDK does not support targeting .NET 11.0.
    Either target .NET 10.0 or lower, or use a version of the .NET SDK that supports .NET 11.0.
    Download the .NET SDK from https://aka.ms/dotnet/download

This step doesn't *need* to use .NET 11, so...

I think we can pass in `$(DotNetStableTargetFramework)` at this step to avoid this problem.