### PR TITLE
Fix _TouchAndroidLinkFlag skipping on NativeAOT incremental builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -243,7 +243,7 @@
 
   <Target Name="_TouchAndroidLinkFlag"
       AfterTargets="ILLink"
-      Condition=" '$(PublishTrimmed)' == 'true' and Exists('$(_LinkSemaphore)') "
+      Condition=" '$(PublishTrimmed)' == 'true' and '$(RunILLink)' != 'false' and Exists('$(_LinkSemaphore)') "
       Inputs="$(_LinkSemaphore)"
       Outputs="$(_AndroidLinkFlag)">
     <!-- This file is an input for _RemoveRegisterAttribute -->


### PR DESCRIPTION
Add '$(RunILLink)' != 'false' to the Condition of _TouchAndroidLinkFlag so it Condition-skips in lockstep with the ILLink target it hooks via AfterTargets. This works around an MSBuild behavior (dotnet/msbuild#13274) where AfterTargets hooks may fire before the target actually executes, leading to a stale flag.

Without this fix, _TouchAndroidLinkFlag's Inputs/Outputs check sees stale timestamps on the first (skipped) ILLink invocation and skips itself, then never runs again when ILLink actually executes.  This can sometimes cause link.flag to go stale, which can cause _RemoveRegisterAttribute and the AssemblyModifierPipeline to skip on incremental builds.

Fixes an issue I found in https://github.com/dotnet/android/pull/10704. Opening as a separate PR to test it in isolation.