### PR TITLE
[build-tools] Fix CI download failures, upgrade xa-prep-tasks and BootstrapTasks to net10.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,7 +13,7 @@
     <BootstrapOutputDirectory>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BootstrapOutputDirectory>
     <TestOutputDirectory>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputDirectory>
     <BootstrapTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\Xamarin.Android.Tools.BootstrapTasks.dll</BootstrapTasksAssembly>
-    <PrepTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\xa-prep-tasks.dll</PrepTasksAssembly>
+    <PrepTasksAssembly>$(BootstrapOutputDirectory)$(DotNetStableTargetFramework)\xa-prep-tasks.dll</PrepTasksAssembly>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(BuildOutputDirectory)dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' and Exists('$(DotNetPreviewPath)') ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' ">dotnet</DotNetPreviewTool>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <BuildOutputDirectory>$(MSBuildThisFileDirectory)bin\$(Configuration)\</BuildOutputDirectory>
     <BootstrapOutputDirectory>$(MSBuildThisFileDirectory)bin\Build$(Configuration)\</BootstrapOutputDirectory>
     <TestOutputDirectory>$(MSBuildThisFileDirectory)bin\Test$(Configuration)\</TestOutputDirectory>
-    <BootstrapTasksAssembly>$(BootstrapOutputDirectory)$(TargetFrameworkNETStandard)\Xamarin.Android.Tools.BootstrapTasks.dll</BootstrapTasksAssembly>
+    <BootstrapTasksAssembly>$(BootstrapOutputDirectory)$(DotNetStableTargetFramework)\Xamarin.Android.Tools.BootstrapTasks.dll</BootstrapTasksAssembly>
     <PrepTasksAssembly>$(BootstrapOutputDirectory)$(DotNetStableTargetFramework)\xa-prep-tasks.dll</PrepTasksAssembly>
     <DotNetPreviewPath Condition=" '$(DotNetPreviewPath)' == '' ">$(BuildOutputDirectory)dotnet\</DotNetPreviewPath>
     <DotNetPreviewTool Condition=" '$(DotNetPreviewTool)' == '' and Exists('$(DotNetPreviewPath)') ">$(DotNetPreviewPath)dotnet</DotNetPreviewTool>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj
@@ -3,7 +3,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkNETStandard)</TargetFramework>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
     <OutputPath>$(BootstrapOutputDirectory)</OutputPath>
   </PropertyGroup>

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateFrameworkList.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/CreateFrameworkList.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					new XAttribute ("AssemblyName", assemblyName.Name),
 					new XAttribute ("Version", version),
 					new XAttribute ("PublicKeyToken", publicKeyToken),
-					new XAttribute ("ProcessorArchitecture", assemblyName.ProcessorArchitecture.ToString ()));
+					new XAttribute ("ProcessorArchitecture", "MSIL"));
 		}
 
 		static string Nullable (string value) => string.IsNullOrEmpty (value) ? null : value;

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/GenerateSupportedPlatforms.cs
@@ -138,7 +138,9 @@ Specifies the supported Android platform versions for this SDK.
 			</AndroidApiInfo>
 			*/
 
-			Version.TryParse (item.GetMetadata ("VersionCodeFull"), out var versionCodeFull);
+			if (!Version.TryParse (item.GetMetadata ("VersionCodeFull"), out var versionCodeFull)) {
+				throw new ArgumentException ($"Invalid VersionCodeFull '{item.GetMetadata ("VersionCodeFull")}' for item '{item.ItemSpec}'");
+			}
 			bool.TryParse (item.GetMetadata ("Stable"), out bool stable);
 
 			return new AndroidVersion (versionCodeFull, item.ItemSpec.TrimStart ('v'), item.GetMetadata ("Name"), item.GetMetadata ("Id"), stable);

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -53,13 +54,18 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 			var source  = cancellationTokenSource = new CancellationTokenSource ();
 			var tasks   = new Task<ITaskItem> [SourceUris.Length];
 
-			// LGTM recommendation
-			//
-			// Using HttpClient without providing a platform specific handler (WinHttpHandler or CurlHandler) where the CheckCertificateRevocationList property is set
-			// to true, will allow revoked certificates to be accepted by the HttpClient as valid.
-			//
-			var handler = new HttpClientHandler {
-				CheckCertificateRevocationList = true,
+			// Configure cert revocation checking in a fail-open state to avoid intermittent
+			// failures on macOS when the CRL/OCSP endpoint is unreachable.
+			// Matches the approach in dotnet/arcade's DownloadFile task:
+			// https://github.com/dotnet/arcade/blob/a07b621/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs#L122-L145
+			var handler = new SocketsHttpHandler ();
+			handler.SslOptions.CertificateChainPolicy = new X509ChainPolicy {
+				RevocationMode = X509RevocationMode.Online,
+				RevocationFlag = X509RevocationFlag.ExcludeRoot,
+				VerificationFlags =
+					X509VerificationFlags.IgnoreCertificateAuthorityRevocationUnknown |
+					X509VerificationFlags.IgnoreEndRevocationUnknown,
+				VerificationTimeIgnored = true,
 			};
 
 			using (var client = new HttpClient (handler)) {

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 					using (var r = await client.GetAsync (uri, HttpCompletionOption.ResponseHeadersRead, source.Token)) {
 						r.EnsureSuccessStatusCode ();
 						using (var s = await r.Content.ReadAsStreamAsync ())
-						using (var o = File.OpenWrite (tempPath)) {
+						using (var o = File.Create (tempPath)) {
 							await s.CopyToAsync (o, 4096, source.Token);
 						}
 					}
@@ -121,7 +121,11 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 						File.Delete (tempPath);
 					} catch {
 					}
-					await TTask.Delay (delay, source.Token);
+					try {
+						await TTask.Delay (delay, source.Token);
+					} catch (OperationCanceledException) {
+						break;
+					}
 				}
 				catch (Exception e) {
 					Log.LogError ("Unable to download URL `{0}` to `{1}`: {2}", uri, destinationFile, e.Message);

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/DownloadUri.cs
@@ -15,6 +15,13 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 
 	public class DownloadUri : MTask, ICancelableTask
 	{
+		const int DefaultMaxRetries = 3;
+		static readonly TimeSpan[] RetryDelays = {
+			TimeSpan.FromSeconds (5),
+			TimeSpan.FromSeconds (15),
+			TimeSpan.FromSeconds (30),
+		};
+
 		public DownloadUri ()
 		{
 		}
@@ -26,6 +33,8 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 		public ITaskItem[]  DestinationFiles    { get; set; }
 
 		public string       HashHeader          { get; set; }
+
+		public int          MaxRetries          { get; set; } = DefaultMaxRetries;
 
 		CancellationTokenSource cancellationTokenSource;
 
@@ -89,21 +98,35 @@ namespace Xamarin.Android.BuildTools.PrepTasks {
 			var tempPath = Path.Combine (dp, "." + dn + ".download");
 			Directory.CreateDirectory(dp);
 
-			Log.LogMessage (MessageImportance.Normal, $"Downloading `{uri}` to `{tempPath}`.");
-			try {
-				using (var r = await client.GetAsync (uri, HttpCompletionOption.ResponseHeadersRead, source.Token)) {
-					r.EnsureSuccessStatusCode ();
-					using (var s = await r.Content.ReadAsStreamAsync ())
-					using (var o = File.OpenWrite (tempPath)) {
-						await s.CopyToAsync (o, 4096, source.Token);
+			int retries = Math.Max (0, MaxRetries);
+			for (int attempt = 0; attempt <= retries; attempt++) {
+				Log.LogMessage (MessageImportance.Normal, $"Downloading `{uri}` to `{tempPath}` (attempt {attempt + 1} of {retries + 1}).");
+				try {
+					using (var r = await client.GetAsync (uri, HttpCompletionOption.ResponseHeadersRead, source.Token)) {
+						r.EnsureSuccessStatusCode ();
+						using (var s = await r.Content.ReadAsStreamAsync ())
+						using (var o = File.OpenWrite (tempPath)) {
+							await s.CopyToAsync (o, 4096, source.Token);
+						}
 					}
+					Log.LogMessage (MessageImportance.Low, $"mv '{tempPath}' '{destinationFile}'.");
+					File.Move (tempPath, destinationFile.ItemSpec);
+					return destinationFile;
 				}
-				Log.LogMessage (MessageImportance.Low, $"mv '{tempPath}' '{destinationFile}'.");
-				File.Move (tempPath, destinationFile.ItemSpec);
-			}
-			catch (Exception e) {
-				Log.LogError ("Unable to download URL `{0}` to `{1}`: {2}", uri, destinationFile, e.Message);
-				Log.LogErrorFromException (e);
+				catch (Exception e) when (attempt < retries && !source.IsCancellationRequested) {
+					var delay = attempt < RetryDelays.Length ? RetryDelays [attempt] : RetryDelays [RetryDelays.Length - 1];
+					Log.LogWarning ("Failed to download URL `{0}` (attempt {1} of {2}): {3}. Retrying in {4} seconds.",
+						uri, attempt + 1, retries + 1, e.Message, (int) delay.TotalSeconds);
+					try {
+						File.Delete (tempPath);
+					} catch {
+					}
+					await TTask.Delay (delay, source.Token);
+				}
+				catch (Exception e) {
+					Log.LogError ("Unable to download URL `{0}` to `{1}`: {2}", uri, destinationFile, e.Message);
+					Log.LogErrorFromException (e);
+				}
 			}
 			return destinationFile;
 		}

--- a/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/HashFileContents.cs
+++ b/build-tools/xa-prep-tasks/Xamarin.Android.BuildTools.PrepTasks/HashFileContents.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		{
 			var     hashes  = new List<TaskItem> (Files.Length);
 			byte[]  block   = new byte [4096];
-			using (var complete = System.Security.Cryptography.HashAlgorithm.Create (HashAlgorithm)) {
+			using (var complete = CreateHashAlgorithm (HashAlgorithm)) {
 				foreach (var file in Files) {
 					var hash    = ProcessFile (complete, block, file.ItemSpec);
 					var e       = new TaskItem (hash);
@@ -87,7 +87,7 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 				}
 				memoryStream.Seek (0, SeekOrigin.Begin);
 
-				using (var fileHash = System.Security.Cryptography.HashAlgorithm.Create (HashAlgorithm)) {
+				using (var fileHash = CreateHashAlgorithm (HashAlgorithm)) {
 					int read;
 					while ((read = memoryStream.Read (block, 0, block.Length)) > 0) {
 						complete.TransformBlock (block, 0, read, block, 0);
@@ -103,6 +103,17 @@ namespace Xamarin.Android.BuildTools.PrepTasks
 		{
 			return string.Join ("", hash.Select (b => b.ToString ("x2")));
 		}
+
+		#pragma warning disable CA5350 // used for content hashing, not security
+		static System.Security.Cryptography.HashAlgorithm CreateHashAlgorithm (string name) =>
+			name.ToUpperInvariant () switch {
+				"SHA1"      => SHA1.Create (),
+				"SHA256"    => SHA256.Create (),
+				"SHA384"    => SHA384.Create (),
+				"SHA512"    => SHA512.Create (),
+				_           => throw new NotSupportedException ($"Hash algorithm '{name}' is not supported."),
+			};
+		#pragma warning restore CA5350
 	}
 }
 

--- a/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
+++ b/build-tools/xa-prep-tasks/xa-prep-tasks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TargetFrameworkNETStandard)</TargetFramework>
+    <TargetFramework>$(DotNetStableTargetFramework)</TargetFramework>
     <RootNamespace>Xamarin.Android.BuildTools.PrepTasks</RootNamespace>
     <OutputPath>$(BootstrapOutputDirectory)</OutputPath>
   </PropertyGroup>


### PR DESCRIPTION
## Description

Fix transient SSL/TLS download failures in CI by adding retry logic and adopting the same fail-open CRL revocation policy used by [dotnet/arcade](https://github.com/dotnet/arcade/blob/a07b621/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs#L122-L145). Also upgrades `xa-prep-tasks` and `BootstrapTasks` from `netstandard2.0` to `net10.0` (required for `SocketsHttpHandler` APIs), and fixes resulting obsolete API warnings.

### Context

macOS CI runners intermittently fail SSL handshakes when CRL/OCSP endpoints are unreachable. The `DOTNET_SYSTEM_NET_SECURITY_NOREVOCATIONCHECKBYDEFAULT` env var is set in CI ([variables.yaml](https://github.com/dotnet/android/blob/main/build-tools/automation/yaml-templates/variables.yaml#L75)), but code explicitly setting `CheckCertificateRevocationList = true` overrides it.

### Changes

#### 1. Retry logic with exponential backoff (`ec45d3ca1`)
- `DownloadUri` task now retries up to 3 times (configurable via `MaxRetries`)
- Exponential backoff delays: 5s → 15s → 30s
- Partial temp files cleaned up between attempts

#### 2. Code review fixes (`d334caf26`)
- `File.OpenWrite` → `File.Create` to properly truncate on retries
- Wrap `Task.Delay` in try/catch for cancellation handling

#### 3. SocketsHttpHandler with fail-open CRL policy (`b5aac5f5a`)
- Replaced `HttpClientHandler` with `SocketsHttpHandler` + `SslClientAuthenticationOptions`
- Uses `X509ChainPolicy` with `IgnoreEndRevocationUnknown | IgnoreCertificateAuthorityRevocationUnknown`
- Still checks revocation, but treats unreachable CRL endpoints as non-fatal
- Matches [dotnet/arcade's DownloadFile approach](https://github.com/dotnet/arcade/blob/a07b621/src/Microsoft.DotNet.Arcade.Sdk/src/DownloadFile.cs#L122-L145)

#### 4. Upgrade BootstrapTasks to `net10.0` (`876262d5a`)
- `SocketsHttpHandler` and `X509ChainPolicy` require `net10.0` (not available in `netstandard2.0`)
- Updated `xa-prep-tasks.csproj` and `BootstrapTasks.csproj` TFMs
- Updated `PrepTasksAssembly` and `BootstrapTasksAssembly` paths in `Directory.Build.props`

#### 5. Fix SYSLIB0045: `HashAlgorithm.Create(string)` obsolete (`891a9f3a5`)
- Replaced with switch expression mapping to parameterless factory methods
- Removed MD5 support (CA5351), suppressed CA5350 for SHA1 (content hashing only)

#### 6. Fix SYSLIB0037 and CS8604 in BootstrapTasks (`f28bb68ac`)
- `CreateFrameworkList`: `AssemblyName.ProcessorArchitecture` is obsolete — hardcode `MSIL`
- `GenerateSupportedPlatforms`: throw on invalid `VersionCodeFull` instead of passing null
