### PR TITLE
[skills] create `read-assembly-store` skill

### DIFF
--- a/.github/skills/read-assembly-store/SKILL.md
+++ b/.github/skills/read-assembly-store/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: read-assembly-store
+description: Read and inspect .NET assembly stores from Android APK, AAB, or raw store files. Use this when users want to inspect, examine, or list assemblies in an APK, AAB, assembly store, or manifest file.
+---
+
+# Read Assembly Store
+
+Read and inspect .NET assembly stores from Android APK, AAB, or raw store files using the `assembly-store-reader-mk2` tool in this repository.
+
+## What It Does
+
+Lists all .NET managed assemblies embedded in an Android app, showing per-assembly metadata (PE image offset/size, debug data, config data, name hashes) grouped by target architecture.
+
+Supports these input types:
+- **APK files** (`.apk`)
+- **AAB files** (`.aab`)
+- **Assembly store files** (`libassembly-store.so`, `assemblies.blob`)
+- **Store manifest files** (`base_assemblies.manifest`)
+- **Store base names** (e.g. `base` or `base_assemblies`)
+
+## How to Run
+
+From the repository root, run the tool using `dotnet-local` to ensure the correct SDK is used.
+
+**On Windows:**
+
+```powershell
+.\dotnet-local.cmd run --project .\tools\assembly-store-reader-mk2\ -- [OPTIONS] <file>
+```
+
+**On macOS/Linux:**
+
+```bash
+./dotnet-local.sh run --project ./tools/assembly-store-reader-mk2/ -- [OPTIONS] <file>
+```
+
+### Options
+
+- `-a`, `--arch=ARCHITECTURES` — Comma-separated list of architectures to limit output to (e.g. `Arm64`, `x64`, `Arm`, `X86`). Aliases like `aarch64`, `arm32`, `armv7a`, `armv8a` also work.
+- `-h`, `--help` — Show help.
+
+## Instructions
+
+1. Determine the user's operating system from the environment context.
+2. Ask the user which file to inspect if not already specified.
+3. Run the appropriate command from the **repository root**, passing the file path and any options after `--`.
+4. Report the output to the user, summarizing the assemblies found per architecture.
+
+## Examples
+
+Inspect an APK:
+
+```powershell
+.\dotnet-local.cmd run --project .\tools\assembly-store-reader-mk2\ -- path\to\app.apk
+```
+
+Inspect an APK, arm64 only:
+
+```powershell
+.\dotnet-local.cmd run --project .\tools\assembly-store-reader-mk2\ -- --arch=Arm64 path\to\app.apk
+```
+
+Inspect a raw store file:
+
+```powershell
+.\dotnet-local.cmd run --project .\tools\assembly-store-reader-mk2\ -- path\to\libassembly-store.so
+```


### PR DESCRIPTION
If you run `copilot` CLI in the repo, `/skills` will list a new `read-assembly-store` skill.

```
❯ can you inspect this .apk D:\src\test\bin\Release\net10.0-android\com.companyname.test-Signed.apk

◐ The user wants to inspect an APK file. There's a skill available called "read-assembly-store" that is specifically designed to "Read and inspect .NET assembly stores from Android APK, AAB, or raw store
  files." This is the perfect skill to use.

● skill(read-assembly-store)

◐ The user wants to inspect an APK file. I have the skill instructions. Let me run the command from the repository root.

● Inspect APK assembly store
  $ .\dotnet-local.cmd run --project .\tools\assembly-store-reader-mk2\ -- D:\src\test\bin\Release\net10.0-android\com.companyname.test-Signed.apk
  └ 198 lines...

● The APK contains 2 assembly stores with 10 assemblies each across two architectures:

  Arm64 and x64 — both contain the same set of assemblies:

  ┌──────────────────────────────────────────┬─────────────┐
  │ Assembly                                 │ Size        │
  ├──────────────────────────────────────────┼─────────────┤
  │ System.Private.CoreLib.dll               │ ~612-616 KB │
  ├──────────────────────────────────────────┼─────────────┤
  │ Mono.Android.dll                         │ ~91-92 KB   │
  ├──────────────────────────────────────────┼─────────────┤
  │ Java.Interop.dll                         │ ~71 KB      │
  ├──────────────────────────────────────────┼─────────────┤
  │ System.Linq.dll                          │ ~8 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ System.Console.dll                       │ ~7 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ Mono.Android.Runtime.dll                 │ ~6 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ System.Runtime.InteropServices.dll       │ ~4 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ System.Runtime.dll                       │ ~3 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ test.dll                                 │ ~2 KB       │
  ├──────────────────────────────────────────┼─────────────┤
  │ _Microsoft.Android.Resource.Designer.dll │ ~1 KB       │
  └──────────────────────────────────────────┴─────────────┘

  No debug or config data is present in any assembly (expected for a Release build). The app is fairly minimal — just your test.dll plus core framework assemblies.
```