### PR TITLE
[Microsoft.Android.Run] target `$(DotNetStableTargetFramework)`

### DIFF
--- a/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
+++ b/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
@@ -5,11 +5,12 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>$(MicrosoftAndroidSdkOutDir)</OutputPath>
     <OutputType>Exe</OutputType>
-    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.Android.Run</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <DebugType>portable</DebugType>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This simplifies my work on the dotnet/sdk repo, as the development branch is still .NET 10 at release/10.0.3xx.

This tool is simple, so it seems fine to use `$(DotNetStableTargetFramework)` for now and allow it to roll forward.