### PR TITLE
[docs] Sync Documentation/docs-mobile with dotnet/docs-mobile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,6 +19,8 @@
 
 ## Critical Rules
 
+**Never use `git commit --amend`:** Always create new commits. The user will squash or fixup as needed.
+
 Reference official Android documentation where helpful:
 * [Android Developer Guide](https://developer.android.com/develop)
 * [Android API Reference](https://developer.android.com/reference)

--- a/Documentation/docs-mobile/getting-started/installation/dependencies.md
+++ b/Documentation/docs-mobile/getting-started/installation/dependencies.md
@@ -51,6 +51,11 @@ We recommend you use the Microsoft Open JDK, this has been tested against our .N
 
  1. Download [Microsoft OpenJDK 21](/java/openjdk/download#openjdk-21).
 
+ 2. Depending on your platform run the appropriate installer.
+
+ 3. It is also good practice to set the `JAVA_HOME` environment variable.
+    This will allow you to use the JDK from the Command Prompt or Terminal.
+
 ## Install the Android SDK manually
 
 > [!NOTE]
@@ -73,9 +78,10 @@ You might find it necessary to install the Android SDK manually:
  6. Run the `sdkmanager` command to install the desired components.
  
  7. Set the `$ANDROID_HOME` environment variable to your Android SDK path:
-```powershell
-$env:ANDROID_HOME = "C:\android-sdk"
-```
+
+    ```powershell
+    $env:ANDROID_HOME = "C:\android-sdk"
+    ```
 
 For example, to install the latest platform and platform tools, use:
 
@@ -107,9 +113,3 @@ The following component types are useful to know:
 
 It is also good practice to set the `ANDROID_HOME` environment variable, as this
 allows you to use certain tooling from the command line.
-
- 2. Depending on your platform run the appropriate installer.
-
- 3. It is also good practice to set the `JAVA_HOME` environment variable.
-    This will allow you to use the JDK from the Command Prompt or Terminal.
-

--- a/Documentation/docs-mobile/getting-started/installation/dependencies.md
+++ b/Documentation/docs-mobile/getting-started/installation/dependencies.md
@@ -44,7 +44,17 @@ Here are all the arguments which the target will use when installing the depende
 > [!NOTE]
 > To make development easier try to avoid using paths which contain spaces or non-ASCII characters.
 
+## Install Microsoft JDK manually
+
+In order to build .NET for Android applications or libraries you need to have a version of the Java Development Kit installed.
+We recommend you use the Microsoft Open JDK, this has been tested against our .NET for Android builds:
+
+ 1. Download [Microsoft OpenJDK 21](/java/openjdk/download#openjdk-21).
+
 ## Install the Android SDK manually
+
+> [!NOTE]
+> On Windows you will need to install JDK first.
 
 You might find it necessary to install the Android SDK manually:
 
@@ -61,6 +71,11 @@ You might find it necessary to install the Android SDK manually:
  5. Navigate to the `android-sdk\cmdline-tools\bin` directory within the directory you created.
 
  6. Run the `sdkmanager` command to install the desired components.
+ 
+ 7. Set the `$ANDROID_HOME` environment variable to your Android SDK path:
+```powershell
+$env:ANDROID_HOME = "C:\android-sdk"
+```
 
 For example, to install the latest platform and platform tools, use:
 
@@ -93,14 +108,8 @@ The following component types are useful to know:
 It is also good practice to set the `ANDROID_HOME` environment variable, as this
 allows you to use certain tooling from the command line.
 
-## Install Microsoft JDK manually
-
-In order to build .NET for Android applications or libraries you need to have a version of the Java Development Kit installed.
-We recommend you use the Microsoft Open JDK, this has been tested against our .NET for Android builds:
-
- 1. Download [Microsoft OpenJDK 21](/java/openjdk/download#openjdk-21).
-
  2. Depending on your platform run the appropriate installer.
 
  3. It is also good practice to set the `JAVA_HOME` environment variable.
     This will allow you to use the JDK from the Command Prompt or Terminal.
+

--- a/Documentation/docs-mobile/messages/adb0000.md
+++ b/Documentation/docs-mobile/messages/adb0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ADB0000
 description: ADB0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0000"
 ---
+
 # .NET for Android error/warning ADB0000
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/adb0010.md
+++ b/Documentation/docs-mobile/messages/adb0010.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ADB0010
 description: ADB0010 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0010"
 ---
+
 # .NET for Android error/warning ADB0010
 
 ## Issue

--- a/Documentation/docs-mobile/messages/adb0020.md
+++ b/Documentation/docs-mobile/messages/adb0020.md
@@ -2,7 +2,10 @@
 title: .NET for Android error ADB0020
 description: ADB0020 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0020"
 ---
+
 # .NET for Android error ADB0020
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/adb0030.md
+++ b/Documentation/docs-mobile/messages/adb0030.md
@@ -2,7 +2,10 @@
 title: .NET for Android error ADB0030
 description: ADB0030 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0030"
 ---
+
 # .NET for Android error ADB0030
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/adb0040.md
+++ b/Documentation/docs-mobile/messages/adb0040.md
@@ -2,7 +2,10 @@
 title: .NET for Android error ADB0040
 description: ADB0040 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0040"
 ---
+
 # .NET for Android error ADB0040
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/adb0050.md
+++ b/Documentation/docs-mobile/messages/adb0050.md
@@ -2,7 +2,10 @@
 title: .NET for Android error ADB0050
 description: ADB0050 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0050"
 ---
+
 # .NET for Android error ADB0050
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/adb0060.md
+++ b/Documentation/docs-mobile/messages/adb0060.md
@@ -2,7 +2,10 @@
 title: .NET for Android error ADB0060
 description: ADB0060 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ADB0060"
 ---
+
 # .NET for Android error ADB0060
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/andas0000.md
+++ b/Documentation/docs-mobile/messages/andas0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ANDAS0000
 description: ANDAS0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ANDAS0000"
 ---
+
 # .NET for Android error/warning ANDAS0000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/andjs0000.md
+++ b/Documentation/docs-mobile/messages/andjs0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ANDJS0000
 description: ANDJS0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ANDJS0000"
 ---
+
 # .NET for Android error/warning ANDJS0000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/andkt0000.md
+++ b/Documentation/docs-mobile/messages/andkt0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ANDKT0000
 description: ANDKT0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ANDKT0000"
 ---
+
 # .NET for Android error/warning ANDKT0000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/andza0000.md
+++ b/Documentation/docs-mobile/messages/andza0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning ANDZA0000
 description: ANDZA0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "ANDZA0000"
 ---
+
 # .NET for Android error/warning ANDZA0000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/apt0000.md
+++ b/Documentation/docs-mobile/messages/apt0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning APT0000
 description: APT0000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "APT0000"
 ---
+
 # .NET for Android error/warning APT0000
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/apt0001.md
+++ b/Documentation/docs-mobile/messages/apt0001.md
@@ -2,7 +2,10 @@
 title: .NET for Android error APT0001
 description: APT0001 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "APT0001"
 ---
+
 # .NET for Android error APT0001
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/apt2000.md
+++ b/Documentation/docs-mobile/messages/apt2000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning APT2000
 description: APT2000 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "APT2000"
 ---
+
 # .NET for Android error/warning APT2000
 
 ## Example APT2000 error messages

--- a/Documentation/docs-mobile/messages/apt2264.md
+++ b/Documentation/docs-mobile/messages/apt2264.md
@@ -2,7 +2,10 @@
 title: .NET for Android error APT2264
 description: APT2264 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "APT2264"
 ---
+
 # .NET for Android error APT2264
 
 ## Issue

--- a/Documentation/docs-mobile/messages/apt2265.md
+++ b/Documentation/docs-mobile/messages/apt2265.md
@@ -2,7 +2,10 @@
 title: .NET for Android error APT2265
 description: APT2265 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "APT2265"
 ---
+
 # .NET for Android error APT2265
 
 ## Issue

--- a/Documentation/docs-mobile/messages/il6200.md
+++ b/Documentation/docs-mobile/messages/il6200.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning IL6200
 description: IL6200 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "IL6200"
 ---
+
 # .NET for Android warning IL6200
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/java0000.md
+++ b/Documentation/docs-mobile/messages/java0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error JAVA0000
 description: JAVA0000 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "JAVA0000"
 ---
+
 # .NET for Android error JAVA0000
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/javac0000.md
+++ b/Documentation/docs-mobile/messages/javac0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error JAVAC0000
 description: JAVAC0000 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "JAVAC0000"
 ---
+
 # .NET for Android error JAVAC0000
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa0000.md
+++ b/Documentation/docs-mobile/messages/xa0000.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0000
 description: XA0000 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0000"
 ---
+
 # .NET for Android error XA0000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0001.md
+++ b/Documentation/docs-mobile/messages/xa0001.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0001
 description: XA0001 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0001"
 ---
+
 # .NET for Android error XA0001
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0002.md
+++ b/Documentation/docs-mobile/messages/xa0002.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0002
 description: XA0002 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0002"
 ---
+
 # .NET for Android error XA0002
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0003.md
+++ b/Documentation/docs-mobile/messages/xa0003.md
@@ -2,20 +2,23 @@
 title: .NET for Android error XA0003
 description: XA0003 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0003"
 ---
+
 # .NET for Android error XA0003
 
 ## Issue
 
-This error means the value for `android:versionCode` in the 
-`AndroidManifest.xml` file is not an integer value. 
+This error means the value for `android:versionCode` in the
+`AndroidManifest.xml` file is not an integer value.
 
-Google requires that the value be an integer within the 
-range of 0 to 2100000000. 
+Google requires that the value be an integer within the
+range of 0 to 2100000000.
 See [https://developer.android.com/studio/publish/versioning](https://developer.android.com/studio/publish/versioning)
 for more details.
 
 ## Solution
 
-Correct the `android:versionCode` in the `AndroidManifest.xml` to 
+Correct the `android:versionCode` in the `AndroidManifest.xml` to
 be an integer in the range of 0 to 2100000000.

--- a/Documentation/docs-mobile/messages/xa0004.md
+++ b/Documentation/docs-mobile/messages/xa0004.md
@@ -11,7 +11,7 @@ f1_keywords:
 ## Issue
 
 This error means the value for `android:versionCode` in the
-`AndroidManifest.xml` file is and integer but is not
+`AndroidManifest.xml` file is an integer but is not
 within the value range of 0 to 2100000000.
 
 Google requires that the value be an integer within the

--- a/Documentation/docs-mobile/messages/xa0004.md
+++ b/Documentation/docs-mobile/messages/xa0004.md
@@ -2,21 +2,24 @@
 title: .NET for Android error XA0004
 description: XA0004 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0004"
 ---
+
 # .NET for Android error XA0004
 
 ## Issue
 
-This error means the value for `android:versionCode` in the 
-`AndroidManifest.xml` file is and integer but is not 
+This error means the value for `android:versionCode` in the
+`AndroidManifest.xml` file is and integer but is not
 within the value range of 0 to 2100000000.
 
-Google requires that the value be an integer within the 
-range of 0 to 2100000000. 
+Google requires that the value be an integer within the
+range of 0 to 2100000000.
 See [https://developer.android.com/studio/publish/versioning](https://developer.android.com/studio/publish/versioning)
 for more details.
 
 ## Solution
 
-Correct the `android:versionCode` in the `AndroidManifest.xml` to 
+Correct the `android:versionCode` in the `AndroidManifest.xml` to
 be an integer in the range of 0 to 2100000000.

--- a/Documentation/docs-mobile/messages/xa0030.md
+++ b/Documentation/docs-mobile/messages/xa0030.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0030
 description: XA0030 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0030"
 ---
+
 # .NET for Android error XA0030
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0031.md
+++ b/Documentation/docs-mobile/messages/xa0031.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0031
 description: XA0031 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0031"
 ---
+
 # .NET for Android error XA0031
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0032.md
+++ b/Documentation/docs-mobile/messages/xa0032.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0032
 description: XA0032 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0032"
 ---
+
 # .NET for Android error XA0032
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0033.md
+++ b/Documentation/docs-mobile/messages/xa0033.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0033
 description: XA0033 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0033"
 ---
+
 # .NET for Android warning XA0033
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0034.md
+++ b/Documentation/docs-mobile/messages/xa0034.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0034
 description: XA0034 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0034"
 ---
+
 # .NET for Android warning XA0034
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0035.md
+++ b/Documentation/docs-mobile/messages/xa0035.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0035
 description: XA0035 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0035"
 ---
+
 # .NET for Android error XA0035
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0036.md
+++ b/Documentation/docs-mobile/messages/xa0036.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0036
 description: XA0036 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0036"
 ---
+
 # .NET for Android warning XA0036
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0101.md
+++ b/Documentation/docs-mobile/messages/xa0101.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0101
 description: XA0101 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0101"
 ---
+
 # .NET for Android warning XA0101
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0102.md
+++ b/Documentation/docs-mobile/messages/xa0102.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0102
 description: XA0102 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0102"
 ---
+
 # .NET for Android warning XA0102
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0103.md
+++ b/Documentation/docs-mobile/messages/xa0103.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0103
 description: XA0103 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0103"
 ---
+
 # .NET for Android error XA0103
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0105.md
+++ b/Documentation/docs-mobile/messages/xa0105.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0105
 description: XA0105 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0105"
 ---
+
 # .NET for Android warning XA0105
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0107.md
+++ b/Documentation/docs-mobile/messages/xa0107.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0107
 description: XA0107 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0107"
 ---
+
 # .NET for Android warning XA0107
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0108.md
+++ b/Documentation/docs-mobile/messages/xa0108.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0108
 description: XA0108 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0108"
 ---
+
 # .NET for Android warning XA0108
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0109.md
+++ b/Documentation/docs-mobile/messages/xa0109.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0109
 description: XA0109 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0109"
 ---
+
 # .NET for Android warning XA0109
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0110.md
+++ b/Documentation/docs-mobile/messages/xa0110.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0110
 description: XA0110 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0110"
 ---
+
 # .NET for Android warning XA0110
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0111.md
+++ b/Documentation/docs-mobile/messages/xa0111.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0111
 description: XA0111 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0111"
 ---
+
 # .NET for Android warning XA0111
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0112.md
+++ b/Documentation/docs-mobile/messages/xa0112.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0112
 description: XA0112 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0112"
 ---
+
 # .NET for Android warning XA0112
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0113.md
+++ b/Documentation/docs-mobile/messages/xa0113.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0113
 description: XA0113 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0113"
 ---
+
 # .NET for Android warning XA0113
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0114.md
+++ b/Documentation/docs-mobile/messages/xa0114.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0114
 description: XA0114 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0114"
 ---
+
 # .NET for Android warning XA0114
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0115.md
+++ b/Documentation/docs-mobile/messages/xa0115.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0115
 description: XA0115 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0115"
 ---
+
 # .NET for Android error XA0115
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa0116.md
+++ b/Documentation/docs-mobile/messages/xa0116.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0116
 description: XA0116 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0116"
 ---
+
 # .NET for Android error XA0116
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0117.md
+++ b/Documentation/docs-mobile/messages/xa0117.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0117
 description: XA0117 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0117"
 ---
+
 # .NET for Android warning XA0117
 
 ## Issue
@@ -31,5 +34,3 @@ older versions of the android platform.
 
 [ndk]: https://developer.android.com/ndk/downloads/revision_history
 [support]: https://developer.android.com/distribute/best-practices/develop/target-sdk
-
-

--- a/Documentation/docs-mobile/messages/xa0118.md
+++ b/Documentation/docs-mobile/messages/xa0118.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0118
 description: XA0118 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0118"
 ---
+
 # .NET for Android warning XA0118
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0119.md
+++ b/Documentation/docs-mobile/messages/xa0119.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0119
 description: XA0119 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0119"
 ---
+
 # .NET for Android warning XA0119
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0120.md
+++ b/Documentation/docs-mobile/messages/xa0120.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0120
 description: XA0120 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0120"
 ---
+
 # .NET for Android warning XA0120
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0121.md
+++ b/Documentation/docs-mobile/messages/xa0121.md
@@ -2,7 +2,11 @@
 title: .NET for Android error XA0121
 description: XA0121 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0121"
 ---
+
+
 # .NET for Android error XA0121
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0122.md
+++ b/Documentation/docs-mobile/messages/xa0122.md
@@ -2,7 +2,11 @@
 title: .NET for Android warning XA0122
 description: XA0122 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0122"
 ---
+
+
 # .NET for Android warning XA0122
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa0125.md
+++ b/Documentation/docs-mobile/messages/xa0125.md
@@ -2,7 +2,11 @@
 title: .NET for Android warning XA0125
 description: XA0125 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0125"
 ---
+
+
 # .NET for Android warning XA0125
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa0126.md
+++ b/Documentation/docs-mobile/messages/xa0126.md
@@ -2,7 +2,11 @@
 title: .NET for Android error XA0126
 description: XA0126 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0126"
 ---
+
+
 # .NET for Android error XA0126
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0127.md
+++ b/Documentation/docs-mobile/messages/xa0127.md
@@ -2,7 +2,11 @@
 title: .NET for Android error XA0127
 description: XA0127 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0127"
 ---
+
+
 # .NET for Android error XA0127
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0128.md
+++ b/Documentation/docs-mobile/messages/xa0128.md
@@ -2,7 +2,11 @@
 title: .NET for Android error XA0128
 description: XA0128 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0128"
 ---
+
+
 # .NET for Android error XA0128
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0129.md
+++ b/Documentation/docs-mobile/messages/xa0129.md
@@ -2,7 +2,11 @@
 title: .NET for Android error XA0129
 description: XA0129 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0129"
 ---
+
+
 # .NET for Android error XA0129
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0130.md
+++ b/Documentation/docs-mobile/messages/xa0130.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0130
 description: XA0130 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0130"
 ---
+
 # .NET for Android error XA0130
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0131.md
+++ b/Documentation/docs-mobile/messages/xa0131.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0131
 description: XA0131 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0131"
 ---
+
 # .NET for Android error XA0131
 
 ## Issue
@@ -15,4 +18,3 @@ Fast Deployment requires 'run-as' in order to function.
 Either enable it by activating the developer options on the device or by setting 'ro.boot.disable_runas' to 'false'.
 If you are unable to activate the developer options you can disable Fast Deployment by setting  `EmbedAssembliesIntoApk = True` in your .csproj. Or turn off `Fast Deployment` in the IDE.
 You will still be able to debug on the device, all the required files will be packaged inside the .apk.
-

--- a/Documentation/docs-mobile/messages/xa0132.md
+++ b/Documentation/docs-mobile/messages/xa0132.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0132
 description: XA0132 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0132"
 ---
+
 # .NET for Android error XA0132
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0132.md
+++ b/Documentation/docs-mobile/messages/xa0132.md
@@ -18,4 +18,4 @@ You should be able to uninstall the app via the Settings app on the device.
 
 This error only seems to happen when the same app is installed under multiple user account.
 Check that you do not have the app installed under a Guest user or a secondary account on
-you device.
+your device.

--- a/Documentation/docs-mobile/messages/xa0133.md
+++ b/Documentation/docs-mobile/messages/xa0133.md
@@ -15,4 +15,4 @@ The 'run-as' tool required by the Fast Deployment system has been disabled on th
 ## Solution
 
 Unfortunately the manufacturer of the device has explicitly disabled the tool we need for Fast Deployment.
-The only option currently is to disable Fast Deployment from the IDE or by setting the the 'EmbedAssembliesIntoApk' MSBuild property to 'true' in the csproj.
+The only option currently is to disable Fast Deployment from the IDE or by setting the 'EmbedAssembliesIntoApk' MSBuild property to 'true' in the csproj.

--- a/Documentation/docs-mobile/messages/xa0133.md
+++ b/Documentation/docs-mobile/messages/xa0133.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0133
 description: XA0133 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0133"
 ---
+
 # .NET for Android error XA0133
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0134.md
+++ b/Documentation/docs-mobile/messages/xa0134.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0134
 description: XA0134 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0134"
 ---
+
 # .NET for Android error XA0134
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0135.md
+++ b/Documentation/docs-mobile/messages/xa0135.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0135
 description: XA0135 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0135"
 ---
+
 # .NET for Android error XA0135
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0136.md
+++ b/Documentation/docs-mobile/messages/xa0136.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0136
 description: XA0136 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0136"
 ---
+
 # .NET for Android error XA0136
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0137.md
+++ b/Documentation/docs-mobile/messages/xa0137.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0137
 description: XA0137 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0137"
 ---
+
 # .NET for Android error XA0137
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0138.md
+++ b/Documentation/docs-mobile/messages/xa0138.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0138
 description: XA0138 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0138"
 ---
+
 # .NET for Android error XA0138
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0139.md
+++ b/Documentation/docs-mobile/messages/xa0139.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0139
 description: XA0139 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0139"
 ---
+
 # .NET for Android error XA0139
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0140.md
+++ b/Documentation/docs-mobile/messages/xa0140.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0140
 description: XA0140 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA0140"
 ---
+
 # .NET for Android error XA0140
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0141.md
+++ b/Documentation/docs-mobile/messages/xa0141.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA0141
 description: XA0141 warning code
 ms.date: 01/08/2025
+f1_keywords:
+  - "XA0141"
 ---
+
 # .NET for Android warning XA0141
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa0142.md
+++ b/Documentation/docs-mobile/messages/xa0142.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA0142
 description: XA0141 error code
 ms.date: 11/09/2024
+f1_keywords:
+  - "XA0142"
 ---
+
 # .NET for Android warning XA0142
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa1000.md
+++ b/Documentation/docs-mobile/messages/xa1000.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1000
 description: XA1000 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1000"
 ---
+
 # .NET for Android warning XA1000
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa1001.md
+++ b/Documentation/docs-mobile/messages/xa1001.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1001
 description: XA1001 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1001"
 ---
+
 # .NET for Android warning XA1001
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1002.md
+++ b/Documentation/docs-mobile/messages/xa1002.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1002
 description: XA1002 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1002"
 ---
+
 # .NET for Android error XA1002
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1003.md
+++ b/Documentation/docs-mobile/messages/xa1003.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1003
 description: XA1003 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1003"
 ---
+
 # .NET for Android error XA1003
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa1004.md
+++ b/Documentation/docs-mobile/messages/xa1004.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1004
 description: XA1004 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1004"
 ---
+
 # .NET for Android error XA1004
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1005.md
+++ b/Documentation/docs-mobile/messages/xa1005.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1005
 description: XA1005 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1005"
 ---
+
 # .NET for Android warning XA1005
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1006.md
+++ b/Documentation/docs-mobile/messages/xa1006.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1006
 description: XA1006 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1006"
 ---
+
 # .NET for Android warning XA1006
 
 ```

--- a/Documentation/docs-mobile/messages/xa1007.md
+++ b/Documentation/docs-mobile/messages/xa1007.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1007
 description: XA1007 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1007"
 ---
+
 # .NET for Android warning XA1007
 
 ```

--- a/Documentation/docs-mobile/messages/xa1008.md
+++ b/Documentation/docs-mobile/messages/xa1008.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1008
 description: XA1008 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1008"
 ---
+
 # .NET for Android warning XA1008
 
 ```

--- a/Documentation/docs-mobile/messages/xa1009.md
+++ b/Documentation/docs-mobile/messages/xa1009.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1009
 description: XA1009 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1009"
 ---
+
 # .NET for Android warning XA1009
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa1010.md
+++ b/Documentation/docs-mobile/messages/xa1010.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1010
 description: XA1010 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1010"
 ---
+
 # .NET for Android warning XA1010
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1011.md
+++ b/Documentation/docs-mobile/messages/xa1011.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1011
 description: XA1011 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1011"
 ---
+
 # .NET for Android error XA1011
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1023.md
+++ b/Documentation/docs-mobile/messages/xa1023.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA1023
 description: XA1023 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1023"
 ---
+
 # .NET for Android error/warning XA1023
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1024.md
+++ b/Documentation/docs-mobile/messages/xa1024.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1024
 description: XA1024 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1024"
 ---
+
 # .NET for Android warning XA1024
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1025.md
+++ b/Documentation/docs-mobile/messages/xa1025.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1025
 description: XA1025 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1025"
 ---
+
 # .NET for Android error XA1025
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1026.md
+++ b/Documentation/docs-mobile/messages/xa1026.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA1026
 description: XA1026 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1026"
 ---
+
 # .NET for Android error/warning XA1026
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1027.md
+++ b/Documentation/docs-mobile/messages/xa1027.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1027
 description: XA1027 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1027"
 ---
+
 # .NET for Android warning XA1027
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1028.md
+++ b/Documentation/docs-mobile/messages/xa1028.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1028
 description: XA1028 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1028"
 ---
+
 # .NET for Android warning XA1028
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1029.md
+++ b/Documentation/docs-mobile/messages/xa1029.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1029
 description: XA1029 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1029"
 ---
+
 # .NET for Android warning XA1029
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1030.md
+++ b/Documentation/docs-mobile/messages/xa1030.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1030
 description: XA1030 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1030"
 ---
+
 # .NET for Android error XA1030
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1031.md
+++ b/Documentation/docs-mobile/messages/xa1031.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1031
 description: XA1031 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1031"
 ---
+
 # .NET for Android error XA1031
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1032.md
+++ b/Documentation/docs-mobile/messages/xa1032.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1032
 description: XA1032 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1032"
 ---
+
 # .NET for Android error XA1032
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1033.md
+++ b/Documentation/docs-mobile/messages/xa1033.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1033
 description: XA1033 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1033"
 ---
+
 # .NET for Android error XA1033
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1034.md
+++ b/Documentation/docs-mobile/messages/xa1034.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1034
 description: XA1034 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1034"
 ---
+
 # .NET for Android error XA1034
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1035.md
+++ b/Documentation/docs-mobile/messages/xa1035.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1035
 description: XA1034 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1035"
 ---
+
 # .NET for Android warning XA1035
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1036.md
+++ b/Documentation/docs-mobile/messages/xa1036.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1036
 description: XA1036 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1036"
 ---
+
 # .NET for Android error XA1036
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1037.md
+++ b/Documentation/docs-mobile/messages/xa1037.md
@@ -2,13 +2,16 @@
 title: .NET for Android warning XA1037
 description: XA1037 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1037"
 ---
+
 # .NET for Android warning XA1037
 
 ## Example messages
 
 ```
-The '_AndroidUseJavaLegacyResolver' MSBuild property is deprecated and will be removed in .NET 10. 
+The '_AndroidUseJavaLegacyResolver' MSBuild property is deprecated and will be removed in .NET 10.
 See https://aka.ms/net-android-deprecations for more details.
 ```
 
@@ -18,5 +21,5 @@ Edit your csproj directly and remove the referenced MSBuild property.
 
 Test your project to ensure the new behavior is functionally equivalent.
 
-If not, file an [issue](https://github.com/xamarin/xamarin-android/issues) so a 
+If not, file an [issue](https://github.com/xamarin/xamarin-android/issues) so a
 solution can be found before the deprecated flag is removed.

--- a/Documentation/docs-mobile/messages/xa1038.md
+++ b/Documentation/docs-mobile/messages/xa1038.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1038
 description: XA1038 error code
 ms.date: 06/27/2024
+f1_keywords:
+  - "XA1038"
 ---
+
 # .NET for Android error XA1038
 
 ## Example messages
@@ -17,5 +20,5 @@ Edit your csproj directly and remove the referenced MSBuild property.
 
 Test your project to ensure the new behavior is functionally equivalent.
 
-If not, file an [issue](https://github.com/xamarin/xamarin-android/issues) so a 
+If not, file an [issue](https://github.com/xamarin/xamarin-android/issues) so a
 solution can be found before the deprecated flag is removed.

--- a/Documentation/docs-mobile/messages/xa1039.md
+++ b/Documentation/docs-mobile/messages/xa1039.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA1039
 description: XA1039 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA1039"
 ---
+
 # .NET for Android error XA1039
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1040.md
+++ b/Documentation/docs-mobile/messages/xa1040.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1040
 description: XA1040 warning code
 ms.date: 02/24/2025
+f1_keywords:
+  - "XA1040"
 ---
+
 # .NET for Android warning XA1040
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa1041.md
+++ b/Documentation/docs-mobile/messages/xa1041.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA1041
 description: XA1041 error code
 ms.date: 03/31/2025
+f1_keywords:
+  - "XA1041"
 ---
+
 # .NET for Android error XA1041
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa2000.md
+++ b/Documentation/docs-mobile/messages/xa2000.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA2000
 description: XA2000 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA2000"
 ---
+
 # .NET for Android warning XA2000
 
 A feature used by your Android app will disappear in a future .NET release.

--- a/Documentation/docs-mobile/messages/xa2001.md
+++ b/Documentation/docs-mobile/messages/xa2001.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA2001
 description: XA2001 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA2001"
 ---
+
 # .NET for Android error XA2001
 
 An `<AndroidResource/>` item was specified in a project that does not

--- a/Documentation/docs-mobile/messages/xa2002.md
+++ b/Documentation/docs-mobile/messages/xa2002.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA2002
 description: XA2002 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA2002"
 ---
+
 # .NET for Android error XA2002
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4214.md
+++ b/Documentation/docs-mobile/messages/xa4214.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4214
 description: XA4214 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4214"
 ---
+
 # .NET for Android warning XA4214
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4215.md
+++ b/Documentation/docs-mobile/messages/xa4215.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4215
 description: XA4215 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4215"
 ---
+
 # .NET for Android error XA4215
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4216.md
+++ b/Documentation/docs-mobile/messages/xa4216.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4216
 description: XA4216 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4216"
 ---
+
 # .NET for Android error XA4216
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4218.md
+++ b/Documentation/docs-mobile/messages/xa4218.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4218
 description: XA4218 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4218"
 ---
+
 # .NET for Android warning XA4218
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4231.md
+++ b/Documentation/docs-mobile/messages/xa4231.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4231
 description: XA4231 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4231"
 ---
+
 # .NET for Android warning XA4231
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4232.md
+++ b/Documentation/docs-mobile/messages/xa4232.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4232
 description: XA4232 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4232"
 ---
+
 # .NET for Android warning XA4232
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4233.md
+++ b/Documentation/docs-mobile/messages/xa4233.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4233
 description: XA4232 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4233"
 ---
+
 # .NET for Android error XA4233
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4234.md
+++ b/Documentation/docs-mobile/messages/xa4234.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4234
 description: XA4234 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4234"
 ---
+
 # .NET for Android error XA4234
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4235.md
+++ b/Documentation/docs-mobile/messages/xa4235.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4235
 description: XA4235 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4235"
 ---
+
 # .NET for Android error XA4235
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4236.md
+++ b/Documentation/docs-mobile/messages/xa4236.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4236
 description: XA4236 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4236"
 ---
+
 # .NET for Android error XA4236
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4237.md
+++ b/Documentation/docs-mobile/messages/xa4237.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4237
 description: XA4237 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4237"
 ---
+
 # .NET for Android error XA4237
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4239.md
+++ b/Documentation/docs-mobile/messages/xa4239.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4239
 description: XA4239 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4239"
 ---
+
 # .NET for Android error XA4239
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4241.md
+++ b/Documentation/docs-mobile/messages/xa4241.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4241
 description: XA4241 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4241"
 ---
+
 # .NET for Android error XA4241
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4242.md
+++ b/Documentation/docs-mobile/messages/xa4242.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4242
 description: XA4242 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4242"
 ---
+
 # .NET for Android error XA4242
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4243.md
+++ b/Documentation/docs-mobile/messages/xa4243.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4243
 description: XA4243 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4243"
 ---
+
 # .NET for Android error XA4243
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4244.md
+++ b/Documentation/docs-mobile/messages/xa4244.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4244
 description: XA4244 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4244"
 ---
+
 # .NET for Android error XA4244
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4245.md
+++ b/Documentation/docs-mobile/messages/xa4245.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4245
 description: XA4245 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4245"
 ---
+
 # .NET for Android error XA4245
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4246.md
+++ b/Documentation/docs-mobile/messages/xa4246.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4246
 description: XA4246 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4246"
 ---
+
 # .NET for Android error XA4246
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4247.md
+++ b/Documentation/docs-mobile/messages/xa4247.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4247
 description: XA4247 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4247"
 ---
+
 # .NET for Android error XA4247
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4248.md
+++ b/Documentation/docs-mobile/messages/xa4248.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4248
 description: XA4248 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4248"
 ---
+
 # .NET for Android error XA4248
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4249.md
+++ b/Documentation/docs-mobile/messages/xa4249.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4249
 description: XA4249 error code
 ms.date: 07/17/2024
+f1_keywords:
+  - "XA4249"
 ---
+
 # .NET for Android error XA4249
 
 ## Example message

--- a/Documentation/docs-mobile/messages/xa4301.md
+++ b/Documentation/docs-mobile/messages/xa4301.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA4301
 description: XA4301 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4301"
 ---
+
 # .NET for Android error/warning XA4301
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4302.md
+++ b/Documentation/docs-mobile/messages/xa4302.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4302
 description: XA4302 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4302"
 ---
+
 # .NET for Android warning XA4302
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4303.md
+++ b/Documentation/docs-mobile/messages/xa4303.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4303
 description: XA4303 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4303"
 ---
+
 # .NET for Android error XA4303
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4304.md
+++ b/Documentation/docs-mobile/messages/xa4304.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4304
 description: XA4304 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4304"
 ---
+
 # .NET for Android warning XA4304
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4305.md
+++ b/Documentation/docs-mobile/messages/xa4305.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4305
 description: XA4305 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4305"
 ---
+
 # .NET for Android warning XA4305
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4306.md
+++ b/Documentation/docs-mobile/messages/xa4306.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4306
 description: XA4306 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4306"
 ---
+
 # .NET for Android warning XA4306
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4307.md
+++ b/Documentation/docs-mobile/messages/xa4307.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4307
 description: XA4307 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4307"
 ---
+
 # .NET for Android error XA4307
 
 ## Issue
@@ -20,8 +23,8 @@ website][proguard].
 ## Solution
 
 Verify you are not declaring a `ProguardConfiguration` build item that
-contains valid entries. This can also be caused by the config file 
-containing a Byte Order Mark (BOM) at the start of the file. If this 
+contains valid entries. This can also be caused by the config file
+containing a Byte Order Mark (BOM) at the start of the file. If this
 is the case remove the BOM or save the file using ASCII encoding.
 
 Consider submitting a [bug][bug] if you are getting this error under

--- a/Documentation/docs-mobile/messages/xa4308.md
+++ b/Documentation/docs-mobile/messages/xa4308.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4308
 description: XA4308 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4308"
 ---
+
 # .NET for Android error XA4308
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa4309.md
+++ b/Documentation/docs-mobile/messages/xa4309.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA4309
 description: XA4309 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4309"
 ---
+
 # .NET for Android warning XA4309
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4310.md
+++ b/Documentation/docs-mobile/messages/xa4310.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4310
 description: XA4310 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4310"
 ---
+
 # .NET for Android warning XA4310
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4312.md
+++ b/Documentation/docs-mobile/messages/xa4312.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA4312
 description: XA4312 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4312"
 ---
+
 # .NET for Android error/warning XA4312
 
 Referencing an [Android Wear][0] application project from an Android

--- a/Documentation/docs-mobile/messages/xa4313.md
+++ b/Documentation/docs-mobile/messages/xa4313.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA4313
 description: XA4313 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4313"
 ---
+
 # .NET for Android error/warning XA4313
 
 The specified Framework assembly has been deprecated.
@@ -21,4 +24,3 @@ from your csproj then add
 ```
 
 to your project to upgrade.
-

--- a/Documentation/docs-mobile/messages/xa4314.md
+++ b/Documentation/docs-mobile/messages/xa4314.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4314
 description: XA4314 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA4314"
 ---
+
 # .NET for Android warning XA4314
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa4315.md
+++ b/Documentation/docs-mobile/messages/xa4315.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA4315
 description: XA4315 warning code
 ms.date: 09/12/2024
+f1_keywords:
+  - "XA4315"
 ---
+
 # .NET for Android warning XA4315
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa5205.md
+++ b/Documentation/docs-mobile/messages/xa5205.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA5205
 description: XA5205 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA5205"
 ---
+
 # .NET for Android error XA5205
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa5207.md
+++ b/Documentation/docs-mobile/messages/xa5207.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA5207
 description: XA5207 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA5207"
 ---
+
 # .NET for Android error XA5207
 
 ## Example messages

--- a/Documentation/docs-mobile/messages/xa5300.md
+++ b/Documentation/docs-mobile/messages/xa5300.md
@@ -2,7 +2,10 @@
 title: .NET for Android error/warning XA5300
 description: XA5300 error/warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA5300"
 ---
+
 # .NET for Android error/warning XA5300
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa5301.md
+++ b/Documentation/docs-mobile/messages/xa5301.md
@@ -2,7 +2,10 @@
 title: .NET for Android error XA5301
 description: XA5301 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA5301"
 ---
+
 # .NET for Android error XA5301
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa5302.md
+++ b/Documentation/docs-mobile/messages/xa5302.md
@@ -2,7 +2,10 @@
 title: .NET for Android warning XA5302
 description: XA5302 warning code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA5302"
 ---
+
 # .NET for Android warning XA5302
 
 ## Issue

--- a/Documentation/docs-mobile/messages/xa8000.md
+++ b/Documentation/docs-mobile/messages/xa8000.md
@@ -17,9 +17,9 @@ Could not find Android Resource '@anim/enterfromright'. Please update @(AndroidR
 
 ## Solution
 
-When trying to upgrade older nuget package references to use the
+When trying to upgrade older NuGet package references to use the
 more recent Resource Designer Assembly, the system might encounter
 fields which cannot be upgraded because the resource is missing
 from either the dependency or the app.
 
-To fix this issue the missing `AndroidResource` needs to be added to the application. Or the Nuget should be upgraded to use .net 8 or later.
+To fix this issue the missing `AndroidResource` needs to be added to the application. Or the NuGet should be upgraded to use .NET 8 or later.

--- a/Documentation/docs-mobile/messages/xa8000.md
+++ b/Documentation/docs-mobile/messages/xa8000.md
@@ -2,7 +2,11 @@
 title: .NET for Android warning XA8000/IL8000
 description: XA8000/IL8000 error code
 ms.date: 04/11/2024
+f1_keywords:
+  - "XA8000"
+  - "IL8000"
 ---
+
 # .NET for Android error XA8000/IL8000
 
 ## Issue


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/10902

Sync local documentation with the upstream dotnet/docs-mobile repo:

- Restore f1_keywords metadata and blank-line style to match docs-mobile
- Use docs-mobile as source of truth for dependencies.md, with JDK 21 fix
- Add f1_keywords to local-only message files (APT2000, XA1040, XA1041)
- Add missing TOC.yml entries for APT2000, XA1039, XA1040, XA1041