### PR TITLE
[TrimmableTypeMap][Core B] Foundation and AssemblyIndex

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/NullableExtensions.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/NullableExtensions.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+static class NullableExtensions
+{
+	// The static methods in System.String are not NRT annotated in netstandard2.0,
+	// so we need to add our own extension methods to make them nullable aware.
+	public static bool IsNullOrEmpty ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrEmpty (str);
+	}
+
+	public static bool IsNullOrWhiteSpace ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrWhiteSpace (str);
+	}
+}


### PR DESCRIPTION
Sliced from #10805
Depends on #10816

## Scope
- Foundation pieces required by scanner (`project`, model/providers)
- `AssemblyIndex` metadata indexing and lookup logic

## Notes
- This keeps scanner indexing concerns isolated from scanner execution flow.
