### PR TITLE
[build] remove `$(TargetsCurrent)`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,9 +27,6 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
     <!-- Disables the transitive restore of packages like Microsoft.AspNetCore.App.Ref, Microsoft.WindowsDesktop.App.Ref -->
     <DisableTransitiveFrameworkReferenceDownloads>true</DisableTransitiveFrameworkReferenceDownloads>
-    <!-- Setting TargetsCurrent=true is necessary until we get https://github.com/dotnet/sdk/pull/52031 -->
-    <!-- Ref: https://github.com/dotnet/macios/issues/24418 -->
-    <TargetsCurrent>true</TargetsCurrent>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This was added in a2c20450, but should not be necessary.