### PR TITLE
[xabt] `GeneratePackageManagerJava` only writes main assembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GeneratePackageManagerJava.cs
@@ -16,9 +16,6 @@ public class GeneratePackageManagerJava : AndroidTask
 	[Required]
 	public string OutputDirectory { get; set; } = "";
 
-	[Required]
-	public ITaskItem [] ResolvedUserAssemblies { get; set; } = [];
-
 	public override bool RunTask ()
 	{
 		// We need to include any special assemblies in the Assemblies list
@@ -31,23 +28,8 @@ public class GeneratePackageManagerJava : AndroidTask
 			pkgmgr.WriteLine ("public class MonoPackageManager_Resources {");
 			pkgmgr.WriteLine ("\tpublic static String[] Assemblies = new String[]{");
 
-			pkgmgr.WriteLine ("\t\t/* We need to ensure that \"{0}\" comes first in this list. */", mainFileName);
+			pkgmgr.WriteLine ("\t\t/* \"{0}\" should be the only entry in this list. */", mainFileName);
 			pkgmgr.WriteLine ("\t\t\"" + mainFileName + "\",");
-			foreach (var assembly in ResolvedUserAssemblies) {
-				if (string.Compare (Path.GetFileName (assembly.ItemSpec), mainFileName, StringComparison.OrdinalIgnoreCase) == 0)
-					continue;
-				pkgmgr.WriteLine ("\t\t\"" + Path.GetFileName (assembly.ItemSpec) + "\",");
-			}
-
-			// Write the assembly dependencies
-			pkgmgr.WriteLine ("\t};");
-			pkgmgr.WriteLine ("\tpublic static String[] Dependencies = new String[]{");
-
-			//foreach (var assembly in assemblies.Except (args.Assemblies)) {
-			//        if (args.SharedRuntime && !Toolbox.IsInSharedRuntime (assembly))
-			//                pkgmgr.WriteLine ("\t\t\"" + Path.GetFileName (assembly) + "\",");
-			//}
-
 			pkgmgr.WriteLine ("\t};");
 
 			pkgmgr.WriteLine ("}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/CheckPackageManagerAssemblyOrder.java
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Expected/CheckPackageManagerAssemblyOrder.java
@@ -1,10 +1,7 @@
 package mono;
 public class MonoPackageManager_Resources {
 	public static String[] Assemblies = new String[]{
-		/* We need to ensure that "HelloAndroid.dll" comes first in this list. */
+		/* "HelloAndroid.dll" should be the only entry in this list. */
 		"HelloAndroid.dll",
-		"Xamarin.AndroidX.SavedState.dll",
-	};
-	public static String[] Dependencies = new String[]{
 	};
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GeneratePackageManagerJavaTests.cs
@@ -76,7 +76,6 @@ namespace Xamarin.Android.Build.Tests
 				BuildEngine = new MockBuildEngine (TestContext.Out),
 				MainAssembly = "linked/HelloAndroid.dll",
 				OutputDirectory = Path.Combine (path, "src", "mono"),
-				ResolvedUserAssemblies = resolvedUserAssembliesList.ToArray (),
 			};
 
 			var configTask = new GenerateNativeApplicationConfigSources {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1877,8 +1877,7 @@ because xbuild doesn't support framework reference assemblies.
   <!-- Create java needed for Mono runtime -->
   <GeneratePackageManagerJava
       MainAssembly="$(TargetPath)"
-      OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono"
-      ResolvedUserAssemblies="@(_ResolvedUserAssemblies)">
+      OutputDirectory="$(_AndroidIntermediateJavaSourceDirectory)mono">
   </GeneratePackageManagerJava>
 
   <GenerateNativeApplicationConfigSources


### PR DESCRIPTION
Reviewing incremental build logs and implementing "dotnet-watch", I noticed we will rebuild Java code, DEX, and APK when the list of assemblies change.

It does not appear this is necessary, as apps seem to work fine when only the "main" assembly is included in this list.

Change: only include the "main" assembly in the list of assemblies passed to `GeneratePackageManagerJava`. This should slightly reduce startup time, as well as incremental build time when assemblies change.
