### PR TITLE
[TrimmableTypeMap] Add UCO wrappers, RegisterNatives, and IAndroidCallableWrapper

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -1,58 +1,123 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection.Metadata;
+using System.Reflection.Metadata.Ecma335;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// JNI primitive type kinds used for mapping JNI signatures → CLR types.
+/// </summary>
+enum JniParamKind
+{
+Void,     // V
+Boolean,  // Z → sbyte
+Byte,     // B → sbyte
+Char,     // C → char
+Short,    // S → short
+Int,      // I → int
+Long,     // J → long
+Float,    // F → float
+Double,   // D → double
+Object,   // L...; or [ → IntPtr
+}
 
 /// <summary>
 /// Helpers for parsing JNI method signatures.
 /// </summary>
 static class JniSignatureHelper
 {
-	/// <summary>
-	/// Parses the JNI parameter type descriptors from a JNI method signature
-	/// and returns them as <see cref="JniParameterInfo"/> records.
-	/// </summary>
-	public static List<JniParameterInfo> ParseParameterTypes (string jniSignature)
-	{
-		var result = new List<JniParameterInfo> ();
-		int i = 1; // skip opening '('
-		while (i < jniSignature.Length && jniSignature [i] != ')') {
-			int start = i;
-			SkipSingleType (jniSignature, ref i);
-			result.Add (new JniParameterInfo { JniType = jniSignature.Substring (start, i - start) });
-		}
-		return result;
-	}
+/// <summary>
+/// Parses the JNI parameter type descriptors from a JNI method signature
+/// and returns them as <see cref="JniParameterInfo"/> records.
+/// </summary>
+public static List<JniParameterInfo> ParseParameterTypes (string jniSignature)
+{
+var result = new List<JniParameterInfo> ();
+int i = 1; // skip opening '('
+while (i < jniSignature.Length && jniSignature [i] != ')') {
+int start = i;
+ParseSingleType (jniSignature, ref i);
+result.Add (new JniParameterInfo { JniType = jniSignature.Substring (start, i - start) });
+}
+return result;
+}
 
-	/// <summary>
-	/// Extracts the return type descriptor from a JNI method signature.
-	/// </summary>
-	public static string ParseReturnTypeString (string jniSignature)
-	{
-		int i = jniSignature.IndexOf (')') + 1;
-		return jniSignature.Substring (i);
-	}
+/// <summary>
+/// Parses the parameter types from a JNI method signature as <see cref="JniParamKind"/> values.
+/// </summary>
+public static List<JniParamKind> ParseParameterKinds (string jniSignature)
+{
+var result = new List<JniParamKind> ();
+int i = 1; // skip opening '('
+while (i < jniSignature.Length && jniSignature [i] != ')') {
+result.Add (ParseSingleType (jniSignature, ref i));
+}
+return result;
+}
 
-	static void SkipSingleType (string sig, ref int i)
-	{
-		switch (sig [i]) {
-		case 'V': case 'Z': case 'B': case 'C': case 'S':
-		case 'I': case 'J': case 'F': case 'D':
-			i++;
-			break;
-		case 'L':
-			int end = sig.IndexOf (';', i);
-			if (end < 0) {
-				throw new ArgumentException ($"Malformed JNI signature: missing ';' after 'L' at index {i} in '{sig}'");
-			}
-			i = end + 1;
-			break;
-		case '[':
-			i++;
-			SkipSingleType (sig, ref i);
-			break;
-		default:
-			throw new ArgumentException ($"Unknown JNI type character '{sig [i]}' in '{sig}' at index {i}");
-		}
-	}
+/// <summary>
+/// Extracts the return type descriptor from a JNI method signature.
+/// </summary>
+public static string ParseReturnTypeString (string jniSignature)
+{
+int i = jniSignature.IndexOf (')') + 1;
+return jniSignature.Substring (i);
+}
+
+/// <summary>
+/// Parses the return type from a JNI method signature.
+/// </summary>
+public static JniParamKind ParseReturnKind (string jniSignature)
+{
+int i = jniSignature.IndexOf (')') + 1;
+return ParseSingleType (jniSignature, ref i);
+}
+
+static JniParamKind ParseSingleType (string sig, ref int i)
+{
+switch (sig [i]) {
+case 'V': i++; return JniParamKind.Void;
+case 'Z': i++; return JniParamKind.Boolean;
+case 'B': i++; return JniParamKind.Byte;
+case 'C': i++; return JniParamKind.Char;
+case 'S': i++; return JniParamKind.Short;
+case 'I': i++; return JniParamKind.Int;
+case 'J': i++; return JniParamKind.Long;
+case 'F': i++; return JniParamKind.Float;
+case 'D': i++; return JniParamKind.Double;
+case 'L':
+int end = sig.IndexOf (';', i);
+if (end < 0) {
+throw new ArgumentException ($"Malformed JNI signature: missing ';' after 'L' at index {i} in '{sig}'");
+}
+i = end + 1;
+return JniParamKind.Object;
+case '[':
+i++;
+ParseSingleType (sig, ref i); // skip element type
+return JniParamKind.Object;
+default:
+throw new ArgumentException ($"Unknown JNI type character '{sig [i]}' in '{sig}' at index {i}");
+}
+}
+
+/// <summary>
+/// Encodes the CLR type for a JNI parameter kind into a signature type encoder.
+/// </summary>
+public static void EncodeClrType (SignatureTypeEncoder encoder, JniParamKind kind)
+{
+switch (kind) {
+case JniParamKind.Boolean: encoder.Boolean (); break;
+case JniParamKind.Byte:    encoder.SByte (); break;
+case JniParamKind.Char:    encoder.Char (); break;
+case JniParamKind.Short:   encoder.Int16 (); break;
+case JniParamKind.Int:     encoder.Int32 (); break;
+case JniParamKind.Long:    encoder.Int64 (); break;
+case JniParamKind.Float:   encoder.Single (); break;
+case JniParamKind.Double:  encoder.Double (); break;
+case JniParamKind.Object:  encoder.IntPtr (); break;
+default: throw new ArgumentException ($"Cannot encode JNI param kind {kind} as CLR type");
+}
+}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// Helpers for parsing JNI method signatures.
+/// </summary>
+static class JniSignatureHelper
+{
+	/// <summary>
+	/// Parses the JNI parameter type descriptors from a JNI method signature
+	/// and returns them as <see cref="JniParameterInfo"/> records.
+	/// </summary>
+	public static List<JniParameterInfo> ParseParameterTypes (string jniSignature)
+	{
+		var result = new List<JniParameterInfo> ();
+		int i = 1; // skip opening '('
+		while (i < jniSignature.Length && jniSignature [i] != ')') {
+			int start = i;
+			SkipSingleType (jniSignature, ref i);
+			result.Add (new JniParameterInfo { JniType = jniSignature.Substring (start, i - start) });
+		}
+		return result;
+	}
+
+	/// <summary>
+	/// Extracts the return type descriptor from a JNI method signature.
+	/// </summary>
+	public static string ParseReturnTypeString (string jniSignature)
+	{
+		int i = jniSignature.IndexOf (')') + 1;
+		return jniSignature.Substring (i);
+	}
+
+	static void SkipSingleType (string sig, ref int i)
+	{
+		switch (sig [i]) {
+		case 'V': case 'Z': case 'B': case 'C': case 'S':
+		case 'I': case 'J': case 'F': case 'D':
+			i++;
+			break;
+		case 'L':
+			int end = sig.IndexOf (';', i);
+			if (end < 0) {
+				throw new ArgumentException ($"Malformed JNI signature: missing ';' after 'L' at index {i} in '{sig}'");
+			}
+			i = end + 1;
+			break;
+		case '[':
+			i++;
+			SkipSingleType (sig, ref i);
+			break;
+		default:
+			throw new ArgumentException ($"Unknown JNI type character '{sig [i]}' in '{sig}' at index {i}");
+		}
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -136,16 +136,32 @@ sealed class JavaPeerProxyData
 	/// </summary>
 	public bool IsGenericDefinition { get; init; }
 
-	/// <summary>Whether this proxy needs ACW support (RegisterNatives + UCO wrappers + IAndroidCallableWrapper).</summary>
+	/// <summary>
+
+	/// Whether this proxy needs ACW support (RegisterNatives + UCO wrappers + IAndroidCallableWrapper).
+
+	/// </summary>
 	public bool IsAcw { get; init; }
 
-	/// <summary>UCO method wrappers for marshal methods (non-constructor).</summary>
+	/// <summary>
+
+	/// UCO method wrappers for marshal methods (non-constructor).
+
+	/// </summary>
 	public List<UcoMethodData> UcoMethods { get; } = new ();
 
-	/// <summary>UCO constructor wrappers.</summary>
+	/// <summary>
+
+	/// UCO constructor wrappers.
+
+	/// </summary>
 	public List<UcoConstructorData> UcoConstructors { get; } = new ();
 
-	/// <summary>RegisterNatives registrations (method name, JNI signature, wrapper name).</summary>
+	/// <summary>
+
+	/// RegisterNatives registrations (method name, JNI signature, wrapper name).
+
+	/// </summary>
 	public List<NativeRegistrationData> NativeRegistrations { get; } = new ();
 }
 
@@ -173,16 +189,30 @@ sealed record TypeRefData
 /// </summary>
 sealed record UcoMethodData
 {
-	/// <summary>Name of the generated wrapper method, e.g., "n_onCreate_uco_0".</summary>
+	/// <summary>
+	/// Name of the generated wrapper method, e.g., "n_onCreate_uco_0".
+	/// </summary>
 	public required string WrapperName { get; init; }
 
-	/// <summary>Name of the n_* callback to call, e.g., "n_OnCreate".</summary>
+	/// <summary>
+
+	/// Name of the n_* callback to call, e.g., "n_OnCreate".
+
+	/// </summary>
 	public required string CallbackMethodName { get; init; }
 
-	/// <summary>Type containing the callback method.</summary>
+	/// <summary>
+
+	/// Type containing the callback method.
+
+	/// </summary>
 	public required TypeRefData CallbackType { get; init; }
 
-	/// <summary>JNI method signature, e.g., "(Landroid/os/Bundle;)V". Used to determine CLR parameter types.</summary>
+	/// <summary>
+
+	/// JNI method signature, e.g., "(Landroid/os/Bundle;)V". Used to determine CLR parameter types.
+
+	/// </summary>
 	public required string JniSignature { get; init; }
 }
 
@@ -194,13 +224,23 @@ sealed record UcoMethodData
 /// </summary>
 sealed record UcoConstructorData
 {
-	/// <summary>Name of the generated wrapper, e.g., "nctor_0_uco".</summary>
+	/// <summary>
+	/// Name of the generated wrapper, e.g., "nctor_0_uco".
+	/// </summary>
 	public required string WrapperName { get; init; }
 
-	/// <summary>Target type to pass to ActivateInstance.</summary>
+	/// <summary>
+
+	/// Target type to pass to ActivateInstance.
+
+	/// </summary>
 	public required TypeRefData TargetType { get; init; }
 
-	/// <summary>JNI constructor signature, e.g., "(Landroid/content/Context;)V". Used for RegisterNatives registration.</summary>
+	/// <summary>
+
+	/// JNI constructor signature, e.g., "(Landroid/content/Context;)V". Used for RegisterNatives registration.
+
+	/// </summary>
 	public required string JniSignature { get; init; }
 }
 
@@ -209,13 +249,23 @@ sealed record UcoConstructorData
 /// </summary>
 sealed record NativeRegistrationData
 {
-	/// <summary>JNI method name to register, e.g., "n_onCreate" or "nctor_0".</summary>
+	/// <summary>
+	/// JNI method name to register, e.g., "n_onCreate" or "nctor_0".
+	/// </summary>
 	public required string JniMethodName { get; init; }
 
-	/// <summary>JNI method signature, e.g., "(Landroid/os/Bundle;)V".</summary>
+	/// <summary>
+
+	/// JNI method signature, e.g., "(Landroid/os/Bundle;)V".
+
+	/// </summary>
 	public required string JniSignature { get; init; }
 
-	/// <summary>Name of the UCO wrapper method whose function pointer to register.</summary>
+	/// <summary>
+
+	/// Name of the UCO wrapper method whose function pointer to register.
+
+	/// </summary>
 	public required string WrapperMethodName { get; init; }
 }
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -136,8 +136,18 @@ sealed class JavaPeerProxyData
 	/// </summary>
 	public bool IsGenericDefinition { get; init; }
 
-}
+	/// <summary>Whether this proxy needs ACW support (RegisterNatives + UCO wrappers + IAndroidCallableWrapper).</summary>
+	public bool IsAcw { get; init; }
 
+	/// <summary>UCO method wrappers for marshal methods (non-constructor).</summary>
+	public List<UcoMethodData> UcoMethods { get; } = new ();
+
+	/// <summary>UCO constructor wrappers.</summary>
+	public List<UcoConstructorData> UcoConstructors { get; } = new ();
+
+	/// <summary>RegisterNatives registrations (method name, JNI signature, wrapper name).</summary>
+	public List<NativeRegistrationData> NativeRegistrations { get; } = new ();
+}
 
 /// <summary>
 /// A cross-assembly type reference (assembly name + full managed type name).
@@ -155,6 +165,58 @@ sealed record TypeRefData
 
 	/// </summary>
 	public required string AssemblyName { get; init; }
+}
+
+/// <summary>
+/// An [UnmanagedCallersOnly] static wrapper for a marshal method.
+/// Body: load all args → call n_* callback → ret.
+/// </summary>
+sealed record UcoMethodData
+{
+	/// <summary>Name of the generated wrapper method, e.g., "n_onCreate_uco_0".</summary>
+	public required string WrapperName { get; init; }
+
+	/// <summary>Name of the n_* callback to call, e.g., "n_OnCreate".</summary>
+	public required string CallbackMethodName { get; init; }
+
+	/// <summary>Type containing the callback method.</summary>
+	public required TypeRefData CallbackType { get; init; }
+
+	/// <summary>JNI method signature, e.g., "(Landroid/os/Bundle;)V". Used to determine CLR parameter types.</summary>
+	public required string JniSignature { get; init; }
+}
+
+/// <summary>
+/// An [UnmanagedCallersOnly] static wrapper for a constructor callback.
+/// Signature must match the full JNI native method signature (jnienv + self + ctor params)
+/// so the ABI is correct when JNI dispatches the call.
+/// Body: TrimmableNativeRegistration.ActivateInstance(self, typeof(TargetType)).
+/// </summary>
+sealed record UcoConstructorData
+{
+	/// <summary>Name of the generated wrapper, e.g., "nctor_0_uco".</summary>
+	public required string WrapperName { get; init; }
+
+	/// <summary>Target type to pass to ActivateInstance.</summary>
+	public required TypeRefData TargetType { get; init; }
+
+	/// <summary>JNI constructor signature, e.g., "(Landroid/content/Context;)V". Used for RegisterNatives registration.</summary>
+	public required string JniSignature { get; init; }
+}
+
+/// <summary>
+/// One JNI native method registration in RegisterNatives.
+/// </summary>
+sealed record NativeRegistrationData
+{
+	/// <summary>JNI method name to register, e.g., "n_onCreate" or "nctor_0".</summary>
+	public required string JniMethodName { get; init; }
+
+	/// <summary>JNI method signature, e.g., "(Landroid/os/Bundle;)V".</summary>
+	public required string JniSignature { get; init; }
+
+	/// <summary>Name of the UCO wrapper method whose function pointer to register.</summary>
+	public required string WrapperMethodName { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// [assembly: TypeMap&lt;Java.Lang.Object&gt;("android/widget/TextView", typeof(TextView_Proxy), typeof(TextView))]          // trimmable (MCW)
 /// [assembly: TypeMapAssociation(typeof(MyTextView), typeof(Android_Widget_TextView_Proxy))]                              // alias
 ///
-/// // One proxy type per Java peer that needs activation:
-/// public sealed class Activity_Proxy : JavaPeerProxy
+/// // One proxy type per Java peer that needs activation or UCO wrappers:
+/// public sealed class Activity_Proxy : JavaPeerProxy, IAndroidCallableWrapper   // IAndroidCallableWrapper for ACWs only
 /// {
 ///     public Activity_Proxy() : base() { }
 ///
@@ -34,9 +34,25 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 ///
 ///     public override Type TargetType =&gt; typeof(Activity);
 ///     public Type InvokerType =&gt; typeof(IOnClickListenerInvoker);    // interfaces only
+///
+///     // UCO wrappers — [UnmanagedCallersOnly] entry points for JNI native methods (ACWs only):
+///     [UnmanagedCallersOnly]
+///     public static void n_OnCreate_uco_0(IntPtr jnienv, IntPtr self, IntPtr p0)
+///         =&gt; Activity.n_OnCreate(jnienv, self, p0);
+///
+///     [UnmanagedCallersOnly]
+///     public static void nctor_0_uco(IntPtr jnienv, IntPtr self)
+///         =&gt; TrimmableNativeRegistration.ActivateInstance(self, typeof(Activity));
+///
+///     // Registers JNI native methods (ACWs only):
+///     public void RegisterNatives(JniType jniType)
+///     {
+///         TrimmableNativeRegistration.RegisterMethod(jniType, "n_OnCreate", "(Landroid/os/Bundle;)V", &amp;n_OnCreate_uco_0);
+///         TrimmableNativeRegistration.RegisterMethod(jniType, "nctor_0", "()V", &amp;nctor_0_uco);
+///     }
 /// }
 ///
-/// // Emitted so the proxy assembly can access internal members in the target assembly:
+/// // Emitted so the proxy assembly can access internal n_* callbacks in the target assembly:
 /// [assembly: IgnoresAccessChecksTo("Mono.Android")]
 /// </code>
 /// </remarks>
@@ -51,8 +67,11 @@ sealed class TypeMapAssemblyEmitter
 	TypeReferenceHandle _javaPeerProxyRef;
 	TypeReferenceHandle _iJavaPeerableRef;
 	TypeReferenceHandle _jniHandleOwnershipRef;
+	TypeReferenceHandle _iAndroidCallableWrapperRef;
 	TypeReferenceHandle _systemTypeRef;
 	TypeReferenceHandle _runtimeTypeHandleRef;
+	TypeReferenceHandle _jniTypeRef;
+	TypeReferenceHandle _trimmableNativeRegistrationRef;
 	TypeReferenceHandle _notSupportedExceptionRef;
 	TypeReferenceHandle _runtimeHelpersRef;
 
@@ -60,6 +79,10 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _getTypeFromHandleRef;
 	MemberReferenceHandle _getUninitializedObjectRef;
 	MemberReferenceHandle _notSupportedExceptionCtorRef;
+	MemberReferenceHandle _activateInstanceRef;
+	MemberReferenceHandle _registerMethodRef;
+	MemberReferenceHandle _ucoAttrCtorRef;
+	BlobHandle _ucoAttrBlobHandle;
 	MemberReferenceHandle _typeMapAttrCtorRef2Arg;
 	MemberReferenceHandle _typeMapAttrCtorRef3Arg;
 	MemberReferenceHandle _typeMapAssociationAttrCtorRef;
@@ -96,8 +119,11 @@ sealed class TypeMapAssemblyEmitter
 		EmitTypeReferences ();
 		EmitMemberReferences ();
 
+		// Track wrapper method names → handles for RegisterNatives
+		var wrapperHandles = new Dictionary<string, MethodDefinitionHandle> ();
+
 		foreach (var proxy in model.ProxyTypes) {
-			EmitProxyType (proxy);
+			EmitProxyType (proxy, wrapperHandles);
 		}
 
 		foreach (var entry in model.Entries) {
@@ -121,10 +147,16 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerable"));
 		_jniHandleOwnershipRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
 			metadata.GetOrAddString ("Android.Runtime"), metadata.GetOrAddString ("JniHandleOwnership"));
+		_iAndroidCallableWrapperRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IAndroidCallableWrapper"));
 		_systemTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Type"));
 		_runtimeTypeHandleRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("RuntimeTypeHandle"));
+		_jniTypeRef = metadata.AddTypeReference (_javaInteropRef,
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JniType"));
+		_trimmableNativeRegistrationRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Android.Runtime"), metadata.GetOrAddString ("TrimmableNativeRegistration"));
 		_notSupportedExceptionRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("NotSupportedException"));
 		_runtimeHelpersRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
@@ -150,6 +182,33 @@ sealed class TypeMapAssemblyEmitter
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
 				rt => rt.Void (),
 				p => p.AddParameter ().Type ().String ()));
+
+		_activateInstanceRef = _pe.AddMemberRef (_trimmableNativeRegistrationRef, "ActivateInstance",
+			sig => sig.MethodSignature ().Parameters (2,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().IntPtr ();
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
+		_registerMethodRef = _pe.AddMemberRef (_trimmableNativeRegistrationRef, "RegisterMethod",
+			sig => sig.MethodSignature ().Parameters (4,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().Type (_jniTypeRef, false);
+					p.AddParameter ().Type ().String ();
+					p.AddParameter ().Type ().String ();
+					p.AddParameter ().Type ().IntPtr ();
+				}));
+
+		var ucoAttrTypeRef = _pe.Metadata.AddTypeReference (_pe.SystemRuntimeInteropServicesRef,
+			_pe.Metadata.GetOrAddString ("System.Runtime.InteropServices"),
+			_pe.Metadata.GetOrAddString ("UnmanagedCallersOnlyAttribute"));
+		_ucoAttrCtorRef = _pe.AddMemberRef (ucoAttrTypeRef, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }));
+
+		// Pre-compute the UCO attribute blob — it's always the same 4 bytes (prolog + no named args)
+		_ucoAttrBlobHandle = _pe.BuildAttributeBlob (b => { });
 
 		EmitTypeMapAttributeCtorRef ();
 		EmitTypeMapAssociationAttributeCtorRef ();
@@ -204,16 +263,21 @@ sealed class TypeMapAssemblyEmitter
 				}));
 	}
 
-	void EmitProxyType (JavaPeerProxyData proxy)
+
+	void EmitProxyType (JavaPeerProxyData proxy, Dictionary<string, MethodDefinitionHandle> wrapperHandles)
 	{
 		var metadata = _pe.Metadata;
-		metadata.AddTypeDefinition (
+		var typeDefHandle = metadata.AddTypeDefinition (
 			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
 			metadata.GetOrAddString (proxy.Namespace),
 			metadata.GetOrAddString (proxy.TypeName),
 			_javaPeerProxyRef,
 			MetadataTokens.FieldDefinitionHandle (metadata.GetRowCount (TableIndex.Field) + 1),
 			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
+
+		if (proxy.IsAcw) {
+			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
+		}
 
 		// .ctor
 		_pe.EmitBody (".ctor",
@@ -236,6 +300,22 @@ sealed class TypeMapAssemblyEmitter
 		if (proxy.InvokerType != null) {
 			EmitTypeGetter ("get_InvokerType", proxy.InvokerType,
 				MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig);
+		}
+
+		// UCO wrappers
+		foreach (var uco in proxy.UcoMethods) {
+			var handle = EmitUcoMethod (uco);
+			wrapperHandles [uco.WrapperName] = handle;
+		}
+
+		foreach (var uco in proxy.UcoConstructors) {
+			var handle = EmitUcoConstructor (uco);
+			wrapperHandles [uco.WrapperName] = handle;
+		}
+
+		// RegisterNatives
+		if (proxy.IsAcw) {
+			EmitRegisterNatives (proxy.NativeRegistrations, wrapperHandles);
 		}
 	}
 
@@ -367,6 +447,106 @@ sealed class TypeMapAssemblyEmitter
 				encoder.Call (_getTypeFromHandleRef);
 				encoder.OpCode (ILOpCode.Ret);
 			});
+	}
+
+	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco)
+	{
+		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
+		var returnKind = JniSignatureHelper.ParseReturnType (uco.JniSignature);
+		int paramCount = 2 + jniParams.Count;
+		bool isVoid = returnKind == JniParamKind.Void;
+
+		Action<BlobEncoder> encodeSig = sig => sig.MethodSignature ().Parameters (paramCount,
+			rt => { if (isVoid) rt.Void (); else JniSignatureHelper.EncodeClrType (rt.Type (), returnKind); },
+			p => {
+				p.AddParameter ().Type ().IntPtr ();
+				p.AddParameter ().Type ().IntPtr ();
+				for (int j = 0; j < jniParams.Count; j++)
+					JniSignatureHelper.EncodeClrType (p.AddParameter ().Type (), jniParams [j]);
+			});
+
+		var callbackTypeHandle = _pe.ResolveTypeRef (uco.CallbackType);
+		var callbackRef = _pe.AddMemberRef (callbackTypeHandle, uco.CallbackMethodName, encodeSig);
+
+		var handle = _pe.EmitBody (uco.WrapperName,
+			MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+			encodeSig,
+			encoder => {
+				for (int p = 0; p < paramCount; p++)
+					encoder.LoadArgument (p);
+				encoder.Call (callbackRef);
+				encoder.OpCode (ILOpCode.Ret);
+			});
+
+		AddUnmanagedCallersOnlyAttribute (handle);
+		return handle;
+	}
+
+	MethodDefinitionHandle EmitUcoConstructor (UcoConstructorData uco)
+	{
+		var userTypeRef = _pe.ResolveTypeRef (uco.TargetType);
+
+		// UCO constructor wrappers must match the JNI native method signature exactly.
+		// The Java JCW declares e.g. "private native void nctor_0(Context p0)" and calls
+		// it with arguments. JNI dispatches with (JNIEnv*, jobject, <ctor params...>),
+		// so the wrapper signature must include all parameters to match the ABI.
+		// Only jnienv (arg 0) and self (arg 1) are used — the constructor parameters
+		// are not forwarded because ActivateInstance creates the managed peer using the
+		// activation ctor (IntPtr, JniHandleOwnership), not the user-visible constructor.
+		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
+		int paramCount = 2 + jniParams.Count;
+
+		var handle = _pe.EmitBody (uco.WrapperName,
+			MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+			sig => sig.MethodSignature ().Parameters (paramCount,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().IntPtr (); // jnienv
+					p.AddParameter ().Type ().IntPtr (); // self
+					for (int j = 0; j < jniParams.Count; j++)
+						JniSignatureHelper.EncodeClrType (p.AddParameter ().Type (), jniParams [j]);
+				}),
+			encoder => {
+				encoder.LoadArgument (1); // self
+				encoder.OpCode (ILOpCode.Ldtoken);
+				encoder.Token (userTypeRef);
+				encoder.Call (_getTypeFromHandleRef);
+				encoder.Call (_activateInstanceRef);
+				encoder.OpCode (ILOpCode.Ret);
+			});
+
+		AddUnmanagedCallersOnlyAttribute (handle);
+		return handle;
+	}
+
+	void EmitRegisterNatives (List<NativeRegistrationData> registrations,
+		Dictionary<string, MethodDefinitionHandle> wrapperHandles)
+	{
+		_pe.EmitBody ("RegisterNatives",
+			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig |
+			MethodAttributes.NewSlot | MethodAttributes.Final,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
+				rt => rt.Void (),
+				p => p.AddParameter ().Type ().Type (_jniTypeRef, false)),
+			encoder => {
+				foreach (var reg in registrations) {
+					if (!wrapperHandles.TryGetValue (reg.WrapperMethodName, out var wrapperHandle)) {
+						continue;
+					}
+					encoder.LoadArgument (1);
+					encoder.LoadString (_pe.Metadata.GetOrAddUserString (reg.JniMethodName));
+					encoder.LoadString (_pe.Metadata.GetOrAddUserString (reg.JniSignature));
+					encoder.OpCode (ILOpCode.Ldftn);
+					encoder.Token (wrapperHandle);
+					encoder.Call (_registerMethodRef);
+				}
+				encoder.OpCode (ILOpCode.Ret);
+			});
+	}
+
+	void AddUnmanagedCallersOnlyAttribute (MethodDefinitionHandle handle)
+	{
+		_pe.Metadata.AddCustomAttribute (handle, _ucoAttrCtorRef, _ucoAttrBlobHandle);
 	}
 
 	void EmitTypeMapAttribute (TypeMapAttributeData entry)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -451,8 +451,8 @@ sealed class TypeMapAssemblyEmitter
 
 	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco)
 	{
-		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
-		var returnKind = JniSignatureHelper.ParseReturnType (uco.JniSignature);
+		var jniParams = JniSignatureHelper.ParseParameterKinds (uco.JniSignature);
+		var returnKind = JniSignatureHelper.ParseReturnKind (uco.JniSignature);
 		int paramCount = 2 + jniParams.Count;
 		bool isVoid = returnKind == JniParamKind.Void;
 
@@ -493,7 +493,7 @@ sealed class TypeMapAssemblyEmitter
 		// Only jnienv (arg 0) and self (arg 1) are used — the constructor parameters
 		// are not forwarded because ActivateInstance creates the managed peer using the
 		// activation ctor (IntPtr, JniHandleOwnership), not the user-visible constructor.
-		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
+		var jniParams = JniSignatureHelper.ParseParameterKinds (uco.JniSignature);
 		int paramCount = 2 + jniParams.Count;
 
 		var handle = _pe.EmitBody (uco.WrapperName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -68,6 +68,12 @@ sealed record JavaPeerInfo
 	public IReadOnlyList<MarshalMethodInfo> MarshalMethods { get; init; } = Array.Empty<MarshalMethodInfo> ();
 
 	/// <summary>
+	/// Java constructors to emit in the JCW .java file.
+	/// Each has a JNI signature and an ordinal index for the nctor_N native method.
+	/// </summary>
+	public IReadOnlyList<JavaConstructorInfo> JavaConstructors { get; init; } = Array.Empty<JavaConstructorInfo> ();
+
+	/// <summary>
 	/// Information about the activation constructor for this type.
 	/// May reference a base type's constructor if the type doesn't define its own.
 	/// </summary>
@@ -177,6 +183,34 @@ sealed record JniParameterInfo
 	/// Managed parameter type name, e.g., "Android.OS.Bundle", "System.Int32".
 	/// </summary>
 	public string ManagedType { get; init; } = "";
+}
+
+/// <summary>
+/// Describes a Java constructor to emit in the JCW .java source file.
+/// </summary>
+sealed record JavaConstructorInfo
+{
+	/// <summary>
+	/// JNI constructor signature, e.g., "(Landroid/content/Context;)V".
+	/// </summary>
+	public required string JniSignature { get; init; }
+
+	/// <summary>
+	/// Ordinal index for the native constructor method (nctor_0, nctor_1, ...).
+	/// </summary>
+	public required int ConstructorIndex { get; init; }
+
+	/// <summary>
+	/// JNI parameter types parsed from the signature.
+	/// Used to generate the Java constructor parameter list.
+	/// </summary>
+	public IReadOnlyList<JniParameterInfo> Parameters { get; init; } = Array.Empty<JniParameterInfo> ();
+
+	/// <summary>
+	/// For [Export] constructors: super constructor arguments string.
+	/// Null for [Register] constructors.
+	/// </summary>
+	public string? SuperArgumentsString { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
 /// <summary>
@@ -12,6 +15,13 @@ sealed record JavaPeerInfo
 	/// Extracted from the [Register] attribute.
 	/// </summary>
 	public required string JavaName { get; init; }
+
+	/// <summary>
+	/// Compat JNI type name, e.g., "myapp.namespace/MyType" for user types (uses raw namespace, not CRC64).
+	/// For MCW binding types (with [Register]), this equals <see cref="JavaName"/>.
+	/// Used by acw-map.txt to support legacy custom view name resolution in layout XMLs.
+	/// </summary>
+	public required string CompatJniName { get; init; }
 
 	/// <summary>
 	/// Full managed type name, e.g., "Android.App.Activity".
@@ -50,6 +60,14 @@ sealed record JavaPeerInfo
 	public bool IsUnconditional { get; init; }
 
 	/// <summary>
+	/// Marshal methods: methods with [Register(name, sig, connector)], [Export], or
+	/// constructor registrations ([Register(".ctor", sig, "")] / [JniConstructorSignature]).
+	/// Constructors are identified by <see cref="MarshalMethodInfo.IsConstructor"/>.
+	/// Ordered — the index in this list is the method's ordinal for RegisterNatives.
+	/// </summary>
+	public IReadOnlyList<MarshalMethodInfo> MarshalMethods { get; init; } = Array.Empty<MarshalMethodInfo> ();
+
+	/// <summary>
 	/// Information about the activation constructor for this type.
 	/// May reference a base type's constructor if the type doesn't define its own.
 	/// </summary>
@@ -66,6 +84,99 @@ sealed record JavaPeerInfo
 	/// Generic types get TypeMap entries but CreateInstance throws NotSupportedException.
 	/// </summary>
 	public bool IsGenericDefinition { get; init; }
+}
+
+/// <summary>
+/// Describes a marshal method (a method with [Register] or [Export]) on a Java peer type.
+/// Contains all data needed to generate a UCO wrapper, a JCW native declaration,
+/// and a RegisterNatives call.
+/// </summary>
+sealed record MarshalMethodInfo
+{
+	/// <summary>
+	/// JNI method name, e.g., "onCreate".
+	/// This is the Java method name (without n_ prefix).
+	/// </summary>
+	public required string JniName { get; init; }
+
+	/// <summary>
+	/// JNI method signature, e.g., "(Landroid/os/Bundle;)V".
+	/// Contains both parameter types and return type.
+	/// </summary>
+	public required string JniSignature { get; init; }
+
+	/// <summary>
+	/// The connector string from [Register], e.g., "GetOnCreate_Landroid_os_Bundle_Handler".
+	/// Null for [Export] methods.
+	/// </summary>
+	public string? Connector { get; init; }
+
+	/// <summary>
+	/// Name of the managed method this maps to, e.g., "OnCreate".
+	/// </summary>
+	public required string ManagedMethodName { get; init; }
+
+	/// <summary>
+	/// Full name of the type that declares the managed method (may be a base type).
+	/// Empty when the declaring type is the same as the peer type.
+	/// </summary>
+	public string DeclaringTypeName { get; init; } = "";
+
+	/// <summary>
+	/// Assembly name of the type that declares the managed method.
+	/// Needed for cross-assembly UCO wrapper generation.
+	/// Empty when the declaring type is the same as the peer type.
+	/// </summary>
+	public string DeclaringAssemblyName { get; init; } = "";
+
+	/// <summary>
+	/// The native callback method name, e.g., "n_onCreate".
+	/// This is the actual method the UCO wrapper delegates to.
+	/// </summary>
+	public required string NativeCallbackName { get; init; }
+
+	/// <summary>
+	/// JNI parameter types for UCO generation.
+	/// </summary>
+	public IReadOnlyList<JniParameterInfo> Parameters { get; init; } = Array.Empty<JniParameterInfo> ();
+
+	/// <summary>
+	/// JNI return type descriptor, e.g., "V", "Landroid/os/Bundle;".
+	/// </summary>
+	public required string JniReturnType { get; init; }
+
+	/// <summary>
+	/// True if this is a constructor registration.
+	/// </summary>
+	public bool IsConstructor { get; init; }
+
+	/// <summary>
+	/// For [Export] methods: Java exception types that the method declares it can throw.
+	/// Null for [Register] methods.
+	/// </summary>
+	public IReadOnlyList<string>? ThrownNames { get; init; }
+
+	/// <summary>
+	/// For [Export] methods: super constructor arguments string.
+	/// Null for [Register] methods.
+	/// </summary>
+	public string? SuperArgumentsString { get; init; }
+}
+
+/// <summary>
+/// Describes a JNI parameter for UCO method generation.
+/// </summary>
+sealed record JniParameterInfo
+{
+	/// <summary>
+	/// JNI type descriptor, e.g., "Landroid/os/Bundle;", "I", "Z".
+	/// </summary>
+	public required string JniType { get; init; }
+
+	/// <summary>
+	/// Managed parameter type name, e.g., "Android.OS.Bundle", "System.Int32".
+	/// </summary>
+	public string ManagedType { get; init; } = "";
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -163,6 +164,7 @@ sealed class JavaPeerScanner : IDisposable
 			//   3. Extends a known Java peer → auto-compute JNI name via CRC64
 			//   4. None of the above → not a Java peer, skip
 			string? jniName = null;
+			string? compatJniName = null;
 			bool doNotGenerateAcw = false;
 
 			index.RegisterInfoByType.TryGetValue (typeHandle, out var registerInfo);
@@ -170,15 +172,17 @@ sealed class JavaPeerScanner : IDisposable
 
 			if (registerInfo is not null && !string.IsNullOrEmpty (registerInfo.JniName)) {
 				jniName = registerInfo.JniName;
+				compatJniName = jniName;
 				doNotGenerateAcw = registerInfo.DoNotGenerateAcw;
 			} else if (attrInfo?.JniName is not null) {
 				// User type with [Activity(Name = "...")] but no [Register]
 				jniName = attrInfo.JniName;
+				compatJniName = jniName;
 			} else {
 				// No explicit JNI name — check if this type extends a known Java peer.
 				// If so, auto-compute JNI name from the managed type name via CRC64.
 				if (ExtendsJavaPeer (typeDef, index)) {
-					jniName = ComputeAutoJniName (typeDef, index);
+					(jniName, compatJniName) = ComputeAutoJniNames (typeDef, index);
 				} else {
 					continue;
 				}
@@ -193,6 +197,9 @@ sealed class JavaPeerScanner : IDisposable
 			var isUnconditional = attrInfo is not null;
 			string? invokerTypeName = null;
 
+			// Collect marshal methods (including constructors) in a single pass over methods
+			var marshalMethods = CollectMarshalMethods (typeDef, index);
+
 			// Resolve activation constructor
 			var activationCtor = ResolveActivationCtor (fullName, typeDef, index);
 
@@ -203,6 +210,7 @@ sealed class JavaPeerScanner : IDisposable
 
 			var peer = new JavaPeerInfo {
 				JavaName = jniName,
+				CompatJniName = compatJniName,
 				ManagedTypeName = fullName,
 				ManagedTypeNamespace = ExtractNamespace (fullName),
 				ManagedTypeShortName = ExtractShortName (fullName),
@@ -211,12 +219,193 @@ sealed class JavaPeerScanner : IDisposable
 				IsAbstract = isAbstract,
 				DoNotGenerateAcw = doNotGenerateAcw,
 				IsUnconditional = isUnconditional,
+				MarshalMethods = marshalMethods,
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				IsGenericDefinition = isGenericDefinition,
 			};
 
 			results [fullName] = peer;
+		}
+	}
+
+	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index)
+	{
+		var methods = new List<MarshalMethodInfo> ();
+
+		// Single pass over methods: collect marshal methods (including constructors)
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			if (!TryGetMethodRegisterInfo (methodDef, index, out var registerInfo, out var exportInfo) || registerInfo is null) {
+				continue;
+			}
+
+			AddMarshalMethod (methods, registerInfo, methodDef, index, exportInfo);
+		}
+
+		// Collect [Register] from properties (attribute is on the property, not the getter)
+		foreach (var propHandle in typeDef.GetProperties ()) {
+			var propDef = index.Reader.GetPropertyDefinition (propHandle);
+			var propRegister = TryGetPropertyRegisterInfo (propDef, index);
+			if (propRegister is null) {
+				continue;
+			}
+
+			var accessors = propDef.GetAccessors ();
+			if (!accessors.Getter.IsNil) {
+				var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
+				AddMarshalMethod (methods, propRegister, getterDef, index);
+			}
+		}
+
+		return methods;
+	}
+
+	static void AddMarshalMethod (List<MarshalMethodInfo> methods, RegisterInfo registerInfo, MethodDefinition methodDef, AssemblyIndex index, ExportInfo? exportInfo = null)
+	{
+		// Skip methods that are just the JNI name (type-level [Register])
+		if (registerInfo.Signature is null && registerInfo.Connector is null) {
+			return;
+		}
+
+		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
+		string nativeCallbackName = $"n_{index.Reader.GetString (methodDef.Name)}";
+		if (isConstructor) {
+			int ctorIndex = 0;
+			foreach (var method in methods) {
+				if (method.IsConstructor) {
+					ctorIndex++;
+				}
+			}
+			nativeCallbackName = ctorIndex == 0 ? "n_ctor" : $"n_ctor_{ctorIndex}";
+		}
+
+		methods.Add (new MarshalMethodInfo {
+			JniName = registerInfo.JniName,
+			JniSignature = registerInfo.Signature ?? "()V",
+			Connector = registerInfo.Connector,
+			ManagedMethodName = index.Reader.GetString (methodDef.Name),
+			NativeCallbackName = nativeCallbackName,
+			JniReturnType = JniSignatureHelper.ParseReturnTypeString (registerInfo.Signature ?? "()V"),
+			Parameters = JniSignatureHelper.ParseParameterTypes (registerInfo.Signature ?? "()V"),
+			IsConstructor = isConstructor,
+			ThrownNames = exportInfo?.ThrownNames,
+			SuperArgumentsString = exportInfo?.SuperArgumentsString,
+		});
+	}
+
+	static bool TryGetMethodRegisterInfo (MethodDefinition methodDef, AssemblyIndex index, out RegisterInfo? registerInfo, out ExportInfo? exportInfo)
+	{
+		exportInfo = null;
+		foreach (var caHandle in methodDef.GetCustomAttributes ()) {
+			var ca = index.Reader.GetCustomAttribute (caHandle);
+			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+
+			if (attrName == "RegisterAttribute") {
+				registerInfo = index.ParseRegisterAttribute (ca);
+				return true;
+			}
+
+			if (attrName == "ExportAttribute") {
+				(registerInfo, exportInfo) = ParseExportAttribute (ca, methodDef, index);
+				return true;
+			}
+		}
+		registerInfo = null;
+		return false;
+	}
+
+	static RegisterInfo? TryGetPropertyRegisterInfo (PropertyDefinition propDef, AssemblyIndex index)
+	{
+		foreach (var caHandle in propDef.GetCustomAttributes ()) {
+			var ca = index.Reader.GetCustomAttribute (caHandle);
+			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+
+			if (attrName == "RegisterAttribute") {
+				return index.ParseRegisterAttribute (ca);
+			}
+		}
+		return null;
+	}
+
+	static (RegisterInfo registerInfo, ExportInfo exportInfo) ParseExportAttribute (CustomAttribute ca, MethodDefinition methodDef, AssemblyIndex index)
+	{
+		var value = index.DecodeAttribute (ca);
+
+		// [Export("name")] or [Export] (uses method name)
+		string? exportName = null;
+		if (value.FixedArguments.Length > 0) {
+			exportName = (string?)value.FixedArguments [0].Value;
+		}
+
+		List<string>? thrownNames = null;
+		string? superArguments = null;
+
+		// Check Named arguments
+		foreach (var named in value.NamedArguments) {
+			if (named.Name == "Name" && named.Value is string name) {
+				exportName = name;
+			} else if (named.Name == "ThrownNames" && named.Value is ImmutableArray<CustomAttributeTypedArgument<string>> names) {
+				thrownNames = new List<string> (names.Length);
+				foreach (var item in names) {
+					if (item.Value is string s) {
+						thrownNames.Add (s);
+					}
+				}
+			} else if (named.Name == "SuperArgumentsString" && named.Value is string superArgs) {
+				superArguments = superArgs;
+			}
+		}
+
+		if (string.IsNullOrEmpty (exportName)) {
+			exportName = index.Reader.GetString (methodDef.Name);
+		}
+		string resolvedExportName = exportName ?? throw new InvalidOperationException ("Export name should not be null at this point.");
+
+		// Build JNI signature from method signature
+		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+		var jniSig = BuildJniSignatureFromManaged (sig);
+
+		return (
+			new RegisterInfo { JniName = resolvedExportName, Signature = jniSig, Connector = null, DoNotGenerateAcw = false },
+			new ExportInfo { ThrownNames = thrownNames, SuperArgumentsString = superArguments }
+		);
+	}
+
+	static string BuildJniSignatureFromManaged (MethodSignature<string> sig)
+	{
+		var sb = new System.Text.StringBuilder ();
+		sb.Append ('(');
+		foreach (var param in sig.ParameterTypes) {
+			sb.Append (ManagedTypeToJniDescriptor (param));
+		}
+		sb.Append (')');
+		sb.Append (ManagedTypeToJniDescriptor (sig.ReturnType));
+		return sb.ToString ();
+	}
+
+	static string ManagedTypeToJniDescriptor (string managedType)
+	{
+		switch (managedType) {
+		case "System.Void": return "V";
+		case "System.Boolean": return "Z";
+		case "System.Byte":
+		case "System.SByte": return "B";
+		case "System.Char": return "C";
+		case "System.Int16":
+		case "System.UInt16": return "S";
+		case "System.Int32":
+		case "System.UInt32": return "I";
+		case "System.Int64":
+		case "System.UInt64": return "J";
+		case "System.Single": return "F";
+		case "System.Double": return "D";
+		case "System.String": return "Ljava/lang/String;";
+		default:
+			if (managedType.EndsWith ("[]")) {
+				return $"[{ManagedTypeToJniDescriptor (managedType.Substring (0, managedType.Length - 2))}";
+			}
+			return "Ljava/lang/Object;";
 		}
 	}
 
@@ -426,21 +615,29 @@ sealed class JavaPeerScanner : IDisposable
 	}
 
 	/// <summary>
-	/// Compute JNI name for a type without [Register] or component Name.
+	/// Compute both JNI name and compat JNI name for a type without [Register] or component Name.
 	/// JNI name uses CRC64 hash of "namespace:assemblyName" for the package.
-	/// If a declaring type has [Register], its JNI name is used as prefix.
+	/// Compat JNI name uses the raw managed namespace (lowercased).
+	/// If a declaring type has [Register], its JNI name is used as prefix for both.
 	/// Generic backticks are replaced with _.
 	/// </summary>
-	static string ComputeAutoJniName (TypeDefinition typeDef, AssemblyIndex index)
+	static (string jniName, string compatJniName) ComputeAutoJniNames (TypeDefinition typeDef, AssemblyIndex index)
 	{
 		var (typeName, parentJniName, ns) = ComputeTypeNameParts (typeDef, index);
 
 		if (parentJniName is not null) {
-			return $"{parentJniName}_{typeName}";
+			var name = $"{parentJniName}_{typeName}";
+			return (name, name);
 		}
 
 		var packageName = GetCrc64PackageName (ns, index.AssemblyName);
-		return $"{packageName}/{typeName}";
+		var jniName = $"{packageName}/{typeName}";
+
+		string compatName = ns.Length == 0
+			? typeName
+			: $"{ns.ToLowerInvariant ().Replace ('.', '/')}/{typeName}";
+
+		return (jniName, compatName);
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -220,6 +220,7 @@ sealed class JavaPeerScanner : IDisposable
 				DoNotGenerateAcw = doNotGenerateAcw,
 				IsUnconditional = isUnconditional,
 				MarshalMethods = marshalMethods,
+				JavaConstructors = BuildJavaConstructors (marshalMethods),
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				IsGenericDefinition = isGenericDefinition,
@@ -710,5 +711,24 @@ sealed class JavaPeerScanner : IDisposable
 		var typePart = lastDot >= 0 ? span.Slice (lastDot + 1) : span;
 		int lastPlus = typePart.LastIndexOf ('+');
 		return (lastPlus >= 0 ? typePart.Slice (lastPlus + 1) : typePart).ToString ();
+	}
+
+	static List<JavaConstructorInfo> BuildJavaConstructors (List<MarshalMethodInfo> marshalMethods)
+	{
+		var ctors = new List<JavaConstructorInfo> ();
+		int ctorIndex = 0;
+		foreach (var mm in marshalMethods) {
+			if (!mm.IsConstructor) {
+				continue;
+			}
+			ctors.Add (new JavaConstructorInfo {
+				JniSignature = mm.JniSignature,
+				ConstructorIndex = ctorIndex,
+				Parameters = mm.Parameters,
+				SuperArgumentsString = mm.SuperArgumentsString,
+			});
+			ctorIndex++;
+		}
+		return ctors;
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -61,6 +61,9 @@ public abstract class FixtureTestBase
 	{
 		var peer = MakePeerWithActivation (jniName, managedName, asmName);
 		peer.DoNotGenerateAcw = false;
+		peer.JavaConstructors = new List<JavaConstructorInfo> {
+			new JavaConstructorInfo { ConstructorIndex = 0, JniSignature = "()V" },
+		};
 		peer.MarshalMethods = new List<MarshalMethodInfo> {
 			new MarshalMethodInfo {
 				JniName = "<init>",

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -40,6 +40,7 @@ public abstract class FixtureTestBase
 		var shortName = typePart.Contains ('+') ? typePart.Substring (typePart.LastIndexOf ('+') + 1) : typePart;
 		return new JavaPeerInfo {
 			JavaName = jniName,
+			CompatJniName = jniName,
 			ManagedTypeName = managedName,
 			ManagedTypeNamespace = ns,
 			ManagedTypeShortName = shortName,
@@ -57,24 +58,51 @@ public abstract class FixtureTestBase
 	}
 
 	protected static JavaPeerInfo MakeAcwPeer (string jniName, string managedName, string asmName)
-		=> MakePeerWithActivation (jniName, managedName, asmName);
+	{
+		var peer = MakePeerWithActivation (jniName, managedName, asmName);
+		peer.DoNotGenerateAcw = false;
+		peer.MarshalMethods = new List<MarshalMethodInfo> {
+			new MarshalMethodInfo {
+				JniName = "<init>",
+				NativeCallbackName = "n_ctor",
+				JniSignature = "()V",
+				JniReturnType = "V",
+				ManagedMethodName = ".ctor",
+				IsConstructor = true,
+			},
+		};
+		return peer;
+	}
 
 	protected static JavaPeerInfo MakeInterfacePeer (
-		string jniName,
-		string managedName,
-		string asmName,
-		string invokerName)
+		string jniName = "android/view/View$OnClickListener",
+		string managedName = "Android.Views.View+IOnClickListener",
+		string asmName = "Mono.Android",
+		string invokerName = "Android.Views.View+IOnClickListenerInvoker")
 	{
 		var ns = managedName.Contains ('.') ? managedName.Substring (0, managedName.LastIndexOf ('.')) : "";
 		var shortName = managedName.Contains ('.') ? managedName.Substring (managedName.LastIndexOf ('.') + 1) : managedName;
 		return new JavaPeerInfo {
 			JavaName = jniName,
+			CompatJniName = jniName,
 			ManagedTypeName = managedName,
 			ManagedTypeNamespace = ns,
 			ManagedTypeShortName = shortName,
 			AssemblyName = asmName,
 			IsInterface = true,
 			InvokerTypeName = invokerName,
+		};
+	}
+
+	protected static MarshalMethodInfo MakeMarshalMethod (string jniName, string callbackName, string jniSig, bool isConstructor = false)
+	{
+		return new MarshalMethodInfo {
+			JniName = jniName,
+			NativeCallbackName = callbackName,
+			JniSignature = jniSig,
+			JniReturnType = JniSignatureHelper.ParseReturnTypeString (jniSig),
+			ManagedMethodName = jniName,
+			IsConstructor = isConstructor,
 		};
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -282,7 +282,63 @@ public class IgnoresAccessChecksTo : IDisposable
 
 	}
 
-	public class CreateInstancePaths : IDisposable
+public class JniSignatureHelperTests
+{
+
+[Theory]
+[InlineData ("()V", 0)]
+[InlineData ("(I)V", 1)]
+[InlineData ("(Landroid/os/Bundle;)V", 1)]
+[InlineData ("(IFJ)V", 3)]
+[InlineData ("(ZLandroid/view/View;I)Z", 3)]
+[InlineData ("([Ljava/lang/String;)V", 1)]
+public void ParseParameterKinds_ParsesCorrectCount (string signature, int expectedCount)
+{
+var actual = JniSignatureHelper.ParseParameterKinds (signature);
+Assert.Equal (expectedCount, actual.Count);
+}
+
+[Theory]
+[InlineData ("(Z)V", JniParamKind.Boolean)]
+[InlineData ("(Ljava/lang/String;)V", JniParamKind.Object)]
+public void ParseParameterKinds_SingleParam_MapsToCorrectKind (string signature, JniParamKind expectedKind)
+{
+var types = JniSignatureHelper.ParseParameterKinds (signature);
+Assert.Single (types);
+Assert.Equal (expectedKind, types [0]);
+}
+
+[Theory]
+[InlineData ("()V", JniParamKind.Void)]
+[InlineData ("()I", JniParamKind.Int)]
+[InlineData ("()Z", JniParamKind.Boolean)]
+[InlineData ("()Ljava/lang/String;", JniParamKind.Object)]
+public void ParseReturnType_MapsToCorrectKind (string signature, JniParamKind expectedKind)
+{
+Assert.Equal (expectedKind, JniSignatureHelper.ParseReturnKind (signature));
+}
+
+}
+
+public class NegativeEdgeCase
+{
+
+[Theory]
+[InlineData ("")]
+[InlineData ("not-a-sig")]
+[InlineData ("(")]
+public void ParseParameterKinds_InvalidSignature_ThrowsOrReturnsEmpty (string signature)
+{
+try {
+var result = JniSignatureHelper.ParseParameterKinds (signature);
+Assert.NotNull (result);
+} catch (Exception ex) when (ex is ArgumentException || ex is IndexOutOfRangeException || ex is FormatException) {
+}
+}
+
+}
+
+public class CreateInstancePaths : IDisposable
 	{
 		readonly string _outputDir = CreateTempDir ();
 		public void Dispose () => DeleteTempDir (_outputDir);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -158,6 +158,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		static List<JavaPeerInfo> MakeDuplicateAliasPeers () => new List<JavaPeerInfo> {
 			new JavaPeerInfo {
 				JavaName = "test/Duplicate",
+				CompatJniName = "test/Duplicate",
 				ManagedTypeName = "Test.Duplicate1",
 				ManagedTypeNamespace = "Test",
 				ManagedTypeShortName = "Duplicate1",
@@ -170,6 +171,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			},
 			new JavaPeerInfo {
 				JavaName = "test/Duplicate",
+				CompatJniName = "test/Duplicate",
 				ManagedTypeName = "Test.Duplicate2",
 				ManagedTypeNamespace = "Test",
 				ManagedTypeShortName = "Duplicate2",

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -170,10 +170,16 @@ var ucoMethod = proxy.GetMethods ()
 .Select (h => reader.GetMethodDefinition (h))
 .First (m => reader.GetString (m.Name).Contains ("_uco_"));
 
-var attrs = ucoMethod.GetCustomAttributes ()
+var attrNames = ucoMethod.GetCustomAttributes ()
 .Select (h => reader.GetCustomAttribute (h))
+.Select (a => {
+var ctorHandle = (MemberReferenceHandle) a.Constructor;
+var ctor = reader.GetMemberReference (ctorHandle);
+var typeRef = reader.GetTypeReference ((TypeReferenceHandle) ctor.Parent);
+return $"{reader.GetString (typeRef.Namespace)}.{reader.GetString (typeRef.Name)}";
+})
 .ToList ();
-Assert.NotEmpty (attrs);
+Assert.Contains ("System.Runtime.InteropServices.UnmanagedCallersOnlyAttribute", attrNames);
 }
 }
 
@@ -323,20 +329,26 @@ Assert.Equal (expectedKind, JniSignatureHelper.ParseReturnKind (signature));
 public class NegativeEdgeCase
 {
 
-[Theory]
-[InlineData ("")]
-[InlineData ("not-a-sig")]
-[InlineData ("(")]
-public void ParseParameterKinds_InvalidSignature_ThrowsOrReturnsEmpty (string signature)
+[Fact]
+public void ParseParameterKinds_EmptyString_ReturnsEmptyList ()
 {
-try {
-var result = JniSignatureHelper.ParseParameterKinds (signature);
-Assert.NotNull (result);
-} catch (Exception ex) when (ex is ArgumentException || ex is IndexOutOfRangeException || ex is FormatException) {
+Assert.Empty (JniSignatureHelper.ParseParameterKinds (""));
 }
+
+[Fact]
+public void ParseParameterKinds_InvalidSignature_Throws ()
+{
+Assert.ThrowsAny<ArgumentException> (() => JniSignatureHelper.ParseParameterKinds ("not-a-sig"));
+}
+
+[Fact]
+public void ParseParameterKinds_UnterminatedSignature_ReturnsEmptyList ()
+{
+Assert.Empty (JniSignatureHelper.ParseParameterKinds ("("));
 }
 
 }
+
 
 public class CreateInstancePaths : IDisposable
 	{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -195,7 +195,7 @@ public class ModelBuilderTests : FixtureTestBase
 		[Fact]
 		public void Build_PeerWithInvoker_CreatesProxy ()
 		{
-			var peer = MakeInterfacePeer ("android/view/View$OnClickListener", "Android.Views.View+IOnClickListener", "Mono.Android", "Android.Views.View+IOnClickListenerInvoker");
+			var peer = MakeInterfacePeer ();
 
 			var model = BuildModel (new [] { peer });
 			Assert.Single (model.ProxyTypes);
@@ -476,7 +476,7 @@ public class ModelBuilderTests : FixtureTestBase
 
 			var model = BuildModel (new [] { peer }, "TypeMap");
 
-			if (peer.ActivationCtor != null) {
+			if (peer.ActivationCtor != null && peer.MarshalMethods.Count > 0) {
 				var proxy = model.ProxyTypes.FirstOrDefault (p => p.TypeName == expectedProxyName);
 				Assert.NotNull (proxy);
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1078,7 +1078,7 @@ public class ModelBuilderTests : FixtureTestBase
 						.First (u => u.WrapperName == name);
 
 					// UCO constructor signature: jnienv + self + JNI params
-					int expectedJniParams = JniSignatureHelper.ParseParameterTypes (modelUco.JniSignature).Count;
+					int expectedJniParams = JniSignatureHelper.ParseParameterKinds (modelUco.JniSignature).Count;
 					int expectedTotal = 2 + expectedJniParams;
 
 					var sig = reader.GetBlobReader (uco.Signature);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
@@ -1,9 +1,61 @@
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
 public partial class JavaPeerScannerTests
 {
+	[Theory]
+	[InlineData ("android/app/Activity", "OnCreate", "onCreate", "(Landroid/os/Bundle;)V")]
+	[InlineData ("android/app/Activity", "OnStart", "onStart", "()V")]
+	[InlineData ("my/app/MainActivity", "OnCreate", "onCreate", "(Landroid/os/Bundle;)V")]
+	[InlineData ("my/app/AbstractBase", "DoWork", "doWork", "()V")]
+	[InlineData ("java/lang/Throwable", "Message", "getMessage", "()Ljava/lang/String;")]
+	[InlineData ("my/app/TouchHandler", "OnTouch", "onTouch", "(Landroid/view/View;I)Z")]
+	[InlineData ("my/app/TouchHandler", "OnFocusChange", "onFocusChange", "(Landroid/view/View;Z)V")]
+	[InlineData ("my/app/TouchHandler", "OnScroll", "onScroll", "(IFJD)V")]
+	[InlineData ("my/app/TouchHandler", "SetItems", "setItems", "([Ljava/lang/String;)V")]
+	public void Scan_MarshalMethod_HasCorrectSignature (string javaName, string managedName, string jniName, string jniSig)
+	{
+		var peers = ScanFixtures ();
+		var method = FindByJavaName (peers, javaName)
+			.MarshalMethods.FirstOrDefault (m => m.ManagedMethodName == managedName || m.JniName == jniName);
+		Assert.NotNull (method);
+		Assert.Equal (jniName, method.JniName);
+		Assert.Equal (jniSig, method.JniSignature);
+	}
+
+	[Fact]
+	public void Scan_MarshalMethod_ConstructorsAndSpecialCases ()
+	{
+		var peers = ScanFixtures ();
+
+		var ctors = FindByJavaName (peers, "my/app/CustomView")
+			.MarshalMethods.Where (m => m.IsConstructor).ToList ();
+		Assert.Equal (2, ctors.Count);
+		Assert.Equal ("()V", ctors [0].JniSignature);
+		Assert.Equal ("(Landroid/content/Context;)V", ctors [1].JniSignature);
+
+		Assert.DoesNotContain (FindByJavaName (peers, "my/app/MyHelper").MarshalMethods, m => m.IsConstructor);
+
+		var exportMethod = FindByJavaName (peers, "my/app/ExportExample").MarshalMethods.Single ();
+		Assert.Equal ("myExportedMethod", exportMethod.JniName);
+		Assert.Null (exportMethod.Connector);
+
+		var onStart = FindByJavaName (peers, "android/app/Activity")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "onStart");
+		Assert.NotNull (onStart);
+		Assert.Equal ("", onStart.Connector);
+
+		var onClick = FindByManagedName (peers, "Android.Views.IOnClickListener")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "onClick");
+		Assert.NotNull (onClick);
+		Assert.Equal ("(Landroid/view/View;)V", onClick.JniSignature);
+
+		Assert.Equal ("Android.Views.IOnClickListenerInvoker",
+			FindByManagedName (peers, "Android.Views.IOnClickListener").InvokerTypeName);
+	}
+
 	[Theory]
 	[InlineData ("android/app/Activity", "Android.App.Activity")]
 	[InlineData ("my/app/SimpleActivity", "Android.App.Activity")]
@@ -42,6 +94,24 @@ public partial class JavaPeerScannerTests
 		Assert.Contains ("android/view/View$OnClickListener",
 			FindByJavaName (peers, "my/app/ClickableView").ImplementedInterfaceJavaNames);
 		Assert.Empty (FindByJavaName (peers, "my/app/MyHelper").ImplementedInterfaceJavaNames);
+	}
+
+	[Theory]
+	[InlineData ("android/app/Activity", "android/app/Activity")]
+	[InlineData ("my/app/MainActivity", "my/app/MainActivity")]
+	public void Scan_CompatJniName (string javaName, string expectedCompat)
+	{
+		var peers = ScanFixtures ();
+		Assert.Equal (expectedCompat, FindByJavaName (peers, javaName).CompatJniName);
+	}
+
+	[Fact]
+	public void Scan_CompatJniName_UnregisteredType_UsesRawNamespace ()
+	{
+		var peers = ScanFixtures ();
+		var unregistered = FindByManagedName (peers, "MyApp.UnregisteredHelper");
+		Assert.StartsWith ("crc64", unregistered.JavaName);
+		Assert.Equal ("myapp/UnregisteredHelper", unregistered.CompatJniName);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.EdgeCases.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.EdgeCases.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
@@ -41,6 +42,8 @@ public partial class JavaPeerScannerTests
 	{
 		var peers = ScanFixtures ();
 		Assert.Equal ("GlobalType", FindByJavaName (peers, "my/app/GlobalType").ManagedTypeName);
+		Assert.Equal ("GlobalUnregisteredType",
+			FindByManagedName (peers, "GlobalUnregisteredType").CompatJniName);
 	}
 
 	[Theory]
@@ -54,4 +57,13 @@ public partial class JavaPeerScannerTests
 		Assert.StartsWith ("crc64", FindByManagedName (peers, managedName).JavaName);
 	}
 
+	[Fact]
+	public void Scan_ExportOnUnregisteredType_MethodDiscovered ()
+	{
+		var peers = ScanFixtures ();
+		var exportMethod = FindByManagedName (peers, "MyApp.UnregisteredExporter")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "doExportedWork");
+		Assert.NotNull (exportMethod);
+		Assert.Null (exportMethod.Connector);
+	}
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/android/issues/10799

## Summary

Adds ACW (Android Callable Wrapper) support to TypeMap proxy types, building on the groundwork from PR #10808.

### Changes
- `UcoMethodData`/`UcoConstructorData`/`NativeRegistrationData` model types
- `ModelBuilder`: generates UCO method wrappers, constructor wrappers, and native method registrations for ACW types
- `TypeMapAssemblyEmitter`: emits `[UnmanagedCallersOnly]` UCO methods, UCO constructor wrappers, `RegisterNatives`, `IAndroidCallableWrapper` interface implementation
- `IsAcw` detection for types that need JNI native method registration
- Cross-assembly `IgnoresAccessChecksTo` for UCO callback types

### Tests
- Tests for all UCO/RegisterNatives generation scenarios (ACW detection, UCO methods, UCO constructors, native registrations)

**Stacked PRs:**
1. PR #10808 — Proxy groundwork with CreateInstance
2. PR #10909 — Marshal method scanning infrastructure
3. PR #10831 ← **this PR** — UCO wrappers + RegisterNatives
4. PR #10830 — JCW Java Source Generation