### PR TITLE
[tests] remove "flaky" MSBuild perf tests

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -147,21 +147,6 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[Retry (Retry)]
-		public void Build_From_Clean_DontIncludeRestore ()
-		{
-			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
-
-			var proj = CreateApplicationProject ();
-			using (var builder = CreateBuilderWithoutLogFile ()) {
-				builder.AutomaticNuGetRestore = false;
-				builder.Target = "Build";
-				builder.Restore (proj);
-				Profile (builder, b => b.Build (proj));
-			}
-		}
-
-		[Test]
-		[Retry (Retry)]
 		public void Build_No_Changes ()
 		{
 			var proj = CreateApplicationProject ();
@@ -256,29 +241,6 @@ namespace Xamarin.Android.Build.Tests
 				libBuilder.Build (lib);
 				builder.Target = "SignAndroidPackage";
 				// Profile AndroidAsset change
-				Profile (builder, b => b.Build (proj));
-			}
-		}
-
-		[Test]
-		[Retry (Retry)]
-		public void Build_JLO_Change ()
-		{
-			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
-
-			var className = "Foo";
-			var proj = CreateApplicationProject ();
-			proj.Sources.Add (new BuildItem.Source ("Foo.cs") {
-				TextContent = () => $"class {className} : Java.Lang.Object {{}}"
-			});
-			using (var builder = CreateBuilderWithoutLogFile ()) {
-				builder.Target = "Build";
-				builder.Build (proj);
-				builder.AutomaticNuGetRestore = false;
-
-				// Profile Java.Lang.Object rename
-				className = "Foo2";
-				proj.Touch ("Foo.cs");
 				Profile (builder, b => b.Build (proj));
 			}
 		}

--- a/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
+++ b/tests/msbuild-times-reference/MSBuildDeviceIntegration.csv
@@ -2,13 +2,11 @@
 # First non-comment row is human description of columns
 Test Name,Time in ms (int)
 # Data
-Build_From_Clean_DontIncludeRestore,13000
 Build_No_Changes,2250
 Build_CSharp_Change,3500
 Build_AndroidResource_Change,2250
 Build_AndroidAsset_Change,6500
 Build_AndroidManifest_Change,4500
-Build_JLO_Change,4500
 Build_XAML_Change,3000
 Install_CSharp_Change,4000
 Install_XAML_Change,3750


### PR DESCRIPTION
These two commonly fail (but also randomly pass!):

* `Build_From_Clean_DontIncludeRestore`
* `Build_JLO_Change`

The general goal of the MSBuild performance tests is to catch large regressions in incremental builds.

Let's remove these two as they are lower value:

* Flaky, due to the long time they take and the variability of build machine performance.

* Perf regressions in initial build time are less important than incremental build time regressions.

It would be higher value for PRs to be greener than run these, I think.

`Build_No_Changes` and `Build_CSharp_Change` are more valuable to keep as they are less flaky and more likely to catch real-world regressions.