### PR TITLE
[tests] Clear ResolvedCodeAnalysisRuleSet to fix CoreCompile incrementality on CI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -142,6 +142,7 @@ C# code uses tabs (not spaces) and Mono style (`.editorconfig`):
 - Preserve existing formatting and comments
 - Space before `(` and `[`: `Foo ()`, `array [0]`
 - Use `""` not `string.Empty`, `[]` not `Array.Empty<T>()`
+- Prefer C# raw string literals (`"""`) for multi-line strings instead of `@""` with escaped quotes
 - Minimal diffs - don't leave random empty lines
 - Do NOT use `#region` or `#endregion`
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -29,6 +29,13 @@ namespace Xamarin.ProjectTools
 	/// <seealso cref="XamarinAndroidBindingProject"/>
 	public class XamarinAndroidApplicationProject : XamarinAndroidCommonProject
 	{
+		// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
+		protected override string ExtraDirectoryBuildTargetsContent => """
+			<PropertyGroup>
+				<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
+			</PropertyGroup>
+		""";
+
 		const string default_strings_xml = @"<?xml version=""1.0"" encoding=""utf-8""?>
 <resources>
 	<string name=""hello"">Hello World, Click Me!</string>
@@ -73,26 +80,6 @@ namespace Xamarin.ProjectTools
 			SetProperty ("XamarinAndroidSupportSkipVerifyVersions", "True");
 			SetProperty ("_FastDeploymentDiagnosticLogging", "True");
 			SupportedOSPlatformVersion = "21.0";
-
-			// Workaround for AndroidX, see: https://github.com/xamarin/AndroidSupportComponents/pull/239
-			Imports.Add (new Import (() => "Directory.Build.targets") {
-				TextContent = () =>
-					@"<Project>
-						<PropertyGroup>
-							<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
-						</PropertyGroup>
-						<!-- Prevent CI Guardian SDL analysis from breaking CoreCompile incrementality.
-						     Guardian's MergeGuardianDotnetAnalyzersRuleSets target regenerates a merged
-						     ruleset file on every build (new timestamp), which is in CoreCompile's Inputs
-						     via $(ResolvedCodeAnalysisRuleSet). Clearing this property ensures CoreCompile
-						     is properly incremental when source files haven't changed. -->
-						<Target Name=""_ClearResolvedCodeAnalysisRuleSet"" BeforeTargets=""CoreCompile"" AfterTargets=""ResolveCodeAnalysisRuleSet;MergeGuardianDotnetAnalyzersRuleSets"">
-							<PropertyGroup>
-								<ResolvedCodeAnalysisRuleSet />
-							</PropertyGroup>
-						</Target>
-					</Project>"
-			});
 
 			AndroidManifest = default_android_manifest;
 			LayoutMain = default_layout_main;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidApplicationProject.cs
@@ -81,6 +81,16 @@ namespace Xamarin.ProjectTools
 						<PropertyGroup>
 							<VectorDrawableCheckBuildToolsVersionTaskBeforeTargets />
 						</PropertyGroup>
+						<!-- Prevent CI Guardian SDL analysis from breaking CoreCompile incrementality.
+						     Guardian's MergeGuardianDotnetAnalyzersRuleSets target regenerates a merged
+						     ruleset file on every build (new timestamp), which is in CoreCompile's Inputs
+						     via $(ResolvedCodeAnalysisRuleSet). Clearing this property ensures CoreCompile
+						     is properly incremental when source files haven't changed. -->
+						<Target Name=""_ClearResolvedCodeAnalysisRuleSet"" BeforeTargets=""CoreCompile"" AfterTargets=""ResolveCodeAnalysisRuleSet;MergeGuardianDotnetAnalyzersRuleSets"">
+							<PropertyGroup>
+								<ResolvedCodeAnalysisRuleSet />
+							</PropertyGroup>
+						</Target>
 					</Project>"
 			});
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/XamarinAndroidProject.cs
@@ -23,6 +23,13 @@ namespace Xamarin.ProjectTools
 	public abstract class XamarinAndroidProject : DotNetXamarinProject
 	{
 		/// <summary>
+		/// Override to provide additional MSBuild XML content inside the auto-generated Directory.Build.targets file.
+		/// The returned string is inserted as-is inside the root &lt;Project&gt; element, before the
+		/// <c>_ClearResolvedCodeAnalysisRuleSet</c> target.
+		/// </summary>
+		protected virtual string ExtraDirectoryBuildTargetsContent => "";
+
+		/// <summary>
 		/// Initializes a new instance of the XamarinAndroidProject class with the specified configuration names.
 		/// Sets the default language to C# and output type to Library.
 		/// </summary>
@@ -35,6 +42,24 @@ namespace Xamarin.ProjectTools
 		{
 			Language = XamarinAndroidProjectLanguage.CSharp;
 			SetProperty (KnownProperties.OutputType, "Library");
+
+			// Prevent CI Guardian SDL analysis from breaking CoreCompile incrementality.
+			// Guardian's MergeGuardianDotnetAnalyzersRuleSets target regenerates a merged
+			// ruleset file on every build (new timestamp), which is in CoreCompile's Inputs
+			// via $(ResolvedCodeAnalysisRuleSet). Clearing this property ensures CoreCompile
+			// is properly incremental when source files haven't changed.
+			Imports.Add (new Import (() => "Directory.Build.targets") {
+				TextContent = () => $"""
+					<Project>
+						{ExtraDirectoryBuildTargetsContent}
+						<Target Name="_ClearResolvedCodeAnalysisRuleSet" BeforeTargets="CoreCompile" AfterTargets="ResolveCodeAnalysisRuleSet;MergeGuardianDotnetAnalyzersRuleSets">
+							<PropertyGroup>
+								<ResolvedCodeAnalysisRuleSet />
+							</PropertyGroup>
+						</Target>
+					</Project>
+				""",
+			});
 		}
 
 		/// <summary>


### PR DESCRIPTION
CI Guardian SDL analysis (MergeGuardianDotnetAnalyzersRuleSets) regenerates a merged .ruleset file on every build with a new timestamp. Since it is in CoreCompile's Inputs, this causes CoreCompile to re-run even when no source files changed, cascading through ILLink -> _GenerateJavaStubs -> _Sign and breaking incrementality tests:
- BasicApplicationRepetitiveReleaseBuild
- CheckTimestamps
- GenerateJavaStubsAndAssembly