### PR TITLE
[build] fix `publish BAR manifest` step

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -1,7 +1,8 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" PrivateAssets="all" GeneratePathProperty="true" />
+    <!-- Use net10.0 version for Feed tasks since CI only has the .NET 10 SDK installed -->
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Feed" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersionNet10)" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.DotNet.Arcade.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersionNet10)" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Import Project="License.targets" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -8,7 +8,8 @@ core workload SDK packs imported by WorkloadManifest.targets.
 -->
 <Project Sdk="Microsoft.Build.NoTargets">
 
-  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersion)" />
+  <!-- Use net10.0 version since CI only has the .NET 10 SDK installed for BAR manifest publishing -->
+  <Sdk Name="Microsoft.DotNet.SharedFramework.Sdk" Version="$(MicrosoftDotNetBuildTasksFeedPackageVersionNet10)" />
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.GenerateUnixFilePermissions" />
 
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,6 +7,8 @@
     <MicrosoftNETCoreAppRefPackageVersion>11.0.0-alpha.1.26064.107</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26064.107</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <!-- Last version built for net10.0, needed for CI steps that only have the .NET 10 SDK installed (e.g., BAR manifest publishing) -->
+    <MicrosoftDotNetBuildTasksFeedPackageVersionNet10>11.0.0-beta.26060.102</MicrosoftDotNetBuildTasksFeedPackageVersionNet10>
     <MicrosoftNETWorkloadMonoToolChainCurrentManifest110100alpha1PackageVersion>11.0.0-alpha.1.26064.107</MicrosoftNETWorkloadMonoToolChainCurrentManifest110100alpha1PackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest110100alpha1PackageVersion>11.0.100-alpha.1.26064.107</MicrosoftNETWorkloadEmscriptenCurrentManifest110100alpha1PackageVersion>
     <MicrosoftNETWorkloadMonoToolChainPackageVersion>$(MicrosoftNETWorkloadMonoToolChainCurrentManifest110100alpha1PackageVersion)</MicrosoftNETWorkloadMonoToolChainPackageVersion>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/blob/097742b3d08fcf96472e20f05794779a4b05157a/eng/Versions.props#L9

This is currently failing with:

    build-tools\create-packs\Directory.Build.targets(188,5):
    error MSB4062: The "PushToBuildStorage" task could not be loaded from the assembly C:\Users\cloudtest\.nuget\packages\microsoft.dotnet.build.tasks.feed\11.0.0-beta.26064.107\build\../tools/net/Microsoft.DotNet.Build.Tasks.Feed.dll.
    Could not load file or assembly 'System.Runtime, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'.
    The system cannot find the file specified. Confirm that the <UsingTask> declaration is correct, that the assembly and all its dependencies are available, and that the task contains a public class that implements Microsoft.Build.Framework.ITask.
    [build-tools\create-packs\Microsoft.Android.Sdk.proj]

`PushToBuildStorage` is now targeting .NET 11, but this is a step that is using a stable .NET SDK (currently .NET 10).

For now, let's just use a slightly older version of the `PushToBuildStorage` task that targets .NET 10.

When .NET 10 Preview 1 has shipped, it will be easy to use the `UseDotNet` yaml task and fix this properly.