### PR TITLE
[xabt] `dotnet watch` support, based on env vars

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -150,6 +150,21 @@ try {
 }
 ```
 
+## Testing
+
+**Modifying project files in tests:** Never use `File.WriteAllText()` directly to update project source files. Instead, use the `Xamarin.ProjectTools` infrastructure:
+
+```csharp
+// 1. Update the in-memory content
+proj.MainActivity = proj.MainActivity.Replace ("old text", "new text");
+// 2. Bump the timestamp so UpdateProjectFiles knows it changed
+proj.Touch ("MainActivity.cs");
+// 3. Write to disk (doNotCleanupOnUpdate preserves other files, saveProject: false skips .csproj regeneration)
+builder.Save (proj, doNotCleanupOnUpdate: true, saveProject: false);
+```
+
+This pattern ensures proper encoding, timestamps, and file attributes are handled correctly. The `Touch` + `Save` pattern is used throughout the test suite for incremental builds and file modifications.
+
 ## Error Patterns
 - **MSBuild Errors:** `XA####` (errors), `XA####` (warnings), `APT####` (Android tools)
 - **Logging:** Use `Log.LogError`, `Log.LogWarning` with error codes and context

--- a/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
+++ b/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
@@ -11,6 +11,7 @@
     <Nullable>enable</Nullable>
     <DebugType>portable</DebugType>
     <RollForward>Major</RollForward>
+    <StartupHookSupport>false</StartupHookSupport>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -33,4 +33,5 @@ This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
   <Import Project="Microsoft.Android.Sdk.Publish.targets" />
   <Import Project="Microsoft.Android.Sdk.RuntimeConfig.targets" />
   <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
+  <Import Project="Microsoft.Android.Sdk.HotReload.targets" Condition=" '$(AndroidApplication)' == 'true' " />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -25,6 +25,7 @@ This file contains targets specific for Android application projects.
     <_AndroidComputeRunArgumentsDependsOn Condition=" '$(_AndroidComputeRunArgumentsDependsOn)' == '' and $([MSBuild]::VersionGreaterThanOrEquals($(NetCoreSdkVersion), 10.0.300)) ">
       _ResolveMonoAndroidSdks;
       _GetAndroidPackageName;
+      _AndroidAdbToolPath;
     </_AndroidComputeRunArgumentsDependsOn>
     <_AndroidComputeRunArgumentsDependsOn Condition=" '$(_AndroidComputeRunArgumentsDependsOn)' == '' ">
       Install;
@@ -52,6 +53,15 @@ This file contains targets specific for Android application projects.
     </GetAvailableAndroidDevices>
   </Target>
 
+  <Target Name="_AndroidAdbToolPath">
+    <PropertyGroup>
+      <_AdbToolPath>$(AdbToolExe)</_AdbToolPath>
+      <_AdbToolPath Condition=" '$(_AdbToolPath)' == '' and $([MSBuild]::IsOSPlatform('windows')) ">adb.exe</_AdbToolPath>
+      <_AdbToolPath Condition=" '$(_AdbToolPath)' == '' and !$([MSBuild]::IsOSPlatform('windows')) ">adb</_AdbToolPath>
+      <_AdbToolPath>$([System.IO.Path]::Combine ('$(AdbToolPath)', '$(_AdbToolPath)'))</_AdbToolPath>
+    </PropertyGroup>
+  </Target>
+
   <Target Name="_AndroidComputeRunArguments"
       BeforeTargets="ComputeRunArguments"
       DependsOnTargets="$(_AndroidComputeRunArgumentsDependsOn)">
@@ -61,10 +71,6 @@ This file contains targets specific for Android application projects.
       <Output TaskParameter="ActivityName" PropertyName="AndroidLaunchActivity" />
     </GetAndroidActivityName>
     <PropertyGroup>
-      <_AdbToolPath>$(AdbToolExe)</_AdbToolPath>
-      <_AdbToolPath Condition=" '$(_AdbToolPath)' == '' and $([MSBuild]::IsOSPlatform('windows')) ">adb.exe</_AdbToolPath>
-      <_AdbToolPath Condition=" '$(_AdbToolPath)' == '' and !$([MSBuild]::IsOSPlatform('windows')) ">adb</_AdbToolPath>
-      <_AdbToolPath>$([System.IO.Path]::Combine ('$(AdbToolPath)', '$(_AdbToolPath)'))</_AdbToolPath>
       <RunWorkingDirectory>$(MSBuildProjectDirectory)</RunWorkingDirectory>
     </PropertyGroup>
     <!-- By default, use `Microsoft.Android.Run` tool to stream logcat and handle Ctrl+C -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -73,7 +73,7 @@ _ResolveAssemblies MSBuild target.
     </ItemGroup>
   </Target>
 
-  <Target Name="_ResolveAssemblies">
+  <Target Name="_ResolveAssemblies" DependsOnTargets="_AndroidConfigureHotReloadEnvironment">
     <ItemGroup>
       <_RIDs Include="$(RuntimeIdentifier)"  Condition=" '$(RuntimeIdentifiers)' == '' " />
       <_RIDs Include="$(RuntimeIdentifiers)" Condition=" '$(RuntimeIdentifiers)' != '' " />
@@ -119,6 +119,7 @@ _ResolveAssemblies MSBuild target.
     </ProcessRuntimePackLibraryDirectories>
 
     <ItemGroup>
+      <ResolvedFileToPublish Include="$(_AndroidHotReloadAgentAssemblyPath)" Condition="Exists('$(_AndroidHotReloadAgentAssemblyPath)')" RuntimeIdentifier="%(_RIDs.Identity)" />
       <ResolvedFileToPublish Remove="@(_NativeLibraryToRemove)" />
     </ItemGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -99,6 +99,7 @@ properties that determine build ordering.
       SignAndroidPackage;
       _DeployApk;
       _DeployAppBundle;
+      _AndroidConfigureAdbReverse;
     </InstallDependsOnTargets>
     <UninstallDependsOnTargets>
       AndroidPrepareForBuild;
@@ -127,12 +128,16 @@ properties that determine build ordering.
     <!-- This should function similar to SignAndroidPackage inside VS plus also deploy -->
     <DeployToDeviceDependsOnTargets Condition=" '$(_AndroidFastDeploymentSupported)' == 'true' ">
       $(_MinimalSignAndroidPackageDependsOn);
+      _GenerateEnvironmentFiles;
       _Upload;
+      _AndroidConfigureAdbReverse;
     </DeployToDeviceDependsOnTargets>
     <DeployToDeviceDependsOnTargets Condition=" '$(_AndroidFastDeploymentSupported)' != 'true' ">
       $(_MinimalSignAndroidPackageDependsOn);
+      _GenerateEnvironmentFiles;
       _DeployApk;
       _DeployAppBundle;
+      _AndroidConfigureAdbReverse;
     </DeployToDeviceDependsOnTargets>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
@@ -1,0 +1,84 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.HotReload.targets
+
+This file contains targets for Hot Reload support in .NET for Android.
+These targets are invoked by dotnet-watch when Hot Reload starts.
+
+dotnet-watch passes environment variables via @(RuntimeEnvironmentVariable) items:
+- DOTNET_STARTUP_HOOKS: Path to Microsoft.Extensions.DotNetDeltaApplier.dll
+- DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT: WebSocket endpoint URL for hot reload communication
+
+The environment variables are written to the app by the _GenerateEnvironmentFiles target
+in Xamarin.Android.Common.targets, which includes @(RuntimeEnvironmentVariable) items.
+
+See: https://github.com/dotnet/sdk/issues/52492
+See: https://github.com/dotnet/sdk/pull/52581
+
+***********************************************************************************************
+-->
+
+<Project>
+
+  <!--
+    _AndroidConfigureHotReloadEnvironment:
+    Configures Hot Reload when dotnet-watch passes environment variables via @(RuntimeEnvironmentVariable).
+    - Adds the Hot Reload agent DLL as a reference so it gets deployed
+    - Updates DOTNET_STARTUP_HOOKS to use just the assembly name (not the full path)
+    - Sets up STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM
+  -->
+  <Target Name="_AndroidConfigureHotReloadEnvironment"
+          Condition=" '@(RuntimeEnvironmentVariable)' != '' ">
+
+    <!-- Extract the startup hooks value from @(RuntimeEnvironmentVariable) -->
+    <PropertyGroup>
+      <_AndroidHotReloadAgentAssemblyPath>@(RuntimeEnvironmentVariable->WithMetadataValue('Identity', 'DOTNET_STARTUP_HOOKS')->'%(Value)'->Exists())</_AndroidHotReloadAgentAssemblyPath>
+    </PropertyGroup>
+
+    <!-- Extract just the assembly name for STARTUP_HOOKS config -->
+    <PropertyGroup Condition=" '$(_AndroidHotReloadAgentAssemblyPath)' != '' ">
+      <_AndroidHotReloadAgentAssemblyName>$([System.IO.Path]::GetFileNameWithoutExtension('$(_AndroidHotReloadAgentAssemblyPath)'))</_AndroidHotReloadAgentAssemblyName>
+    </PropertyGroup>
+
+    <!--
+      Update DOTNET_STARTUP_HOOKS in @(RuntimeEnvironmentVariable) to use just the assembly name.
+      The full path doesn't work on Android since the DLL is deployed alongside the app.
+    -->
+    <ItemGroup Condition=" '$(_AndroidHotReloadAgentAssemblyName)' != '' ">
+      <RuntimeEnvironmentVariable Remove="DOTNET_STARTUP_HOOKS" />
+      <RuntimeEnvironmentVariable Include="DOTNET_STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" />
+      <!-- Set STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM (read by Mono runtime) -->
+      <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" Condition=" '$(UseMonoRuntime)' == 'true' " />
+    </ItemGroup>
+
+  </Target>
+
+  <!--
+    _AndroidConfigureAdbReverse:
+    Sets up adb reverse port forwarding when using WebSocket endpoint from @(RuntimeEnvironmentVariable).
+    Extracts the port from DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT and sets up reverse forwarding.
+    This allows the device/emulator to connect back to the host machine.
+  -->
+  <Target Name="_AndroidConfigureAdbReverse"
+          Condition=" '@(RuntimeEnvironmentVariable)' != '' "
+          DependsOnTargets="_AndroidAdbToolPath">
+
+    <!-- Extract the WebSocket endpoint URL and parse the port -->
+    <PropertyGroup>
+      <_AndroidWebSocketEndpoint>@(RuntimeEnvironmentVariable->WithMetadataValue('Identity', 'DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT')->'%(Value)')</_AndroidWebSocketEndpoint>
+    </PropertyGroup>
+
+    <!-- Parse port from WebSocket URL (e.g., ws://localhost:9000 or http://localhost:9000) -->
+    <PropertyGroup Condition=" '$(_AndroidWebSocketEndpoint)' != '' ">
+      <_AndroidWebSocketPort>$([System.UriBuilder]::new('$(_AndroidWebSocketEndpoint)').Port)</_AndroidWebSocketPort>
+      <!-- UriBuilder.Port returns -1 when no port is specified -->
+      <_AndroidWebSocketPort Condition=" '$(_AndroidWebSocketPort)' == '-1' "></_AndroidWebSocketPort>
+    </PropertyGroup>
+
+    <Exec Condition=" '$(_AndroidWebSocketPort)' != '' "
+          Command="&quot;$(_AdbToolPath)&quot; reverse tcp:$(_AndroidWebSocketPort) tcp:$(_AndroidWebSocketPort)" />
+
+  </Target>
+
+</Project>
+

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ProjectCapabilities.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.ProjectCapabilities.targets
@@ -17,6 +17,7 @@ Docs about @(ProjectCapability):
     <ProjectCapability Include="Mobile" />
     <ProjectCapability Include="Android" />
     <ProjectCapability Include="AndroidApplication" Condition="$(AndroidApplication)" />
+    <ProjectCapability Include="HotReloadWebSockets" Condition="$(AndroidApplication)" />
     <ProjectCapability Include="RuntimeEnvironmentVariableSupport" Condition="$(AndroidApplication)" />
     <ProjectCapability Condition="'$(_KeepLaunchProfiles)' != 'true'" Remove="LaunchProfiles" />
   </ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -31,7 +31,7 @@ namespace Xamarin.ProjectTools
 		/// </summary>
 		/// <param name="args">command arguments</param>
 		/// <returns>A started Process instance. Caller is responsible for disposing.</returns>
-		protected Process ExecuteProcess (params string [] args)
+		protected Process ExecuteProcess (string [] args, string workingDirectory = null)
 		{
 			var p = new Process ();
 			p.StartInfo.FileName = Path.Combine (TestEnvironment.DotNetPreviewDirectory, "dotnet");
@@ -40,6 +40,9 @@ namespace Xamarin.ProjectTools
 			p.StartInfo.UseShellExecute = false;
 			p.StartInfo.RedirectStandardOutput = true;
 			p.StartInfo.RedirectStandardError = true;
+			if (!string.IsNullOrEmpty (workingDirectory)) {
+				p.StartInfo.WorkingDirectory = workingDirectory;
+			}
 			p.StartInfo.SetEnvironmentVariable ("DOTNET_MULTILEVEL_LOOKUP", "0");
 			p.StartInfo.SetEnvironmentVariable ("PATH", TestEnvironment.DotNetPreviewDirectory + Path.PathSeparator + Environment.GetEnvironmentVariable ("PATH"));
 			if (TestEnvironment.UseLocalBuildOutput) {
@@ -191,7 +194,7 @@ namespace Xamarin.ProjectTools
 				arguments.AddRange (parameters);
 			}
 
-			return ExecuteProcess (arguments.ToArray ());
+			return ExecuteProcess (arguments.ToArray (), workingDirectory: ProjectDirectory);
 		}
 
 		public IEnumerable<string> LastBuildOutput {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -172,6 +172,27 @@ namespace Xamarin.ProjectTools
 			return ExecuteProcess (arguments.ToArray ());
 		}
 
+		/// <summary>
+		/// Starts `dotnet watch` and returns a running Process that can be monitored and killed.
+		/// This is used for hot reload testing where dotnet-watch builds, deploys, and watches for file changes.
+		/// </summary>
+		/// <param name="parameters">Additional arguments to pass to `dotnet watch`.</param>
+		/// <returns>A running Process instance. Caller is responsible for disposing.</returns>
+		public Process StartWatch (string [] parameters = null)
+		{
+			var arguments = new List<string> {
+				"watch",
+				"--project", $"\"{projectOrSolution}\"",
+				"--non-interactive",
+				"--verbose",
+			};
+			if (parameters != null) {
+				arguments.AddRange (parameters);
+			}
+
+			return ExecuteProcess (arguments.ToArray ());
+		}
+
 		public IEnumerable<string> LastBuildOutput {
 			get {
 				if (!string.IsNullOrEmpty (BuildLogFile) && File.Exists (BuildLogFile)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -184,7 +184,7 @@ namespace Xamarin.ProjectTools
 				"watch",
 				"--project", $"\"{projectOrSolution}\"",
 				"--non-interactive",
-				"--verbose",
+				"--verbosity", "diag",
 			};
 			if (parameters != null) {
 				arguments.AddRange (parameters);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -184,6 +184,7 @@ namespace Xamarin.ProjectTools
 				"watch",
 				"--project", $"\"{projectOrSolution}\"",
 				"--non-interactive",
+				"--verbose",
 				"--verbosity", "diag",
 			};
 			if (parameters != null) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DotNetCLI.cs
@@ -189,6 +189,7 @@ namespace Xamarin.ProjectTools
 				"--non-interactive",
 				"--verbose",
 				"--verbosity", "diag",
+				"-bl",
 			};
 			if (parameters != null) {
 				arguments.AddRange (parameters);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/ProjectBuilder.cs
@@ -74,8 +74,13 @@ namespace Xamarin.ProjectTools
 					Cleanup ();
 		}
 
-		bool built_before;
 		bool last_build_result;
+
+		/// <summary>
+		/// Indicates whether the project has been built at least once.
+		/// Set to true after Build(), or manually when using external build tools (e.g. DotNetCLI.StartWatch).
+		/// </summary>
+		public bool BuiltBefore { get; set; }
 
 		/// <summary>
 		/// Gets the build output from the last build operation.
@@ -97,7 +102,7 @@ namespace Xamarin.ProjectTools
 		{
 			var files = project.Save (saveProject);
 
-			if (!built_before) {
+			if (!BuiltBefore) {
 				if (project.ShouldPopulate) {
 					if (Directory.Exists (ProjectDirectory)) {
 						FileSystemUtils.SetDirectoryWriteable (ProjectDirectory);
@@ -130,7 +135,7 @@ namespace Xamarin.ProjectTools
 			Output = project.CreateBuildOutput (this);
 
 			bool result = BuildInternal (Path.Combine (ProjectDirectory, project.ProjectFilePath), Target, parameters, environmentVariables, restore: project.ShouldRestorePackageReferences, binlogName: Path.GetFileNameWithoutExtension (BuildLogFile));
-			built_before = true;
+			BuiltBefore = true;
 
 			if (CleanupAfterSuccessfulBuild)
 				Cleanup ();
@@ -194,7 +199,7 @@ namespace Xamarin.ProjectTools
 			//logs
 			if (!last_build_result)
 				return;
-			built_before = false;
+			BuiltBefore = false;
 
 			var projectDirectory = Path.Combine (XABuildPaths.TestOutputDirectory, ProjectDirectory);
 			if (Directory.Exists (projectDirectory)) {

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1773,7 +1773,7 @@ because xbuild doesn't support framework reference assemblies.
   </PrepareAbiItems>
 </Target>
 
-<Target Name="_GenerateEnvironmentFiles">
+<Target Name="_GenerateEnvironmentFiles" DependsOnTargets="_AndroidConfigureHotReloadEnvironment">
   <ItemGroup>
     <_GeneratedAndroidEnvironment Include="mono.enable_assembly_preload=0" Condition=" '$(AndroidEnablePreloadAssemblies)' != 'True' " />
     <_GeneratedAndroidEnvironment Include="DOTNET_MODIFIABLE_ASSEMBLIES=Debug" Condition=" '$(AndroidIncludeDebugSymbols)' == 'true' and '$(AndroidUseInterpreter)' == 'true' " />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -199,6 +199,118 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void DotNetWatchHotReload ()
+		{
+			const string initialMessage = "DOTNET_WATCH_INITIAL_12345";
+			const string hotReloadMessage = "DOTNET_WATCH_HOT_RELOAD_APPLIED";
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetProperty ("AndroidUseInterpreter", "true");
+
+			// Add a Console.WriteLine that will appear in logcat
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				$"Console.WriteLine (\"{initialMessage}\");");
+
+			// Add a MetadataUpdateHandler that logs when hot reload is applied
+			proj.Sources.Add (new BuildItem.Source ("HotReloadService.cs") {
+				TextContent = () =>
+@"using System;
+
+[assembly: System.Reflection.Metadata.MetadataUpdateHandlerAttribute (typeof (UnderTest.HotReloadService))]
+
+namespace UnderTest
+{
+	public static class HotReloadService
+	{
+		internal static void ClearCache (Type[]? types) { }
+		internal static void UpdateApplication (Type[]? types)
+		{
+			Console.WriteLine (""" + hotReloadMessage + @""");
+		}
+	}
+}
+"
+			});
+
+			using var builder = CreateApkBuilder ();
+			builder.Save (proj);
+
+			var dotnet = new DotNetCLI (Path.Combine (Root, builder.ProjectDirectory, proj.ProjectFilePath));
+
+			// Start dotnet watch which will build, deploy, and watch for changes
+			using var process = dotnet.StartWatch ();
+
+			var locker = new Lock ();
+			var output = new StringBuilder ();
+			var initialMessageEvent = new ManualResetEventSlim ();
+			var hotReloadAppliedEvent = new ManualResetEventSlim ();
+			bool foundInitialMessage = false;
+			bool foundHotReloadMessage = false;
+
+			process.OutputDataReceived += (sender, e) => {
+				if (e.Data != null) {
+					lock (locker) {
+						output.AppendLine (e.Data);
+						if (e.Data.Contains (initialMessage)) {
+							foundInitialMessage = true;
+							initialMessageEvent.Set ();
+						}
+						if (e.Data.Contains (hotReloadMessage)) {
+							foundHotReloadMessage = true;
+							hotReloadAppliedEvent.Set ();
+						}
+					}
+				}
+			};
+			process.ErrorDataReceived += (sender, e) => {
+				if (e.Data != null) {
+					lock (locker) {
+						output.AppendLine ($"STDERR: {e.Data}");
+						// dotnet watch status messages (e.g., "changes applied") go to stderr
+						if (e.Data.Contains (hotReloadMessage)) {
+							foundHotReloadMessage = true;
+							hotReloadAppliedEvent.Set ();
+						}
+					}
+				}
+			};
+
+			process.BeginOutputReadLine ();
+			process.BeginErrorReadLine ();
+
+			string logPath = Path.Combine (Root, builder.ProjectDirectory, "dotnet-watch-output.log");
+
+			try {
+				// Wait for the initial message to appear (app launched and running)
+				Assert.IsTrue (initialMessageEvent.Wait (TimeSpan.FromMinutes (5)),
+					$"Initial message '{initialMessage}' was not found in output. See {logPath} for details.");
+
+				// Modify the source file to trigger hot reload
+				string mainActivityPath = Path.Combine (Root, builder.ProjectDirectory, "MainActivity.cs");
+				string content = File.ReadAllText (mainActivityPath);
+				content = content.Replace (
+					$"Console.WriteLine (\"{initialMessage}\");",
+					$"Console.WriteLine (\"{initialMessage}\");\n\t\t\tConsole.WriteLine (\"MODIFIED_LINE\");");
+				File.WriteAllText (mainActivityPath, content);
+
+				// Wait for hot reload to apply (MetadataUpdateHandler fires Console.WriteLine)
+				Assert.IsTrue (hotReloadAppliedEvent.Wait (TimeSpan.FromMinutes (2)),
+					$"Hot reload message '{hotReloadMessage}' was not found in output. See {logPath} for details.");
+			} finally {
+				// Kill the process
+				if (!process.HasExited) {
+					process.Kill (entireProcessTree: true);
+					process.WaitForExit ();
+				}
+
+				// Write the output to a log file for debugging
+				File.WriteAllText (logPath, output.ToString ());
+				TestContext.AddTestAttachment (logPath);
+			}
+		}
+
+		[Test]
 		[TestCase (true)]
 		[TestCase (false)]
 		public void DeployToDevice (bool isRelease)

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Android.Build.Tests
 			const string hotReloadMessage = "DOTNET_WATCH_HOT_RELOAD_APPLIED";
 
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("AndroidUseInterpreter", "true");
+			proj.SetRuntime (AndroidRuntime.CoreCLR); // CoreCLR only for now, as MonoVM requires: https://github.com/dotnet/runtime/commit/c8e2a6110c69601540c25f2099053505fa088b9e
 
 			// Enable hot reload log messages from the delta client
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidEnvironment", "env.txt") {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -212,30 +212,16 @@ namespace Xamarin.Android.Build.Tests
 				TextContent = () => "HOTRELOAD_DELTA_CLIENT_LOG_MESSAGES=[HotReload]",
 			});
 
-			// Add a Console.WriteLine that will appear in logcat
+			// Call a helper method from OnCreate that will appear in logcat
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
 				"//${AFTER_ONCREATE}",
-				$"Console.WriteLine (\"{initialMessage}\");");
+				"UnderTest.AppHelper.PrintMessage ();");
 
-			// Add a MetadataUpdateHandler that logs when hot reload is applied
-			proj.Sources.Add (new BuildItem.Source ("HotReloadService.cs") {
-				TextContent = () =>
-@"using System;
-
-[assembly: System.Reflection.Metadata.MetadataUpdateHandlerAttribute (typeof (UnderTest.HotReloadService))]
-
-namespace UnderTest
-{
-	public static class HotReloadService
-	{
-		internal static void ClearCache (Type[]? types) { }
-		internal static void UpdateApplication (Type[]? types)
-		{
-			Console.WriteLine (""" + hotReloadMessage + @""");
-		}
-	}
-}
-"
+			// Add a vanilla C# helper class (no Java interop) that we'll hot-reload,
+			// and a MetadataUpdateHandler that logs when hot reload is applied.
+			string appHelperBody = $"""Console.WriteLine ("{initialMessage}");""";
+			proj.Sources.Add (new BuildItem.Source ("AppHelper.cs") {
+				TextContent = () => GetAppHelperSource (appHelperBody, hotReloadMessage),
 			});
 
 			using var builder = CreateApkBuilder ();
@@ -289,11 +275,12 @@ namespace UnderTest
 				// There is no explicit "ready" signal from dotnet watch after deploy completes.
 				Thread.Sleep (5000);
 
-				// Modify the source file to trigger hot reload
-				proj.MainActivity = proj.MainActivity.Replace (
-					$"Console.WriteLine (\"{initialMessage}\");",
-					$"Console.WriteLine (\"{initialMessage}\");\n\t\t\tConsole.WriteLine (\"MODIFIED_LINE\");");
-				proj.Touch ("MainActivity.cs");
+				// Modify the vanilla C# helper class (not the Java-interop MainActivity)
+				appHelperBody = $"""
+					Console.WriteLine ("{initialMessage}");
+					Console.WriteLine ("MODIFIED_LINE");
+					""";
+				proj.Touch ("AppHelper.cs");
 				builder.BuiltBefore = true; // dotnet watch will build, not builder.Build()
 				builder.Save (proj, doNotCleanupOnUpdate: true, saveProject: false);
 
@@ -1760,5 +1747,31 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), 30);
 			Assert.IsTrue (didLaunch, "Activity should have started.");
 		}
+
+		static string GetAppHelperSource (string appHelperBody, string hotReloadMessage) => $$"""
+			using System;
+
+			[assembly: System.Reflection.Metadata.MetadataUpdateHandlerAttribute (typeof (UnderTest.HotReloadService))]
+
+			namespace UnderTest
+			{
+				public static class AppHelper
+				{
+					public static void PrintMessage ()
+					{
+						{{appHelperBody}}
+					}
+				}
+
+				public static class HotReloadService
+				{
+					internal static void ClearCache (Type[]? types) { }
+					internal static void UpdateApplication (Type[]? types)
+					{
+						Console.WriteLine ("{{hotReloadMessage}}");
+					}
+				}
+			}
+			""";
 	}
 }

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -207,6 +207,11 @@ namespace Xamarin.Android.Build.Tests
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("AndroidUseInterpreter", "true");
 
+			// Enable hot reload log messages from the delta client
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidEnvironment", "env.txt") {
+				TextContent = () => "HOTRELOAD_DELTA_CLIENT_LOG_MESSAGES=[HotReload]",
+			});
+
 			// Add a Console.WriteLine that will appear in logcat
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
 				"//${AFTER_ONCREATE}",
@@ -245,19 +250,15 @@ namespace UnderTest
 			var output = new StringBuilder ();
 			var initialMessageEvent = new ManualResetEventSlim ();
 			var hotReloadAppliedEvent = new ManualResetEventSlim ();
-			bool foundInitialMessage = false;
-			bool foundHotReloadMessage = false;
 
 			process.OutputDataReceived += (sender, e) => {
 				if (e.Data != null) {
 					lock (locker) {
 						output.AppendLine (e.Data);
 						if (e.Data.Contains (initialMessage)) {
-							foundInitialMessage = true;
 							initialMessageEvent.Set ();
 						}
 						if (e.Data.Contains (hotReloadMessage)) {
-							foundHotReloadMessage = true;
 							hotReloadAppliedEvent.Set ();
 						}
 					}
@@ -269,7 +270,6 @@ namespace UnderTest
 						output.AppendLine ($"STDERR: {e.Data}");
 						// dotnet watch status messages (e.g., "changes applied") go to stderr
 						if (e.Data.Contains (hotReloadMessage)) {
-							foundHotReloadMessage = true;
 							hotReloadAppliedEvent.Set ();
 						}
 					}

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -268,7 +268,6 @@ namespace UnderTest
 				if (e.Data != null) {
 					lock (locker) {
 						output.AppendLine ($"STDERR: {e.Data}");
-						// dotnet watch status messages (e.g., "changes applied") go to stderr
 						if (e.Data.Contains (hotReloadMessage)) {
 							hotReloadAppliedEvent.Set ();
 						}
@@ -285,6 +284,10 @@ namespace UnderTest
 				// Wait for the initial message to appear (app launched and running)
 				Assert.IsTrue (initialMessageEvent.Wait (TimeSpan.FromMinutes (5)),
 					$"Initial message '{initialMessage}' was not found in output. See {logPath} for details.");
+
+				// Give dotnet watch time to finish post-deploy setup and start its file watcher.
+				// There is no explicit "ready" signal from dotnet watch after deploy completes.
+				Thread.Sleep (5000);
 
 				// Modify the source file to trigger hot reload
 				proj.MainActivity = proj.MainActivity.Replace (

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -287,12 +287,11 @@ namespace UnderTest
 					$"Initial message '{initialMessage}' was not found in output. See {logPath} for details.");
 
 				// Modify the source file to trigger hot reload
-				string mainActivityPath = Path.Combine (Root, builder.ProjectDirectory, "MainActivity.cs");
-				string content = File.ReadAllText (mainActivityPath);
-				content = content.Replace (
+				proj.MainActivity = proj.MainActivity.Replace (
 					$"Console.WriteLine (\"{initialMessage}\");",
 					$"Console.WriteLine (\"{initialMessage}\");\n\t\t\tConsole.WriteLine (\"MODIFIED_LINE\");");
-				File.WriteAllText (mainActivityPath, content);
+				proj.Touch ("MainActivity.cs");
+				builder.Save (proj, doNotCleanupOnUpdate: true, saveProject: false);
 
 				// Wait for hot reload to apply (MetadataUpdateHandler fires Console.WriteLine)
 				Assert.IsTrue (hotReloadAppliedEvent.Wait (TimeSpan.FromMinutes (2)),

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -294,6 +294,7 @@ namespace UnderTest
 					$"Console.WriteLine (\"{initialMessage}\");",
 					$"Console.WriteLine (\"{initialMessage}\");\n\t\t\tConsole.WriteLine (\"MODIFIED_LINE\");");
 				proj.Touch ("MainActivity.cs");
+				builder.BuiltBefore = true; // dotnet watch will build, not builder.Build()
 				builder.Save (proj, doNotCleanupOnUpdate: true, saveProject: false);
 
 				// Wait for hot reload to apply (MetadataUpdateHandler fires Console.WriteLine)


### PR DESCRIPTION
Context: https://github.com/dotnet/sdk/issues/52492
Context: https://github.com/dotnet/sdk/pull/52581

`dotnet-watch` now runs Android applications via:

    dotnet watch 🚀 [helloandroid (net10.0-android)] Launched 'D:\src\xamarin-android\bin\Debug\dotnet\dotnet.exe' with arguments 'run --no-build -e DOTNET_WATCH=1 -e DOTNET_WATCH_ITERATION=1 -e DOTNET_MODIFIABLE_ASSEMBLIES=debug -e DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT=ws://localhost:9000 -e DOTNET_STARTUP_HOOKS=D:\src\xamarin-android\bin\Debug\dotnet\sdk\10.0.300-dev\DotnetTools\dotnet-watch\10.0.300-dev\tools\net10.0\any\hotreload\net10.0\Microsoft.Extensions.DotNetDeltaApplier.dll -bl': process id 3356

And so the pieces on Android for this to work are:

## Startup Hook Assembly ##

Parse out the value:

    <_AndroidHotReloadAgentAssemblyPath>@(RuntimeEnvironmentVariable->WithMetadataValue('Identity', 'DOTNET_STARTUP_HOOKS')->'%(Value)'->Exists())</_AndroidHotReloadAgentAssemblyPath>

And verify this assembly is included in the app:

    <ResolvedFileToPublish Include="$(_AndroidHotReloadAgentAssemblyPath)" />

Then, for Android, we need to patch up `$DOTNET_STARTUP_HOOKS` to be just the assembly name, not the full path:

    <_AndroidHotReloadAgentAssemblyName>$([System.IO.Path]::GetFileNameWithoutExtension('$(_AndroidHotReloadAgentAssemblyPath)'))</_AndroidHotReloadAgentAssemblyName>
    ...
    <RuntimeEnvironmentVariable Include="DOTNET_STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" />

## Port Forwarding ##

A new `_AndroidConfigureAdbReverse` target runs after deploying apps, that does:

    adb reverse tcp:9000 tcp:9000

I parsed the value out of:

    <_AndroidWebSocketEndpoint>@(RuntimeEnvironmentVariable->WithMetadataValue('Identity', 'DOTNET_WATCH_HOTRELOAD_WEBSOCKET_ENDPOINT')->'%(Value)')</_AndroidWebSocketEndpoint>
    <_AndroidWebSocketPort>$([System.Text.RegularExpressions.Regex]::Match('$(_AndroidWebSocketEndpoint)', ':(\d+)').Groups[1].Value)</_AndroidWebSocketPort>

## Prevent Startup Hooks in Microsoft.Android.Run ##

When I was implementing this, I keep seeing *two* clients connect to `dotnet-watch` and I was pulling my hair to figure out why!

Then I realized that `Microsoft.Android.Run` was also getting `$DOTNET_STARTUP_HOOKS`, and so we had a desktop process + mobile process both trying to connect!

Easiest fix, is to disable startup hook support in `Microsoft.Android.Run`. I reviewed the code in `dotnet run`, and it doesn't seem correct to try to clear the env vars.

## Conclusion ##

With these changes, everything is working!

    dotnet watch 🔥 C# and Razor changes applied in 23ms.

This will depend on getting changes in dotnet/sdk before we merge.