### PR TITLE
[build] try to address Linux build warning

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -48,7 +48,7 @@ variables:
 - name: WindowsPoolImage1ESPT
   value: 1ESPT-Windows2022
 - name: LinuxPoolImage1ESPT
-  value: 1ESPT-Ubuntu22.04
+  value: 1ESPT-Ubuntu22.04-v2
 - name: VSEngMicroBuildPool
   value: VSEngSS-MicroBuild2022-1ES
 - name: TeamName


### PR DESCRIPTION
Trying to fix:

    1ES PT Non-Blocking Error: The artifact linux-1es-gpt-prerequisites is deprecated. Please update the artifact to linux-1es-pt-prerequisites-v2. For more information visit https://aka.ms/1espt/v1-prerequisite-deprecation-linux. MAUI-1ESPT/1ESPT-Ubuntu22.04