### PR TITLE
[TrimmableTypeMap] Add GetFunctionPointer(int) ordinal dispatch

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -361,9 +361,10 @@ sealed class TypeMapAssemblyEmitter
 			wrapperHandles [uco.WrapperName] = handle;
 		}
 
-		// RegisterNatives
+		// RegisterNatives + GetFunctionPointer
 		if (proxy.IsAcw) {
 			EmitRegisterNatives (proxy.NativeRegistrations, wrapperHandles);
+			EmitGetFunctionPointer (proxy.NativeRegistrations, wrapperHandles);
 		}
 	}
 
@@ -727,6 +728,52 @@ sealed class TypeMapAssemblyEmitter
 	void AddUnmanagedCallersOnlyAttribute (MethodDefinitionHandle handle)
 	{
 		_pe.Metadata.AddCustomAttribute (handle, _ucoAttrCtorRef, _ucoAttrBlobHandle);
+	}
+
+	/// <summary>
+	/// Emits GetFunctionPointer(int methodIndex) → IntPtr that maps ordinals to UCO wrapper function pointers.
+	/// Used as an alternative dispatch mechanism to RegisterNatives.
+	/// </summary>
+	void EmitGetFunctionPointer (List<NativeRegistrationData> registrations,
+		Dictionary<string, MethodDefinitionHandle> wrapperHandles)
+	{
+		// Collect resolved handles in registration order
+		var resolvedHandles = new List<MethodDefinitionHandle> ();
+		foreach (var reg in registrations) {
+			if (wrapperHandles.TryGetValue (reg.WrapperMethodName, out var handle)) {
+				resolvedHandles.Add (handle);
+			}
+		}
+
+		_pe.EmitBody ("GetFunctionPointer",
+			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.HideBySig |
+			MethodAttributes.NewSlot | MethodAttributes.Final,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
+				rt => rt.Type ().IntPtr (),
+				p => p.AddParameter ().Type ().Int32 ()),
+			encoder => {
+				// For each registration, emit:
+				//   ldarg.1          // load methodIndex
+				//   ldc.i4 <index>   // load constant
+				//   bne.un.s <skip>  // if not equal, skip to next
+				//   ldftn <wrapper>  // load function pointer
+				//   ret
+				//   <skip>:
+				for (int i = 0; i < resolvedHandles.Count; i++) {
+					encoder.LoadArgument (1);
+					encoder.LoadConstantI4 (i);
+					// bne.un.s with offset = 7 (ldftn is 2-byte opcode + 4-byte token = 6, ret is 1 byte)
+					encoder.OpCode (ILOpCode.Bne_un_s);
+					encoder.CodeBuilder.WriteSByte (7);
+					encoder.OpCode (ILOpCode.Ldftn);
+					encoder.Token (resolvedHandles [i]);
+					encoder.OpCode (ILOpCode.Ret);
+				}
+				// Default: return IntPtr.Zero
+				encoder.OpCode (ILOpCode.Ldc_i4_0);
+				encoder.OpCode (ILOpCode.Conv_i);
+				encoder.OpCode (ILOpCode.Ret);
+			});
 	}
 
 	void EmitTypeMapAttribute (TypeMapAttributeData entry)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -504,4 +504,22 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	{
 		Assert.Empty (JniSignatureHelper.ParseParameterTypes ("("));
 	}
+
+	[Fact]
+	public void Generate_AcwProxy_HasGetFunctionPointer ()
+	{
+		var peers = ScanFixtures ();
+		var acwPeer = peers.First (p => p.JavaName == "my/app/MainActivity");
+		Assert.False (acwPeer.DoNotGenerateAcw);
+
+		using var stream = GenerateAssembly (new [] { acwPeer }, "GetFnPtrTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var methodDefs = reader.MethodDefinitions
+			.Select (h => reader.GetMethodDefinition (h))
+			.Select (m => reader.GetString (m.Name))
+			.ToList ();
+		Assert.Contains ("GetFunctionPointer", methodDefs);
+	}
 }


### PR DESCRIPTION
Part of https://github.com/dotnet/android/issues/10799
Stacked on #10917.

## Summary

Adds `GetFunctionPointer(int methodIndex)` to ACW proxy types. This method maps ordinal indices to `[UnmanagedCallersOnly]` wrapper function pointers, providing an alternative dispatch mechanism to `RegisterNatives`.

### IL emission

Emits a chain of comparisons:
```csharp
public IntPtr GetFunctionPointer (int methodIndex)
{
    if (methodIndex == 0) return &wrapper_0;
    if (methodIndex == 1) return &wrapper_1;
    // ...
    return IntPtr.Zero;
}
```

Each case uses `ldftn` to load the function pointer of the corresponding `[UnmanagedCallersOnly]` static method, using the same `wrapperHandles` dictionary populated during UCO emission.

### Tests

- Verifies `GetFunctionPointer` method exists on generated ACW proxy types