### PR TITLE
[build] Make local build quieter

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -191,6 +191,13 @@
     <AndroidSupportedTargetAotAbisSplit>$(AndroidSupportedTargetAotAbis.Split(':'))</AndroidSupportedTargetAotAbisSplit>
   </PropertyGroup>
 
+  <!-- Noise generators -->
+  <PropertyGroup>
+    <!-- Setting this to `true` makes the GenerateJavaCallableWrappers target to output list of everything that's found
+         in android.jar; Enabled by default only on CI  -->
+    <AndroidNoisyJCW Condition=" '$(AndroidNoisyJCW)' == '' and '$(RunningOnCI)' == 'true' ">true</AndroidNoisyJCW>
+  </PropertyGroup>
+
   <!-- Unit Test Properties -->
   <PropertyGroup>
     <!-- When changing the version below, please also update the 'build-tools/scripts/nunit3-console*' scripts -->

--- a/build-tools/scripts/JavaCallableWrappers.targets
+++ b/build-tools/scripts/JavaCallableWrappers.targets
@@ -35,8 +35,9 @@
       <_MonoAndroidJar>$(OutputPath)mono.android.jar</_MonoAndroidJar>
       <_MonoAndroidRuntimeJar>$(MicrosoftAndroidSdkOutDir)java_runtime.jar</_MonoAndroidRuntimeJar>
     </PropertyGroup>
-    <Message Text="# jonp: what's *in* _AndroidJar=`$(_AndroidJar)`?" />
+    <Message Condition=" '$(AndroidNoisyJCW)' == 'true' " Text="# jonp: what's *in* _AndroidJar=`$(_AndroidJar)`?" />
     <Exec
+        Condition=" '$(AndroidNoisyJCW)' == 'true' "
         Command="&quot;$(JarPath)&quot; tf $(_AndroidJar)"
     />
     <Exec


### PR DESCRIPTION
The `GenerateJavaCallableWrappers` target by default lists contents
of the `android.jar` archive, resulting in thousands of lines printed
to the terminal while building the repository. While logging the
`android.jar` contents might be useful at times, it's mostly just
wasted time and space when building the repository locally in the
daily development cycle.

Add a property named `AndroidNoisyJCW` which, if set to `true`,
enables logging of `android.jar` contents. The property defaults to
an empty value unless it runs on CI, where it is set to `true`.

Disabling the output prevents around 1.7mb of output from being
written to the terminal.
