### PR TITLE
Use JDK 21 instead of 11

### DIFF
--- a/Documentation/docs-mobile/getting-started/installation/dependencies.md
+++ b/Documentation/docs-mobile/getting-started/installation/dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: "Install .NET for Android dependencies"
 description: "Learn how to install .NET for Android dependencies so you can create native Android applications."
-ms.date: 11/01/2023
+ms.date: 03/06/2026
 ---
 # Install .NET for Android dependencies
 
@@ -98,7 +98,7 @@ allows you to use certain tooling from the command line.
 In order to build .NET for Android applications or libraries you need to have a version of the Java Development Kit installed.
 We recommend you use the Microsoft Open JDK, this has been tested against our .NET for Android builds:
 
- 1. Download [Microsoft OpenJDK 11](/java/openjdk/download#openjdk-11).
+ 1. Download [Microsoft OpenJDK 21](/java/openjdk/download#openjdk-21).
 
  2. Depending on your platform run the appropriate installer.
 


### PR DESCRIPTION
Here is what happens when building with JDK 11:
```
    MANIFESTMERGER : error LinkageError occurred while loading main class com.xamarin.manifestmerger.Main
    MSBUILD : java error AMM0000: 
      Error: LinkageError occurred while loading main class com.xamarin.manifestmerger.Main
      java.lang.UnsupportedClassVersionError
       com/xamarin/manifestmerger/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 55.
      0
      
    /usr/local/share/dotnet/packs/Microsoft.Android.Sdk.Darwin/36.1.30/tools/Xamarin.Android.Common.targets(1692,3): error XAAMM0000: 
      Error: LinkageError occurred while loading main class com.xamarin.manifestmerger.Main
      	java.lang.UnsupportedClassVersionError: com/xamarin/manifestmerger/Main has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only 
      recognizes class file versions up to 55.0
```

Here is what happens when building with JDK 25:
```
    /usr/local/share/dotnet/packs/Microsoft.Android.Sdk.Darwin/36.1.30/targets/Microsoft.Android.Sdk.Tooling.targets(22,5): error XA0030: Building with JDK version `25.0.2` is not supported. Please install JDK version `21.0`. See https://aka.ms/xamarin/jdk9-errors
```