### PR TITLE
Bump to DevDiv/android-platform-support/main@21730a73

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@2ca8c22cc27b2f437275ee01e054c92847728617
+DevDiv/android-platform-support:main@21730a73e34c7dafbb2db46995e12a1dbc245805


### PR DESCRIPTION
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC2ca8c22cc27b2f437275ee01e054c92847728617&targetVersion=GC21730a73e34c7dafbb2db46995e12a1dbc245805

* Merged PR 701848: [Xamarin.Installer.Build.Tasks] allow `$(AndroidSdkDirectory)` to be blank

* Merged PR 701850: Bump to dotnet/android-tools/main@fb95edd3

* Merged PR 699939: [Mono.AndroidTools] remove `host:devices` fallback

* Merged PR 699731: [manifests] add JDK 21.0.8, 21.0.9

* Merged PR 699034: Bump `$(JavaSdkVersion)` to 21.0.8

* Merged PR 694463: Fix JAVA_HOME paths with parentheses breaking batch scripts

* Merged PR 692339: [Xamarin.Installer.AndroidSDK] expand license acceptance error

* Merged PR 690408: Remove XA paths when looking for ApkSigner

* Merged PR 684829: update submodule dotnet/android-tools to ca74eba

* Merged PR 683696: Update System.Text.Json to 8.0.6