### PR TITLE
[tests] fix `SubscribeToAppDomainUnhandledException(CoreCLR)`

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -268,7 +268,11 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 				IsRelease = true,
 			};
 			proj.SetRuntime (runtime);
-			proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");
+			if (runtime == AndroidRuntime.MonoVM) {
+				proj.SetAndroidSupportedAbis ("armeabi-v7a", "arm64-v8a", "x86", "x86_64");
+			} else {
+				proj.SetRuntimeIdentifiers (new [] {"arm64-v8a", "x86_64"});
+			}
 			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
 @"			AppDomain.CurrentDomain.UnhandledException += (sender, e) => {
 				Console.WriteLine (""# Unhandled Exception: sender={0}; e.IsTerminating={1}; e.ExceptionObject={2}"",


### PR DESCRIPTION
When backporting, we lost a snippet that is present on main, causing this test to fail on `release/10.0.1xx`.