### PR TITLE
[skills] Add AZDO build investigator skill

### DIFF
--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -35,18 +35,18 @@ Filter `bucket == "fail"`. Each has a `link` with the AZDO build URL. Multiple f
 - `https://dev.azure.com/{org}/{project}/_build/results?buildId={id}`
 - `https://{org}.visualstudio.com/{project}/_build/results?buildId={id}`
 
-Extract `{org}`, `{project}` (may be a GUID — that's fine), and `{buildId}`.
+Extract `{org}`, `{project}` (may be a GUID — that's fine), `{buildId}`, and the full `{orgUrl}` (either `https://dev.azure.com/{org}` or `https://{org}.visualstudio.com`). Use `{orgUrl}` consistently in all subsequent `az` commands.
 
 ### 2. Get Build Overview
 
 ```powershell
-az pipelines runs show --id {buildId} --org https://dev.azure.com/{org} --project {project}
+az pipelines runs show --id {buildId} --org {orgUrl} --project {project}
 ```
 
 ### 3. Get Failed Jobs & Tasks (Timeline)
 
 ```powershell
-az devops invoke --area build --resource timeline --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --query "records[?result=='failed'] | [].{name:name, type:type, result:result, log:log, issues:issues, errorCount:errorCount}" --output json
+az devops invoke --area build --resource timeline --route-parameters project={project} buildId={buildId} --org {orgUrl} --project {project} --query "records[?result=='failed'] | [].{name:name, type:type, result:result, log:log, issues:issues, errorCount:errorCount}" --output json
 ```
 
 Check the `issues` array first — it often contains the root cause directly.
@@ -56,13 +56,13 @@ Check the `issues` array first — it often contains the root cause directly.
 Get log URLs from failed timeline records, then fetch by log ID:
 
 ```powershell
-az devops invoke --area build --resource logs --route-parameters buildId={buildId} logId={logId} --org https://dev.azure.com/{org} --project {project} --output json
+az devops invoke --area build --resource logs --route-parameters project={project} buildId={buildId} logId={logId} --org {orgUrl} --project {project} --output json
 ```
 
 ### 5. Check for .binlog Artifacts
 
 ```powershell
-az pipelines runs artifact list --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
+az pipelines runs artifact list --run-id {buildId} --org {orgUrl} --project {project}
 ```
 
 Look for artifact names containing `binlog`, `msbuild`, or `build-log`.
@@ -72,7 +72,7 @@ Look for artifact names containing `binlog`, `msbuild`, or `build-log`.
 ```powershell
 $tempDir = Join-Path $env:TEMP "azdo-binlog-$buildId"
 New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
-az pipelines runs artifact download --artifact-name "{artifactName}" --path $tempDir --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
+az pipelines runs artifact download --artifact-name "{artifactName}" --path $tempDir --run-id {buildId} --org {orgUrl} --project {project}
 ```
 
 Key `binlogtool` commands:

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -9,7 +9,7 @@ Given a build URL or GitHub PR URL, fetch run details, find failed jobs/tasks, d
 
 ## Prerequisites
 
-All three tools below are **required only when needed** (gh for PR URLs, az always, binlogtool for .binlog analysis). If any is missing, **stop immediately**, show the relevant setup link, and do NOT install on the user's behalf.
+The tools below are required as follows: `az` is always required; `gh` is required only for GitHub PR URLs; `binlogtool` is required only for .binlog analysis. If any required tool is missing for the current task, **stop immediately**, show the relevant setup link, and do NOT install on the user's behalf.
 
 | Tool | Check | Install / Docs |
 |------|-------|----------------|
@@ -56,7 +56,8 @@ Check the `issues` array first — it often contains the root cause directly.
 Get log URLs from failed timeline records, then fetch by log ID:
 
 ```powershell
-az devops invoke --area build --resource logs --route-parameters project={project} buildId={buildId} logId={logId} --org {orgUrl} --project {project} --output json
+# The logs endpoint returns raw text; save to a file instead of requesting JSON
+az devops invoke --area build --resource logs --route-parameters project={project} buildId={buildId} logId={logId} --org {orgUrl} --project {project} --out-file "build-{buildId}-log-{logId}.log"
 ```
 
 ### 5. Check for .binlog Artifacts

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: azdo-build-investigator
+description: Investigate Azure DevOps (AZDO) pipeline build failures by fetching logs, downloading artifacts, and analyzing .binlog files to find the root cause of errors. Use this when users share an AZDO build URL, a GitHub PR URL, or ask about a failing pipeline, build errors, or CI failures.
+---
+
+# AZDO Build Investigator
+
+Investigate Azure DevOps pipeline build failures to find root causes. Given a build URL or GitHub PR URL, this skill fetches run details, identifies failed jobs/tasks, downloads logs and .binlog artifacts, and produces a summarized error trail.
+
+## Prerequisites
+
+### GitHub CLI (for PR URLs)
+
+If the user provides a GitHub PR URL, the `gh` CLI is required to look up the failing checks. If `gh` is not found, **stop immediately** and tell the user to set it up manually:
+
+- **Install GitHub CLI:** https://docs.github.com/github-cli/github-cli/quickstart
+
+Do NOT attempt to install or configure the GitHub CLI on the user's behalf.
+
+### Azure CLI with DevOps Extension
+
+This skill requires the Azure CLI with the `azure-devops` extension. If the `az` command is not found or `az devops` is not available, **stop immediately** and tell the user to set it up manually:
+
+- **Install Azure CLI:** https://learn.microsoft.com/cli/azure/install-azure-cli
+- **Install the DevOps extension:** `az extension add --name azure-devops`
+- **DevOps extension docs:** https://learn.microsoft.com/cli/azure/devops
+- **Authenticate:** `az login`
+- **Configure defaults:** `az devops configure --defaults organization=https://dev.azure.com/ORGNAME project=PROJECTNAME`
+
+Do NOT attempt to install or configure these tools on the user's behalf.
+
+### binlogtool (.NET Global Tool)
+
+For `.binlog` analysis, this skill uses the `binlogtool` .NET global tool. Check if it's installed:
+
+```shell
+dotnet tool list -g | findstr binlogtool   # Windows
+dotnet tool list -g | grep binlogtool      # macOS/Linux
+```
+
+If missing, install it:
+
+```shell
+dotnet tool install -g binlogtool
+```
+
+- **NuGet page:** https://www.nuget.org/packages/binlogtool
+- **MSBuild binary log info:** https://msbuildlog.com
+
+## Investigation Workflow
+
+Follow these steps in order. Stop early if the root cause is found.
+
+### Step 1: Determine the Input URL Type
+
+The user may provide either:
+- A **GitHub PR URL** like `https://github.com/{owner}/{repo}/pull/{number}`
+- An **AZDO build URL** like `https://dev.azure.com/{org}/{project}/_build/results?buildId={id}`
+
+If the URL is a GitHub PR, go to Step 1a. If it's an AZDO build URL, skip to Step 1b.
+
+### Step 1a: Resolve GitHub PR to AZDO Build URLs
+
+Use the `gh` CLI to list check runs on the PR and find failing ones:
+
+```powershell
+gh pr checks {prNumber} --repo {owner}/{repo} --json "name,state,link,bucket"
+```
+
+Filter for checks where `bucket` is `fail` (or `state` is `FAILURE`). Each failing check has a `link` field containing the AZDO build URL. The `name` field identifies which check failed.
+
+If there are **multiple failing checks**, list them for the user and ask which one to investigate, or investigate all of them starting with the first.
+
+If there are **no failing checks**, tell the user all checks are passing (or still in progress if `state` is `IN_PROGRESS`).
+
+Extract the AZDO build URL from the `link` field and continue to Step 1b.
+
+### Step 1b: Parse the AZDO Build URL
+
+Extract the organization, project, and build/run ID from the URL. AZDO build URLs follow these patterns:
+
+```
+https://dev.azure.com/{org}/{project}/_build/results?buildId={id}
+https://dev.azure.com/{org}/{project}/_build/results?buildId={id}&view=results
+https://{org}.visualstudio.com/{project}/_build/results?buildId={id}
+```
+
+Note: The `{project}` field may be a GUID (e.g., `cbb18261-c48f-4abb-8651-8cdcb5474649`) — this is fine, `az` commands accept project GUIDs.
+
+### Step 2: Check Tool Availability
+
+Verify `az` is available:
+
+```powershell
+az --version
+```
+
+If it fails, tell the user to install Azure CLI and the DevOps extension (see Prerequisites above), then stop.
+
+### Step 3: Get Build Overview
+
+```powershell
+az pipelines runs show --id {buildId} --org https://dev.azure.com/{org} --project {project}
+```
+
+Report: pipeline name, status, result, source branch, start/finish times, and the reason it ran.
+
+### Step 4: Get Build Timeline (Failed Jobs & Tasks)
+
+Use the REST API via `az devops invoke` to get the build timeline, which contains every job and task with its status and error details:
+
+```powershell
+az devops invoke --area build --resource timeline --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --query "records[?result=='failed'] | [].{name:name, type:type, result:result, log:log, issues:issues, errorCount:errorCount}" --output json
+```
+
+This returns the failed records. For each failed task/job, note:
+- The **name** and **type** (Job or Task)
+- The **issues** array which often contains the actual error messages
+- The **log** object which has a URL to the full log
+
+If the timeline shows error messages in the `issues` field, these are often sufficient to identify the root cause without downloading full logs.
+
+### Step 5: Download and Read Full Logs (if needed)
+
+If the timeline issues don't reveal the root cause, download the full log for a failed task. The log URL from the timeline response can be fetched directly:
+
+```powershell
+az devops invoke --area build --resource timeline --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --query "records[?result=='failed' && log!=null] | [].{name:name, logUrl:log.url}" --output json
+```
+
+Then fetch individual log content using the log URL via `az devops invoke` or use:
+
+```powershell
+# Get all logs for the build
+az devops invoke --area build --resource logs --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --output json
+```
+
+To fetch a specific log by its ID:
+
+```powershell
+az devops invoke --area build --resource logs --route-parameters buildId={buildId} logId={logId} --org https://dev.azure.com/{org} --project {project} --output json
+```
+
+### Step 6: Check for .binlog Artifacts
+
+List artifacts attached to the run:
+
+```powershell
+az pipelines runs artifact list --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
+```
+
+Look for artifacts with names containing `binlog`, `msbuild`, or `build-log`. Common artifact names in this repo include patterns like `Build *.binlog`, `msbuild.binlog`, etc.
+
+### Step 7: Download and Analyze .binlog Files
+
+If .binlog artifacts are found, download them to a temp directory:
+
+```powershell
+$tempDir = Join-Path $env:TEMP "azdo-binlog-$buildId"
+New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+az pipelines runs artifact download --artifact-name "{artifactName}" --path $tempDir --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
+```
+
+Then analyze with `binlogtool`. First check if it's installed (see Prerequisites). Then:
+
+**Search for errors:**
+
+```powershell
+binlogtool search "$tempDir\*.binlog" "error"
+```
+
+**Search for specific error codes (useful for this repo):**
+
+```powershell
+binlogtool search "$tempDir\*.binlog" "XA"
+binlogtool search "$tempDir\*.binlog" "error CS"
+binlogtool search "$tempDir\*.binlog" "error NU"
+```
+
+**Reconstruct full text logs from a .binlog:**
+
+```powershell
+binlogtool reconstruct "$tempDir\file.binlog" "$tempDir\reconstructed"
+```
+
+Then search the reconstructed text logs for error patterns.
+
+**Other useful binlogtool commands:**
+
+```powershell
+# List NuGet packages referenced in the build
+binlogtool listnuget "$tempDir\file.binlog" "$tempDir\nuget-list"
+
+# List all properties set during the build
+binlogtool listproperties "$tempDir\file.binlog"
+
+# Check for double-write issues (files written multiple times)
+binlogtool doublewrites "$tempDir\file.binlog" "$tempDir\doublewrites"
+```
+
+### Step 8: Summarize Findings
+
+Present a clear root-cause summary:
+
+1. **Build Overview** — Pipeline name, branch, trigger, overall result
+2. **Failed Stage/Job/Task** — Which part of the pipeline failed
+3. **Error Messages** — The actual error text, with error codes if present
+4. **Root Cause** — Your analysis of what went wrong
+5. **Suggestions** — Possible fixes or next investigation steps
+
+## Error Patterns (dotnet/android Repository)
+
+When investigating builds from this repository, look for these common error patterns:
+
+### MSBuild / Build Task Errors
+- **`XA####`** — .NET for Android build errors/warnings (e.g., `XA0000`–`XA9999`). Search the repo's `Documentation/` or source for the error code meaning.
+- **`APT####`** — Android asset/resource packaging tool errors
+- **`error CS####`** — C# compiler errors
+- **`error NU####`** — NuGet restore/package errors
+
+### Test Failures
+- **`NUnit`** / **`xUnit`** test failures — Look for `Failed :` or `Assert.` in logs
+- **Device test crashes** — Look for `System.TimeoutException`, `ADB`, `emulator`, or `device not found`
+- **`MSBuildDeviceIntegration`** — Integration test failures often show as build errors in test projects
+
+### Infrastructure / Environment
+- **`Agent.BuildDirectory`** / **disk space** — Out of disk space on CI agents
+- **`##[error]`** — Azure DevOps pipeline error annotations
+- **`Process exit code`** — Non-zero exit codes from build steps
+- **Timeout** — Tasks exceeding time limits
+
+### NuGet / Dependency
+- **`NU1100`–`NU1699`** — NuGet dependency resolution failures
+- **`error NU1301`** — Unable to load service index (feed connectivity)
+
+## Cleanup
+
+After investigation, clean up downloaded artifacts:
+
+```powershell
+Remove-Item -Recurse -Force (Join-Path $env:TEMP "azdo-binlog-$buildId")
+```
+
+## Tips
+
+- If `az devops invoke` returns auth errors, the user needs to run `az login` and may need to configure `az devops configure --defaults`.
+- The `--detect` flag on `az` commands tries to auto-detect org/project from the git remote — this works when running from within the repo directory.
+- For very large builds with many failures, focus on the **first** error chronologically — later errors are often cascading failures.
+- `.binlog` files contain much richer detail than text logs. If the text logs show a generic "Build FAILED" message, the `.binlog` will have the specific MSBuild target and task that failed.
+- Use `binlogtool search` with broad terms first (`error`, `failed`), then narrow down with specific codes.

--- a/.github/skills/azdo-build-investigator/SKILL.md
+++ b/.github/skills/azdo-build-investigator/SKILL.md
@@ -5,155 +5,69 @@ description: Investigate Azure DevOps (AZDO) pipeline build failures by fetching
 
 # AZDO Build Investigator
 
-Investigate Azure DevOps pipeline build failures to find root causes. Given a build URL or GitHub PR URL, this skill fetches run details, identifies failed jobs/tasks, downloads logs and .binlog artifacts, and produces a summarized error trail.
+Given a build URL or GitHub PR URL, fetch run details, find failed jobs/tasks, download logs and .binlog artifacts, and produce a summarized root-cause error trail.
 
 ## Prerequisites
 
-### GitHub CLI (for PR URLs)
+All three tools below are **required only when needed** (gh for PR URLs, az always, binlogtool for .binlog analysis). If any is missing, **stop immediately**, show the relevant setup link, and do NOT install on the user's behalf.
 
-If the user provides a GitHub PR URL, the `gh` CLI is required to look up the failing checks. If `gh` is not found, **stop immediately** and tell the user to set it up manually:
+| Tool | Check | Install / Docs |
+|------|-------|----------------|
+| `gh` (GitHub CLI) | `gh --version` | https://docs.github.com/github-cli/github-cli/quickstart |
+| `az` (Azure CLI + DevOps ext) | `az --version` | Install: https://learn.microsoft.com/cli/azure/install-azure-cli — Extension: `az extension add --name azure-devops` — Docs: https://learn.microsoft.com/cli/azure/devops — Then: `az login` and `az devops configure --defaults organization=https://dev.azure.com/ORGNAME project=PROJECTNAME` |
+| `binlogtool` (.NET global tool) | `dotnet tool list -g` | `dotnet tool install -g binlogtool` — https://www.nuget.org/packages/binlogtool |
 
-- **Install GitHub CLI:** https://docs.github.com/github-cli/github-cli/quickstart
+## Workflow
 
-Do NOT attempt to install or configure the GitHub CLI on the user's behalf.
+Follow in order. Stop early if root cause is found.
 
-### Azure CLI with DevOps Extension
+### 1. Resolve Input URL
 
-This skill requires the Azure CLI with the `azure-devops` extension. If the `az` command is not found or `az devops` is not available, **stop immediately** and tell the user to set it up manually:
-
-- **Install Azure CLI:** https://learn.microsoft.com/cli/azure/install-azure-cli
-- **Install the DevOps extension:** `az extension add --name azure-devops`
-- **DevOps extension docs:** https://learn.microsoft.com/cli/azure/devops
-- **Authenticate:** `az login`
-- **Configure defaults:** `az devops configure --defaults organization=https://dev.azure.com/ORGNAME project=PROJECTNAME`
-
-Do NOT attempt to install or configure these tools on the user's behalf.
-
-### binlogtool (.NET Global Tool)
-
-For `.binlog` analysis, this skill uses the `binlogtool` .NET global tool. Check if it's installed:
-
-```shell
-dotnet tool list -g | findstr binlogtool   # Windows
-dotnet tool list -g | grep binlogtool      # macOS/Linux
-```
-
-If missing, install it:
-
-```shell
-dotnet tool install -g binlogtool
-```
-
-- **NuGet page:** https://www.nuget.org/packages/binlogtool
-- **MSBuild binary log info:** https://msbuildlog.com
-
-## Investigation Workflow
-
-Follow these steps in order. Stop early if the root cause is found.
-
-### Step 1: Determine the Input URL Type
-
-The user may provide either:
-- A **GitHub PR URL** like `https://github.com/{owner}/{repo}/pull/{number}`
-- An **AZDO build URL** like `https://dev.azure.com/{org}/{project}/_build/results?buildId={id}`
-
-If the URL is a GitHub PR, go to Step 1a. If it's an AZDO build URL, skip to Step 1b.
-
-### Step 1a: Resolve GitHub PR to AZDO Build URLs
-
-Use the `gh` CLI to list check runs on the PR and find failing ones:
+**GitHub PR** (`https://github.com/{owner}/{repo}/pull/{number}`):
 
 ```powershell
 gh pr checks {prNumber} --repo {owner}/{repo} --json "name,state,link,bucket"
 ```
 
-Filter for checks where `bucket` is `fail` (or `state` is `FAILURE`). Each failing check has a `link` field containing the AZDO build URL. The `name` field identifies which check failed.
+Filter `bucket == "fail"`. Each has a `link` with the AZDO build URL. Multiple failures → ask user which to investigate. No failures → report passing/in-progress.
 
-If there are **multiple failing checks**, list them for the user and ask which one to investigate, or investigate all of them starting with the first.
+**AZDO build URL** patterns:
+- `https://dev.azure.com/{org}/{project}/_build/results?buildId={id}`
+- `https://{org}.visualstudio.com/{project}/_build/results?buildId={id}`
 
-If there are **no failing checks**, tell the user all checks are passing (or still in progress if `state` is `IN_PROGRESS`).
+Extract `{org}`, `{project}` (may be a GUID — that's fine), and `{buildId}`.
 
-Extract the AZDO build URL from the `link` field and continue to Step 1b.
-
-### Step 1b: Parse the AZDO Build URL
-
-Extract the organization, project, and build/run ID from the URL. AZDO build URLs follow these patterns:
-
-```
-https://dev.azure.com/{org}/{project}/_build/results?buildId={id}
-https://dev.azure.com/{org}/{project}/_build/results?buildId={id}&view=results
-https://{org}.visualstudio.com/{project}/_build/results?buildId={id}
-```
-
-Note: The `{project}` field may be a GUID (e.g., `cbb18261-c48f-4abb-8651-8cdcb5474649`) — this is fine, `az` commands accept project GUIDs.
-
-### Step 2: Check Tool Availability
-
-Verify `az` is available:
-
-```powershell
-az --version
-```
-
-If it fails, tell the user to install Azure CLI and the DevOps extension (see Prerequisites above), then stop.
-
-### Step 3: Get Build Overview
+### 2. Get Build Overview
 
 ```powershell
 az pipelines runs show --id {buildId} --org https://dev.azure.com/{org} --project {project}
 ```
 
-Report: pipeline name, status, result, source branch, start/finish times, and the reason it ran.
-
-### Step 4: Get Build Timeline (Failed Jobs & Tasks)
-
-Use the REST API via `az devops invoke` to get the build timeline, which contains every job and task with its status and error details:
+### 3. Get Failed Jobs & Tasks (Timeline)
 
 ```powershell
 az devops invoke --area build --resource timeline --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --query "records[?result=='failed'] | [].{name:name, type:type, result:result, log:log, issues:issues, errorCount:errorCount}" --output json
 ```
 
-This returns the failed records. For each failed task/job, note:
-- The **name** and **type** (Job or Task)
-- The **issues** array which often contains the actual error messages
-- The **log** object which has a URL to the full log
+Check the `issues` array first — it often contains the root cause directly.
 
-If the timeline shows error messages in the `issues` field, these are often sufficient to identify the root cause without downloading full logs.
+### 4. Fetch Full Logs (if needed)
 
-### Step 5: Download and Read Full Logs (if needed)
-
-If the timeline issues don't reveal the root cause, download the full log for a failed task. The log URL from the timeline response can be fetched directly:
-
-```powershell
-az devops invoke --area build --resource timeline --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --query "records[?result=='failed' && log!=null] | [].{name:name, logUrl:log.url}" --output json
-```
-
-Then fetch individual log content using the log URL via `az devops invoke` or use:
-
-```powershell
-# Get all logs for the build
-az devops invoke --area build --resource logs --route-parameters buildId={buildId} --org https://dev.azure.com/{org} --project {project} --output json
-```
-
-To fetch a specific log by its ID:
+Get log URLs from failed timeline records, then fetch by log ID:
 
 ```powershell
 az devops invoke --area build --resource logs --route-parameters buildId={buildId} logId={logId} --org https://dev.azure.com/{org} --project {project} --output json
 ```
 
-### Step 6: Check for .binlog Artifacts
-
-List artifacts attached to the run:
+### 5. Check for .binlog Artifacts
 
 ```powershell
 az pipelines runs artifact list --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
 ```
 
-Look for artifacts with names containing `binlog`, `msbuild`, or `build-log`. Common artifact names in this repo include patterns like `Build *.binlog`, `msbuild.binlog`, etc.
+Look for artifact names containing `binlog`, `msbuild`, or `build-log`.
 
-### Step 7: Download and Analyze .binlog Files
-
-If .binlog artifacts are found, download them to a temp directory:
+### 6. Download & Analyze .binlog
 
 ```powershell
 $tempDir = Join-Path $env:TEMP "azdo-binlog-$buildId"
@@ -161,90 +75,41 @@ New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
 az pipelines runs artifact download --artifact-name "{artifactName}" --path $tempDir --run-id {buildId} --org https://dev.azure.com/{org} --project {project}
 ```
 
-Then analyze with `binlogtool`. First check if it's installed (see Prerequisites). Then:
-
-**Search for errors:**
+Key `binlogtool` commands:
 
 ```powershell
-binlogtool search "$tempDir\*.binlog" "error"
+binlogtool search "$tempDir\*.binlog" "error"          # broad search
+binlogtool search "$tempDir\*.binlog" "XA"             # .NET Android errors
+binlogtool search "$tempDir\*.binlog" "error CS"       # C# compiler
+binlogtool search "$tempDir\*.binlog" "error NU"       # NuGet
+binlogtool reconstruct "$tempDir\file.binlog" "$tempDir\reconstructed"  # full text log
+binlogtool listproperties "$tempDir\file.binlog"       # MSBuild properties
+binlogtool doublewrites "$tempDir\file.binlog" "$tempDir\dw"            # double-write issues
 ```
 
-**Search for specific error codes (useful for this repo):**
+### 7. Summarize
 
-```powershell
-binlogtool search "$tempDir\*.binlog" "XA"
-binlogtool search "$tempDir\*.binlog" "error CS"
-binlogtool search "$tempDir\*.binlog" "error NU"
-```
+Report: **Build overview** (pipeline, branch, trigger, result) → **Failed stage/job/task** → **Error messages** (with codes) → **Root cause analysis** → **Suggested fixes**.
 
-**Reconstruct full text logs from a .binlog:**
-
-```powershell
-binlogtool reconstruct "$tempDir\file.binlog" "$tempDir\reconstructed"
-```
-
-Then search the reconstructed text logs for error patterns.
-
-**Other useful binlogtool commands:**
-
-```powershell
-# List NuGet packages referenced in the build
-binlogtool listnuget "$tempDir\file.binlog" "$tempDir\nuget-list"
-
-# List all properties set during the build
-binlogtool listproperties "$tempDir\file.binlog"
-
-# Check for double-write issues (files written multiple times)
-binlogtool doublewrites "$tempDir\file.binlog" "$tempDir\doublewrites"
-```
-
-### Step 8: Summarize Findings
-
-Present a clear root-cause summary:
-
-1. **Build Overview** — Pipeline name, branch, trigger, overall result
-2. **Failed Stage/Job/Task** — Which part of the pipeline failed
-3. **Error Messages** — The actual error text, with error codes if present
-4. **Root Cause** — Your analysis of what went wrong
-5. **Suggestions** — Possible fixes or next investigation steps
-
-## Error Patterns (dotnet/android Repository)
-
-When investigating builds from this repository, look for these common error patterns:
-
-### MSBuild / Build Task Errors
-- **`XA####`** — .NET for Android build errors/warnings (e.g., `XA0000`–`XA9999`). Search the repo's `Documentation/` or source for the error code meaning.
-- **`APT####`** — Android asset/resource packaging tool errors
-- **`error CS####`** — C# compiler errors
-- **`error NU####`** — NuGet restore/package errors
-
-### Test Failures
-- **`NUnit`** / **`xUnit`** test failures — Look for `Failed :` or `Assert.` in logs
-- **Device test crashes** — Look for `System.TimeoutException`, `ADB`, `emulator`, or `device not found`
-- **`MSBuildDeviceIntegration`** — Integration test failures often show as build errors in test projects
-
-### Infrastructure / Environment
-- **`Agent.BuildDirectory`** / **disk space** — Out of disk space on CI agents
-- **`##[error]`** — Azure DevOps pipeline error annotations
-- **`Process exit code`** — Non-zero exit codes from build steps
-- **Timeout** — Tasks exceeding time limits
-
-### NuGet / Dependency
-- **`NU1100`–`NU1699`** — NuGet dependency resolution failures
-- **`error NU1301`** — Unable to load service index (feed connectivity)
-
-## Cleanup
-
-After investigation, clean up downloaded artifacts:
+### 8. Cleanup
 
 ```powershell
 Remove-Item -Recurse -Force (Join-Path $env:TEMP "azdo-binlog-$buildId")
 ```
 
+## Error Patterns (dotnet/android)
+
+| Category | Patterns to search |
+|----------|--------------------|
+| MSBuild | `XA####` (.NET Android), `APT####` (Android tooling), `error CS####` (C#), `error NU####` (NuGet) |
+| Tests | `Failed :`, `Assert.`, `System.TimeoutException`, `ADB`, `device not found` |
+| Infra | `##[error]`, disk space, `Process exit code`, timeout |
+| NuGet | `NU1100`–`NU1699` (resolution), `NU1301` (feed connectivity) |
+
 ## Tips
 
-- If `az devops invoke` returns auth errors, the user needs to run `az login` and may need to configure `az devops configure --defaults`.
-- The `--detect` flag on `az` commands tries to auto-detect org/project from the git remote — this works when running from within the repo directory.
-- For very large builds with many failures, focus on the **first** error chronologically — later errors are often cascading failures.
-- `.binlog` files contain much richer detail than text logs. If the text logs show a generic "Build FAILED" message, the `.binlog` will have the specific MSBuild target and task that failed.
-- Use `binlogtool search` with broad terms first (`error`, `failed`), then narrow down with specific codes.
+- Auth errors → user needs `az login` + `az devops configure --defaults`
+- `--detect` auto-detects org/project from git remote when run inside the repo
+- Focus on the **first** error chronologically — later errors often cascade
+- `.binlog` has richer detail than text logs; use it when text logs show only generic "Build FAILED"
+- `binlogtool search` broad terms first, then narrow with specific codes


### PR DESCRIPTION
Add a Copilot skill for investigating Azure DevOps pipeline build failures. Given a build URL, it fetches run details, identifies failed jobs/tasks via the timeline API, downloads .binlog artifacts, and analyzes them with binlogtool to find root causes.

Example usage:

    ❯ what are the errors here: https://github.com/dotnet/android/pull/10881

    ◐ The user is asking about errors in a GitHub PR. This is a CI/build failure investigation task. There's an `azdo-build-investigator` skill available that can investigate Azure DevOps pipeline build failures
    and analyze .binlog files. However, this is a GitHub PR URL, not an AZDO URL directly. Let me check if the skill can handle GitHub PR URLs - the skill description says "Use this when users share an AZDO
    build URL, a GitHub PR URL, or ask about a failing pipeline, build errors, or CI failures." So yes, this skill can handle GitHub PR URLs.

    Let me invoke the `azdo-build-investigator` skill.

    ● skill(azdo-build-investigator)

    ◐ Let me follow the skill workflow to investigate the GitHub PR. The URL is https://github.com/dotnet/android/pull/10881.

    First, let me check if `gh` CLI and `az` CLI are available, and then get the failing checks from the PR.

    ● Get failing checks from PR #10881
    $ gh pr checks 10881 --repo dotnet/android --json "name,state,link,bucket" 2>&1
    └ 39 lines...

    ◐ There's one failing check: `Xamarin.Android-PR` with a link to `https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_build/results?buildId=13452282`. Let me parse this:
    - Org: `devdiv` (or `devdiv.visualstudio.com`)
    - Project: `0bdbc590-a062-4c3f-b0f6-9383f67865ee`
    - Build ID: `13452282`

    Let me get the build timeline.

    ● Get failed build timeline records
    $ az devops invoke --area build --resource timeline --route-parameters buildId=13452282 --org https://devdiv.visualstudio.com --project 0bdbc590-a062-4c3f-b0f6-9383f67865ee --query "records[?result=='failed']
    | [].{name:name, type:type, issues:issues, errorCount:errorCount}" --output json 2>&1
    └ 6 lines...

    ● Get failed build timeline records with project as route param
    $ az devops invoke --area build --resource timeline --route-parameters project=0bdbc590-a062-4c3f-b0f6-9383f67865ee buildId=13452282 --org https://devdiv.visualstudio.com --query "records[?result=='failed'] |
    [].{name:name, type:type, issues:issues, errorCount:errorCount}" --output json 2>&1
    └ 182 lines...

    ◐ Now I have a clear picture of the failure. The `Xamarin.Android-PR` check is failing in the `Pack .NET Maui` task with 78 RS0016 errors. These are all Roslyn public API analyzer errors — the new symbols
    added by this PR are not registered in the declared public API files.

    The affected files are in `src\AI\src\Essentials.AI\Platform\MaciOS\`:
    1. `NLEmbeddingExtensions.cs` - `NLEmbeddingExtensions` class and `AsIEmbeddingGenerator` method
    2. `NLEmbeddingGenerator.cs` - `NLEmbeddingGenerator` class, constructor, `GenerateAsync`, `Dispose`

    3. `AppleIntelligenceChatClient.cs` - `AppleIntelligenceChatClient` class, constructor, `GetResponseAsync`, `GetStreamingResponseAsync`

    The root cause is that these new public types and members need to be registered in the `PublicAPI.Shipped.txt` or `PublicAPI.Unshipped.txt` file tracked by the `[MAUIAI0001]` analyzer — this is actually a
    MAUI repo issue where the integration build is failing. The fix requires updating the public API declaration file.

    ● The failing check is Xamarin.Android-PR — specifically the "Pack .NET Maui" task, with 78 RS0016 errors.

    -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

    Root Cause: Missing Public API Declarations

    The new Apple Intelligence / MAUI AI types added by this PR are not registered in the public API surface file. All errors are RS0016 from the Roslyn PublicApiAnalyzers:

    "Symbol is not part of the declared public API"

    The affected symbols are all in src\AI\src\Essentials.AI\Platform\MaciOS\ (a MAUI repo path, not this repo):

    ┌──────────────────────────────────┬─────────────────────────────────────────────────────────────────────┐
    │ File                             │ New Public Symbols                                                  │
    ├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
    │ AppleIntelligenceChatClient.cs   │ Class, constructor, GetResponseAsync, GetStreamingResponseAsync     │
    ├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
    │ NLEmbeddingGenerator.cs          │ Class, constructor, GenerateAsync, Dispose                          │
    ├──────────────────────────────────┼─────────────────────────────────────────────────────────────────────┤
    │ NLEmbeddingExtensions.cs         │ Class, AsIEmbeddingGenerator extension method                       │
    └──────────────────────────────────┴─────────────────────────────────────────────────────────────────────┘

    Fix

    The PublicAPI.Unshipped.txt file for the [MAUIAI0001] project needs to be updated to include all these new symbols. This is done in the MAUI repo — you need to add entries like:

    [MAUIAI0001]Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient
    [MAUIAI0001]Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.AppleIntelligenceChatClient() -> void
    [MAUIAI0001]Microsoft.Maui.Essentials.AI.AppleIntelligenceChatClient.GetResponseAsync(...) -> ...
    ...

    to the PublicAPI.Unshipped.txt file in that project. The full list of symbols to add can be found in the 78 error messages from the build log.