### PR TITLE
[build] troubleshoot signing failure

### DIFF
--- a/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
+++ b/build-tools/automation/yaml-templates/install-microbuild-tooling.yaml
@@ -18,6 +18,29 @@ steps:
     version: '2.8.0'
     condition: and(${{ parameters.condition }}, eq(variables['agent.os'], 'Darwin'))
 
+- pwsh: |
+    Write-Host "=== Environment Variable Analysis ==="
+    $vars = [Environment]::GetEnvironmentVariables()
+    $totalSize = 0
+    $varList = $vars.Keys | ForEach-Object {
+      $size = $_.Length + $vars[$_].Length + 2  # +2 for = and null terminator
+      $totalSize += $size
+      [PSCustomObject]@{
+        Name = $_
+        ValueLength = $vars[$_].Length
+        TotalSize = $size
+      }
+    } | Sort-Object TotalSize -Descending
+    
+    Write-Host "`nTop 50 largest environment variables:"
+    $varList | Select-Object -First 50 | Format-Table -AutoSize
+    
+    Write-Host "`nTotal environment block size: $totalSize bytes"
+    Write-Host "Windows limit: 65535 bytes"
+    Write-Host "Over limit by: $($totalSize - 65535) bytes"
+  displayName: Debug - Analyze environment variables before signing
+  condition: ${{ parameters.condition }}
+
 - task: MicroBuildSigningPlugin@4
   displayName: install signing plugin
   condition: ${{ parameters.condition }}


### PR DESCRIPTION
Our signing step is failing due to:

    Add-Type : The environment block used to start a process cannot be longer than 65535 bytes.  Your environment block is
    75815 bytes long.  Remove some environment variables and try again.
    At D:\a\_work\_tasks\MicroBuildSigningPlugin...

Adding a step to view the environment size during the build to help diagnose.

We may be able to clear some environment variables to workaround.