### PR TITLE
[build] Use all available CPU cores for NUnit test parallelism

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -22,7 +22,7 @@ variables:
 - name: NUnitConsoleVersion
   value: 3.16.3
 - name: NUnit.NumberOfTestWorkers
-  value: 4
+  value: -1
 - name: DotNetSdkVersion
   value: 10.0
 - name: DotNetSdkQuality


### PR DESCRIPTION
Change NUnit.NumberOfTestWorkers from 4 to -1 (the NUnit default), which makes NUnit auto-detect the number of workers using Environment.ProcessorCount.

On macOS-14-arm64 CI agents this should double test parallelism from 4 to 8 workers, helping the Xamarin.Android.Build.Tests suite complete within the 180-minute timeout.

See: https://docs.nunit.org/articles/vs-test-adapter/Tips-And-Tricks.html#numberOfTestWorkers