### PR TITLE
[build] use `MicroBuild.1ES.Official` based on pipeline name

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -49,7 +49,7 @@ variables:
     value: dnceng-dotnet9
 
 extends:
-  ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android')) }}:
+  ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android') }}:
     template: azure-pipelines/MicroBuild.1ES.Official.yml@1esPipelines
   ${{ else }}:
     template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@1esPipelines


### PR DESCRIPTION
The `Xamarin.Android` production pipeline *must* always use the `MicroBuild.1ES.Official` template. It would fail/warn otherwise if running on pull requests.

Update the yaml condition to behave this way, which will allow us to test changes on pull requests.