### PR TITLE
[Mono.Android] fix `$DOTNET_STARTUP_HOOKS` on CoreCLR

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -204,9 +204,11 @@ namespace Android.Runtime
 				return;
 			}
 
-			// Pass empty string for diagnosticStartupHooks parameter
-			// The method will read STARTUP_HOOKS from AppContext internally
-			method.Invoke (null, [ "" ]);
+			// ProcessStartupHooks accepts startup hooks directly via parameter.
+			// It will also read STARTUP_HOOKS from AppContext internally.
+			// Pass DOTNET_STARTUP_HOOKS env var value so it works without needing AppContext setup.
+			string? startupHooks = Environment.GetEnvironmentVariable ("DOTNET_STARTUP_HOOKS");
+			method.Invoke (null, [ startupHooks ?? "" ]);
 		}
 
 		static void SetSynchronizationContext () =>

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -52,11 +52,12 @@
     <StartupHookSupport>true</StartupHookSupport>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(Configuration)' == 'Debug' ">
+  <ItemGroup>
     <!-- trying to track:
       JNI ERROR (app bug): accessed deleted Global 0x3056
     -->
-    <AndroidEnvironment Include="env.txt" />
+    <AndroidEnvironment Include="env.txt" Condition=" '$(Configuration)' == 'Debug' " />
+    <AndroidEnvironment Include="hotreload.env" />
   </ItemGroup>
 
   <ItemGroup>
@@ -231,7 +232,8 @@
     <RuntimeHostConfigurationOption Include="test_bool"    Value="true" />
     <RuntimeHostConfigurationOption Include="test_integer" Value="42" />
     <RuntimeHostConfigurationOption Include="test_string"  Value="foo" />
-    <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="StartupHook" />
+    <!-- Set STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM (read via AppContext.GetData) -->
+    <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="StartupHook" Condition=" '$(UseMonoRuntime)' == 'true' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(AndroidPackageFormat)' != 'aab' ">

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System/StartupHookTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System/StartupHookTest.cs
@@ -8,6 +8,20 @@ namespace SystemTests
 	public class StartupHookTest
 	{
 		[Test]
+		public void FeatureFlagIsEnabled ()
+		{
+			// NOTE: this is set to true in tests\Mono.Android-Tests\Mono.Android-Tests\Mono.Android.NET-Tests.csproj
+			Assert.IsTrue (Microsoft.Android.Runtime.RuntimeFeature.StartupHookSupport, "RuntimeFeature.StartupHookSupport should be true");
+		}
+
+		[Test]
+		public void EnvironmentVariableIsSet ()
+		{
+			var value = Environment.GetEnvironmentVariable ("DOTNET_STARTUP_HOOKS");
+			Assert.AreEqual ("StartupHook", value, "DOTNET_STARTUP_HOOKS should be set to 'StartupHook'");
+		}
+
+		[Test]
 		public void IsInitialized ()
 		{
 			var type = Type.GetType ("StartupHook, StartupHook", throwOnError: true);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/env.txt
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/env.txt
@@ -1,4 +1,3 @@
 # Environment Variables and system properties
 # debug.mono.log=gref,default
 debug.mono.debug=1
-DOTNET_STARTUP_HOOKS=StartupHook

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/hotreload.env
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/hotreload.env
@@ -1,0 +1,1 @@
+DOTNET_STARTUP_HOOKS=StartupHook


### PR DESCRIPTION
Context: https://github.com/dotnet/android/pull/10699

Bringing useful changes from #10699 to main, such as fixing CoreCLR behavior and updating tests to verify setting `$DOTNET_STARTUP_HOOKS` works as intended for CoreCLR and NativeAOT.

I will send a future PR to dotnet/runtime to fix Mono.