### PR TITLE
[build] Ignore MAUI public API analyzer errors (RS0016) in MAUI integration lane

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -120,6 +120,8 @@ extends:
           clean: all
         variables:
           BuildVersion: $(Build.BuildId)
+          # Ignore MAUI's public API analyzer errors (RS0016) - dotnet/android does not care about those
+          PublicApiType: Generate
         steps:
         - checkout: maui
           clean: true


### PR DESCRIPTION
Set PublicApiType=Generate on the maui_tests_integration job to skip the Microsoft.CodeAnalysis.PublicApiAnalyzers package, which produces RS0016 errors for new/changed MAUI APIs that dotnet/android does not need to validate.