### PR TITLE
$(AndroidPackVersionSuffix)=preview.2; main is .NET 11 preview 2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.1.99</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.1</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview1

We branched for .NET 11 Preview 1 from 51a3e112 into `release/11.0.1xx-preview1`; the main branch is now .NET 11 Preview 2.