### PR TITLE
[WIP][TrimmableTypeMap] Add marshal method scanning infrastructure

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// Helpers for parsing JNI method signatures.
+/// </summary>
+static class JniSignatureHelper
+{
+	/// <summary>
+	/// Parses the JNI parameter type descriptors from a JNI method signature
+	/// and returns them as <see cref="JniParameterInfo"/> records.
+	/// </summary>
+	public static List<JniParameterInfo> ParseParameterTypes (string jniSignature)
+	{
+		var result = new List<JniParameterInfo> ();
+		int i = 1; // skip opening '('
+		while (i < jniSignature.Length && jniSignature [i] != ')') {
+			int start = i;
+			SkipSingleType (jniSignature, ref i);
+			result.Add (new JniParameterInfo { JniType = jniSignature.Substring (start, i - start) });
+		}
+		return result;
+	}
+
+	/// <summary>
+	/// Extracts the return type descriptor from a JNI method signature.
+	/// </summary>
+	public static string ParseReturnTypeString (string jniSignature)
+	{
+		int i = jniSignature.IndexOf (')') + 1;
+		return jniSignature.Substring (i);
+	}
+
+	static void SkipSingleType (string sig, ref int i)
+	{
+		switch (sig [i]) {
+		case 'V': case 'Z': case 'B': case 'C': case 'S':
+		case 'I': case 'J': case 'F': case 'D':
+			i++;
+			break;
+		case 'L':
+			int end = sig.IndexOf (';', i);
+			if (end < 0) {
+				throw new ArgumentException ($"Malformed JNI signature: missing ';' after 'L' at index {i} in '{sig}'");
+			}
+			i = end + 1;
+			break;
+		case '[':
+			i++;
+			SkipSingleType (sig, ref i);
+			break;
+		default:
+			throw new ArgumentException ($"Unknown JNI type character '{sig [i]}' in '{sig}' at index {i}");
+		}
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -280,6 +280,15 @@ sealed record RegisterInfo
 	public bool DoNotGenerateAcw { get; init; }
 }
 
+/// <summary>
+/// Parsed [Export] attribute data for a method.
+/// </summary>
+sealed record ExportInfo
+{
+	public IReadOnlyList<string>? ThrownNames { get; init; }
+	public string? SuperArgumentsString { get; init; }
+}
+
 class TypeAttributeInfo (string attributeName)
 {
 	public string AttributeName { get; } = attributeName;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
@@ -14,6 +15,13 @@ sealed record JavaPeerInfo
 	/// Extracted from the [Register] attribute.
 	/// </summary>
 	public required string JavaName { get; init; }
+
+	/// <summary>
+	/// Compat JNI type name, e.g., "myapp.namespace/MyType" for user types (uses raw namespace, not CRC64).
+	/// For MCW binding types (with [Register]), this equals <see cref="JavaName"/>.
+	/// Used by acw-map.txt to support legacy custom view name resolution in layout XMLs.
+	/// </summary>
+	public required string CompatJniName { get; init; }
 
 	/// <summary>
 	/// Full managed type name, e.g., "Android.App.Activity".
@@ -51,6 +59,14 @@ sealed record JavaPeerInfo
 	public bool IsUnconditional { get; init; }
 
 	/// <summary>
+	/// Marshal methods: methods with [Register(name, sig, connector)], [Export], or
+	/// constructor registrations ([Register(".ctor", sig, "")] / [JniConstructorSignature]).
+	/// Constructors are identified by <see cref="MarshalMethodInfo.IsConstructor"/>.
+	/// Ordered — the index in this list is the method's ordinal for RegisterNatives.
+	/// </summary>
+	public IReadOnlyList<MarshalMethodInfo> MarshalMethods { get; init; } = Array.Empty<MarshalMethodInfo> ();
+
+	/// <summary>
 	/// Information about the activation constructor for this type.
 	/// May reference a base type's constructor if the type doesn't define its own.
 	/// </summary>
@@ -77,6 +93,99 @@ sealed record JavaPeerInfo
 	/// Generic types get TypeMap entries but CreateInstance throws NotSupportedException.
 	/// </summary>
 	public bool IsGenericDefinition { get; init; }
+}
+
+/// <summary>
+/// Describes a marshal method (a method with [Register] or [Export]) on a Java peer type.
+/// Contains all data needed to generate a UCO wrapper, a JCW native declaration,
+/// and a RegisterNatives call.
+/// </summary>
+sealed record MarshalMethodInfo
+{
+	/// <summary>
+	/// JNI method name, e.g., "onCreate".
+	/// This is the Java method name (without n_ prefix).
+	/// </summary>
+	public required string JniName { get; init; }
+
+	/// <summary>
+	/// JNI method signature, e.g., "(Landroid/os/Bundle;)V".
+	/// Contains both parameter types and return type.
+	/// </summary>
+	public required string JniSignature { get; init; }
+
+	/// <summary>
+	/// The connector string from [Register], e.g., "GetOnCreate_Landroid_os_Bundle_Handler".
+	/// Null for [Export] methods.
+	/// </summary>
+	public string? Connector { get; init; }
+
+	/// <summary>
+	/// Name of the managed method this maps to, e.g., "OnCreate".
+	/// </summary>
+	public required string ManagedMethodName { get; init; }
+
+	/// <summary>
+	/// Full name of the type that declares the managed method (may be a base type).
+	/// Empty when the declaring type is the same as the peer type.
+	/// </summary>
+	public string DeclaringTypeName { get; init; } = "";
+
+	/// <summary>
+	/// Assembly name of the type that declares the managed method.
+	/// Needed for cross-assembly UCO wrapper generation.
+	/// Empty when the declaring type is the same as the peer type.
+	/// </summary>
+	public string DeclaringAssemblyName { get; init; } = "";
+
+	/// <summary>
+	/// The native callback method name, e.g., "n_onCreate".
+	/// This is the actual method the UCO wrapper delegates to.
+	/// </summary>
+	public required string NativeCallbackName { get; init; }
+
+	/// <summary>
+	/// JNI parameter types for UCO generation.
+	/// </summary>
+	public IReadOnlyList<JniParameterInfo> Parameters { get; init; } = Array.Empty<JniParameterInfo> ();
+
+	/// <summary>
+	/// JNI return type descriptor, e.g., "V", "Landroid/os/Bundle;".
+	/// </summary>
+	public required string JniReturnType { get; init; }
+
+	/// <summary>
+	/// True if this is a constructor registration.
+	/// </summary>
+	public bool IsConstructor { get; init; }
+
+	/// <summary>
+	/// For [Export] methods: Java exception types that the method declares it can throw.
+	/// Null for [Register] methods.
+	/// </summary>
+	public IReadOnlyList<string>? ThrownNames { get; init; }
+
+	/// <summary>
+	/// For [Export] methods: super constructor arguments string.
+	/// Null for [Register] methods.
+	/// </summary>
+	public string? SuperArgumentsString { get; init; }
+}
+
+/// <summary>
+/// Describes a JNI parameter for UCO method generation.
+/// </summary>
+sealed record JniParameterInfo
+{
+	/// <summary>
+	/// JNI type descriptor, e.g., "Landroid/os/Bundle;", "I", "Z".
+	/// </summary>
+	public required string JniType { get; init; }
+
+	/// <summary>
+	/// Managed parameter type name, e.g., "Android.OS.Bundle", "System.Int32".
+	/// </summary>
+	public string ManagedType { get; init; } = "";
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Metadata;
@@ -164,6 +165,7 @@ sealed class JavaPeerScanner : IDisposable
 			//   3. Extends a known Java peer → auto-compute JNI name via CRC64
 			//   4. None of the above → not a Java peer, skip
 			string? jniName = null;
+			string? compatJniName = null;
 			bool doNotGenerateAcw = false;
 
 			index.RegisterInfoByType.TryGetValue (typeHandle, out var registerInfo);
@@ -171,15 +173,17 @@ sealed class JavaPeerScanner : IDisposable
 
 			if (registerInfo is not null && !string.IsNullOrEmpty (registerInfo.JniName)) {
 				jniName = registerInfo.JniName;
+				compatJniName = jniName;
 				doNotGenerateAcw = registerInfo.DoNotGenerateAcw;
 			} else if (attrInfo?.JniName is not null) {
 				// User type with [Activity(Name = "...")] but no [Register]
 				jniName = attrInfo.JniName;
+				compatJniName = jniName;
 			} else {
 				// No explicit JNI name — check if this type extends a known Java peer.
 				// If so, auto-compute JNI name from the managed type name via CRC64.
 				if (ExtendsJavaPeer (typeDef, index)) {
-					jniName = ComputeAutoJniName (typeDef, index);
+					(jniName, compatJniName) = ComputeAutoJniNames (typeDef, index);
 				} else {
 					continue;
 				}
@@ -193,6 +197,9 @@ sealed class JavaPeerScanner : IDisposable
 
 			var isUnconditional = attrInfo is not null;
 			string? invokerTypeName = null;
+
+			// Collect marshal methods (including constructors) in a single pass over methods
+			var marshalMethods = CollectMarshalMethods (typeDef, index);
 
 			// Resolve activation constructor
 			var activationCtor = ResolveActivationCtor (fullName, typeDef, index);
@@ -214,6 +221,7 @@ sealed class JavaPeerScanner : IDisposable
 
 			var peer = new JavaPeerInfo {
 				JavaName = jniName,
+				CompatJniName = compatJniName,
 				ManagedTypeName = fullName,
 				ManagedTypeNamespace = ExtractNamespace (fullName),
 				ManagedTypeShortName = ExtractShortName (fullName),
@@ -222,6 +230,7 @@ sealed class JavaPeerScanner : IDisposable
 				IsAbstract = isAbstract,
 				DoNotGenerateAcw = doNotGenerateAcw,
 				IsUnconditional = isUnconditional,
+				MarshalMethods = marshalMethods,
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				IsGenericDefinition = isGenericDefinition,
@@ -230,6 +239,186 @@ sealed class JavaPeerScanner : IDisposable
 			};
 
 			results [fullName] = peer;
+		}
+	}
+
+	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index)
+	{
+		var methods = new List<MarshalMethodInfo> ();
+
+		// Single pass over methods: collect marshal methods (including constructors)
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			if (!TryGetMethodRegisterInfo (methodDef, index, out var registerInfo, out var exportInfo) || registerInfo is null) {
+				continue;
+			}
+
+			AddMarshalMethod (methods, registerInfo, methodDef, index, exportInfo);
+		}
+
+		// Collect [Register] from properties (attribute is on the property, not the getter)
+		foreach (var propHandle in typeDef.GetProperties ()) {
+			var propDef = index.Reader.GetPropertyDefinition (propHandle);
+			var propRegister = TryGetPropertyRegisterInfo (propDef, index);
+			if (propRegister is null) {
+				continue;
+			}
+
+			var accessors = propDef.GetAccessors ();
+			if (!accessors.Getter.IsNil) {
+				var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
+				AddMarshalMethod (methods, propRegister, getterDef, index);
+			}
+		}
+
+		return methods;
+	}
+
+	static void AddMarshalMethod (List<MarshalMethodInfo> methods, RegisterInfo registerInfo, MethodDefinition methodDef, AssemblyIndex index, ExportInfo? exportInfo = null)
+	{
+		// Skip methods that are just the JNI name (type-level [Register])
+		if (registerInfo.Signature is null && registerInfo.Connector is null) {
+			return;
+		}
+
+		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
+		string nativeCallbackName = $"n_{index.Reader.GetString (methodDef.Name)}";
+		if (isConstructor) {
+			int ctorIndex = 0;
+			foreach (var method in methods) {
+				if (method.IsConstructor) {
+					ctorIndex++;
+				}
+			}
+			nativeCallbackName = ctorIndex == 0 ? "n_ctor" : $"n_ctor_{ctorIndex}";
+		}
+
+		methods.Add (new MarshalMethodInfo {
+			JniName = registerInfo.JniName,
+			JniSignature = registerInfo.Signature ?? "()V",
+			Connector = registerInfo.Connector,
+			ManagedMethodName = index.Reader.GetString (methodDef.Name),
+			NativeCallbackName = nativeCallbackName,
+			JniReturnType = JniSignatureHelper.ParseReturnTypeString (registerInfo.Signature ?? "()V"),
+			Parameters = JniSignatureHelper.ParseParameterTypes (registerInfo.Signature ?? "()V"),
+			IsConstructor = isConstructor,
+			ThrownNames = exportInfo?.ThrownNames,
+			SuperArgumentsString = exportInfo?.SuperArgumentsString,
+		});
+	}
+
+	static bool TryGetMethodRegisterInfo (MethodDefinition methodDef, AssemblyIndex index, out RegisterInfo? registerInfo, out ExportInfo? exportInfo)
+	{
+		exportInfo = null;
+		foreach (var caHandle in methodDef.GetCustomAttributes ()) {
+			var ca = index.Reader.GetCustomAttribute (caHandle);
+			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+
+			if (attrName == "RegisterAttribute") {
+				registerInfo = index.ParseRegisterAttribute (ca);
+				return true;
+			}
+
+			if (attrName == "ExportAttribute") {
+				(registerInfo, exportInfo) = ParseExportAttribute (ca, methodDef, index);
+				return true;
+			}
+		}
+		registerInfo = null;
+		return false;
+	}
+
+	static RegisterInfo? TryGetPropertyRegisterInfo (PropertyDefinition propDef, AssemblyIndex index)
+	{
+		foreach (var caHandle in propDef.GetCustomAttributes ()) {
+			var ca = index.Reader.GetCustomAttribute (caHandle);
+			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+
+			if (attrName == "RegisterAttribute") {
+				return index.ParseRegisterAttribute (ca);
+			}
+		}
+		return null;
+	}
+
+	static (RegisterInfo registerInfo, ExportInfo exportInfo) ParseExportAttribute (CustomAttribute ca, MethodDefinition methodDef, AssemblyIndex index)
+	{
+		var value = index.DecodeAttribute (ca);
+
+		// [Export("name")] or [Export] (uses method name)
+		string? exportName = null;
+		if (value.FixedArguments.Length > 0) {
+			exportName = (string?)value.FixedArguments [0].Value;
+		}
+
+		List<string>? thrownNames = null;
+		string? superArguments = null;
+
+		// Check Named arguments
+		foreach (var named in value.NamedArguments) {
+			if (named.Name == "Name" && named.Value is string name) {
+				exportName = name;
+			} else if (named.Name == "ThrownNames" && named.Value is ImmutableArray<CustomAttributeTypedArgument<string>> names) {
+				thrownNames = new List<string> (names.Length);
+				foreach (var item in names) {
+					if (item.Value is string s) {
+						thrownNames.Add (s);
+					}
+				}
+			} else if (named.Name == "SuperArgumentsString" && named.Value is string superArgs) {
+				superArguments = superArgs;
+			}
+		}
+
+		if (string.IsNullOrEmpty (exportName)) {
+			exportName = index.Reader.GetString (methodDef.Name);
+		}
+		string resolvedExportName = exportName ?? throw new InvalidOperationException ("Export name should not be null at this point.");
+
+		// Build JNI signature from method signature
+		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+		var jniSig = BuildJniSignatureFromManaged (sig);
+
+		return (
+			new RegisterInfo { JniName = resolvedExportName, Signature = jniSig, Connector = null, DoNotGenerateAcw = false },
+			new ExportInfo { ThrownNames = thrownNames, SuperArgumentsString = superArguments }
+		);
+	}
+
+	static string BuildJniSignatureFromManaged (MethodSignature<string> sig)
+	{
+		var sb = new System.Text.StringBuilder ();
+		sb.Append ('(');
+		foreach (var param in sig.ParameterTypes) {
+			sb.Append (ManagedTypeToJniDescriptor (param));
+		}
+		sb.Append (')');
+		sb.Append (ManagedTypeToJniDescriptor (sig.ReturnType));
+		return sb.ToString ();
+	}
+
+	static string ManagedTypeToJniDescriptor (string managedType)
+	{
+		switch (managedType) {
+		case "System.Void": return "V";
+		case "System.Boolean": return "Z";
+		case "System.Byte":
+		case "System.SByte": return "B";
+		case "System.Char": return "C";
+		case "System.Int16":
+		case "System.UInt16": return "S";
+		case "System.Int32":
+		case "System.UInt32": return "I";
+		case "System.Int64":
+		case "System.UInt64": return "J";
+		case "System.Single": return "F";
+		case "System.Double": return "D";
+		case "System.String": return "Ljava/lang/String;";
+		default:
+			if (managedType.EndsWith ("[]")) {
+				return $"[{ManagedTypeToJniDescriptor (managedType.Substring (0, managedType.Length - 2))}";
+			}
+			return "Ljava/lang/Object;";
 		}
 	}
 
@@ -453,21 +642,29 @@ sealed class JavaPeerScanner : IDisposable
 	}
 
 	/// <summary>
-	/// Compute JNI name for a type without [Register] or component Name.
+	/// Compute both JNI name and compat JNI name for a type without [Register] or component Name.
 	/// JNI name uses CRC64 hash of "namespace:assemblyName" for the package.
-	/// If a declaring type has [Register], its JNI name is used as prefix.
+	/// Compat JNI name uses the raw managed namespace (lowercased).
+	/// If a declaring type has [Register], its JNI name is used as prefix for both.
 	/// Generic backticks are replaced with _.
 	/// </summary>
-	static string ComputeAutoJniName (TypeDefinition typeDef, AssemblyIndex index)
+	static (string jniName, string compatJniName) ComputeAutoJniNames (TypeDefinition typeDef, AssemblyIndex index)
 	{
 		var (typeName, parentJniName, ns) = ComputeTypeNameParts (typeDef, index);
 
 		if (parentJniName is not null) {
-			return $"{parentJniName}_{typeName}";
+			var name = $"{parentJniName}_{typeName}";
+			return (name, name);
 		}
 
 		var packageName = GetCrc64PackageName (ns, index.AssemblyName);
-		return $"{packageName}/{typeName}";
+		var jniName = $"{packageName}/{typeName}";
+
+		string compatName = ns.Length == 0
+			? typeName
+			: $"{ns.ToLowerInvariant ().Replace ('.', '/')}/{typeName}";
+
+		return (jniName, compatName);
 	}
 
 	/// <summary>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -57,6 +57,7 @@ public abstract class FixtureTestBase
 		var (ns, shortName) = ParseManagedTypeName (managedName);
 		return new JavaPeerInfo {
 			JavaName = jniName,
+			CompatJniName = jniName,
 			ManagedTypeName = managedName,
 			ManagedTypeNamespace = ns,
 			ManagedTypeShortName = shortName,
@@ -76,17 +77,32 @@ public abstract class FixtureTestBase
 	}
 
 	private protected static JavaPeerInfo MakeAcwPeer (string jniName, string managedName, string asmName)
-		=> MakePeerWithActivation (jniName, managedName, asmName);
+	{
+		return MakePeerWithActivation (jniName, managedName, asmName) with {
+			DoNotGenerateAcw = false,
+			MarshalMethods = new List<MarshalMethodInfo> {
+				new MarshalMethodInfo {
+					JniName = "<init>",
+					NativeCallbackName = "n_ctor",
+					JniSignature = "()V",
+					JniReturnType = "V",
+					ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+			},
+		};
+	}
 
 	private protected static JavaPeerInfo MakeInterfacePeer (
-		string jniName,
-		string managedName,
-		string asmName,
-		string invokerName)
+		string jniName = "android/view/View$OnClickListener",
+		string managedName = "Android.Views.View+IOnClickListener",
+		string asmName = "Mono.Android",
+		string invokerName = "Android.Views.View+IOnClickListenerInvoker")
 	{
 		var (ns, shortName) = ParseManagedTypeName (managedName);
 		return new JavaPeerInfo {
 			JavaName = jniName,
+			CompatJniName = jniName,
 			ManagedTypeName = managedName,
 			ManagedTypeNamespace = ns,
 			ManagedTypeShortName = shortName,
@@ -107,4 +123,16 @@ public abstract class FixtureTestBase
 			.Select (i => reader.GetMemberReference (MetadataTokens.MemberReferenceHandle (i)))
 			.Select (m => reader.GetString (m.Name))
 			.ToList ();
+
+	private protected static MarshalMethodInfo MakeMarshalMethod (string jniName, string callbackName, string jniSig, bool isConstructor = false)
+	{
+		return new MarshalMethodInfo {
+			JniName = jniName,
+			NativeCallbackName = callbackName,
+			JniSignature = jniSig,
+			JniReturnType = JniSignatureHelper.ParseReturnTypeString (jniSig),
+			ManagedMethodName = jniName,
+			IsConstructor = isConstructor,
+		};
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -106,6 +106,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var peers = new List<JavaPeerInfo> {
 			new JavaPeerInfo {
 				JavaName = "test/Duplicate",
+				CompatJniName = "test/Duplicate",
 				ManagedTypeName = "Test.Duplicate1",
 				ManagedTypeNamespace = "Test",
 				ManagedTypeShortName = "Duplicate1",
@@ -118,6 +119,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			},
 			new JavaPeerInfo {
 				JavaName = "test/Duplicate",
+				CompatJniName = "test/Duplicate",
 				ManagedTypeName = "Test.Duplicate2",
 				ManagedTypeNamespace = "Test",
 				ManagedTypeShortName = "Duplicate2",

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -183,7 +183,7 @@ public class ModelBuilderTests : FixtureTestBase
 		[Fact]
 		public void Build_PeerWithInvoker_CreatesProxy ()
 		{
-			var peer = MakeInterfacePeer ("android/view/View$OnClickListener", "Android.Views.View+IOnClickListener", "Mono.Android", "Android.Views.View+IOnClickListenerInvoker");
+			var peer = MakeInterfacePeer ();
 
 			var model = BuildModel (new [] { peer });
 			Assert.Single (model.ProxyTypes);
@@ -434,7 +434,7 @@ public class ModelBuilderTests : FixtureTestBase
 
 			var model = BuildModel (new [] { peer }, "TypeMap");
 
-			if (peer.ActivationCtor != null) {
+			if (peer.ActivationCtor != null && peer.MarshalMethods.Count > 0) {
 				var proxy = model.ProxyTypes.FirstOrDefault (p => p.TypeName == expectedProxyName);
 				Assert.NotNull (proxy);
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
@@ -1,9 +1,58 @@
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
 public partial class JavaPeerScannerTests
 {
+	[Theory]
+	[InlineData ("android/app/Activity", "OnCreate", "onCreate", "(Landroid/os/Bundle;)V")]
+	[InlineData ("android/app/Activity", "OnStart", "onStart", "()V")]
+	[InlineData ("my/app/MainActivity", "OnCreate", "onCreate", "(Landroid/os/Bundle;)V")]
+	[InlineData ("my/app/AbstractBase", "DoWork", "doWork", "()V")]
+	[InlineData ("java/lang/Throwable", "Message", "getMessage", "()Ljava/lang/String;")]
+	[InlineData ("my/app/TouchHandler", "OnTouch", "onTouch", "(Landroid/view/View;I)Z")]
+	[InlineData ("my/app/TouchHandler", "OnFocusChange", "onFocusChange", "(Landroid/view/View;Z)V")]
+	[InlineData ("my/app/TouchHandler", "OnScroll", "onScroll", "(IFJD)V")]
+	[InlineData ("my/app/TouchHandler", "SetItems", "setItems", "([Ljava/lang/String;)V")]
+	public void Scan_MarshalMethod_HasCorrectSignature (string javaName, string managedName, string jniName, string jniSig)
+	{
+		var method = FindFixtureByJavaName (javaName)
+			.MarshalMethods.FirstOrDefault (m => m.ManagedMethodName == managedName || m.JniName == jniName);
+		Assert.NotNull (method);
+		Assert.Equal (jniName, method.JniName);
+		Assert.Equal (jniSig, method.JniSignature);
+	}
+
+	[Fact]
+	public void Scan_MarshalMethod_ConstructorsAndSpecialCases ()
+	{
+		var ctors = FindFixtureByJavaName ("my/app/CustomView")
+			.MarshalMethods.Where (m => m.IsConstructor).ToList ();
+		Assert.Equal (2, ctors.Count);
+		Assert.Equal ("()V", ctors [0].JniSignature);
+		Assert.Equal ("(Landroid/content/Context;)V", ctors [1].JniSignature);
+
+		Assert.DoesNotContain (FindFixtureByJavaName ("my/app/MyHelper").MarshalMethods, m => m.IsConstructor);
+
+		var exportMethod = FindFixtureByJavaName ("my/app/ExportExample").MarshalMethods.Single ();
+		Assert.Equal ("myExportedMethod", exportMethod.JniName);
+		Assert.Null (exportMethod.Connector);
+
+		var onStart = FindFixtureByJavaName ("android/app/Activity")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "onStart");
+		Assert.NotNull (onStart);
+		Assert.Equal ("", onStart.Connector);
+
+		var onClick = FindFixtureByManagedName ("Android.Views.IOnClickListener")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "onClick");
+		Assert.NotNull (onClick);
+		Assert.Equal ("(Landroid/view/View;)V", onClick.JniSignature);
+
+		Assert.Equal ("Android.Views.IOnClickListenerInvoker",
+			FindFixtureByManagedName ("Android.Views.IOnClickListener").InvokerTypeName);
+	}
+
 	[Theory]
 	[InlineData ("android/app/Activity", "Android.App.Activity")]
 	[InlineData ("my/app/SimpleActivity", "Android.App.Activity")]
@@ -38,6 +87,22 @@ public partial class JavaPeerScannerTests
 		Assert.Contains ("android/view/View$OnClickListener",
 			FindFixtureByJavaName ("my/app/ClickableView").ImplementedInterfaceJavaNames);
 		Assert.Empty (FindFixtureByJavaName ("my/app/MyHelper").ImplementedInterfaceJavaNames);
+	}
+
+	[Theory]
+	[InlineData ("android/app/Activity", "android/app/Activity")]
+	[InlineData ("my/app/MainActivity", "my/app/MainActivity")]
+	public void Scan_CompatJniName (string javaName, string expectedCompat)
+	{
+		Assert.Equal (expectedCompat, FindFixtureByJavaName (javaName).CompatJniName);
+	}
+
+	[Fact]
+	public void Scan_CompatJniName_UnregisteredType_UsesRawNamespace ()
+	{
+		var unregistered = FindFixtureByManagedName ("MyApp.UnregisteredHelper");
+		Assert.StartsWith ("crc64", unregistered.JavaName);
+		Assert.Equal ("myapp/UnregisteredHelper", unregistered.CompatJniName);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.EdgeCases.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.EdgeCases.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
@@ -36,6 +37,8 @@ public partial class JavaPeerScannerTests
 	public void Scan_EmptyNamespace_Handled ()
 	{
 		Assert.Equal ("GlobalType", FindFixtureByJavaName ("my/app/GlobalType").ManagedTypeName);
+		Assert.Equal ("GlobalUnregisteredType",
+			FindFixtureByManagedName ("GlobalUnregisteredType").CompatJniName);
 	}
 
 	[Theory]
@@ -46,5 +49,14 @@ public partial class JavaPeerScannerTests
 	public void Scan_UnregisteredType_DiscoveredWithCrc64Name (string managedName)
 	{
 		Assert.StartsWith ("crc64", FindFixtureByManagedName (managedName).JavaName);
+	}
+
+	[Fact]
+	public void Scan_ExportOnUnregisteredType_MethodDiscovered ()
+	{
+		var exportMethod = FindFixtureByManagedName ("MyApp.UnregisteredExporter")
+			.MarshalMethods.FirstOrDefault (m => m.JniName == "doExportedWork");
+		Assert.NotNull (exportMethod);
+		Assert.Null (exportMethod.Connector);
 	}
 }


### PR DESCRIPTION
Stacked on #10808.

## Summary

Adds scanner support for collecting marshal methods from Java peer types. This infrastructure was split out from #10808 to keep that PR focused on TypeMap proxy groundwork.

### Changes
- `MarshalMethodInfo` and `JniParameterInfo` data models
- `CompatJniName` property for legacy layout XML support  
- `CollectMarshalMethods`, `ParseExportAttribute`, JNI signature parsing
- `JniSignatureHelper` with bug fix for malformed L-type signatures (infinite loop)
- `MakeMarshalMethod` and `MakeAcwPeer` test helpers
- Scanner tests for marshal method collection and CompatJniName

### Consumers
- PR #10831 (UCO wrappers + RegisterNatives)
- PR #10811 (Export support)

**Stacked PRs:**
1. PR #10808 — Proxy groundwork with CreateInstance
2. **This PR** — Marshal method scanning infrastructure
3. PR #10831 — UCO wrappers + RegisterNatives