### PR TITLE
android-reviewer: @copilot prefix for Copilot-authored PRs

### DIFF
--- a/.github/skills/android-reviewer/SKILL.md
+++ b/.github/skills/android-reviewer/SKILL.md
@@ -98,6 +98,8 @@ Write a temp JSON file:
 
 If no issues found **and CI is green**, submit with empty `comments` and a positive summary.
 
+**Copilot-authored PRs:** If the PR author is `Copilot` (the GitHub Copilot coding agent) and the verdict is ⚠️ Needs Changes or ❌ Reject, prefix the review `body` with `@copilot ` so the comment automatically triggers Copilot to address the feedback. Do NOT add the prefix for ✅ LGTM verdicts.
+
 ### 8. Submit as a single batch
 
 ```powershell


### PR DESCRIPTION
When the android-reviewer skill reviews a PR authored by Copilot and the verdict is ⚠️ Needs Changes or ❌ Reject, the review body is now prefixed with `@copilot ` so the comment automatically triggers the Copilot coding agent to address the feedback.

No prefix is added for ✅ LGTM verdicts.

Used here: https://github.com/dotnet/android/pull/10920#pullrequestreview-3942239856