### PR TITLE
Add PrinterCapabilitiesInfo color modes to methodmap

### DIFF
--- a/build-tools/enumification-helpers/methodmap.ext.csv
+++ b/build-tools/enumification-helpers/methodmap.ext.csv
@@ -900,6 +900,9 @@
 19, android.nfc, NfcAdapter, enableReaderMode, flags, Android.Nfc.NfcReaderFlags
 19, android.print, PrintAttributes, getColorMode, return, Android.Print.PrintColorMode
 19, android.print, PrintAttributes.Builder, setColorMode, colorMode, Android.Print.PrintColorMode
+23, android.print, PrinterCapabilitiesInfo.Builder, setColorModes, colorModes, Android.Print.PrintColorMode
+23, android.print, PrinterCapabilitiesInfo.Builder, setColorModes, defaultColorMode, Android.Print.PrintColorMode
+23, android.print, PrinterCapabilitiesInfo, getColorModes, return, Android.Print.PrintColorMode
 19, android.print, PrintDocumentInfo, getContentType, return, Android.Print.PrintContentType
 19, android.print, PrintDocumentInfo.Builder, setContentType, type, Android.Print.PrintContentType
 19, android.print, PrintJobInfo, getState, return, Android.Print.PrintJobState


### PR DESCRIPTION
This PR adds support to use `Enum` for `PrinterCapabilitiesInfo.Builder.SetColorModes` method instead of `int`.

Current way:
```csharp
var printer = new PrinterInfo.Builder(printerId, "Test printer", PrinterStatus.Idle)
    .SetCapabilities(new PrinterCapabilitiesInfo.Builder(printerId)
        .SetColorModes((int)(PrintColorMode.Color | PrintColorMode.Monochrome), (int)PrintColorMode.Color)
        .Build())
    .Build();
```

With this PR (and #10688):
```csharp
var printer = new PrinterInfo.Builder(printerId, "Test printer", PrinterStatus.Idle)
    .SetCapabilities(new PrinterCapabilitiesInfo.Builder(printerId)
        .SetColorModes(PrintColorMode.Color | PrintColorMode.Monochrome, PrintColorMode.Color)
        .Build())
    .Build();
```



- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests
