### PR TITLE
[release/10.0.1xx] set `$(UseDefaultPublishRuntimeIdentifier)=false`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -13,6 +13,8 @@
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseDesignerAssembly)' == 'True' ">false</AndroidUseIntermediateDesignerFile>
     <AndroidUseIntermediateDesignerFile Condition=" '$(AndroidUseIntermediateDesignerFile)' == '' ">$(AndroidGenerateResourceDesigner)</AndroidUseIntermediateDesignerFile>
     <AllowSelfContainedWithoutRuntimeIdentifier Condition =" '$(AllowSelfContainedWithoutRuntimeIdentifier)' == '' ">true</AllowSelfContainedWithoutRuntimeIdentifier>
+    <!-- Prevent .NET SDK from adding the host RID to RuntimeIdentifiers, see: https://github.com/dotnet/android/issues/10722 -->
+    <UseDefaultPublishRuntimeIdentifier Condition=" '$(UseDefaultPublishRuntimeIdentifier)' == '' ">false</UseDefaultPublishRuntimeIdentifier>
     <SelfContained Condition=" '$(SelfContained)' == '' ">true</SelfContained>
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/pull/52566

Newer .NET SDKs want this value to be set, to prevent a restore of your desktop OS's RID.