### PR TITLE
$(AndroidPackVersionSuffix)=preview.3; main is .NET 11 preview 3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.1.99</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.2</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview2

We branched for .NET 11 Preview 2 from 1dec8d882 into `release/11.0.1xx-preview2`; the main branch is now .NET 11 Preview 3.