### PR TITLE
Migrate StripEmbeddedLibraries from ILLink step

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ILLink.targets
@@ -71,7 +71,6 @@ This file contains the .NET 5-specific targets to customize ILLink
           Type="MonoDroid.Tuner.AddKeepAlivesStep"
       />
       <!-- Custom steps that run after CleanStep -->
-      <_TrimmerCustomSteps Include="$(_AndroidLinkerCustomStepAssembly)" AfterStep="CleanStep" Type="MonoDroid.Tuner.StripEmbeddedLibraries" />
       <_TrimmerCustomSteps
           Condition=" '$(AndroidLinkResources)' == 'true' "
           Include="$(_AndroidLinkerCustomStepAssembly)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -140,6 +140,10 @@ public class AssemblyModifierPipeline : AndroidTask
 		findJavaObjectsStep.Initialize (context);
 		pipeline.Steps.Add (findJavaObjectsStep);
 
+		// StripEmbeddedLibrariesStep
+		var stripEmbeddedLibrariesStep = new StripEmbeddedLibrariesStep (Log);
+		pipeline.Steps.Add (stripEmbeddedLibrariesStep);
+
 		// SaveChangedAssemblyStep
 		var writerParameters = new WriterParameters {
 			DeterministicMvid = Deterministic,

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Build.Tasks.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Linker\MonoDroid.Tuner\FixLegacyResourceDesignerStep.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\LinkDesignerBase.cs" />
     <Compile Include="Linker\MonoDroid.Tuner\RemoveResourceDesignerStep.cs" />
+    <Compile Include="Linker\MonoDroid.Tuner\StripEmbeddedLibrariesStep.cs" />
     <Compile Include="Linker\External\Linker\Annotations.cs" />
     <Compile Include="Linker\External\Linker\AssemblyAction.cs" />
     <Compile Include="Linker\External\Linker\AssemblyResolver.cs" />


### PR DESCRIPTION
Changes this from an ILLink step to run in AssemblyModifierPipeline.

I'm hitting some failures locally that might have to do with the modiifier pipeline modifying assemblies in-place - opening this to see if it repros in ci.