### PR TITLE
[Draft][Proposal] Trimmable Type Map

### DIFF
--- a/Documentation/project-docs/TrimmableTypemapSpec.md
+++ b/Documentation/project-docs/TrimmableTypemapSpec.md
@@ -786,7 +786,7 @@ This is significant because the trimmable typemap already eliminates the native 
 - **Registration trigger**: Java `native` methods must be registered before first invocation. The existing Java static initializer pattern (`mono.android.Runtime.register()` called from each JCW's `<clinit>`) can be reused — the trimmable typemap just needs to route it to the proxy's `RegisterNatives` method instead of the legacy reflection-based path.
 - **GC safety**: Unlike the current delegate-based `RegisterNatives`, `[UnmanagedCallersOnly]` static method pointers are stable and do not require `GCHandle` protection.
 
-> **Open question:** Should `RegisterNatives` be used for all builds, or should Release builds use LLVM IR for the static symbol resolution benefit? The performance difference is likely negligible in practice since `RegisterNatives` runs once per class at load time, but this needs measurement.
+> **Runtime performance is not a concern.** Benchmarking on a Samsung Galaxy A16 (MediaTek mt6789, Android 14) confirms that `RegisterNatives` is marginally _faster_ than `dlsym` on the hot path (~328ns vs ~340ns per call for void methods, ~357ns vs ~369ns for `int` return). The ~3% difference is negligible — both approaches are dominated by the JNI call overhead itself. Since `RegisterNatives` is equal-or-better at runtime and dramatically simpler at build time, there is no reason to retain the LLVM IR approach for marshal methods.
 
 ---
 


### PR DESCRIPTION
This specification defines the architecture for enabling Java-to-.NET interoperability in .NET Android applications using the .NET Type Mapping API. The design is fully compatible with Native AOT and trimming.

- **AOT-Safe**: All type instantiation and method resolution works with Native AOT
- **Trimming-Safe**: Proper annotations ensure required types survive aggressive trimming
- **Developer Experience**: No changes required to existing .NET Android application code

Expands on https://github.com/dotnet/runtime/issues/120121

## Proof of concept 

See https://github.com/dotnet/android/compare/dev/simonrozsival/trimmable-typemap

## Core idea

Each Java peer type is registered using assembly-level attributes:

```csharp
// TypeMap<TUniverse>(string jniClassName, Type proxyType, Type trimTarget)
// - jniClassName: Java class name used as lookup key
// - proxyType: The proxy type RETURNED by TypeMap lookups
// - trimTarget: Ensures trimmer preserves mapping when target is used

[assembly: TypeMap<Java.Lang.Object>("com/example/MainActivity", typeof(MainActivity_Proxy))] // no trim target -> unconditionally preserved
[assembly: TypeMap<Java.Lang.Object>("com/example/MainActivity", typeof(MainActivity_Proxy), typeof(MainActivity))] // trim target -> type map record will be trimmed if trim target is trimmed
```

The `*_Proxy` types are generated _attribute_ classes which is applied to itself:

```csharp
// Proxy applies ITSELF as an attribute to ITSELF
[MainActivity_Proxy]  // Self-application
public sealed class MainActivity_Proxy : JavaPeerProxy, IAndroidCallableWrapper
{
    public override IJavaPeerable CreateInstance(IntPtr handle, JniHandleOwnership transfer)
        => new MainActivity(handle, transfer);
    
    public override JavaPeerContainerFactory GetContainerFactory()
        => JavaPeerContainerFactory.Create<MainActivity>();
    
    // IAndroidCallableWrapper - only on ACW types
    public IntPtr GetFunctionPointer(int methodIndex) => methodIndex switch {
        0 => (IntPtr)(delegate* unmanaged<...>)&n_OnCreate,
        _ => IntPtr.Zero
    };
    
    // marshal methods...
    [UnmanagedCallersOnly]
    public static void n_OnCreate(...) { ... }
}

// At runtime:
Type proxyType = typeMap["com/example/MainActivity"];  // Returns typeof(MainActivity_Proxy)
JavaPeerProxy proxy = proxyType.GetCustomAttribute<JavaPeerProxy>();  // Returns MainActivity_Proxy instance
IJavaPeerable instance = proxy.CreateInstance(handle, transfer);  // Returns MainActivity instance
```

**Why this works:**
1. TypeMap returns the proxy type, not the target type
2. The .NET runtime's `GetCustomAttribute<T>()` instantiates attributes in an trimming and AOT-safe manner
3. The `trimTarget` parameter ensures the mapping is preserved when the target type survives trimming

/cc @jtschuster 

---

### Related

- https://github.com/dotnet/runtime/issues/110691
- https://github.com/dotnet/runtime/issues/113362
- https://github.com/dotnet/runtime/issues/120271
- https://github.com/dotnet/runtime/issues/120204
- https://github.com/dotnet/runtime/issues/123683
- https://github.com/dotnet/runtime/issues/123678
- https://github.com/dotnet/android/issues/10062
