### PR TITLE
uses-feature.version should be settable according to android documentation

### DIFF
--- a/build-tools/manifest-attribute-codegen/metadata.xml
+++ b/build-tools/manifest-attribute-codegen/metadata.xml
@@ -429,7 +429,7 @@
   <element path="uses-feature.glEsVersion" name="GLESVersion" manualMap="true" />
   <element path="uses-feature.name" readonly="true" />
   <element path="uses-feature.required" visible="true" />
-  <element path="uses-feature.version" readonly="true" />
+  <element path="uses-feature.version" visible="true" />
 
   <!-- <uses-library> - https://developer.android.com/guide/topics/manifest/uses-library-element -->
   <element path="uses-library.name" visible="true" />

--- a/src/Mono.Android/Android.App/UsesFeatureAttribute.cs
+++ b/src/Mono.Android/Android.App/UsesFeatureAttribute.cs
@@ -26,7 +26,7 @@ public sealed partial class UsesFeatureAttribute : Attribute {
 
 	public bool Required { get; set; }
 
-	public int Version { get; private set; }
+	public int Version { get; set; }
 
 #if XABT_MANIFEST_EXTENSIONS
 	static Xamarin.Android.Manifest.ManifestDocumentElement<UsesFeatureAttribute> mapping = new ("uses-feature");
@@ -49,7 +49,7 @@ public sealed partial class UsesFeatureAttribute : Attribute {
 			member: "Version",
 			attributeName: "version",
 			getter: self => self.Version,
-			setter: null
+			setter: (self, value) => self.Version = (int) value
 		);
 
 		AddManualMapping ();


### PR DESCRIPTION
https://developer.android.com/guide/topics/manifest/uses-feature-element#hw-features
`version` is used for vulkan features. This attribute operates similarly to `glEsVersion` and therefore should be similarly settable.

There is no other way to use this attribute property currently aside from reflection.