### PR TITLE
Localized file check-in by OneLocBuild Task: Build definition ID 17928: Build ID 13427813

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.cs.resx
@@ -1073,6 +1073,22 @@ Pokud chcete pro sestavení z příkazového řádku použít vlastní cestu JDK
     <value>Příkaz {0} selhal.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Spustitelný soubor gradlew nebyl v adresáři projektu {0} nalezen. Ujistěte se prosím, že cesta ke složce projektu Gradle je správná a že obsahuje skripty Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.de.resx
@@ -1073,6 +1073,22 @@ Um einen benutzerdefinierten JDK-Pfad für einen Befehlszeilenbuild zu verwenden
     <value>Befehl „{0}“ fehlgeschlagen.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Die ausführbare Datei „gradlew“ wurde im Projektverzeichnis „{0}“ nicht gefunden. Stellen Sie sicher, dass der Pfad zu Ihrem Gradle-Projektordner korrekt ist und dass er Gradle Wrapper-Skripts enthält.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.es.resx
@@ -1073,6 +1073,22 @@ Para usar una ruta de acceso de JDK personalizada para una compilación de líne
     <value>Error del comando '{0}'.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>No se encontró el ejecutable 'gradlew' en el directorio del proyecto '{0}'. Asegúrese de que la ruta de acceso a la carpeta del proyecto de Gradle es correcta y que contiene scripts de contenedores de Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.fr.resx
@@ -1073,6 +1073,22 @@ Pour utiliser un chemin JDK personnalisé pour une build de ligne de commande, d
     <value>La commande « {0} » a échoué.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>L’exécutable « gradlew » est introuvable dans le répertoire du projet « {0} ». Veuillez vérifier que le chemin d’accès au dossier de votre projet Gradle est correct et qu’il contient des scripts Wrapper Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.it.resx
@@ -1073,6 +1073,22 @@ Per usare un percorso JDK personalizzato per una compilazione della riga di coma
     <value>Comando '{0}' non riuscito.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Il file eseguibile 'gradlew' non è stato trovato nella directory di progetto '{0}'. Assicurarsi che il percorso della cartella di progetto Gradle sia corretto e che contenga script wrapper di Gradle.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ja.resx
@@ -1074,6 +1074,22 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>コマンド '{0}' が失敗しました。\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>プロジェクト ディレクトリ '{0}' に実行可能ファイル 'gradlew' が見つかりません。Gradle プロジェクト フォルダーへのパスが正しいこと、Gradle ラッパー スクリプトが含まれていることを確認してください。</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ko.resx
@@ -1073,6 +1073,22 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>'{0}' 명령이 실패했습니다.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>프로젝트 디렉터리 '{0}'에서 실행 파일 'gradlew'를 찾을 수 없습니다. Gradle 프로젝트 폴더의 경로가 올바르고 Gradle Wrapper 스크립트가 포함되어 있는지 확인하세요.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pl.resx
@@ -1073,6 +1073,22 @@ Aby użyć niestandardowej ścieżki zestawu JDK dla kompilacji wiersza poleceni
     <value>Wykonanie polecenia „{0}” nie powiodło się.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Nie znaleziono pliku wykonywalnego „gradlew” w katalogu projektu „{0}”. Upewnij się, że ścieżka do folderu projektu Gradle jest poprawna i że zawiera skrypty Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.pt-BR.resx
@@ -1073,6 +1073,22 @@ Para usar um caminho JDK personalizado para um build de linha de comando, defina
     <value>O comando '{0}' falhou.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Executável 'gradlew' não encontrado no diretório do projeto '{0}'. Verifique se o caminho para a pasta do projeto Gradle está correto e se ele contém scripts do Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.ru.resx
@@ -1073,6 +1073,22 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>Не удалось выполнить команду "{0}".\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Исполняемый файл "gradlew" не найден в каталоге проекта "{0}". Убедитесь, что путь к папке проекта Gradle указан правильно и что она содержит сценарии Gradle Wrapper.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.tr.resx
@@ -1073,6 +1073,22 @@ Bir komut satırı derlemesi için özel bir SDK yolu kullanmak için 'JavaSdkDi
     <value>'{0}' komutu başarısız oldu.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>'Gradlew' yürütülebilir dosyası '{0}' proje dizininde bulunamadı. Lütfen Gradle proje klasör yolunun doğru olduğundan ve Gradle Sarmalayıcı betikleri içerdiğinden emin olun.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hans.resx
@@ -1073,6 +1073,22 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>命令 '{0}' 失败。\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>在项目目录 ‘{0}’ 中找不到可执行的 ‘gradlew’。请确保 Gradle 项目文件夹的路径正确无误，并且包含 Gradle 包装器脚本。</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.zh-Hant.resx
@@ -1073,6 +1073,22 @@ In this message, the term "handheld app" means "app for handheld devices."
     <value>指令 '{0}' 失敗。\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>
   </data>
+  <data name="XA0143" xml:space="preserve">
+    <value>Failed to launch the Android emulator for AVD '{0}': {1}</value>
+    <comment>{0} - The AVD name.
+{1} - The exception message.</comment>
+  </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
+    <comment>{0} - The AVD name.
+{1} - The process exit code.</comment>
+  </data>
+  <data name="XA0145" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
+    <comment>The following is a literal name and should not be translated: BootTimeoutSeconds
+{0} - The AVD name.
+{1} - The timeout in seconds.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>在專案目錄 '{0}' 中找不到可執行檔 'gradlew'。請確定 Gradle 專案資料夾的路徑正確，且其中包含 Gradle 包裝函式指令碼。</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper


### PR DESCRIPTION
This is the pull request automatically created by the OneLocBuild task in the build process to check-in localized files generated based upon translation source files (.lcl files) handed-back from the downstream localization pipeline. If there are issues in translations, visit https://aka.ms/icxLocBug and log bugs for fixes. The OneLocBuild wiki is https://aka.ms/onelocbuild and the localization process in general is documented at https://aka.ms/AllAboutLoc.