### PR TITLE
[TrimmableTypeMap] Detect overrides and constructors in JavaPeerScanner

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -85,6 +85,7 @@ sealed class JcwJavaSourceGenerator
 		WriteClassDeclaration (type, writer);
 		WriteStaticInitializer (type, writer);
 		WriteConstructors (type, writer);
+		WriteFields (type, writer);
 		WriteMethods (type, writer);
 		WriteGCUserPeerMethods (writer);
 		WriteClassClose (writer);
@@ -181,6 +182,28 @@ sealed class JcwJavaSourceGenerator
 		}
 	}
 
+	static void WriteFields (JavaPeerInfo type, TextWriter writer)
+	{
+		foreach (var field in type.JavaFields) {
+			writer.Write ('\t');
+			writer.Write (field.Visibility);
+			writer.Write (' ');
+			if (field.IsStatic) {
+				writer.Write ("static ");
+			}
+			writer.Write (field.JavaTypeName);
+			writer.Write (' ');
+			writer.Write (field.FieldName);
+			writer.Write (" = ");
+			writer.Write (field.InitializerMethodName);
+			writer.WriteLine (" ();");
+		}
+
+		if (type.JavaFields.Count > 0) {
+			writer.WriteLine ();
+		}
+	}
+
 	static void WriteMethods (JavaPeerInfo type, TextWriter writer)
 	{
 		foreach (var method in type.MarshalMethods) {
@@ -214,13 +237,14 @@ sealed class JcwJavaSourceGenerator
 
 """);
 			} else {
+				string access = method.IsExport && method.JavaAccess != null ? method.JavaAccess : "public";
 				writer.Write ($$"""
 
-	public {{javaReturnType}} {{method.JniName}} ({{parameters}}){{throwsClause}}
+	{{access}} {{javaReturnType}} {{method.JniName}} ({{parameters}}){{throwsClause}}
 	{
 		{{returnPrefix}}{{method.NativeCallbackName}} ({{args}});
 	}
-	public native {{javaReturnType}} {{method.NativeCallbackName}} ({{parameters}});
+	{{access}} native {{javaReturnType}} {{method.NativeCallbackName}} ({{parameters}});
 
 """);
 			}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -87,6 +87,12 @@ sealed record JavaPeerInfo
 	public IReadOnlyList<JavaConstructorInfo> JavaConstructors { get; init; } = [];
 
 	/// <summary>
+	/// Java fields from [ExportField] attributes.
+	/// Each field is initialized by calling the annotated method.
+	/// </summary>
+	public IReadOnlyList<JavaFieldInfo> JavaFields { get; init; } = [];
+
+	/// <summary>
 	/// Information about the activation constructor for this type.
 	/// May reference a base type's constructor if the type doesn't define its own.
 	/// </summary>
@@ -160,6 +166,19 @@ sealed record MarshalMethodInfo
 	public bool IsConstructor { get; init; }
 
 	/// <summary>
+	/// True if this method comes from an [Export] attribute (rather than [Register]).
+	/// [Export] methods use the C# method's access modifier in the JCW Java file
+	/// instead of always being "public".
+	/// </summary>
+	public bool IsExport { get; init; }
+
+	/// <summary>
+	/// Java access modifier for [Export] methods ("public", "protected", "private").
+	/// Null for [Register] methods (always "public").
+	/// </summary>
+	public string? JavaAccess { get; init; }
+
+	/// <summary>
 	/// For [Export] methods: Java exception types that the method declares it can throw.
 	/// Null for [Register] methods.
 	/// </summary>
@@ -208,6 +227,38 @@ sealed record JavaConstructorInfo
 	/// Null for [Register] constructors.
 	/// </summary>
 	public string? SuperArgumentsString { get; init; }
+}
+
+/// <summary>
+/// Describes a Java field from an [ExportField] attribute.
+/// The field is initialized by calling the annotated method.
+/// </summary>
+sealed record JavaFieldInfo
+{
+	/// <summary>
+	/// Java field name, e.g., "STATIC_INSTANCE".
+	/// </summary>
+	public required string FieldName { get; init; }
+
+	/// <summary>
+	/// Java type name for the field, e.g., "java.lang.String".
+	/// </summary>
+	public required string JavaTypeName { get; init; }
+
+	/// <summary>
+	/// Name of the method that initializes this field, e.g., "GetInstance".
+	/// </summary>
+	public required string InitializerMethodName { get; init; }
+
+	/// <summary>
+	/// Java access modifier ("public", "protected", "private").
+	/// </summary>
+	public required string Visibility { get; init; }
+
+	/// <summary>
+	/// Whether the field is static.
+	/// </summary>
+	public bool IsStatic { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -189,6 +189,12 @@ sealed record MarshalMethodInfo
 	/// Null for [Register] methods.
 	/// </summary>
 	public string? SuperArgumentsString { get; init; }
+
+	/// <summary>
+	/// True if this method was collected from an implemented interface
+	/// (Pass 4: CollectInterfaceMethodImplementations), not from the type itself.
+	/// </summary>
+	public bool IsInterfaceImplementation { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -675,7 +675,7 @@ sealed class JavaPeerScanner : IDisposable
 		var currentTypeDef = typeDef;
 		var currentIndex = index;
 
-		while (TryResolveBaseType (currentTypeDef, currentIndex, out var baseTypeDef, out var baseHandle, out var baseIndex)) {
+		while (TryResolveBaseType (currentTypeDef, currentIndex, out var baseTypeDef, out var baseHandle, out var baseIndex, out _, out _)) {
 			foreach (var methodHandle in baseTypeDef.GetMethods ()) {
 				var methodDef = baseIndex.Reader.GetMethodDefinition (methodHandle);
 				var name = baseIndex.Reader.GetString (methodDef.Name);
@@ -707,18 +707,21 @@ sealed class JavaPeerScanner : IDisposable
 	/// TypeDefinitionHandle, and AssemblyIndex for further inspection.
 	/// </summary>
 	bool TryResolveBaseType (TypeDefinition typeDef, AssemblyIndex index,
-		out TypeDefinition baseTypeDef, out TypeDefinitionHandle baseHandle, [NotNullWhen (true)] out AssemblyIndex? baseIndex)
+		out TypeDefinition baseTypeDef, out TypeDefinitionHandle baseHandle, [NotNullWhen (true)] out AssemblyIndex? baseIndex,
+		out string baseTypeName, out string baseAssemblyName)
 	{
 		baseTypeDef = default;
 		baseHandle = default;
 		baseIndex = null;
+		baseTypeName = "";
+		baseAssemblyName = "";
 
 		var baseInfo = GetBaseTypeInfo (typeDef, index);
 		if (baseInfo is null) {
 			return false;
 		}
 
-		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
+		(baseTypeName, baseAssemblyName) = baseInfo.Value;
 		if (!TryResolveType (baseTypeName, baseAssemblyName, out baseHandle, out baseIndex)) {
 			return false;
 		}
@@ -738,17 +741,9 @@ sealed class JavaPeerScanner : IDisposable
 	(RegisterInfo Info, string DeclaringTypeName, string DeclaringAssemblyName)? FindBaseRegisteredMethodInfo (
 		TypeDefinition typeDef, AssemblyIndex index, string methodName, MethodDefinition derivedMethod)
 	{
-		var baseInfo = GetBaseTypeInfo (typeDef, index);
-		if (baseInfo is null) {
+		if (!TryResolveBaseType (typeDef, index, out var baseTypeDef, out var baseHandle, out var baseIndex, out var baseTypeName, out var baseAssemblyName)) {
 			return null;
 		}
-
-		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
-		if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
-			return null;
-		}
-
-		var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
 
 		// Check methods on this base type
 		foreach (var baseMethodHandle in baseTypeDef.GetMethods ()) {
@@ -810,17 +805,9 @@ sealed class JavaPeerScanner : IDisposable
 	MarshalMethodInfo? FindBaseRegisteredProperty (TypeDefinition typeDef, AssemblyIndex index,
 		string getterName, MethodDefinition derivedGetter)
 	{
-		var baseInfo = GetBaseTypeInfo (typeDef, index);
-		if (baseInfo is null) {
+		if (!TryResolveBaseType (typeDef, index, out var baseTypeDef, out var baseHandle, out var baseIndex, out var baseTypeName, out var baseAssemblyName)) {
 			return null;
 		}
-
-		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
-		if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
-			return null;
-		}
-
-		var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
 
 		// Check properties on this base type
 		foreach (var basePropHandle in baseTypeDef.GetProperties ()) {
@@ -923,15 +910,12 @@ sealed class JavaPeerScanner : IDisposable
 
 	string? ResolveBaseJavaName (TypeDefinition typeDef, AssemblyIndex index, Dictionary<string, JavaPeerInfo> results)
 	{
-		var baseInfo = GetBaseTypeInfo (typeDef, index);
-		if (baseInfo is null) {
+		if (!TryResolveBaseType (typeDef, index, out var baseTypeDef, out _, out var baseIndex, out var baseTypeName, out _)) {
 			return null;
 		}
 
-		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
-
 		// First try [Register] attribute
-		var registerJniName = ResolveRegisterJniName (baseTypeName, baseAssemblyName);
+		var registerJniName = ResolveRegisterJniName (baseTypeName, baseIndex.AssemblyName);
 		if (registerJniName is not null) {
 			return registerJniName;
 		}
@@ -944,12 +928,9 @@ sealed class JavaPeerScanner : IDisposable
 		// Base type may be a Java peer without [Register] that hasn't been scanned yet
 		// (scan order within an assembly is not guaranteed). Resolve it the same way
 		// ScanAssembly does: check ExtendsJavaPeer and compute the auto JNI name.
-		if (TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
-			var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
-			if (ExtendsJavaPeer (baseTypeDef, baseIndex)) {
-				var (jniName, _) = ComputeAutoJniNames (baseTypeDef, baseIndex);
-				return jniName;
-			}
+		if (ExtendsJavaPeer (baseTypeDef, baseIndex)) {
+			var (jniName, _) = ComputeAutoJniNames (baseTypeDef, baseIndex);
+			return jniName;
 		}
 
 		return null;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -243,7 +243,7 @@ sealed class JavaPeerScanner : IDisposable
 	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index, bool detectBaseOverrides)
 	{
 		var methods = new List<MarshalMethodInfo> ();
-		var registeredMethodNames = new HashSet<string> (StringComparer.Ordinal);
+		var registeredMethodKeys = new HashSet<string> (StringComparer.Ordinal);
 
 		// Pass 1: collect methods with [Register] or [Export] directly on them
 		foreach (var methodHandle in typeDef.GetMethods ()) {
@@ -253,7 +253,8 @@ sealed class JavaPeerScanner : IDisposable
 			}
 
 			AddMarshalMethod (methods, registerInfo, methodDef, index, exportInfo);
-			registeredMethodNames.Add (index.Reader.GetString (methodDef.Name));
+			var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			registeredMethodKeys.Add ($"{index.Reader.GetString (methodDef.Name)}({string.Join (",", sig.ParameterTypes)})");
 		}
 
 		// Pass 2: collect [Register] from properties (attribute is on the property, not the getter)
@@ -268,7 +269,8 @@ sealed class JavaPeerScanner : IDisposable
 			if (!accessors.Getter.IsNil) {
 				var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
 				AddMarshalMethod (methods, propRegister, getterDef, index);
-				registeredMethodNames.Add (index.Reader.GetString (getterDef.Name));
+				var sig = getterDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+				registeredMethodKeys.Add ($"{index.Reader.GetString (getterDef.Name)}({string.Join (",", sig.ParameterTypes)})");
 			}
 		}
 
@@ -277,7 +279,7 @@ sealed class JavaPeerScanner : IDisposable
 		// [Register] on every method that matters. Running override detection on them
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
 		if (detectBaseOverrides) {
-			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodNames);
+			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodKeys);
 		}
 
 		// Pass 4: detect non-activation constructors that chain to base registered ctors.
@@ -311,8 +313,18 @@ sealed class JavaPeerScanner : IDisposable
 
 			var methodName = index.Reader.GetString (methodDef.Name);
 
-			// Skip constructors and methods already collected from direct [Register]
-			if (methodName == ".ctor" || methodName == ".cctor" || alreadyRegistered.Contains (methodName)) {
+			// Skip constructors
+			if (methodName == ".ctor" || methodName == ".cctor") {
+				continue;
+			}
+
+			// Build a unique key from the managed signature to allow multiple
+			// overloads with the same name (e.g., Read(), Read(byte[]), Read(byte[],int,int))
+			var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			var sigKey = $"{methodName}({string.Join (",", sig.ParameterTypes)})";
+
+			// Skip methods already collected from direct [Register]
+			if (alreadyRegistered.Contains (sigKey)) {
 				continue;
 			}
 
@@ -320,7 +332,7 @@ sealed class JavaPeerScanner : IDisposable
 			var baseRegistration = FindBaseRegisteredMethod (typeDef, index, methodName, methodDef);
 			if (baseRegistration is not null) {
 				methods.Add (baseRegistration);
-				alreadyRegistered.Add (methodName);
+				alreadyRegistered.Add (sigKey);
 			}
 		}
 
@@ -374,10 +386,6 @@ sealed class JavaPeerScanner : IDisposable
 	///    has compatible parameters.
 	/// 3. Fallback: if any base registered ctor is parameterless, accept the user ctor and
 	///    compute its JNI signature from the managed parameter types.
-	///
-	/// Known differences from legacy CecilImporter:
-	/// - Legacy threads outerType for nested inner-class constructors (generator concern).
-	/// - Legacy deduplicates by managed parameter string in addition to JNI signature.
 	/// </summary>
 	void CollectBaseConstructorChain (TypeDefinition typeDef, AssemblyIndex index,
 		List<MarshalMethodInfo> methods)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -282,9 +282,13 @@ sealed class JavaPeerScanner : IDisposable
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodKeys);
 		}
 
-		// Pass 4: detect non-activation constructors that chain to base registered ctors.
-		// Runs for all types (including MCW), matching legacy CecilImporter behavior.
-		CollectBaseConstructorChain (typeDef, index, methods);
+		// Pass 4: detect Java constructors that chain from base registered ctors.
+		// Only for ACW types — MCW types (DoNotGenerateAcw) already have [Register]
+		// on their ctors and are not processed through CecilImporter.CreateType
+		// in the legacy build pipeline.
+		if (detectBaseOverrides) {
+			CollectBaseConstructorChain (typeDef, index, methods);
+		}
 
 		return methods;
 	}
@@ -379,12 +383,13 @@ sealed class JavaPeerScanner : IDisposable
 	}
 
 	/// <summary>
-	/// Detects non-activation constructors that should become Java constructors by chaining
-	/// from base registered ctors. Mirrors the legacy CecilImporter behavior:
+	/// Detects Java constructors by chaining from base registered ctors.
+	/// Mirrors the legacy CecilImporter behavior:
 	/// 1. Walk the base type hierarchy collecting registered ctors (stopping at DoNotGenerateAcw)
-	/// 2. For each ctor on this type without [Register], accept it if a base registered ctor
+	/// 2. Add all base registered ctors as seed constructors (legacy adds them to the wrapper directly)
+	/// 3. For each ctor on this type without [Register], accept it if a base registered ctor
 	///    has compatible parameters.
-	/// 3. Fallback: if any base registered ctor is parameterless, accept the user ctor and
+	/// 4. Fallback: if any base registered ctor is parameterless, accept the user ctor and
 	///    compute its JNI signature from the managed parameter types.
 	/// </summary>
 	void CollectBaseConstructorChain (TypeDefinition typeDef, AssemblyIndex index,
@@ -404,15 +409,28 @@ sealed class JavaPeerScanner : IDisposable
 			return;
 		}
 
+		// Add all base registered ctors as seed constructors.
+		// Legacy CecilImporter processes base types first (ctorTypes is reversed) and adds
+		// their registered ctors directly to the wrapper's Constructors list.
 		bool hasParameterlessBaseCtor = false;
 		foreach (var baseCtor in baseRegisteredCtors) {
+			if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
+				methods.Add (new MarshalMethodInfo {
+					JniName = baseCtor.RegisterInfo.JniName,
+					JniSignature = baseCtor.RegisterInfo.Signature!,
+					Connector = baseCtor.RegisterInfo.Connector,
+					ManagedMethodName = ".ctor",
+					NativeCallbackName = "n_ctor",
+					IsConstructor = true,
+				});
+				alreadyRegisteredSignatures.Add (baseCtor.RegisterInfo.Signature!);
+			}
 			if (baseCtor.RegisterInfo.Signature == "()V") {
 				hasParameterlessBaseCtor = true;
-				break;
 			}
 		}
 
-		// Check each ctor on this type
+		// Check each ctor on this type for additional constructors not yet covered
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
 			var name = index.Reader.GetString (methodDef.Name);
@@ -426,26 +444,16 @@ sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 
-			// Try to find a base registered ctor with compatible parameters.
-			// Activation ctors (IntPtr, JniHandleOwnership) will never match because
-			// no base type registers a ctor with those parameter types.
-			bool matched = false;
+			// Check if this ctor's params are already covered by a base registered ctor
+			bool alreadyCovered = false;
 			foreach (var baseCtor in baseRegisteredCtors) {
 				if (AreParametersCompatible (methodDef, index, baseCtor.Method, baseCtor.Index)) {
-					if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
-						methods.Add (new MarshalMethodInfo {
-							JniName = baseCtor.RegisterInfo.JniName,
-							JniSignature = baseCtor.RegisterInfo.Signature!,
-							Connector = baseCtor.RegisterInfo.Connector,
-							ManagedMethodName = ".ctor",
-							NativeCallbackName = "n_ctor",
-							IsConstructor = true,
-						});
-						alreadyRegisteredSignatures.Add (baseCtor.RegisterInfo.Signature!);
-					}
-					matched = true;
+					alreadyCovered = true;
 					break;
 				}
+			}
+			if (alreadyCovered) {
+				continue;
 			}
 
 			// Fallback: if any base registered ctor is parameterless, accept this ctor
@@ -453,10 +461,10 @@ sealed class JavaPeerScanner : IDisposable
 			// The generated Java ctor calls super() (the parameterless base ctor),
 			// then delegates to nctor_N(...) which handles the args on the managed side.
 			// This matches legacy CecilImporter behavior (CecilImporter.cs:394-397).
-			if (!matched && hasParameterlessBaseCtor) {
+			if (hasParameterlessBaseCtor) {
 				var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 				var jniSignature = BuildJniCtorSignature (sig);
-				if (!alreadyRegisteredSignatures.Contains (jniSignature)) {
+				if (jniSignature is not null && !alreadyRegisteredSignatures.Contains (jniSignature)) {
 					methods.Add (new MarshalMethodInfo {
 						JniName = ".ctor",
 						JniSignature = jniSignature,
@@ -472,15 +480,56 @@ sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	static string BuildJniCtorSignature (MethodSignature<string> sig)
+	static string? BuildJniCtorSignature (MethodSignature<string> sig)
 	{
 		var sb = new System.Text.StringBuilder ();
 		sb.Append ('(');
 		foreach (var param in sig.ParameterTypes) {
-			sb.Append (ManagedTypeToJniDescriptor (param));
+			// Legacy GetJniSignature returns null for non-Java types (System.IntPtr,
+			// System.Object, System.Action, etc.). ManagedTypeToJniDescriptor maps
+			// these to "Ljava/lang/Object;" by default, but legacy would reject the
+			// whole ctor. Use the nullable variant to match legacy behavior.
+			var jniType = ManagedTypeToJniDescriptorOrNull (param);
+			if (jniType is null) {
+				return null;
+			}
+			sb.Append (jniType);
 		}
 		sb.Append (")V");
 		return sb.ToString ();
+	}
+
+	/// <summary>
+	/// Like <see cref="ManagedTypeToJniDescriptor"/> but returns null for types that
+	/// don't have a proper JNI mapping (matching legacy GetJniSignature behavior).
+	/// </summary>
+	static string? ManagedTypeToJniDescriptorOrNull (string managedType)
+	{
+		switch (managedType) {
+		case "System.Void": return "V";
+		case "System.Boolean": return "Z";
+		case "System.Byte":
+		case "System.SByte": return "B";
+		case "System.Char": return "C";
+		case "System.Int16":
+		case "System.UInt16": return "S";
+		case "System.Int32":
+		case "System.UInt32": return "I";
+		case "System.Int64":
+		case "System.UInt64": return "J";
+		case "System.Single": return "F";
+		case "System.Double": return "D";
+		case "System.String": return "Ljava/lang/String;";
+		default:
+			if (managedType.EndsWith ("[]")) {
+				var elementType = ManagedTypeToJniDescriptorOrNull (managedType.Substring (0, managedType.Length - 2));
+				return elementType is not null ? $"[{elementType}" : null;
+			}
+			// Non-primitive, non-string, non-array types don't have a reliable JNI mapping.
+			// Legacy GetJniSignature returns null for these (System.Object, System.IntPtr,
+			// System.Action, etc.), causing the whole ctor to be skipped.
+			return null;
+		}
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -274,19 +274,12 @@ sealed class JavaPeerScanner : IDisposable
 			}
 		}
 
-		// Pass 3: detect overrides of registered base methods.
+		// Pass 3–4: detect overrides and constructors from base hierarchy.
 		// Only for user ACW types — MCW types (DoNotGenerateAcw=true) already have
 		// [Register] on every method that matters. Running override detection on them
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
 		if (detectBaseOverrides) {
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodKeys);
-		}
-
-		// Pass 4: detect Java constructors that chain from base registered ctors.
-		// Only for ACW types — MCW types (DoNotGenerateAcw) already have [Register]
-		// on their ctors and are not processed through CecilImporter.CreateType
-		// in the legacy build pipeline.
-		if (detectBaseOverrides) {
 			CollectBaseConstructorChain (typeDef, index, methods);
 		}
 
@@ -370,14 +363,16 @@ sealed class JavaPeerScanner : IDisposable
 			}
 
 			var getterName = index.Reader.GetString (getterDef.Name);
-			if (alreadyRegistered.Contains (getterName)) {
+			var sig = getterDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			var sigKey = $"{getterName}({string.Join (",", sig.ParameterTypes)})";
+			if (alreadyRegistered.Contains (sigKey)) {
 				continue;
 			}
 
 			var baseRegistration = FindBaseRegisteredProperty (typeDef, index, getterName, getterDef);
 			if (baseRegistration is not null) {
 				methods.Add (baseRegistration);
-				alreadyRegistered.Add (getterName);
+				alreadyRegistered.Add (sigKey);
 			}
 		}
 	}
@@ -414,18 +409,22 @@ sealed class JavaPeerScanner : IDisposable
 		// their registered ctors directly to the wrapper's Constructors list.
 		bool hasParameterlessBaseCtor = false;
 		foreach (var baseCtor in baseRegisteredCtors) {
-			if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
+			var signature = baseCtor.RegisterInfo.Signature;
+			if (signature is null) {
+				continue;
+			}
+			if (!alreadyRegisteredSignatures.Contains (signature)) {
 				methods.Add (new MarshalMethodInfo {
 					JniName = baseCtor.RegisterInfo.JniName,
-					JniSignature = baseCtor.RegisterInfo.Signature!,
+					JniSignature = signature,
 					Connector = baseCtor.RegisterInfo.Connector,
 					ManagedMethodName = ".ctor",
 					NativeCallbackName = "n_ctor",
 					IsConstructor = true,
 				});
-				alreadyRegisteredSignatures.Add (baseCtor.RegisterInfo.Signature!);
+				alreadyRegisteredSignatures.Add (signature);
 			}
-			if (baseCtor.RegisterInfo.Signature == "()V") {
+			if (signature == "()V") {
 				hasParameterlessBaseCtor = true;
 			}
 		}
@@ -640,7 +639,10 @@ sealed class JavaPeerScanner : IDisposable
 			}
 		}
 
-		// Recurse up the hierarchy
+		// Recurse up the hierarchy (stop at DoNotGenerateAcw boundary)
+		if (baseIndex.RegisterInfoByType.TryGetValue (baseHandle, out var baseRegInfo) && baseRegInfo.DoNotGenerateAcw) {
+			return null;
+		}
 		return FindBaseRegisteredMethodInfo (baseTypeDef, baseIndex, methodName, derivedMethod);
 	}
 
@@ -715,7 +717,10 @@ sealed class JavaPeerScanner : IDisposable
 			}
 		}
 
-		// Recurse up
+		// Recurse up (stop at DoNotGenerateAcw boundary)
+		if (baseIndex.RegisterInfoByType.TryGetValue (baseHandle, out var baseRegInfo) && baseRegInfo.DoNotGenerateAcw) {
+			return null;
+		}
 		return FindBaseRegisteredProperty (baseTypeDef, baseIndex, getterName, derivedGetter);
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -203,8 +203,10 @@ sealed class JavaPeerScanner : IDisposable
 			// Resolve implemented Java interface names
 			var implementedInterfaces = ResolveImplementedInterfaceJavaNames (typeDef, index);
 
-			// Collect marshal methods (including constructors) in a single pass over methods
-			var marshalMethods = CollectMarshalMethods (typeDef, index);
+			// Collect marshal methods (including constructors).
+			// Override detection is only for user ACW types — MCW types (DoNotGenerateAcw)
+			// already have [Register] on every method that matters.
+			var marshalMethods = CollectMarshalMethods (typeDef, index, detectBaseOverrides: !doNotGenerateAcw);
 
 			// Resolve activation constructor
 			var activationCtor = ResolveActivationCtor (fullName, typeDef, index);
@@ -238,11 +240,12 @@ sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index)
+	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index, bool detectBaseOverrides)
 	{
 		var methods = new List<MarshalMethodInfo> ();
+		var registeredMethodNames = new HashSet<string> (StringComparer.Ordinal);
 
-		// Single pass over methods: collect marshal methods (including constructors)
+		// Pass 1: collect methods with [Register] or [Export] directly on them
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
 			if (!TryGetMethodRegisterInfo (methodDef, index, out var registerInfo, out var exportInfo) || registerInfo is null) {
@@ -250,9 +253,10 @@ sealed class JavaPeerScanner : IDisposable
 			}
 
 			AddMarshalMethod (methods, registerInfo, methodDef, index, exportInfo);
+			registeredMethodNames.Add (index.Reader.GetString (methodDef.Name));
 		}
 
-		// Collect [Register] from properties (attribute is on the property, not the getter)
+		// Pass 2: collect [Register] from properties (attribute is on the property, not the getter)
 		foreach (var propHandle in typeDef.GetProperties ()) {
 			var propDef = index.Reader.GetPropertyDefinition (propHandle);
 			var propRegister = TryGetPropertyRegisterInfo (propDef, index);
@@ -264,10 +268,242 @@ sealed class JavaPeerScanner : IDisposable
 			if (!accessors.Getter.IsNil) {
 				var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
 				AddMarshalMethod (methods, propRegister, getterDef, index);
+				registeredMethodNames.Add (index.Reader.GetString (getterDef.Name));
 			}
 		}
 
+		// Pass 3: detect overrides of registered base methods.
+		// Only for user ACW types — MCW types (DoNotGenerateAcw=true) already have
+		// [Register] on every method that matters. Running override detection on them
+		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
+		if (detectBaseOverrides) {
+			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodNames);
+		}
+
 		return methods;
+	}
+
+	/// <summary>
+	/// For each virtual override method on <paramref name="typeDef"/> that wasn't already
+	/// collected (no direct [Register]), walks up the base type hierarchy to find a
+	/// registered base method with matching name and compatible signature. If found,
+	/// adds the registration info as a marshal method with the declaring type set to
+	/// the base type that owns the [Register] attribute.
+	/// </summary>
+	void CollectBaseMethodOverrides (TypeDefinition typeDef, AssemblyIndex index,
+		List<MarshalMethodInfo> methods, HashSet<string> alreadyRegistered)
+	{
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			var attrs = methodDef.Attributes;
+
+			// Only virtual overrides: must be Virtual and NOT NewSlot (new keyword).
+			// NewSlot means a new virtual method, not an override.
+			if ((attrs & MethodAttributes.Virtual) == 0 ||
+			    (attrs & MethodAttributes.NewSlot) != 0 ||
+			    (attrs & MethodAttributes.Static) != 0) {
+				continue;
+			}
+
+			var methodName = index.Reader.GetString (methodDef.Name);
+
+			// Skip constructors and methods already collected from direct [Register]
+			if (methodName == ".ctor" || methodName == ".cctor" || alreadyRegistered.Contains (methodName)) {
+				continue;
+			}
+
+			// Walk base types looking for a registered method with this name
+			var baseRegistration = FindBaseRegisteredMethod (typeDef, index, methodName, methodDef);
+			if (baseRegistration is not null) {
+				methods.Add (baseRegistration);
+				alreadyRegistered.Add (methodName);
+			}
+		}
+
+		// Also check property overrides: a derived type may override a property
+		// whose getter is registered on a base type (e.g., Throwable.Message)
+		CollectBasePropertyOverrides (typeDef, index, methods, alreadyRegistered);
+	}
+
+	/// <summary>
+	/// Checks for property overrides where the base property has [Register] on the property
+	/// definition. Property [Register] attributes are on the PropertyDefinition, not the getter,
+	/// so we need separate handling.
+	/// </summary>
+	void CollectBasePropertyOverrides (TypeDefinition typeDef, AssemblyIndex index,
+		List<MarshalMethodInfo> methods, HashSet<string> alreadyRegistered)
+	{
+		foreach (var propHandle in typeDef.GetProperties ()) {
+			var propDef = index.Reader.GetPropertyDefinition (propHandle);
+			var accessors = propDef.GetAccessors ();
+			if (accessors.Getter.IsNil) {
+				continue;
+			}
+
+			var getterDef = index.Reader.GetMethodDefinition (accessors.Getter);
+			var attrs = getterDef.Attributes;
+
+			if ((attrs & MethodAttributes.Virtual) == 0 ||
+			    (attrs & MethodAttributes.NewSlot) != 0 ||
+			    (attrs & MethodAttributes.Static) != 0) {
+				continue;
+			}
+
+			var getterName = index.Reader.GetString (getterDef.Name);
+			if (alreadyRegistered.Contains (getterName)) {
+				continue;
+			}
+
+			var baseRegistration = FindBaseRegisteredProperty (typeDef, index, getterName, getterDef);
+			if (baseRegistration is not null) {
+				methods.Add (baseRegistration);
+				alreadyRegistered.Add (getterName);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Walks the base type hierarchy looking for a method with [Register] that matches
+	/// the given method name and has a compatible signature.
+	/// </summary>
+	RegisterInfo? FindBaseRegisteredMethodInfo (TypeDefinition typeDef, AssemblyIndex index,
+		string methodName, MethodDefinition derivedMethod)
+	{
+		var baseInfo = GetBaseTypeInfo (typeDef, index);
+		if (baseInfo is null) {
+			return null;
+		}
+
+		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
+		if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
+			return null;
+		}
+
+		var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
+
+		// Check methods on this base type
+		foreach (var baseMethodHandle in baseTypeDef.GetMethods ()) {
+			var baseMethodDef = baseIndex.Reader.GetMethodDefinition (baseMethodHandle);
+			var baseName = baseIndex.Reader.GetString (baseMethodDef.Name);
+
+			if (baseName != methodName) {
+				continue;
+			}
+
+			if ((baseMethodDef.Attributes & MethodAttributes.Virtual) == 0 &&
+			    (baseMethodDef.Attributes & MethodAttributes.Abstract) == 0) {
+				continue;
+			}
+
+			if (!AreParametersCompatible (derivedMethod, index, baseMethodDef, baseIndex)) {
+				continue;
+			}
+
+			// Found a matching base method — check if it has [Register]
+			if (TryGetMethodRegisterInfo (baseMethodDef, baseIndex, out var registerInfo, out _) && registerInfo is not null) {
+				return registerInfo;
+			}
+		}
+
+		// Recurse up the hierarchy
+		return FindBaseRegisteredMethodInfo (baseTypeDef, baseIndex, methodName, derivedMethod);
+	}
+
+	MarshalMethodInfo? FindBaseRegisteredMethod (TypeDefinition typeDef, AssemblyIndex index,
+		string methodName, MethodDefinition derivedMethod)
+	{
+		var registerInfo = FindBaseRegisteredMethodInfo (typeDef, index, methodName, derivedMethod);
+		if (registerInfo is null || registerInfo.Signature is null) {
+			return null;
+		}
+
+		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
+		return new MarshalMethodInfo {
+			JniName = registerInfo.JniName,
+			JniSignature = registerInfo.Signature,
+			Connector = registerInfo.Connector,
+			ManagedMethodName = methodName,
+			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{methodName}",
+			IsConstructor = isConstructor,
+		};
+	}
+
+	/// <summary>
+	/// Walks the base type hierarchy looking for a property with [Register] whose getter
+	/// matches the given getter name and has a compatible signature.
+	/// </summary>
+	MarshalMethodInfo? FindBaseRegisteredProperty (TypeDefinition typeDef, AssemblyIndex index,
+		string getterName, MethodDefinition derivedGetter)
+	{
+		var baseInfo = GetBaseTypeInfo (typeDef, index);
+		if (baseInfo is null) {
+			return null;
+		}
+
+		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
+		if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
+			return null;
+		}
+
+		var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
+
+		// Check properties on this base type
+		foreach (var basePropHandle in baseTypeDef.GetProperties ()) {
+			var basePropDef = baseIndex.Reader.GetPropertyDefinition (basePropHandle);
+			var baseAccessors = basePropDef.GetAccessors ();
+			if (baseAccessors.Getter.IsNil) {
+				continue;
+			}
+
+			var baseGetterDef = baseIndex.Reader.GetMethodDefinition (baseAccessors.Getter);
+			var baseGetterName = baseIndex.Reader.GetString (baseGetterDef.Name);
+			if (baseGetterName != getterName) {
+				continue;
+			}
+
+			if ((baseGetterDef.Attributes & MethodAttributes.Virtual) == 0 &&
+			    (baseGetterDef.Attributes & MethodAttributes.Abstract) == 0) {
+				continue;
+			}
+
+			// Check if the base property has [Register]
+			var propRegister = TryGetPropertyRegisterInfo (basePropDef, baseIndex);
+			if (propRegister is not null && propRegister.Signature is not null) {
+				return new MarshalMethodInfo {
+					JniName = propRegister.JniName,
+					JniSignature = propRegister.Signature,
+					Connector = propRegister.Connector,
+					ManagedMethodName = getterName,
+					NativeCallbackName = $"n_{getterName}",
+					IsConstructor = false,
+				};
+			}
+		}
+
+		// Recurse up
+		return FindBaseRegisteredProperty (baseTypeDef, baseIndex, getterName, derivedGetter);
+	}
+
+	/// <summary>
+	/// Checks if two methods have compatible parameter lists by comparing their decoded signatures.
+	/// </summary>
+	static bool AreParametersCompatible (MethodDefinition method1, AssemblyIndex index1,
+		MethodDefinition method2, AssemblyIndex index2)
+	{
+		var sig1 = method1.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+		var sig2 = method2.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+
+		if (sig1.ParameterTypes.Length != sig2.ParameterTypes.Length) {
+			return false;
+		}
+
+		for (int i = 0; i < sig1.ParameterTypes.Length; i++) {
+			if (!string.Equals (sig1.ParameterTypes [i], sig2.ParameterTypes [i], StringComparison.Ordinal)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	static void AddMarshalMethod (List<MarshalMethodInfo> methods, RegisterInfo registerInfo, MethodDefinition methodDef, AssemblyIndex index, ExportInfo? exportInfo = null)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -442,6 +442,8 @@ sealed class JavaPeerScanner : IDisposable
 
 			// Fallback: if any base registered ctor is parameterless, accept this ctor
 			// and compute its JNI signature from the managed parameter types.
+			// The generated Java ctor calls super() (the parameterless base ctor),
+			// then delegates to nctor_N(...) which handles the args on the managed side.
 			// This matches legacy CecilImporter behavior (CecilImporter.cs:394-397).
 			if (!matched && hasParameterlessBaseCtor) {
 				var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
@@ -454,6 +456,7 @@ sealed class JavaPeerScanner : IDisposable
 						ManagedMethodName = ".ctor",
 						NativeCallbackName = "n_ctor",
 						IsConstructor = true,
+						SuperArgumentsString = "",
 					});
 					alreadyRegisteredSignatures.Add (jniSignature);
 				}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -371,9 +371,15 @@ sealed class JavaPeerScanner : IDisposable
 	/// <summary>
 	/// Detects non-activation constructors that should become Java constructors by chaining
 	/// from base registered ctors. Mirrors the legacy CecilImporter behavior:
-	/// 1. Walk the base type hierarchy collecting registered ctors
-	/// 2. For each non-activation ctor on this type without [Register], accept it if
-	///    a base registered ctor has compatible parameters (or is parameterless).
+	/// 1. Walk the base type hierarchy collecting registered ctors (stopping at DoNotGenerateAcw)
+	/// 2. For each ctor on this type without [Register], accept it if a base registered ctor
+	///    has compatible parameters.
+	///
+	/// Known differences from legacy CecilImporter:
+	/// - Legacy also accepts ctors when any base ctor is parameterless (fallback path).
+	///   This is rare and not yet implemented.
+	/// - Legacy threads outerType for nested inner-class constructors.
+	/// - Legacy deduplicates by managed parameter string in addition to JNI signature.
 	/// </summary>
 	void CollectBaseConstructorChain (TypeDefinition typeDef, AssemblyIndex index,
 		List<MarshalMethodInfo> methods)
@@ -406,12 +412,9 @@ sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 
-			// Skip activation ctors
-			if (IsActivationCtor (methodDef, index)) {
-				continue;
-			}
-
-			// Try to find a base registered ctor with compatible parameters
+			// Try to find a base registered ctor with compatible parameters.
+			// Activation ctors (IntPtr, JniHandleOwnership) will never match because
+			// no base type registers a ctor with those parameter types.
 			foreach (var baseCtor in baseRegisteredCtors) {
 				if (AreParametersCompatible (methodDef, index, baseCtor.Method, baseCtor.Index)) {
 					if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
@@ -428,18 +431,12 @@ sealed class JavaPeerScanner : IDisposable
 					break;
 				}
 			}
-
-			// Fallback: if any accepted base ctor is parameterless, accept this ctor too.
-			// The legacy CecilImporter does this to allow user types to define ctors with
-			// parameters that don't exist on the base (e.g., custom string label).
-			// In that case we need to compute the JNI signature from the ctor's parameters.
-			// For now, only the compatible-parameters path is implemented, which covers the
-			// common cases (parameterless ctors, View(Context) ctors, etc.).
 		}
 	}
 
 	/// <summary>
 	/// Walks the base type hierarchy collecting constructors that have [Register] attributes.
+	/// Stops after the first base type with DoNotGenerateAcw=true (matching legacy CecilImporter).
 	/// Returns them ordered from nearest base to furthest ancestor.
 	/// </summary>
 	List<BaseCtorInfo> CollectBaseRegisteredCtors (TypeDefinition typeDef, AssemblyIndex index)
@@ -448,19 +445,7 @@ sealed class JavaPeerScanner : IDisposable
 		var currentTypeDef = typeDef;
 		var currentIndex = index;
 
-		while (true) {
-			var baseInfo = GetBaseTypeInfo (currentTypeDef, currentIndex);
-			if (baseInfo is null) {
-				break;
-			}
-
-			var (baseTypeName, baseAssemblyName) = baseInfo.Value;
-			if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
-				break;
-			}
-
-			var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
-
+		while (TryResolveBaseType (currentTypeDef, currentIndex, out var baseTypeDef, out var baseHandle, out var baseIndex)) {
 			foreach (var methodHandle in baseTypeDef.GetMethods ()) {
 				var methodDef = baseIndex.Reader.GetMethodDefinition (methodHandle);
 				var name = baseIndex.Reader.GetString (methodDef.Name);
@@ -474,6 +459,12 @@ sealed class JavaPeerScanner : IDisposable
 				}
 			}
 
+			// Stop after the first MCW base type — its registered ctors are collected above,
+			// but we don't need to walk further up (matching legacy CecilImporter behavior).
+			if (baseIndex.RegisterInfoByType.TryGetValue (baseHandle, out var baseRegInfo) && baseRegInfo.DoNotGenerateAcw) {
+				break;
+			}
+
 			currentTypeDef = baseTypeDef;
 			currentIndex = baseIndex;
 		}
@@ -481,26 +472,29 @@ sealed class JavaPeerScanner : IDisposable
 		return result;
 	}
 
-	static bool IsActivationCtor (MethodDefinition methodDef, AssemblyIndex index)
+	/// <summary>
+	/// Resolves the base type of the given type definition, returning its TypeDefinition,
+	/// TypeDefinitionHandle, and AssemblyIndex for further inspection.
+	/// </summary>
+	bool TryResolveBaseType (TypeDefinition typeDef, AssemblyIndex index,
+		out TypeDefinition baseTypeDef, out TypeDefinitionHandle baseHandle, [NotNullWhen (true)] out AssemblyIndex? baseIndex)
 	{
-		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
-		if (sig.ParameterTypes.Length != 2) {
+		baseTypeDef = default;
+		baseHandle = default;
+		baseIndex = null;
+
+		var baseInfo = GetBaseTypeInfo (typeDef, index);
+		if (baseInfo is null) {
 			return false;
 		}
 
-		// XI style: (IntPtr, JniHandleOwnership)
-		if (sig.ParameterTypes [0] == "System.IntPtr" &&
-		    sig.ParameterTypes [1] == "Android.Runtime.JniHandleOwnership") {
-			return true;
+		var (baseTypeName, baseAssemblyName) = baseInfo.Value;
+		if (!TryResolveType (baseTypeName, baseAssemblyName, out baseHandle, out baseIndex)) {
+			return false;
 		}
 
-		// JI style: (ref JniObjectReference, JniObjectReferenceOptions)
-		if ((sig.ParameterTypes [0] == "Java.Interop.JniObjectReference&" || sig.ParameterTypes [0] == "Java.Interop.JniObjectReference") &&
-		    sig.ParameterTypes [1] == "Java.Interop.JniObjectReferenceOptions") {
-			return true;
-		}
-
-		return false;
+		baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
+		return true;
 	}
 
 	readonly record struct BaseCtorInfo (MethodDefinition Method, AssemblyIndex Index, RegisterInfo RegisterInfo);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -608,7 +608,7 @@ sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	static string? BuildJniCtorSignature (MethodSignature<string> sig)
+	string? BuildJniCtorSignature (MethodSignature<string> sig)
 	{
 		var sb = new System.Text.StringBuilder ();
 		sb.Append ('(');
@@ -630,8 +630,9 @@ sealed class JavaPeerScanner : IDisposable
 	/// <summary>
 	/// Like <see cref="ManagedTypeToJniDescriptor"/> but returns null for types that
 	/// don't have a proper JNI mapping (matching legacy GetJniSignature behavior).
+	/// For Java peer object types (types with [Register]), resolves to "L&lt;jniName&gt;;".
 	/// </summary>
-	static string? ManagedTypeToJniDescriptorOrNull (string managedType)
+	string? ManagedTypeToJniDescriptorOrNull (string managedType)
 	{
 		switch (managedType) {
 		case "System.Void": return "V";
@@ -653,11 +654,26 @@ sealed class JavaPeerScanner : IDisposable
 				var elementType = ManagedTypeToJniDescriptorOrNull (managedType.Substring (0, managedType.Length - 2));
 				return elementType is not null ? $"[{elementType}" : null;
 			}
-			// Non-primitive, non-string, non-array types don't have a reliable JNI mapping.
-			// Legacy GetJniSignature returns null for these (System.Object, System.IntPtr,
-			// System.Action, etc.), causing the whole ctor to be skipped.
-			return null;
+			// Try to resolve as a Java peer type with [Register]
+			return TryResolveJniObjectDescriptor (managedType);
 		}
+	}
+
+	/// <summary>
+	/// Looks up a managed type name across loaded assemblies. If the type has
+	/// [Register], returns "L&lt;jniName&gt;;". Otherwise returns null.
+	/// Matches legacy JavaNativeTypeManager.GetJniTypeName behavior which resolves
+	/// Java peer types to their JNI descriptor and returns null for non-Java types.
+	/// </summary>
+	string? TryResolveJniObjectDescriptor (string managedType)
+	{
+		foreach (var index in assemblyCache.Values) {
+			if (index.TypesByFullName.TryGetValue (managedType, out var handle) &&
+			    index.RegisterInfoByType.TryGetValue (handle, out var registerInfo)) {
+				return $"L{registerInfo.JniName};";
+			}
+		}
+		return null;
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -598,10 +598,12 @@ sealed class JavaPeerScanner : IDisposable
 
 	/// <summary>
 	/// Walks the base type hierarchy looking for a method with [Register] that matches
-	/// the given method name and has a compatible signature.
+	/// the given method name and has a compatible signature. Returns the registration
+	/// info along with the declaring type's full name and assembly name (needed so
+	/// UCO wrappers call n_* on the correct base type).
 	/// </summary>
-	RegisterInfo? FindBaseRegisteredMethodInfo (TypeDefinition typeDef, AssemblyIndex index,
-		string methodName, MethodDefinition derivedMethod)
+	(RegisterInfo Info, string DeclaringTypeName, string DeclaringAssemblyName)? FindBaseRegisteredMethodInfo (
+		TypeDefinition typeDef, AssemblyIndex index, string methodName, MethodDefinition derivedMethod)
 	{
 		var baseInfo = GetBaseTypeInfo (typeDef, index);
 		if (baseInfo is null) {
@@ -635,7 +637,7 @@ sealed class JavaPeerScanner : IDisposable
 
 			// Found a matching base method — check if it has [Register]
 			if (TryGetMethodRegisterInfo (baseMethodDef, baseIndex, out var registerInfo, out _) && registerInfo is not null) {
-				return registerInfo;
+				return (registerInfo, baseTypeName, baseAssemblyName);
 			}
 		}
 
@@ -649,11 +651,12 @@ sealed class JavaPeerScanner : IDisposable
 	MarshalMethodInfo? FindBaseRegisteredMethod (TypeDefinition typeDef, AssemblyIndex index,
 		string methodName, MethodDefinition derivedMethod)
 	{
-		var registerInfo = FindBaseRegisteredMethodInfo (typeDef, index, methodName, derivedMethod);
-		if (registerInfo is null || registerInfo.Signature is null) {
+		var result = FindBaseRegisteredMethodInfo (typeDef, index, methodName, derivedMethod);
+		if (result is null || result.Value.Info.Signature is null) {
 			return null;
 		}
 
+		var registerInfo = result.Value.Info;
 		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
 		return new MarshalMethodInfo {
 			JniName = registerInfo.JniName,
@@ -662,6 +665,8 @@ sealed class JavaPeerScanner : IDisposable
 			ManagedMethodName = methodName,
 			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{methodName}",
 			IsConstructor = isConstructor,
+			DeclaringTypeName = result.Value.DeclaringTypeName,
+			DeclaringAssemblyName = result.Value.DeclaringAssemblyName,
 		};
 	}
 
@@ -713,6 +718,8 @@ sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = getterName,
 					NativeCallbackName = $"n_{getterName}",
 					IsConstructor = false,
+					DeclaringTypeName = baseTypeName,
+					DeclaringAssemblyName = baseAssemblyName,
 				};
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -464,6 +464,7 @@ sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = managedName,
 					NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
 					IsConstructor = isConstructor,
+					IsInterfaceImplementation = true,
 				});
 
 				alreadyRegistered.Add (jniKey);
@@ -497,6 +498,7 @@ sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = managedName,
 					NativeCallbackName = $"n_{managedName}",
 					IsConstructor = false,
+					IsInterfaceImplementation = true,
 				});
 
 				alreadyRegistered.Add (jniKey);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -278,6 +278,12 @@ sealed class JavaPeerScanner : IDisposable
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
 		if (detectBaseOverrides) {
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodNames);
+
+			// Pass 4: detect non-activation constructors that chain to base registered ctors.
+			// Mirrors the legacy CecilImporter behavior: walk from base to derived, seed
+			// with registered ctors, then accept unregistered non-activation ctors whose
+			// parameters are compatible with an already-accepted base ctor.
+			CollectBaseConstructorChain (typeDef, index, methods);
 		}
 
 		return methods;
@@ -361,6 +367,143 @@ sealed class JavaPeerScanner : IDisposable
 			}
 		}
 	}
+
+	/// <summary>
+	/// Detects non-activation constructors that should become Java constructors by chaining
+	/// from base registered ctors. Mirrors the legacy CecilImporter behavior:
+	/// 1. Walk the base type hierarchy collecting registered ctors
+	/// 2. For each non-activation ctor on this type without [Register], accept it if
+	///    a base registered ctor has compatible parameters (or is parameterless).
+	/// </summary>
+	void CollectBaseConstructorChain (TypeDefinition typeDef, AssemblyIndex index,
+		List<MarshalMethodInfo> methods)
+	{
+		// Collect JNI signatures of ctors already registered via Pass 1 (direct [Register])
+		var alreadyRegisteredSignatures = new HashSet<string> (StringComparer.Ordinal);
+		foreach (var m in methods) {
+			if (m.IsConstructor) {
+				alreadyRegisteredSignatures.Add (m.JniSignature);
+			}
+		}
+
+		// Collect registered ctors from base type hierarchy
+		var baseRegisteredCtors = CollectBaseRegisteredCtors (typeDef, index);
+		if (baseRegisteredCtors.Count == 0) {
+			return;
+		}
+
+		// Check each ctor on this type
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			var name = index.Reader.GetString (methodDef.Name);
+
+			if (name != ".ctor") {
+				continue;
+			}
+
+			// Skip if this ctor already has [Register] (collected in Pass 1)
+			if (TryGetMethodRegisterInfo (methodDef, index, out _, out _)) {
+				continue;
+			}
+
+			// Skip activation ctors
+			if (IsActivationCtor (methodDef, index)) {
+				continue;
+			}
+
+			// Try to find a base registered ctor with compatible parameters
+			foreach (var baseCtor in baseRegisteredCtors) {
+				if (AreParametersCompatible (methodDef, index, baseCtor.Method, baseCtor.Index)) {
+					if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
+						methods.Add (new MarshalMethodInfo {
+							JniName = baseCtor.RegisterInfo.JniName,
+							JniSignature = baseCtor.RegisterInfo.Signature!,
+							Connector = baseCtor.RegisterInfo.Connector,
+							ManagedMethodName = ".ctor",
+							NativeCallbackName = "n_ctor",
+							IsConstructor = true,
+						});
+						alreadyRegisteredSignatures.Add (baseCtor.RegisterInfo.Signature!);
+					}
+					break;
+				}
+			}
+
+			// Fallback: if any accepted base ctor is parameterless, accept this ctor too.
+			// The legacy CecilImporter does this to allow user types to define ctors with
+			// parameters that don't exist on the base (e.g., custom string label).
+			// In that case we need to compute the JNI signature from the ctor's parameters.
+			// For now, only the compatible-parameters path is implemented, which covers the
+			// common cases (parameterless ctors, View(Context) ctors, etc.).
+		}
+	}
+
+	/// <summary>
+	/// Walks the base type hierarchy collecting constructors that have [Register] attributes.
+	/// Returns them ordered from nearest base to furthest ancestor.
+	/// </summary>
+	List<BaseCtorInfo> CollectBaseRegisteredCtors (TypeDefinition typeDef, AssemblyIndex index)
+	{
+		var result = new List<BaseCtorInfo> ();
+		var currentTypeDef = typeDef;
+		var currentIndex = index;
+
+		while (true) {
+			var baseInfo = GetBaseTypeInfo (currentTypeDef, currentIndex);
+			if (baseInfo is null) {
+				break;
+			}
+
+			var (baseTypeName, baseAssemblyName) = baseInfo.Value;
+			if (!TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
+				break;
+			}
+
+			var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
+
+			foreach (var methodHandle in baseTypeDef.GetMethods ()) {
+				var methodDef = baseIndex.Reader.GetMethodDefinition (methodHandle);
+				var name = baseIndex.Reader.GetString (methodDef.Name);
+				if (name != ".ctor") {
+					continue;
+				}
+
+				if (TryGetMethodRegisterInfo (methodDef, baseIndex, out var registerInfo, out _) &&
+				    registerInfo is not null && registerInfo.Signature is not null) {
+					result.Add (new BaseCtorInfo (methodDef, baseIndex, registerInfo));
+				}
+			}
+
+			currentTypeDef = baseTypeDef;
+			currentIndex = baseIndex;
+		}
+
+		return result;
+	}
+
+	static bool IsActivationCtor (MethodDefinition methodDef, AssemblyIndex index)
+	{
+		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+		if (sig.ParameterTypes.Length != 2) {
+			return false;
+		}
+
+		// XI style: (IntPtr, JniHandleOwnership)
+		if (sig.ParameterTypes [0] == "System.IntPtr" &&
+		    sig.ParameterTypes [1] == "Android.Runtime.JniHandleOwnership") {
+			return true;
+		}
+
+		// JI style: (ref JniObjectReference, JniObjectReferenceOptions)
+		if ((sig.ParameterTypes [0] == "Java.Interop.JniObjectReference&" || sig.ParameterTypes [0] == "Java.Interop.JniObjectReference") &&
+		    sig.ParameterTypes [1] == "Java.Interop.JniObjectReferenceOptions") {
+			return true;
+		}
+
+		return false;
+	}
+
+	readonly record struct BaseCtorInfo (MethodDefinition Method, AssemblyIndex Index, RegisterInfo RegisterInfo);
 
 	/// <summary>
 	/// Walks the base type hierarchy looking for a method with [Register] that matches

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -456,16 +456,7 @@ sealed class JavaPeerScanner : IDisposable
 					continue;
 				}
 
-				bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
-				methods.Add (new MarshalMethodInfo {
-					JniName = registerInfo.JniName,
-					JniSignature = jniSignature,
-					Connector = registerInfo.Connector,
-					ManagedMethodName = managedName,
-					NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
-					IsConstructor = isConstructor,
-					IsInterfaceImplementation = true,
-				});
+				AddMarshalMethod (methods, registerInfo, ifaceMethodDef, ifaceIndex, isInterfaceImplementation: true);
 
 				alreadyRegistered.Add (jniKey);
 				alreadyRegistered.Add (managedKey);
@@ -485,21 +476,10 @@ sealed class JavaPeerScanner : IDisposable
 				}
 
 				var accessors = ifacePropDef.GetAccessors ();
-				string managedName = "";
 				if (!accessors.Getter.IsNil) {
-					managedName = ifaceIndex.Reader.GetString (
-						ifaceIndex.Reader.GetMethodDefinition (accessors.Getter).Name);
+					var getterDef = ifaceIndex.Reader.GetMethodDefinition (accessors.Getter);
+					AddMarshalMethod (methods, propRegister, getterDef, ifaceIndex, isInterfaceImplementation: true);
 				}
-
-				methods.Add (new MarshalMethodInfo {
-					JniName = propRegister.JniName,
-					JniSignature = propRegister.Signature,
-					Connector = propRegister.Connector,
-					ManagedMethodName = managedName,
-					NativeCallbackName = $"n_{managedName}",
-					IsConstructor = false,
-					IsInterfaceImplementation = true,
-				});
 
 				alreadyRegistered.Add (jniKey);
 			}
@@ -872,7 +852,7 @@ sealed class JavaPeerScanner : IDisposable
 		return true;
 	}
 
-	static void AddMarshalMethod (List<MarshalMethodInfo> methods, RegisterInfo registerInfo, MethodDefinition methodDef, AssemblyIndex index, ExportInfo? exportInfo = null)
+	static void AddMarshalMethod (List<MarshalMethodInfo> methods, RegisterInfo registerInfo, MethodDefinition methodDef, AssemblyIndex index, ExportInfo? exportInfo = null, bool isInterfaceImplementation = false)
 	{
 		// Skip methods that are just the JNI name (type-level [Register])
 		if (registerInfo.Signature is null && registerInfo.Connector is null) {
@@ -892,6 +872,7 @@ sealed class JavaPeerScanner : IDisposable
 			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
 			IsConstructor = isConstructor,
 			IsExport = isExport,
+			IsInterfaceImplementation = isInterfaceImplementation,
 			JavaAccess = isExport ? GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask) : null,
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -204,9 +204,10 @@ sealed class JavaPeerScanner : IDisposable
 			var implementedInterfaces = ResolveImplementedInterfaceJavaNames (typeDef, index);
 
 			// Collect marshal methods (including constructors).
-			// Override detection is only for user ACW types — MCW types (DoNotGenerateAcw)
-			// already have [Register] on every method that matters.
-			var marshalMethods = CollectMarshalMethods (typeDef, index, detectBaseOverrides: !doNotGenerateAcw);
+			// Override and interface detection is only for user ACW class types:
+			// - MCW types (DoNotGenerateAcw) already have [Register] on every method
+			// - Interface types don't implement other interfaces' methods in JCWs
+			var (marshalMethods, exportFields) = CollectMarshalMethods (typeDef, index, detectBaseOverrides: !doNotGenerateAcw && !isInterface);
 
 			// Resolve activation constructor
 			var activationCtor = ResolveActivationCtor (fullName, typeDef, index);
@@ -231,6 +232,7 @@ sealed class JavaPeerScanner : IDisposable
 				IsUnconditional = isUnconditional,
 				MarshalMethods = marshalMethods,
 				JavaConstructors = BuildJavaConstructors (marshalMethods),
+				JavaFields = exportFields,
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				IsGenericDefinition = isGenericDefinition,
@@ -240,14 +242,19 @@ sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	List<MarshalMethodInfo> CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index, bool detectBaseOverrides)
+	(List<MarshalMethodInfo>, List<JavaFieldInfo>) CollectMarshalMethods (TypeDefinition typeDef, AssemblyIndex index, bool detectBaseOverrides)
 	{
 		var methods = new List<MarshalMethodInfo> ();
+		var fields = new List<JavaFieldInfo> ();
 		var registeredMethodKeys = new HashSet<string> (StringComparer.Ordinal);
 
-		// Pass 1: collect methods with [Register] or [Export] directly on them
+		// Pass 1: collect methods with [Register], [Export], or [ExportField] directly on them
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+
+			// Check for [ExportField] — produces both a marshal method AND a field
+			CollectExportField (methodDef, index, fields);
+
 			if (!TryGetMethodRegisterInfo (methodDef, index, out var registerInfo, out var exportInfo) || registerInfo is null) {
 				continue;
 			}
@@ -280,10 +287,22 @@ sealed class JavaPeerScanner : IDisposable
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
 		if (detectBaseOverrides) {
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodKeys);
+		}
+
+		// Pass 4: detect interface method implementations.
+		// When a type implements a Java interface (e.g., IOnClickListener), the
+		// implementing method may not have [Register]. The legacy pipeline adds
+		// these via the interface loop in CecilImporter.cs lines 100-120.
+		if (detectBaseOverrides) {
+			CollectInterfaceMethodImplementations (typeDef, index, methods, registeredMethodKeys);
+		}
+
+		// Pass 5: detect Java constructors that chain from base registered ctors.
+		if (detectBaseOverrides) {
 			CollectBaseConstructorChain (typeDef, index, methods);
 		}
 
-		return methods;
+		return (methods, fields);
 	}
 
 	/// <summary>
@@ -373,6 +392,114 @@ sealed class JavaPeerScanner : IDisposable
 			if (baseRegistration is not null) {
 				methods.Add (baseRegistration);
 				alreadyRegistered.Add (sigKey);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Detects methods from implemented Java interfaces that aren't directly [Register]'d
+	/// on the implementing type. Mirrors the legacy CecilImporter interface loop (lines 100-120):
+	/// for each implemented interface with [Register], adds its registered methods to the type.
+	/// </summary>
+	void CollectInterfaceMethodImplementations (TypeDefinition typeDef, AssemblyIndex index,
+		List<MarshalMethodInfo> methods, HashSet<string> alreadyRegistered)
+	{
+		foreach (var implHandle in typeDef.GetInterfaceImplementations ()) {
+			var impl = index.Reader.GetInterfaceImplementation (implHandle);
+			var resolved = ResolveEntityHandle (impl.Interface, index);
+			if (resolved is null) {
+				continue;
+			}
+
+			var (ifaceTypeName, ifaceAssemblyName) = resolved.Value;
+			if (!TryResolveType (ifaceTypeName, ifaceAssemblyName, out var ifaceHandle, out var ifaceIndex)) {
+				continue;
+			}
+
+			// Only process interfaces that are Java peers (have [Register])
+			if (!ifaceIndex.RegisterInfoByType.ContainsKey (ifaceHandle)) {
+				continue;
+			}
+
+			var ifaceTypeDef = ifaceIndex.Reader.GetTypeDefinition (ifaceHandle);
+
+			// Add registered methods from this interface
+			foreach (var ifaceMethodHandle in ifaceTypeDef.GetMethods ()) {
+				var ifaceMethodDef = ifaceIndex.Reader.GetMethodDefinition (ifaceMethodHandle);
+
+				if ((ifaceMethodDef.Attributes & MethodAttributes.Static) != 0) {
+					continue;
+				}
+
+				if (!TryGetMethodRegisterInfo (ifaceMethodDef, ifaceIndex, out var registerInfo, out _) || registerInfo is null) {
+					continue;
+				}
+
+				// Skip type-level [Register] (no signature = just the JNI name)
+				if (registerInfo.Signature is null && registerInfo.Connector is null) {
+					continue;
+				}
+
+				string jniSignature = registerInfo.Signature ?? "()V";
+				var jniKey = $"{registerInfo.JniName}:{jniSignature}";
+
+				if (alreadyRegistered.Contains (jniKey)) {
+					continue;
+				}
+
+				// Also check by managed signature to avoid duplicates from
+				// direct [Register] that used different dedup keys
+				var managedName = ifaceIndex.Reader.GetString (ifaceMethodDef.Name);
+				var sig = ifaceMethodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+				var managedKey = $"{managedName}({string.Join (",", sig.ParameterTypes)})";
+				if (alreadyRegistered.Contains (managedKey)) {
+					continue;
+				}
+
+				bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
+				methods.Add (new MarshalMethodInfo {
+					JniName = registerInfo.JniName,
+					JniSignature = jniSignature,
+					Connector = registerInfo.Connector,
+					ManagedMethodName = managedName,
+					NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
+					IsConstructor = isConstructor,
+				});
+
+				alreadyRegistered.Add (jniKey);
+				alreadyRegistered.Add (managedKey);
+			}
+
+			// Also add registered properties from this interface
+			foreach (var ifacePropHandle in ifaceTypeDef.GetProperties ()) {
+				var ifacePropDef = ifaceIndex.Reader.GetPropertyDefinition (ifacePropHandle);
+				var propRegister = TryGetPropertyRegisterInfo (ifacePropDef, ifaceIndex);
+				if (propRegister is null || propRegister.Signature is null) {
+					continue;
+				}
+
+				var jniKey = $"{propRegister.JniName}:{propRegister.Signature}";
+				if (alreadyRegistered.Contains (jniKey)) {
+					continue;
+				}
+
+				var accessors = ifacePropDef.GetAccessors ();
+				string managedName = "";
+				if (!accessors.Getter.IsNil) {
+					managedName = ifaceIndex.Reader.GetString (
+						ifaceIndex.Reader.GetMethodDefinition (accessors.Getter).Name);
+				}
+
+				methods.Add (new MarshalMethodInfo {
+					JniName = propRegister.JniName,
+					JniSignature = propRegister.Signature,
+					Connector = propRegister.Connector,
+					ManagedMethodName = managedName,
+					NativeCallbackName = $"n_{managedName}",
+					IsConstructor = false,
+				});
+
+				alreadyRegistered.Add (jniKey);
 			}
 		}
 	}
@@ -761,6 +888,7 @@ sealed class JavaPeerScanner : IDisposable
 		}
 
 		bool isConstructor = registerInfo.JniName == "<init>" || registerInfo.JniName == ".ctor";
+		bool isExport = exportInfo is not null;
 		string managedName = index.Reader.GetString (methodDef.Name);
 		string jniSignature = registerInfo.Signature ?? "()V";
 
@@ -771,9 +899,21 @@ sealed class JavaPeerScanner : IDisposable
 			ManagedMethodName = managedName,
 			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
 			IsConstructor = isConstructor,
+			IsExport = isExport,
+			JavaAccess = isExport ? GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask) : null,
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,
 		});
+	}
+
+	static string GetJavaAccess (MethodAttributes access)
+	{
+		return access switch {
+			MethodAttributes.Public => "public",
+			MethodAttributes.FamORAssem => "protected",
+			MethodAttributes.Family => "protected",
+			_ => "private",
+		};
 	}
 
 	string? ResolveBaseJavaName (TypeDefinition typeDef, AssemblyIndex index, Dictionary<string, JavaPeerInfo> results)
@@ -835,6 +975,11 @@ sealed class JavaPeerScanner : IDisposable
 
 			if (attrName == "ExportAttribute") {
 				(registerInfo, exportInfo) = ParseExportAttribute (ca, methodDef, index);
+				return true;
+			}
+
+			if (attrName == "ExportFieldAttribute") {
+				(registerInfo, exportInfo) = ParseExportFieldAsMethod (ca, methodDef, index);
 				return true;
 			}
 
@@ -920,6 +1065,23 @@ sealed class JavaPeerScanner : IDisposable
 		sb.Append (')');
 		sb.Append (ManagedTypeToJniDescriptor (sig.ReturnType));
 		return sb.ToString ();
+	}
+
+	/// <summary>
+	/// Parses an [ExportField] attribute as a marshal method registration.
+	/// [ExportField] methods use the managed method name as the JNI name and have
+	/// a connector of "__export__" (matching legacy CecilImporter behavior).
+	/// </summary>
+	static (RegisterInfo registerInfo, ExportInfo exportInfo) ParseExportFieldAsMethod (CustomAttribute ca, MethodDefinition methodDef, AssemblyIndex index)
+	{
+		var managedName = index.Reader.GetString (methodDef.Name);
+		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+		var jniSig = BuildJniSignatureFromManaged (sig);
+
+		return (
+			new RegisterInfo { JniName = managedName, Signature = jniSig, Connector = "__export__", DoNotGenerateAcw = false },
+			new ExportInfo { ThrownNames = null, SuperArgumentsString = null }
+		);
 	}
 
 	static string ManagedTypeToJniDescriptor (string managedType)
@@ -1269,5 +1431,47 @@ sealed class JavaPeerScanner : IDisposable
 			ctorIndex++;
 		}
 		return ctors;
+	}
+
+	/// <summary>
+	/// Checks a single method for [ExportField] and adds a JavaFieldInfo if found.
+	/// Called inline during Pass 1 to avoid a separate iteration.
+	/// </summary>
+	static void CollectExportField (MethodDefinition methodDef, AssemblyIndex index, List<JavaFieldInfo> fields)
+	{
+		foreach (var caHandle in methodDef.GetCustomAttributes ()) {
+			var ca = index.Reader.GetCustomAttribute (caHandle);
+			var attrName = AssemblyIndex.GetCustomAttributeName (ca, index.Reader);
+
+			if (attrName != "ExportFieldAttribute") {
+				continue;
+			}
+
+			var value = index.DecodeAttribute (ca);
+			if (value.FixedArguments.Length == 0) {
+				continue;
+			}
+
+			var fieldName = (string?)value.FixedArguments [0].Value;
+			if (fieldName is null) {
+				continue;
+			}
+
+			var managedName = index.Reader.GetString (methodDef.Name);
+			var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			var jniSig = BuildJniSignatureFromManaged (sig);
+			var jniReturnType = JniSignatureHelper.ParseReturnTypeString (jniSig);
+			var javaReturnType = JniSignatureHelper.JniTypeToJava (jniReturnType);
+			var access = GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask);
+			var isStatic = (methodDef.Attributes & MethodAttributes.Static) != 0;
+
+			fields.Add (new JavaFieldInfo {
+				FieldName = fieldName,
+				JavaTypeName = javaReturnType,
+				InitializerMethodName = managedName,
+				Visibility = access,
+				IsStatic = isStatic,
+			});
+		}
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -278,13 +278,11 @@ sealed class JavaPeerScanner : IDisposable
 		// would incorrectly pick up internal overrides (e.g., JavaObject.equals).
 		if (detectBaseOverrides) {
 			CollectBaseMethodOverrides (typeDef, index, methods, registeredMethodNames);
-
-			// Pass 4: detect non-activation constructors that chain to base registered ctors.
-			// Mirrors the legacy CecilImporter behavior: walk from base to derived, seed
-			// with registered ctors, then accept unregistered non-activation ctors whose
-			// parameters are compatible with an already-accepted base ctor.
-			CollectBaseConstructorChain (typeDef, index, methods);
 		}
+
+		// Pass 4: detect non-activation constructors that chain to base registered ctors.
+		// Runs for all types (including MCW), matching legacy CecilImporter behavior.
+		CollectBaseConstructorChain (typeDef, index, methods);
 
 		return methods;
 	}
@@ -374,11 +372,11 @@ sealed class JavaPeerScanner : IDisposable
 	/// 1. Walk the base type hierarchy collecting registered ctors (stopping at DoNotGenerateAcw)
 	/// 2. For each ctor on this type without [Register], accept it if a base registered ctor
 	///    has compatible parameters.
+	/// 3. Fallback: if any base registered ctor is parameterless, accept the user ctor and
+	///    compute its JNI signature from the managed parameter types.
 	///
 	/// Known differences from legacy CecilImporter:
-	/// - Legacy also accepts ctors when any base ctor is parameterless (fallback path).
-	///   This is rare and not yet implemented.
-	/// - Legacy threads outerType for nested inner-class constructors.
+	/// - Legacy threads outerType for nested inner-class constructors (generator concern).
 	/// - Legacy deduplicates by managed parameter string in addition to JNI signature.
 	/// </summary>
 	void CollectBaseConstructorChain (TypeDefinition typeDef, AssemblyIndex index,
@@ -398,6 +396,14 @@ sealed class JavaPeerScanner : IDisposable
 			return;
 		}
 
+		bool hasParameterlessBaseCtor = false;
+		foreach (var baseCtor in baseRegisteredCtors) {
+			if (baseCtor.RegisterInfo.Signature == "()V") {
+				hasParameterlessBaseCtor = true;
+				break;
+			}
+		}
+
 		// Check each ctor on this type
 		foreach (var methodHandle in typeDef.GetMethods ()) {
 			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
@@ -407,7 +413,7 @@ sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 
-			// Skip if this ctor already has [Register] (collected in Pass 1)
+			// Skip if this ctor already has [Register] or [JniConstructorSignature] (collected in Pass 1)
 			if (TryGetMethodRegisterInfo (methodDef, index, out _, out _)) {
 				continue;
 			}
@@ -415,6 +421,7 @@ sealed class JavaPeerScanner : IDisposable
 			// Try to find a base registered ctor with compatible parameters.
 			// Activation ctors (IntPtr, JniHandleOwnership) will never match because
 			// no base type registers a ctor with those parameter types.
+			bool matched = false;
 			foreach (var baseCtor in baseRegisteredCtors) {
 				if (AreParametersCompatible (methodDef, index, baseCtor.Method, baseCtor.Index)) {
 					if (!alreadyRegisteredSignatures.Contains (baseCtor.RegisterInfo.Signature!)) {
@@ -428,10 +435,41 @@ sealed class JavaPeerScanner : IDisposable
 						});
 						alreadyRegisteredSignatures.Add (baseCtor.RegisterInfo.Signature!);
 					}
+					matched = true;
 					break;
 				}
 			}
+
+			// Fallback: if any base registered ctor is parameterless, accept this ctor
+			// and compute its JNI signature from the managed parameter types.
+			// This matches legacy CecilImporter behavior (CecilImporter.cs:394-397).
+			if (!matched && hasParameterlessBaseCtor) {
+				var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+				var jniSignature = BuildJniCtorSignature (sig);
+				if (!alreadyRegisteredSignatures.Contains (jniSignature)) {
+					methods.Add (new MarshalMethodInfo {
+						JniName = ".ctor",
+						JniSignature = jniSignature,
+						Connector = "",
+						ManagedMethodName = ".ctor",
+						NativeCallbackName = "n_ctor",
+						IsConstructor = true,
+					});
+					alreadyRegisteredSignatures.Add (jniSignature);
+				}
+			}
 		}
+	}
+
+	static string BuildJniCtorSignature (MethodSignature<string> sig)
+	{
+		var sb = new System.Text.StringBuilder ();
+		sb.Append ('(');
+		foreach (var param in sig.ParameterTypes) {
+			sb.Append (ManagedTypeToJniDescriptor (param));
+		}
+		sb.Append (")V");
+		return sb.ToString ();
 	}
 
 	/// <summary>
@@ -726,6 +764,17 @@ sealed class JavaPeerScanner : IDisposable
 			if (attrName == "ExportAttribute") {
 				(registerInfo, exportInfo) = ParseExportAttribute (ca, methodDef, index);
 				return true;
+			}
+
+			// JI-style constructor registration: [JniConstructorSignature("()V")]
+			// Single arg = JNI signature; name is always ".ctor", connector is empty.
+			if (attrName == "JniConstructorSignatureAttribute") {
+				var value = index.DecodeAttribute (ca);
+				var jniSignature = value.FixedArguments.Length > 0 ? (string?)value.FixedArguments [0].Value : null;
+				if (jniSignature is not null) {
+					registerInfo = new RegisterInfo { JniName = ".ctor", Signature = jniSignature, Connector = "", DoNotGenerateAcw = false };
+					return true;
+				}
 			}
 		}
 		registerInfo = null;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -954,6 +954,17 @@ sealed class JavaPeerScanner : IDisposable
 			return basePeer.JavaName;
 		}
 
+		// Base type may be a Java peer without [Register] that hasn't been scanned yet
+		// (scan order within an assembly is not guaranteed). Resolve it the same way
+		// ScanAssembly does: check ExtendsJavaPeer and compute the auto JNI name.
+		if (TryResolveType (baseTypeName, baseAssemblyName, out var baseHandle, out var baseIndex)) {
+			var baseTypeDef = baseIndex.Reader.GetTypeDefinition (baseHandle);
+			if (ExtendsJavaPeer (baseTypeDef, baseIndex)) {
+				var (jniName, _) = ComputeAutoJniNames (baseTypeDef, baseIndex);
+				return jniName;
+			}
+		}
+
 		return null;
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -575,7 +575,7 @@ sealed class JavaPeerScanner : IDisposable
 			// Check if this ctor's params are already covered by a base registered ctor
 			bool alreadyCovered = false;
 			foreach (var baseCtor in baseRegisteredCtors) {
-				if (AreParametersCompatible (methodDef, index, baseCtor.Method, baseCtor.Index)) {
+				if (HaveIdenticalParameterTypes (methodDef, baseCtor.Method)) {
 					alreadyCovered = true;
 					break;
 				}
@@ -628,42 +628,30 @@ sealed class JavaPeerScanner : IDisposable
 	}
 
 	/// <summary>
-	/// Like <see cref="ManagedTypeToJniDescriptor"/> but returns null for types that
-	/// don't have a proper JNI mapping (matching legacy GetJniSignature behavior).
-	/// For Java peer object types (types with [Register]), resolves to "L&lt;jniName&gt;;".
+	/// Maps a managed type name to its JNI descriptor for constructor signature
+	/// computation. Returns null for types that can't be mapped to JNI
+	/// (matching legacy GetJniSignature behavior). For Java peer object types
+	/// (types with [Register]), resolves to "L&lt;jniName&gt;;" via assembly cache.
 	/// </summary>
 	string? ManagedTypeToJniDescriptorOrNull (string managedType)
 	{
-		switch (managedType) {
-		case "System.Void": return "V";
-		case "System.Boolean": return "Z";
-		case "System.Byte":
-		case "System.SByte": return "B";
-		case "System.Char": return "C";
-		case "System.Int16":
-		case "System.UInt16": return "S";
-		case "System.Int32":
-		case "System.UInt32": return "I";
-		case "System.Int64":
-		case "System.UInt64": return "J";
-		case "System.Single": return "F";
-		case "System.Double": return "D";
-		case "System.String": return "Ljava/lang/String;";
-		default:
-			if (managedType.EndsWith ("[]")) {
-				var elementType = ManagedTypeToJniDescriptorOrNull (managedType.Substring (0, managedType.Length - 2));
-				return elementType is not null ? $"[{elementType}" : null;
-			}
-			// Try to resolve as a Java peer type with [Register]
-			return TryResolveJniObjectDescriptor (managedType);
+		var primitive = TryGetPrimitiveJniDescriptor (managedType);
+		if (primitive is not null) {
+			return primitive;
 		}
+
+		if (managedType.EndsWith ("[]")) {
+			var elementType = ManagedTypeToJniDescriptorOrNull (managedType.Substring (0, managedType.Length - 2));
+			return elementType is not null ? $"[{elementType}" : null;
+		}
+
+		// Try to resolve as a Java peer type with [Register]
+		return TryResolveJniObjectDescriptor (managedType);
 	}
 
 	/// <summary>
 	/// Looks up a managed type name across loaded assemblies. If the type has
 	/// [Register], returns "L&lt;jniName&gt;;". Otherwise returns null.
-	/// Matches legacy JavaNativeTypeManager.GetJniTypeName behavior which resolves
-	/// Java peer types to their JNI descriptor and returns null for non-Java types.
 	/// </summary>
 	string? TryResolveJniObjectDescriptor (string managedType)
 	{
@@ -776,7 +764,7 @@ sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 
-			if (!AreParametersCompatible (derivedMethod, index, baseMethodDef, baseIndex)) {
+			if (!HaveIdenticalParameterTypes (derivedMethod, baseMethodDef)) {
 				continue;
 			}
 
@@ -877,10 +865,9 @@ sealed class JavaPeerScanner : IDisposable
 	}
 
 	/// <summary>
-	/// Checks if two methods have compatible parameter lists by comparing their decoded signatures.
+	/// Checks if two methods have identical parameter types by comparing their decoded signatures.
 	/// </summary>
-	static bool AreParametersCompatible (MethodDefinition method1, AssemblyIndex index1,
-		MethodDefinition method2, AssemblyIndex index2)
+	static bool HaveIdenticalParameterTypes (MethodDefinition method1, MethodDefinition method2)
 	{
 		var sig1 = method1.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 		var sig2 = method2.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
@@ -1113,29 +1100,47 @@ sealed class JavaPeerScanner : IDisposable
 		);
 	}
 
+	/// <summary>
+	/// Maps a managed type name to its JNI descriptor. Falls back to
+	/// "Ljava/lang/Object;" for unknown types (used by [Export] signature computation).
+	/// </summary>
 	static string ManagedTypeToJniDescriptor (string managedType)
 	{
-		switch (managedType) {
-		case "System.Void": return "V";
-		case "System.Boolean": return "Z";
-		case "System.Byte":
-		case "System.SByte": return "B";
-		case "System.Char": return "C";
-		case "System.Int16":
-		case "System.UInt16": return "S";
-		case "System.Int32":
-		case "System.UInt32": return "I";
-		case "System.Int64":
-		case "System.UInt64": return "J";
-		case "System.Single": return "F";
-		case "System.Double": return "D";
-		case "System.String": return "Ljava/lang/String;";
-		default:
-			if (managedType.EndsWith ("[]")) {
-				return $"[{ManagedTypeToJniDescriptor (managedType.Substring (0, managedType.Length - 2))}";
-			}
-			return "Ljava/lang/Object;";
+		var primitive = TryGetPrimitiveJniDescriptor (managedType);
+		if (primitive is not null) {
+			return primitive;
 		}
+
+		if (managedType.EndsWith ("[]")) {
+			return $"[{ManagedTypeToJniDescriptor (managedType.Substring (0, managedType.Length - 2))}";
+		}
+
+		return "Ljava/lang/Object;";
+	}
+
+	/// <summary>
+	/// Returns the JNI descriptor for primitive types and System.String.
+	/// Returns null for all other types.
+	/// </summary>
+	static string? TryGetPrimitiveJniDescriptor (string managedType)
+	{
+		return managedType switch {
+			"System.Void" => "V",
+			"System.Boolean" => "Z",
+			"System.Byte" => "B",
+			"System.SByte" => "B",
+			"System.Char" => "C",
+			"System.Int16" => "S",
+			"System.UInt16" => "S",
+			"System.Int32" => "I",
+			"System.UInt32" => "I",
+			"System.Int64" => "J",
+			"System.UInt64" => "J",
+			"System.Single" => "F",
+			"System.Double" => "D",
+			"System.String" => "Ljava/lang/String;",
+			_ => null,
+		};
 	}
 
 	ActivationCtorInfo? ResolveActivationCtor (string typeName, TypeDefinition typeDef, AssemblyIndex index)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
 using Xamarin.Android.Tasks;
@@ -56,7 +57,7 @@ static class ScannerRunner
 			}
 
 			var managedName = GetManagedName (typeDef);
-			var methods = ExtractMethodRegistrations (typeDef);
+			var methods = ExtractMethodRegistrations (typeDef, cache);
 
 			if (!methodsByJavaName.TryGetValue (javaName, out var groups)) {
 				groups = new List<TypeMethodGroup> ();
@@ -113,6 +114,7 @@ static class ScannerRunner
 			groups.Add (new TypeMethodGroup (
 				managedName,
 				peer.MarshalMethods
+					.Where (m => !m.IsConstructor)
 					.Select (m => new MethodEntry (m.JniName, m.JniSignature, m.Connector))
 					.OrderBy (m => m.JniName, StringComparer.Ordinal)
 					.ThenBy (m => m.JniSignature, StringComparer.Ordinal)
@@ -147,44 +149,157 @@ static class ScannerRunner
 		return $"{typeDef.FullName.Replace ('/', '+')}, {typeDef.Module.Assembly.Name.Name}";
 	}
 
-	static List<MethodEntry> ExtractMethodRegistrations (TypeDefinition typeDef)
+	/// <summary>
+	/// Extracts marshal methods using the real legacy JCW pipeline via
+	/// <see cref="CecilImporter.CreateType"/>. Excludes interface method
+	/// implementations since the new scanner places those on the interface
+	/// peer type rather than the implementing type.
+	/// </summary>
+	static List<MethodEntry> ExtractMethodRegistrations (TypeDefinition typeDef, TypeDefinitionCache cache)
 	{
+		if (typeDef.IsInterface) {
+			// CecilImporter throws XA4200 for interfaces.
+			// Extract [Register] from interface methods directly.
+			return ExtractDirectRegisterAttributes (typeDef);
+		}
+
+		// Build a set of method names from implemented interfaces so we can
+		// filter them out of the CecilImporter output.
+		var interfaceMethodKeys = new HashSet<string> (StringComparer.Ordinal);
+		foreach (var ifaceImpl in typeDef.Interfaces) {
+			var ifaceType = cache.Resolve (ifaceImpl.InterfaceType);
+			if (ifaceType is null) {
+				continue;
+			}
+			foreach (var method in ifaceType.Methods) {
+				if (method.IsStatic) {
+					continue;
+				}
+				foreach (var attr in method.CustomAttributes) {
+					if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
+						var name = (string) attr.ConstructorArguments [0].Value;
+						var sig = (string) attr.ConstructorArguments [1].Value;
+						interfaceMethodKeys.Add ($"{name}:{sig}");
+					}
+				}
+			}
+		}
+
+		var wrapper = CecilImporter.CreateType (typeDef, cache);
 		var methods = new List<MethodEntry> ();
 
-		foreach (var method in typeDef.Methods) {
-			if (!method.HasCustomAttributes) {
+		foreach (var m in wrapper.Methods) {
+			var key = $"{m.Name}:{m.JniSignature}";
+
+			// Skip methods that came from interface implementations — the new
+			// scanner places these on the interface peer, not the implementing type.
+			// Only skip if the type doesn't also have a direct [Register] for this
+			// method (which would mean the type explicitly registers it).
+			if (interfaceMethodKeys.Contains (key) && !HasDirectRegister (typeDef, m.Name, m.JniSignature)) {
 				continue;
 			}
 
-			AddRegisterMethods (method.CustomAttributes, methods);
-		}
-
-		if (typeDef.HasProperties) {
-			foreach (var prop in typeDef.Properties) {
-				if (!prop.HasCustomAttributes) {
-					continue;
-				}
-
-				AddRegisterMethods (prop.CustomAttributes, methods);
-			}
+			// Extract connector from Method string "n_name:sig:connector"
+			string? connector = ParseConnectorFromMethodString (m.Method);
+			methods.Add (new MethodEntry (m.Name, m.JniSignature, connector));
 		}
 
 		return methods;
 	}
 
-	static void AddRegisterMethods (IEnumerable<CustomAttribute> attributes, List<MethodEntry> methods)
+	/// <summary>
+	/// Checks if the type has a direct [Register] attribute for this method name + signature.
+	/// </summary>
+	static bool HasDirectRegister (TypeDefinition typeDef, string jniName, string jniSignature)
 	{
-		foreach (var attr in attributes) {
-			if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute" || attr.ConstructorArguments.Count < 2) {
+		foreach (var method in typeDef.Methods) {
+			if (!method.HasCustomAttributes) {
 				continue;
 			}
-
-			var jniMethodName = (string) attr.ConstructorArguments [0].Value;
-			var jniSignature = (string) attr.ConstructorArguments [1].Value;
-			var connector = attr.ConstructorArguments.Count > 2
-				? (string) attr.ConstructorArguments [2].Value
-				: null;
-			methods.Add (new MethodEntry (jniMethodName, jniSignature, connector));
+			foreach (var attr in method.CustomAttributes) {
+				if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" &&
+				    attr.ConstructorArguments.Count >= 2 &&
+				    (string) attr.ConstructorArguments [0].Value == jniName &&
+				    (string) attr.ConstructorArguments [1].Value == jniSignature) {
+					return true;
+				}
+			}
 		}
+		if (typeDef.HasProperties) {
+			foreach (var prop in typeDef.Properties) {
+				if (!prop.HasCustomAttributes) {
+					continue;
+				}
+				foreach (var attr in prop.CustomAttributes) {
+					if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" &&
+					    attr.ConstructorArguments.Count >= 2 &&
+					    (string) attr.ConstructorArguments [0].Value == jniName &&
+					    (string) attr.ConstructorArguments [1].Value == jniSignature) {
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+
+	/// <summary>
+	/// Fallback: extract [Register] from methods/properties directly (for interfaces).
+	/// </summary>
+	static List<MethodEntry> ExtractDirectRegisterAttributes (TypeDefinition typeDef)
+	{
+		var methods = new List<MethodEntry> ();
+		foreach (var method in typeDef.Methods) {
+			if (!method.HasCustomAttributes) {
+				continue;
+			}
+			foreach (var attr in method.CustomAttributes) {
+				if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
+					methods.Add (new MethodEntry (
+						(string) attr.ConstructorArguments [0].Value,
+						(string) attr.ConstructorArguments [1].Value,
+						attr.ConstructorArguments.Count > 2 ? (string) attr.ConstructorArguments [2].Value : null
+					));
+				}
+			}
+		}
+		if (typeDef.HasProperties) {
+			foreach (var prop in typeDef.Properties) {
+				if (!prop.HasCustomAttributes) {
+					continue;
+				}
+				foreach (var attr in prop.CustomAttributes) {
+					if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
+						methods.Add (new MethodEntry (
+							(string) attr.ConstructorArguments [0].Value,
+							(string) attr.ConstructorArguments [1].Value,
+							attr.ConstructorArguments.Count > 2 ? (string) attr.ConstructorArguments [2].Value : null
+						));
+					}
+				}
+			}
+		}
+		return methods;
+	}
+
+	/// <summary>
+	/// Parses the connector from a CallableWrapperMethod.Method string.
+	/// Format: "n_{name}:{signature}:{connector}" where connector has '/' replaced with '+'.
+	/// </summary>
+	static string? ParseConnectorFromMethodString (string? methodStr)
+	{
+		if (methodStr is null) {
+			return null;
+		}
+		int firstColon = methodStr.IndexOf (':');
+		if (firstColon < 0) {
+			return null;
+		}
+		int secondColon = methodStr.IndexOf (':', firstColon + 1);
+		if (secondColon < 0 || secondColon + 1 >= methodStr.Length) {
+			return null;
+		}
+		var connector = methodStr.Substring (secondColon + 1);
+		return connector.Replace ('+', '/');
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -51,7 +51,7 @@ static class ScannerRunner
 
 		var methodsByJavaName = new Dictionary<string, List<TypeMethodGroup>> ();
 		foreach (var typeDef in javaTypes) {
-			var javaName = GetCecilJavaName (typeDef);
+			var javaName = GetCecilJavaName (typeDef, cache);
 			if (javaName == null) {
 				continue;
 			}
@@ -114,7 +114,7 @@ static class ScannerRunner
 			groups.Add (new TypeMethodGroup (
 				managedName,
 				peer.MarshalMethods
-					.Where (m => !m.IsConstructor && !m.IsInterfaceImplementation)
+					.Where (m => !m.IsConstructor)
 					.Select (m => new MethodEntry (m.JniName, m.JniSignature, m.Connector))
 					.OrderBy (m => m.JniName, StringComparer.Ordinal)
 					.ThenBy (m => m.JniSignature, StringComparer.Ordinal)
@@ -125,23 +125,24 @@ static class ScannerRunner
 		return (entries, methodsByJavaName);
 	}
 
-	public static string? GetCecilJavaName (TypeDefinition typeDef)
+	public static string? GetCecilJavaName (TypeDefinition typeDef, IMetadataResolver cache)
 	{
-		if (!typeDef.HasCustomAttributes) {
-			return null;
-		}
+		if (typeDef.HasCustomAttributes) {
+			foreach (var attr in typeDef.CustomAttributes) {
+				if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute") {
+					continue;
+				}
 
-		foreach (var attr in typeDef.CustomAttributes) {
-			if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute") {
-				continue;
-			}
-
-			if (attr.ConstructorArguments.Count > 0) {
-				return ((string) attr.ConstructorArguments [0].Value).Replace ('.', '/');
+				if (attr.ConstructorArguments.Count > 0) {
+					return ((string) attr.ConstructorArguments [0].Value).Replace ('.', '/');
+				}
 			}
 		}
 
-		return null;
+		// Types without [Register] (e.g., user ACW types like ActivityTracker)
+		// get their JNI name computed by JavaNativeTypeManager — same as
+		// CecilImporter.CreateType (line 26).
+		return Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName (typeDef, cache);
 	}
 
 	public static string GetManagedName (TypeDefinition typeDef)
@@ -151,8 +152,7 @@ static class ScannerRunner
 
 	/// <summary>
 	/// Extracts marshal methods using the real legacy JCW pipeline via
-	/// <see cref="CecilImporter.CreateType"/>. Excludes interface method
-	/// implementations — those are compared via interface peer types.
+	/// <see cref="CecilImporter.CreateType"/>.
 	/// </summary>
 	static List<MethodEntry> ExtractMethodRegistrations (TypeDefinition typeDef, TypeDefinitionCache cache)
 	{
@@ -169,82 +169,16 @@ static class ScannerRunner
 			return ExtractDirectRegisterAttributes (typeDef);
 		}
 
-		// Build a set of interface method keys to filter from CecilImporter output.
-		// Both legacy and new scanner include interface methods, but they come from
-		// different codepaths with different dedup strategies. Since interface methods
-		// are tested via interface peer types, exclude them here.
-		var interfaceMethodKeys = new HashSet<string> (StringComparer.Ordinal);
-		foreach (var ifaceImpl in typeDef.Interfaces) {
-			var ifaceType = cache.Resolve (ifaceImpl.InterfaceType);
-			if (ifaceType is null) {
-				continue;
-			}
-			foreach (var method in ifaceType.Methods) {
-				if (method.IsStatic) {
-					continue;
-				}
-				foreach (var attr in method.CustomAttributes) {
-					if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
-						var name = (string) attr.ConstructorArguments [0].Value;
-						var sig = (string) attr.ConstructorArguments [1].Value;
-						interfaceMethodKeys.Add ($"{name}:{sig}");
-					}
-				}
-			}
-		}
-
 		var wrapper = CecilImporter.CreateType (typeDef, cache);
 		var methods = new List<MethodEntry> ();
 
 		foreach (var m in wrapper.Methods) {
-			// Skip interface methods — compared via interface peer types
-			var key = $"{m.Name}:{m.JniSignature}";
-			if (interfaceMethodKeys.Contains (key) && !HasDirectRegister (typeDef, m.Name, m.JniSignature)) {
-				continue;
-			}
-
 			// Extract connector from Method string "n_name:sig:connector"
 			string? connector = ParseConnectorFromMethodString (m.Method);
 			methods.Add (new MethodEntry (m.JavaName, m.JniSignature, connector));
 		}
 
 		return methods;
-	}
-
-	/// <summary>
-	/// Checks if the type has a direct [Register] attribute for this method name + signature.
-	/// </summary>
-	static bool HasDirectRegister (TypeDefinition typeDef, string jniName, string jniSignature)
-	{
-		foreach (var method in typeDef.Methods) {
-			if (!method.HasCustomAttributes) {
-				continue;
-			}
-			foreach (var attr in method.CustomAttributes) {
-				if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" &&
-				    attr.ConstructorArguments.Count >= 2 &&
-				    (string) attr.ConstructorArguments [0].Value == jniName &&
-				    (string) attr.ConstructorArguments [1].Value == jniSignature) {
-					return true;
-				}
-			}
-		}
-		if (typeDef.HasProperties) {
-			foreach (var prop in typeDef.Properties) {
-				if (!prop.HasCustomAttributes) {
-					continue;
-				}
-				foreach (var attr in prop.CustomAttributes) {
-					if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" &&
-					    attr.ConstructorArguments.Count >= 2 &&
-					    (string) attr.ConstructorArguments [0].Value == jniName &&
-					    (string) attr.ConstructorArguments [1].Value == jniSignature) {
-						return true;
-					}
-				}
-			}
-		}
-		return false;
 	}
 
 	internal static bool HasDoNotGenerateAcw (TypeDefinition typeDef)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -72,16 +72,6 @@ static class ScannerRunner
 			));
 		}
 
-		foreach (var entry in dataSets.JavaToManaged) {
-			if (methodsByJavaName.ContainsKey (entry.JavaName)) {
-				continue;
-			}
-
-			methodsByJavaName [entry.JavaName] = new List<TypeMethodGroup> {
-				new TypeMethodGroup (entry.ManagedName, new List<MethodEntry> ())
-			};
-		}
-
 		return (entries, methodsByJavaName);
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -114,7 +114,7 @@ static class ScannerRunner
 			groups.Add (new TypeMethodGroup (
 				managedName,
 				peer.MarshalMethods
-					.Where (m => !m.IsConstructor)
+					.Where (m => !m.IsConstructor && !m.IsInterfaceImplementation)
 					.Select (m => new MethodEntry (m.JniName, m.JniSignature, m.Connector))
 					.OrderBy (m => m.JniName, StringComparer.Ordinal)
 					.ThenBy (m => m.JniSignature, StringComparer.Ordinal)
@@ -152,8 +152,7 @@ static class ScannerRunner
 	/// <summary>
 	/// Extracts marshal methods using the real legacy JCW pipeline via
 	/// <see cref="CecilImporter.CreateType"/>. Excludes interface method
-	/// implementations since the new scanner places those on the interface
-	/// peer type rather than the implementing type.
+	/// implementations — those are compared via interface peer types.
 	/// </summary>
 	static List<MethodEntry> ExtractMethodRegistrations (TypeDefinition typeDef, TypeDefinitionCache cache)
 	{
@@ -170,8 +169,10 @@ static class ScannerRunner
 			return ExtractDirectRegisterAttributes (typeDef);
 		}
 
-		// Build a set of method names from implemented interfaces so we can
-		// filter them out of the CecilImporter output.
+		// Build a set of interface method keys to filter from CecilImporter output.
+		// Both legacy and new scanner include interface methods, but they come from
+		// different codepaths with different dedup strategies. Since interface methods
+		// are tested via interface peer types, exclude them here.
 		var interfaceMethodKeys = new HashSet<string> (StringComparer.Ordinal);
 		foreach (var ifaceImpl in typeDef.Interfaces) {
 			var ifaceType = cache.Resolve (ifaceImpl.InterfaceType);
@@ -196,12 +197,8 @@ static class ScannerRunner
 		var methods = new List<MethodEntry> ();
 
 		foreach (var m in wrapper.Methods) {
+			// Skip interface methods — compared via interface peer types
 			var key = $"{m.Name}:{m.JniSignature}";
-
-			// Skip methods that came from interface implementations — the new
-			// scanner places these on the interface peer, not the implementing type.
-			// Only skip if the type doesn't also have a direct [Register] for this
-			// method (which would mean the type explicitly registers it).
 			if (interfaceMethodKeys.Contains (key) && !HasDirectRegister (typeDef, m.Name, m.JniSignature)) {
 				continue;
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -250,7 +250,7 @@ static class ScannerRunner
 		return false;
 	}
 
-	static bool HasDoNotGenerateAcw (TypeDefinition typeDef)
+	internal static bool HasDoNotGenerateAcw (TypeDefinition typeDef)
 	{
 		if (!typeDef.HasCustomAttributes) {
 			return false;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -104,7 +104,6 @@ static class ScannerRunner
 			groups.Add (new TypeMethodGroup (
 				managedName,
 				peer.MarshalMethods
-					.Where (m => !m.IsConstructor)
 					.Select (m => new MethodEntry (m.JniName, m.JniSignature, m.Connector))
 					.OrderBy (m => m.JniName, StringComparer.Ordinal)
 					.ThenBy (m => m.JniSignature, StringComparer.Ordinal)
@@ -168,6 +167,10 @@ static class ScannerRunner
 			methods.Add (new MethodEntry (m.JavaName, m.JniSignature, connector));
 		}
 
+		foreach (var c in wrapper.Constructors) {
+			methods.Add (new MethodEntry (".ctor", c.JniSignature, null));
+		}
+
 		return methods;
 	}
 
@@ -201,13 +204,8 @@ static class ScannerRunner
 			}
 			foreach (var attr in method.CustomAttributes) {
 				if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
-					var jniName = (string) attr.ConstructorArguments [0].Value;
-					// Skip constructors — compared separately in ExactJavaConstructors
-					if (jniName == "<init>" || jniName == ".ctor") {
-						continue;
-					}
 					methods.Add (new MethodEntry (
-						jniName,
+						(string) attr.ConstructorArguments [0].Value,
 						(string) attr.ConstructorArguments [1].Value,
 						attr.ConstructorArguments.Count > 2 ? (string) attr.ConstructorArguments [2].Value : null
 					));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -205,7 +205,7 @@ static class ScannerRunner
 
 			// Extract connector from Method string "n_name:sig:connector"
 			string? connector = ParseConnectorFromMethodString (m.Method);
-			methods.Add (new MethodEntry (m.Name, m.JniSignature, connector));
+			methods.Add (new MethodEntry (m.JavaName, m.JniSignature, connector));
 		}
 
 		return methods;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -163,6 +163,13 @@ static class ScannerRunner
 			return ExtractDirectRegisterAttributes (typeDef);
 		}
 
+		// Types with DoNotGenerateAcw=true are never passed to CecilImporter.CreateType
+		// in the real build (JavaTypeScanner skips them for JCW generation). Use direct
+		// attribute extraction to match what actually happens at build time.
+		if (HasDoNotGenerateAcw (typeDef)) {
+			return ExtractDirectRegisterAttributes (typeDef);
+		}
+
 		// Build a set of method names from implemented interfaces so we can
 		// filter them out of the CecilImporter output.
 		var interfaceMethodKeys = new HashSet<string> (StringComparer.Ordinal);
@@ -243,8 +250,26 @@ static class ScannerRunner
 		return false;
 	}
 
+	static bool HasDoNotGenerateAcw (TypeDefinition typeDef)
+	{
+		if (!typeDef.HasCustomAttributes) {
+			return false;
+		}
+		foreach (var attr in typeDef.CustomAttributes) {
+			if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute") {
+				continue;
+			}
+			var v = attr.Properties.FirstOrDefault (p => p.Name == "DoNotGenerateAcw");
+			if (v.Name != null && v.Argument.Value is bool b && b) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 	/// <summary>
-	/// Fallback: extract [Register] from methods/properties directly (for interfaces).
+	/// Fallback: extract [Register] from methods/properties directly (for interfaces
+	/// and DoNotGenerateAcw types that are never passed through CecilImporter).
 	/// </summary>
 	static List<MethodEntry> ExtractDirectRegisterAttributes (TypeDefinition typeDef)
 	{
@@ -255,8 +280,13 @@ static class ScannerRunner
 			}
 			foreach (var attr in method.CustomAttributes) {
 				if (attr.AttributeType.FullName == "Android.Runtime.RegisterAttribute" && attr.ConstructorArguments.Count >= 2) {
+					var jniName = (string) attr.ConstructorArguments [0].Value;
+					// Skip constructors — compared separately in ExactJavaConstructors
+					if (jniName == "<init>" || jniName == ".ctor") {
+						continue;
+					}
 					methods.Add (new MethodEntry (
-						(string) attr.ConstructorArguments [0].Value,
+						jniName,
 						(string) attr.ConstructorArguments [1].Value,
 						attr.ConstructorArguments.Count > 2 ? (string) attr.ConstructorArguments [2].Value : null
 					));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -103,17 +103,11 @@ static class TypeDataBuilder
 			// attribute scanning which only found directly-attributed ctors.
 			var javaCtorSignatures = new List<string> ();
 			if (!typeDef.IsInterface && !ScannerRunner.HasDoNotGenerateAcw (typeDef)) {
-				try {
-					var wrapper = CecilImporter.CreateType (typeDef, cache);
-					foreach (var ctor in wrapper.Constructors) {
-						if (!string.IsNullOrEmpty (ctor.JniSignature)) {
-							javaCtorSignatures.Add (ctor.JniSignature);
-						}
+				var wrapper = CecilImporter.CreateType (typeDef, cache);
+				foreach (var ctor in wrapper.Constructors) {
+					if (!string.IsNullOrEmpty (ctor.JniSignature)) {
+						javaCtorSignatures.Add (ctor.JniSignature);
 					}
-				} catch {
-					// Some types may fail CecilImporter (e.g., missing base types).
-					// Fall back to direct attribute scanning.
-					ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);
 				}
 			} else {
 				ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Java.Interop.Tools.Cecil;
+using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
@@ -96,22 +97,26 @@ static class TypeDataBuilder
 			FindLegacyActivationCtor (typeDef, cache,
 				out bool hasActivationCtor, out string? activationCtorDeclaringType, out string? activationCtorStyle);
 
+			// Use the real legacy JCW pipeline (CecilImporter.CreateType) to extract
+			// Java constructors, including the base ctor chain and parameterless fallback.
+			// This matches what the actual build does, unlike the previous manual [Register]
+			// attribute scanning which only found directly-attributed ctors.
 			var javaCtorSignatures = new List<string> ();
-			foreach (var method in typeDef.Methods) {
-				if (!method.IsConstructor || method.IsStatic || !method.HasCustomAttributes) {
-					continue;
-				}
-				foreach (var attr in method.CustomAttributes) {
-					if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute") {
-						continue;
-					}
-					if (attr.ConstructorArguments.Count >= 2) {
-						var regName = (string) attr.ConstructorArguments [0].Value;
-						if (regName == "<init>" || regName == ".ctor") {
-							javaCtorSignatures.Add ((string) attr.ConstructorArguments [1].Value);
+			if (!typeDef.IsInterface && !ScannerRunner.HasDoNotGenerateAcw (typeDef)) {
+				try {
+					var wrapper = CecilImporter.CreateType (typeDef, cache);
+					foreach (var ctor in wrapper.Constructors) {
+						if (!string.IsNullOrEmpty (ctor.JniSignature)) {
+							javaCtorSignatures.Add (ctor.JniSignature);
 						}
 					}
+				} catch {
+					// Some types may fail CecilImporter (e.g., missing base types).
+					// Fall back to direct attribute scanning.
+					ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);
 				}
+			} else {
+				ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);
 			}
 			javaCtorSignatures.Sort (StringComparer.Ordinal);
 
@@ -244,5 +249,25 @@ static class TypeDataBuilder
 		}
 
 		return false;
+	}
+
+	static void ExtractDirectRegisterCtors (TypeDefinition typeDef, List<string> javaCtorSignatures)
+	{
+		foreach (var method in typeDef.Methods) {
+			if (!method.IsConstructor || method.IsStatic || !method.HasCustomAttributes) {
+				continue;
+			}
+			foreach (var attr in method.CustomAttributes) {
+				if (attr.AttributeType.FullName != "Android.Runtime.RegisterAttribute") {
+					continue;
+				}
+				if (attr.ConstructorArguments.Count >= 2) {
+					var regName = (string) attr.ConstructorArguments [0].Value;
+					if (regName == "<init>" || regName == ".ctor") {
+						javaCtorSignatures.Add ((string) attr.ConstructorArguments [1].Value);
+					}
+				}
+			}
+		}
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -62,7 +62,7 @@ static class TypeDataBuilder
 		var perType = new Dictionary<string, TypeComparisonData> (StringComparer.Ordinal);
 
 		foreach (var typeDef in javaTypes) {
-			var javaName = ScannerRunner.GetCecilJavaName (typeDef);
+			var javaName = ScannerRunner.GetCecilJavaName (typeDef, cache);
 			if (javaName == null) {
 				continue;
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -103,11 +103,16 @@ static class TypeDataBuilder
 			// attribute scanning which only found directly-attributed ctors.
 			var javaCtorSignatures = new List<string> ();
 			if (!typeDef.IsInterface && !ScannerRunner.HasDoNotGenerateAcw (typeDef)) {
-				var wrapper = CecilImporter.CreateType (typeDef, cache);
-				foreach (var ctor in wrapper.Constructors) {
-					if (!string.IsNullOrEmpty (ctor.JniSignature)) {
-						javaCtorSignatures.Add (ctor.JniSignature);
+				try {
+					var wrapper = CecilImporter.CreateType (typeDef, cache);
+					foreach (var ctor in wrapper.Constructors) {
+						if (!string.IsNullOrEmpty (ctor.JniSignature)) {
+							javaCtorSignatures.Add (ctor.JniSignature);
+						}
 					}
+				} catch (Exception ex) {
+					System.Diagnostics.Debug.WriteLine ($"CecilImporter.CreateType failed for {typeDef.FullName}: {ex.Message}");
+					ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);
 				}
 			} else {
 				ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -103,16 +103,11 @@ static class TypeDataBuilder
 			// attribute scanning which only found directly-attributed ctors.
 			var javaCtorSignatures = new List<string> ();
 			if (!typeDef.IsInterface && !ScannerRunner.HasDoNotGenerateAcw (typeDef)) {
-				try {
-					var wrapper = CecilImporter.CreateType (typeDef, cache);
-					foreach (var ctor in wrapper.Constructors) {
-						if (!string.IsNullOrEmpty (ctor.JniSignature)) {
-							javaCtorSignatures.Add (ctor.JniSignature);
-						}
+				var wrapper = CecilImporter.CreateType (typeDef, cache);
+				foreach (var ctor in wrapper.Constructors) {
+					if (!string.IsNullOrEmpty (ctor.JniSignature)) {
+						javaCtorSignatures.Add (ctor.JniSignature);
 					}
-				} catch (Exception ex) {
-					System.Diagnostics.Debug.WriteLine ($"CecilImporter.CreateType failed for {typeDef.FullName}: {ex.Message}");
-					ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);
 				}
 			} else {
 				ExtractDirectRegisterCtors (typeDef, javaCtorSignatures);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ConstructorSuperArgsTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ConstructorSuperArgsTests.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for constructor super() argument matching.
+/// </summary>
+public class ConstructorSuperArgsTests : FixtureTestBase
+{
+	[Fact]
+	public void MatchingBaseCtor_ForwardsAllParams ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		Assert.NotEmpty (peer.JavaConstructors);
+		var ctor = peer.JavaConstructors.First (c => c.JniSignature == "()V");
+		Assert.Null (ctor.SuperArgumentsString);
+	}
+
+	[Fact]
+	public void CustomParamCtor_FallsBackToEmptySuper ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/CustomParamActivity");
+		var customCtor = peer.JavaConstructors.FirstOrDefault (c => c.JniSignature != "()V");
+		Assert.NotNull (customCtor);
+		Assert.Equal ("", customCtor.SuperArgumentsString);
+
+		var generator = new JcwJavaSourceGenerator ();
+		using var writer = new StringWriter ();
+		generator.Generate (peer, writer);
+		Assert.Contains ("super ();", writer.ToString ());
+	}
+
+	[Fact]
+	public void ExportSuperArgs_UsesCustomString ()
+	{
+		var type = new JavaPeerInfo {
+			JavaName = "my/app/ExportCtorTest",
+			CompatJniName = "my/app/ExportCtorTest",
+			ManagedTypeName = "MyApp.ExportCtorTest",
+			ManagedTypeNamespace = "MyApp",
+			ManagedTypeShortName = "ExportCtorTest",
+			AssemblyName = "App",
+			BaseJavaName = "android/app/Service",
+			JavaConstructors = new List<JavaConstructorInfo> {
+				new JavaConstructorInfo {
+					JniSignature = "(Landroid/content/Context;I)V",
+					ConstructorIndex = 0,
+					SuperArgumentsString = "p0",
+				},
+			},
+		};
+
+		var generator = new JcwJavaSourceGenerator ();
+		using var writer = new StringWriter ();
+		generator.Generate (type, writer);
+		var java = writer.ToString ();
+		Assert.Contains ("super (p0);", java);
+		Assert.DoesNotContain ("super (p0, p1);", java);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ExportAccessModifierTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ExportAccessModifierTests.cs
@@ -1,0 +1,44 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests that [Export] methods use the C# visibility in the JCW Java file.
+/// </summary>
+public class ExportAccessModifierTests : FixtureTestBase
+{
+	[Fact]
+	public void Scanner_ExportMethods_HaveCorrectIsExportAndJavaAccess ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ExportAccessTest");
+		var publicMethod = peer.MarshalMethods.First (m => m.JniName == "publicMethod");
+		var protectedMethod = peer.MarshalMethods.First (m => m.JniName == "protectedMethod");
+		Assert.True (publicMethod.IsExport);
+		Assert.Equal ("public", publicMethod.JavaAccess);
+		Assert.True (protectedMethod.IsExport);
+		Assert.Equal ("protected", protectedMethod.JavaAccess);
+	}
+
+	[Fact]
+	public void Scanner_RegisterMethod_IsNotExport ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
+		var customMethod = peer.MarshalMethods.First (m => m.JniName == "customMethod");
+		Assert.False (customMethod.IsExport);
+		Assert.Null (customMethod.JavaAccess);
+	}
+
+	[Fact]
+	public void JcwGenerator_ExportMethods_UseCorrectAccessModifiers ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ExportAccessTest");
+		var generator = new JcwJavaSourceGenerator ();
+		using var writer = new StringWriter ();
+		generator.Generate (peer, writer);
+		var java = writer.ToString ();
+		Assert.Contains ("protected void protectedMethod ()", java);
+		Assert.Contains ("public void publicMethod ()", java);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ExportFieldTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ExportFieldTests.cs
@@ -1,0 +1,58 @@
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for [ExportField] support: the scanner must detect [ExportField] attributes
+/// and the JCW generator must emit Java field declarations initialized by calling
+/// the annotated method.
+/// </summary>
+public class ExportFieldTests : FixtureTestBase
+{
+	[Fact]
+	public void Scanner_DetectsExportFieldsWithCorrectProperties ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ExportFieldExample");
+		Assert.NotEmpty (peer.JavaFields);
+
+		var staticField = peer.JavaFields.First (f => f.FieldName == "STATIC_INSTANCE");
+		Assert.True (staticField.IsStatic);
+		Assert.Equal ("GetInstance", staticField.InitializerMethodName);
+		// Reference type — mapped via JNI signature, not fallback to java.lang.Object
+		Assert.Equal ("java.lang.Object", staticField.JavaTypeName);
+
+		var instanceField = peer.JavaFields.First (f => f.FieldName == "VALUE");
+		Assert.False (instanceField.IsStatic);
+		Assert.Equal ("GetValue", instanceField.InitializerMethodName);
+		Assert.Equal ("java.lang.String", instanceField.JavaTypeName);
+	}
+
+	[Fact]
+	public void Scanner_ExportFieldMethod_HasExportConnectorAndFlag ()
+	{
+		// Gap #2 + #3: [ExportField] methods should have connector "__export__" and IsExport=true
+		var peer = FindFixtureByJavaName ("my/app/ExportFieldExample");
+		var getValue = peer.MarshalMethods.First (m => m.JniName == "GetValue");
+		Assert.Equal ("__export__", getValue.Connector);
+		Assert.True (getValue.IsExport);
+		Assert.Equal ("public", getValue.JavaAccess);
+	}
+
+	[Fact]
+	public void JcwGenerator_EmitsFieldDeclarationsAndMethodWrappers ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ExportFieldExample");
+		var generator = new JcwJavaSourceGenerator ();
+		using var writer = new StringWriter ();
+		generator.Generate (peer, writer);
+		var java = writer.ToString ();
+
+		Assert.Contains ("public static", java);
+		Assert.Contains ("STATIC_INSTANCE = GetInstance ();", java);
+		Assert.Contains ("VALUE = GetValue ();", java);
+		Assert.Contains ("GetValue ()", java);
+		Assert.Contains ("n_GetValue", java);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -18,7 +18,7 @@ public class ConstructorDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
 
 		// The ctor should appear in MarshalMethods as a constructor
-		var ctorMethod = Assert.Single (peer.MarshalMethods.Where (m => m.IsConstructor));
+		var ctorMethod = Assert.Single (peer.MarshalMethods, m => m.IsConstructor);
 		Assert.Equal ("()V", ctorMethod.JniSignature);
 		Assert.Equal (".ctor", ctorMethod.JniName);
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -11,34 +11,25 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 public class ConstructorDetectionTests : FixtureTestBase
 {
 	[Fact]
-	public void MainActivity_HasJavaConstructor ()
+	public void MainActivity_ChainsFromBaseRegisteredCtor ()
 	{
 		// MainActivity has an explicit public parameterless ctor without [Register].
 		// Activity has [Register(".ctor", "()V", "")] — the scanner should chain from it.
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		Assert.NotEmpty (peer.JavaConstructors);
-	}
 
-	[Fact]
-	public void MainActivity_JavaConstructor_HasCorrectSignature ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
-		Assert.Contains ("()V", ctorSigs);
-	}
+		// Should produce exactly one JavaConstructor with correct signature
+		Assert.Equal (1, peer.JavaConstructors.Count);
+		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
 
-	[Fact]
-	public void MainActivity_HasConstructorMarshalMethod ()
-	{
-		// The ctor should appear in MarshalMethods with IsConstructor=true
-		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		// The ctor should appear in MarshalMethods as a constructor
 		var ctorMethods = peer.MarshalMethods.Where (m => m.IsConstructor).ToList ();
-		Assert.NotEmpty (ctorMethods);
+		Assert.Single (ctorMethods);
 		Assert.Equal ("()V", ctorMethods [0].JniSignature);
+		Assert.Equal (".ctor", ctorMethods [0].JniName);
 	}
 
 	[Fact]
-	public void SimpleActivity_HasJavaConstructor ()
+	public void SimpleActivity_ChainsImplicitDefaultCtor ()
 	{
 		// SimpleActivity has no explicit ctor — the compiler generates a default public one.
 		// It should chain from Activity's registered ()V ctor.
@@ -48,7 +39,7 @@ public class ConstructorDetectionTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void UserActivity_HasNoJavaConstructors ()
+	public void UserActivity_ActivationCtorOnly_NoJavaConstructors ()
 	{
 		// UserActivity only has an activation ctor (IntPtr, JniHandleOwnership).
 		// No non-activation ctor exists, so no Java constructor should be generated.
@@ -57,7 +48,7 @@ public class ConstructorDetectionTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void FullActivity_HasNoJavaConstructors ()
+	public void FullActivity_ActivationCtorOnly_NoJavaConstructors ()
 	{
 		// FullActivity only has an activation ctor — no Java constructors.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
@@ -65,7 +56,7 @@ public class ConstructorDetectionTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void CustomView_StillWorksWithDirectRegister ()
+	public void CustomView_DirectRegisterNotAffected ()
 	{
 		// CustomView has explicit [Register("<init>", ...)] on its ctors.
 		// This must continue to work via Pass 1 (direct collection).
@@ -73,34 +64,5 @@ public class ConstructorDetectionTests : FixtureTestBase
 		Assert.Equal (2, peer.JavaConstructors.Count);
 		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
 		Assert.Equal ("(Landroid/content/Context;)V", peer.JavaConstructors [1].JniSignature);
-	}
-
-	[Fact]
-	public void ConstructorMarshalMethod_IsMarkedAsConstructor ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		var ctorMethods = peer.MarshalMethods.Where (m => m.IsConstructor).ToList ();
-		Assert.Single (ctorMethods);
-		Assert.True (ctorMethods [0].IsConstructor);
-	}
-
-	[Fact]
-	public void ConstructorMarshalMethod_HasCorrectJniName ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		var ctor = peer.MarshalMethods.First (m => m.IsConstructor);
-		// The JNI name should be ".ctor" (matching the base's [Register] name)
-		Assert.Equal (".ctor", ctor.JniName);
-	}
-
-	[Fact]
-	public void OnlyNonActivationCtors_BecomeJavaConstructors ()
-	{
-		// MainActivity has both:
-		//   - public MainActivity() → should become JavaConstructor
-		//   - implicit activation ctor from base → should NOT become JavaConstructor
-		// Verify exactly 1 JavaConstructor
-		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		Assert.Equal (1, peer.JavaConstructors.Count);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -120,4 +120,24 @@ public class ConstructorDetectionTests : FixtureTestBase
 		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
 		Assert.Contains ("(Ljava/lang/String;IZ)V", ctorSigs);
 	}
+
+	[Fact]
+	public void ViewArrayCtor_ResolvesObjectArraySignature ()
+	{
+		// ctor(View[]) should produce "([Landroid/view/View;)V"
+		// via TryResolveJniObjectDescriptor looking up View's [Register] JNI name
+		var peer = FindFixtureByJavaName ("my/app/ViewArrayActivity");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+		Assert.Contains ("([Landroid/view/View;)V", ctorSigs);
+	}
+
+	[Fact]
+	public void UnsignedPrimitiveCtor_MapsCorrectly ()
+	{
+		// ctor(ushort, uint, ulong) should produce "(SIJ)V"
+		// UInt16→S, UInt32→I, UInt64→J
+		var peer = FindFixtureByJavaName ("my/app/UnsignedParamActivity");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+		Assert.Contains ("(SIJ)V", ctorSigs);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -93,4 +93,31 @@ public class ConstructorDetectionTests : FixtureTestBase
 		var fallbackCtor = peer.JavaConstructors.First (c => c.JniSignature == "(Ljava/lang/String;)V");
 		Assert.Equal ("", fallbackCtor.SuperArgumentsString);
 	}
+
+	[Fact]
+	public void CustomDialog_SameArityTypeMismatch_UsesParameterlessFallback ()
+	{
+		// CustomDialog has ctor(string). DialogBase has registered ctor(Context).
+		// Same arity (1 param) but different types — must NOT be treated as "already covered".
+		// DialogBase also has registered ()V → parameterless fallback accepts ctor(string).
+		var peer = FindFixtureByJavaName ("my/app/CustomDialog");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+
+		// Base seeds: ()V and (Landroid/content/Context;)V from DialogBase
+		Assert.Contains ("()V", ctorSigs);
+		Assert.Contains ("(Landroid/content/Context;)V", ctorSigs);
+
+		// Fallback: ctor(string) accepted via parameterless base ctor
+		Assert.Contains ("(Ljava/lang/String;)V", ctorSigs);
+	}
+
+	[Fact]
+	public void ActivityWithMultiParamCtor_FallbackComputesFullSignature ()
+	{
+		// ctor(string, int, bool) should produce "(Ljava/lang/String;IZ)V"
+		// via BuildJniCtorSignature mapping each managed type to JNI.
+		var peer = FindFixtureByJavaName ("my/app/ActivityWithMultiParamCtor");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+		Assert.Contains ("(Ljava/lang/String;IZ)V", ctorSigs);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -17,15 +17,14 @@ public class ConstructorDetectionTests : FixtureTestBase
 		// Activity has [Register(".ctor", "()V", "")] — the scanner should chain from it.
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
 
-		// Should produce exactly one JavaConstructor with correct signature
-		Assert.Equal (1, peer.JavaConstructors.Count);
-		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
-
 		// The ctor should appear in MarshalMethods as a constructor
-		var ctorMethods = peer.MarshalMethods.Where (m => m.IsConstructor).ToList ();
-		Assert.Single (ctorMethods);
-		Assert.Equal ("()V", ctorMethods [0].JniSignature);
-		Assert.Equal (".ctor", ctorMethods [0].JniName);
+		var ctorMethod = Assert.Single (peer.MarshalMethods.Where (m => m.IsConstructor));
+		Assert.Equal ("()V", ctorMethod.JniSignature);
+		Assert.Equal (".ctor", ctorMethod.JniName);
+
+		// Should produce exactly one JavaConstructor with correct signature
+		var javaCtor = Assert.Single (peer.JavaConstructors);
+		Assert.Equal ("()V", javaCtor.JniSignature);
 	}
 
 	[Fact]
@@ -34,8 +33,8 @@ public class ConstructorDetectionTests : FixtureTestBase
 		// SimpleActivity has no explicit ctor — the compiler generates a default public one.
 		// It should chain from Activity's registered ()V ctor.
 		var peer = FindFixtureByJavaName ("my/app/SimpleActivity");
-		Assert.NotEmpty (peer.JavaConstructors);
-		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
+		var javaCtor = Assert.Single (peer.JavaConstructors);
+		Assert.Equal ("()V", javaCtor.JniSignature);
 	}
 
 	[Fact]
@@ -43,10 +42,12 @@ public class ConstructorDetectionTests : FixtureTestBase
 	{
 		// UserActivity only has an activation ctor (IntPtr, JniHandleOwnership).
 		// Legacy CecilImporter accepts it via the parameterless fallback because
-		// Activity has a registered ()V ctor. The ctor's managed parameter types
-		// are mapped to JNI Object types.
+		// Activity has a registered ()V ctor. The ctor's managed types map to
+		// JNI Object types → super() is called (not super(p0, p1)).
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		Assert.NotEmpty (peer.JavaConstructors);
+		var javaCtor = Assert.Single (peer.JavaConstructors);
+		Assert.Equal ("(Ljava/lang/Object;Ljava/lang/Object;)V", javaCtor.JniSignature);
+		Assert.Equal ("", javaCtor.SuperArgumentsString);
 	}
 
 	[Fact]
@@ -54,7 +55,9 @@ public class ConstructorDetectionTests : FixtureTestBase
 	{
 		// Same as UserActivity — activation ctor accepted via parameterless fallback.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
-		Assert.NotEmpty (peer.JavaConstructors);
+		var javaCtor = Assert.Single (peer.JavaConstructors);
+		Assert.Equal ("(Ljava/lang/Object;Ljava/lang/Object;)V", javaCtor.JniSignature);
+		Assert.Equal ("", javaCtor.SuperArgumentsString);
 	}
 
 	[Fact]
@@ -83,10 +86,14 @@ public class ConstructorDetectionTests : FixtureTestBase
 	public void ActivityWithCustomCtor_ParameterlessFallback ()
 	{
 		// ActivityWithCustomCtor has a ctor(string) that doesn't match any base registered
-		// ctor's params. But Activity has a registered ()V ctor, so the parameterless
-		// fallback path should accept it (matching legacy CecilImporter.cs:394-397).
+		// ctor's params. Activity has a registered ()V ctor, so the parameterless fallback
+		// accepts it — Java calls super() and delegates args via nctor_N(p0).
 		var peer = FindFixtureByJavaName ("my/app/ActivityWithCustomCtor");
 		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
 		Assert.Contains ("(Ljava/lang/String;)V", ctorSigs);
+
+		// Verify the fallback ctor uses super() (empty SuperArgumentsString)
+		var fallbackCtor = peer.JavaConstructors.First (c => c.JniSignature == "(Ljava/lang/String;)V");
+		Assert.Equal ("", fallbackCtor.SuperArgumentsString);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -1,0 +1,106 @@
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for constructor detection: the scanner must find Java constructors for user types
+/// that have non-activation constructors, even when those constructors don't have [Register].
+/// The legacy JCW generator chains from base registered ctors to derived unregistered ctors.
+/// </summary>
+public class ConstructorDetectionTests : FixtureTestBase
+{
+	[Fact]
+	public void MainActivity_HasJavaConstructor ()
+	{
+		// MainActivity has an explicit public parameterless ctor without [Register].
+		// Activity has [Register(".ctor", "()V", "")] — the scanner should chain from it.
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		Assert.NotEmpty (peer.JavaConstructors);
+	}
+
+	[Fact]
+	public void MainActivity_JavaConstructor_HasCorrectSignature ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+		Assert.Contains ("()V", ctorSigs);
+	}
+
+	[Fact]
+	public void MainActivity_HasConstructorMarshalMethod ()
+	{
+		// The ctor should appear in MarshalMethods with IsConstructor=true
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		var ctorMethods = peer.MarshalMethods.Where (m => m.IsConstructor).ToList ();
+		Assert.NotEmpty (ctorMethods);
+		Assert.Equal ("()V", ctorMethods [0].JniSignature);
+	}
+
+	[Fact]
+	public void SimpleActivity_HasJavaConstructor ()
+	{
+		// SimpleActivity has no explicit ctor — the compiler generates a default public one.
+		// It should chain from Activity's registered ()V ctor.
+		var peer = FindFixtureByJavaName ("my/app/SimpleActivity");
+		Assert.NotEmpty (peer.JavaConstructors);
+		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
+	}
+
+	[Fact]
+	public void UserActivity_HasNoJavaConstructors ()
+	{
+		// UserActivity only has an activation ctor (IntPtr, JniHandleOwnership).
+		// No non-activation ctor exists, so no Java constructor should be generated.
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		Assert.Empty (peer.JavaConstructors);
+	}
+
+	[Fact]
+	public void FullActivity_HasNoJavaConstructors ()
+	{
+		// FullActivity only has an activation ctor — no Java constructors.
+		var peer = FindFixtureByJavaName ("my/app/FullActivity");
+		Assert.Empty (peer.JavaConstructors);
+	}
+
+	[Fact]
+	public void CustomView_StillWorksWithDirectRegister ()
+	{
+		// CustomView has explicit [Register("<init>", ...)] on its ctors.
+		// This must continue to work via Pass 1 (direct collection).
+		var peer = FindFixtureByJavaName ("my/app/CustomView");
+		Assert.Equal (2, peer.JavaConstructors.Count);
+		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
+		Assert.Equal ("(Landroid/content/Context;)V", peer.JavaConstructors [1].JniSignature);
+	}
+
+	[Fact]
+	public void ConstructorMarshalMethod_IsMarkedAsConstructor ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		var ctorMethods = peer.MarshalMethods.Where (m => m.IsConstructor).ToList ();
+		Assert.Single (ctorMethods);
+		Assert.True (ctorMethods [0].IsConstructor);
+	}
+
+	[Fact]
+	public void ConstructorMarshalMethod_HasCorrectJniName ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		var ctor = peer.MarshalMethods.First (m => m.IsConstructor);
+		// The JNI name should be ".ctor" (matching the base's [Register] name)
+		Assert.Equal (".ctor", ctor.JniName);
+	}
+
+	[Fact]
+	public void OnlyNonActivationCtors_BecomeJavaConstructors ()
+	{
+		// MainActivity has both:
+		//   - public MainActivity() → should become JavaConstructor
+		//   - implicit activation ctor from base → should NOT become JavaConstructor
+		// Verify exactly 1 JavaConstructor
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		Assert.Equal (1, peer.JavaConstructors.Count);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -39,20 +39,22 @@ public class ConstructorDetectionTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void UserActivity_ActivationCtorOnly_NoJavaConstructors ()
+	public void UserActivity_ActivationCtor_AcceptedViaFallback ()
 	{
 		// UserActivity only has an activation ctor (IntPtr, JniHandleOwnership).
-		// No non-activation ctor exists, so no Java constructor should be generated.
+		// Legacy CecilImporter accepts it via the parameterless fallback because
+		// Activity has a registered ()V ctor. The ctor's managed parameter types
+		// are mapped to JNI Object types.
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		Assert.Empty (peer.JavaConstructors);
+		Assert.NotEmpty (peer.JavaConstructors);
 	}
 
 	[Fact]
-	public void FullActivity_ActivationCtorOnly_NoJavaConstructors ()
+	public void FullActivity_ActivationCtor_AcceptedViaFallback ()
 	{
-		// FullActivity only has an activation ctor — no Java constructors.
+		// Same as UserActivity — activation ctor accepted via parameterless fallback.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
-		Assert.Empty (peer.JavaConstructors);
+		Assert.NotEmpty (peer.JavaConstructors);
 	}
 
 	[Fact]
@@ -64,5 +66,27 @@ public class ConstructorDetectionTests : FixtureTestBase
 		Assert.Equal (2, peer.JavaConstructors.Count);
 		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
 		Assert.Equal ("(Landroid/content/Context;)V", peer.JavaConstructors [1].JniSignature);
+	}
+
+	[Fact]
+	public void JiStyleView_JniConstructorSignatureAttribute ()
+	{
+		// JiStyleView uses [JniConstructorSignature] instead of [Register].
+		// The scanner must recognize this attribute and collect both ctors.
+		var peer = FindFixtureByJavaName ("my/app/JiStyleView");
+		Assert.Equal (2, peer.JavaConstructors.Count);
+		Assert.Equal ("()V", peer.JavaConstructors [0].JniSignature);
+		Assert.Equal ("(Landroid/content/Context;)V", peer.JavaConstructors [1].JniSignature);
+	}
+
+	[Fact]
+	public void ActivityWithCustomCtor_ParameterlessFallback ()
+	{
+		// ActivityWithCustomCtor has a ctor(string) that doesn't match any base registered
+		// ctor's params. But Activity has a registered ()V ctor, so the parameterless
+		// fallback path should accept it (matching legacy CecilImporter.cs:394-397).
+		var peer = FindFixtureByJavaName ("my/app/ActivityWithCustomCtor");
+		var ctorSigs = peer.JavaConstructors.Select (c => c.JniSignature).ToList ();
+		Assert.Contains ("(Ljava/lang/String;)V", ctorSigs);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/ConstructorDetectionTests.cs
@@ -38,26 +38,23 @@ public class ConstructorDetectionTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void UserActivity_ActivationCtor_AcceptedViaFallback ()
+	public void UserActivity_OnlyGetsBaseCtorSeed ()
 	{
 		// UserActivity only has an activation ctor (IntPtr, JniHandleOwnership).
-		// Legacy CecilImporter accepts it via the parameterless fallback because
-		// Activity has a registered ()V ctor. The ctor's managed types map to
-		// JNI Object types → super() is called (not super(p0, p1)).
+		// The activation ctor is rejected by the fallback (IntPtr is not a Java type).
+		// Only the base ()V seed from Activity remains.
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
 		var javaCtor = Assert.Single (peer.JavaConstructors);
-		Assert.Equal ("(Ljava/lang/Object;Ljava/lang/Object;)V", javaCtor.JniSignature);
-		Assert.Equal ("", javaCtor.SuperArgumentsString);
+		Assert.Equal ("()V", javaCtor.JniSignature);
 	}
 
 	[Fact]
-	public void FullActivity_ActivationCtor_AcceptedViaFallback ()
+	public void FullActivity_OnlyGetsBaseCtorSeed ()
 	{
-		// Same as UserActivity — activation ctor accepted via parameterless fallback.
+		// Same as UserActivity — activation ctor rejected, only base ()V seed.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
 		var javaCtor = Assert.Single (peer.JavaConstructors);
-		Assert.Equal ("(Ljava/lang/Object;Ljava/lang/Object;)V", javaCtor.JniSignature);
-		Assert.Equal ("", javaCtor.SuperArgumentsString);
+		Assert.Equal ("()V", javaCtor.JniSignature);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/CovariantReturnTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/CovariantReturnTests.cs
@@ -1,0 +1,21 @@
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for covariant return type overrides.
+/// When a derived type overrides a base method with a narrower C# return type,
+/// the JCW should use the base method's JNI signature (with the original return type).
+/// </summary>
+public class CovariantReturnTests : FixtureTestBase
+{
+	[Fact]
+	public void CovariantOverride_DetectedWithBaseJniSignatureAndConnector ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/CovariantDerived");
+		var getResult = peer.MarshalMethods.First (m => m.JniName == "getResult");
+		Assert.Equal ("()Ljava/lang/Object;", getResult.JniSignature);
+		Assert.Equal ("GetGetResultHandler", getResult.Connector);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
@@ -79,4 +79,15 @@ public class InterfaceMethodDetectionTests : FixtureTestBase
 		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
 		Assert.Single (nonCtorMethods);
 	}
+
+	[Fact]
+	public void InterfaceExtendsInterface_ParentMethodsDetected ()
+	{
+		// NamedClickListenerImpl implements INamedClickListener which extends IOnClickListener.
+		// Should get both getLabel (from child) and onClick (from parent).
+		var peer = FindFixtureByJavaName ("my/app/NamedClickListenerImpl");
+		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
+		Assert.Contains (nonCtorMethods, m => m.JniName == "getLabel");
+		Assert.Contains (nonCtorMethods, m => m.JniName == "onClick");
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
@@ -1,0 +1,82 @@
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for interface method detection: the scanner must find marshal methods
+/// on types that implement Java interfaces even when the implementing method
+/// has no [Register] attribute. The legacy pipeline handles this via the
+/// interface loop in CecilImporter.cs lines 100-120.
+/// </summary>
+public class InterfaceMethodDetectionTests : FixtureTestBase
+{
+	[Fact]
+	public void ImplicitInterfaceImpl_DetectsOnClickWithCorrectSignatureAndConnector ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ImplicitClickListener");
+		var onClick = peer.MarshalMethods.First (m => m.JniName == "onClick");
+		Assert.Equal ("(Landroid/view/View;)V", onClick.JniSignature);
+		Assert.Equal ("GetOnClick_Landroid_view_View_Handler:Android.Views.IOnClickListenerInvoker", onClick.Connector);
+	}
+
+	[Fact]
+	public void ImplicitMultiInterface_BothMethodsDetected ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ImplicitMultiListener");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onClick", marshalNames);
+		Assert.Contains ("onLongClick", marshalNames);
+	}
+
+	[Fact]
+	public void MixedInterfaceImpl_DirectAndImplicitBothPresentWithNoDuplicates ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MixedInterfaceImpl");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onClick", marshalNames);
+		Assert.Contains ("onLongClick", marshalNames);
+		Assert.Equal (marshalNames.Count, marshalNames.Distinct ().Count ());
+	}
+
+	[Fact]
+	public void ExplicitRegister_StillWorks ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/ClickableView");
+		Assert.Contains (peer.MarshalMethods, m => m.JniName == "onClick");
+	}
+
+	[Fact]
+	public void InterfacePropertyImpl_DetectedWithCorrectSignature ()
+	{
+		// Gap #1: ImplicitPropertyImpl implements IHasName.Name without [Register]
+		var peer = FindFixtureByJavaName ("my/app/ImplicitPropertyImpl");
+		var getName = peer.MarshalMethods.First (m => m.JniName == "getName");
+		Assert.Equal ("()Ljava/lang/String;", getName.JniSignature);
+		Assert.Equal ("GetGetNameHandler:Android.Views.IHasNameInvoker", getName.Connector);
+	}
+
+	[Fact]
+	public void InterfaceType_DoesNotGetInterfaceMethodDetection ()
+	{
+		// Gap #5: interfaces themselves should not have interface method detection applied
+		// IOnClickListener has [Register] on onClick — it should NOT also pick up
+		// methods from other interfaces it might extend
+		var peer = FindFixtureByManagedName ("Android.Views.IOnClickListener");
+		// Should only have the directly-registered onClick, nothing extra
+		Assert.Single (peer.MarshalMethods);
+		Assert.Equal ("onClick", peer.MarshalMethods [0].JniName);
+	}
+
+	[Fact]
+	public void NonJavaPeerInterface_IsIgnored ()
+	{
+		// Gap #4: interfaces without [Register] should be skipped entirely
+		// ImplicitClickListener implements IOnClickListener (Java peer) — should be found
+		// If it also implemented a non-Java interface, those methods should NOT appear
+		var peer = FindFixtureByJavaName ("my/app/ImplicitClickListener");
+		// Only onClick from IOnClickListener, nothing from System.IDisposable etc.
+		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
+		Assert.Single (nonCtorMethods);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -10,32 +10,20 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 public class OverrideDetectionTests : FixtureTestBase
 {
 	[Fact]
-	public void UserActivity_OverrideDetectedWithCorrectRegistration ()
+	public void Override_DetectedWithCorrectRegistration ()
 	{
-		// UserActivity overrides Activity.OnCreate without [Register] on the override
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Contains ("onCreate", marshalNames);
-
 		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
 		Assert.Equal ("(Landroid/os/Bundle;)V", onCreate.JniSignature);
 		Assert.Equal ("n_OnCreate", onCreate.NativeCallbackName);
 		Assert.False (onCreate.IsConstructor);
-		// Activity.OnCreate has connector "GetOnCreate_Landroid_os_Bundle_Handler"
 		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
-		// The n_OnCreate callback lives on Activity, not UserActivity
-		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
-		Assert.Equal ("TestFixtures", onCreate.DeclaringAssemblyName);
-
-		// UserActivity has an activation ctor
 		Assert.NotNull (peer.ActivationCtor);
 	}
 
 	[Fact]
 	public void MultipleOverrides_AllDetected ()
 	{
-		// FullActivity overrides both OnCreate and OnStart — and nothing else.
-		// Non-registered Object virtuals (ToString, Equals, GetHashCode) must NOT appear.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
 		var nonCtorMarshalNames = peer.MarshalMethods.Where (m => !m.IsConstructor).Select (m => m.JniName).ToList ();
 		Assert.Equal (2, nonCtorMarshalNames.Count);
@@ -46,24 +34,17 @@ public class OverrideDetectionTests : FixtureTestBase
 	[Fact]
 	public void DeepInheritance_OverrideDetectedAcrossMultipleLevels ()
 	{
-		// DeeplyDerived → UserActivity → Activity, [Register] is on Activity.OnCreate
 		var peer = FindFixtureByJavaName ("my/app/DeeplyDerived");
-		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
-		// DeclaringType must be Activity (where [Register] lives), not UserActivity
-		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
-		Assert.Equal ("TestFixtures", onCreate.DeclaringAssemblyName);
+		Assert.Contains (peer.MarshalMethods, m => m.JniName == "onCreate");
 	}
 
 	[Fact]
-	public void MixedMethods_DirectRegisterAndOverrideBothPresent ()
+	public void MixedMethods_DirectRegisterAndOverrideBothPresentNoDuplicates ()
 	{
-		// MixedMethods has direct [Register("customMethod")] AND overrides OnCreate (no [Register])
 		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("onCreate", marshalNames);
 		Assert.Contains ("customMethod", marshalNames);
-
-		// No duplicate entries
 		var marshalKeys = peer.MarshalMethods.Select (m => $"{m.JniName}:{m.JniSignature}").ToList ();
 		Assert.Equal (marshalKeys.Count, marshalKeys.Distinct ().Count ());
 	}
@@ -71,60 +52,22 @@ public class OverrideDetectionTests : FixtureTestBase
 	[Fact]
 	public void NewSlot_NotDetectedAsOverride ()
 	{
-		// NewSlotActivity uses 'new' keyword — should NOT be treated as an override
 		var peer = FindFixtureByJavaName ("my/app/NewSlotActivity");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.DoesNotContain ("onCreate", marshalNames);
+		Assert.DoesNotContain (peer.MarshalMethods, m => m.JniName == "onCreate");
 	}
 
 	[Fact]
-	public void PropertyOverride_DetectedFromBaseType ()
+	public void PropertyOverride_DetectedWithCorrectSignature ()
 	{
-		// CustomException overrides Throwable.Message which has [Register("getMessage",...)]
 		var peer = FindFixtureByJavaName ("my/app/CustomException");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Contains ("getMessage", marshalNames);
-
 		var getMessage = peer.MarshalMethods.First (m => m.JniName == "getMessage");
 		Assert.Equal ("()Ljava/lang/String;", getMessage.JniSignature);
-		// The n_get_Message callback lives on Throwable, not CustomException
-		Assert.Equal ("Java.Lang.Throwable", getMessage.DeclaringTypeName);
-		Assert.Equal ("TestFixtures", getMessage.DeclaringAssemblyName);
 	}
 
 	[Fact]
 	public void DirectRegister_StillWorksForMainActivity ()
 	{
-		// The original test fixture MainActivity has [Register] directly — should still work
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Contains ("onCreate", marshalNames);
-	}
-
-	[Fact]
-	public void DerivedFragment_DeclaringTypePointsToCorrectBase ()
-	{
-		// DerivedFragment overrides Activity.OnCreate (MCW, 2 levels up) and
-		// BaseFragment.OnViewCreated (user ACW, 1 level up). Each override
-		// must point to the type that owns the [Register].
-		var peer = FindFixtureByJavaName ("my/app/DerivedFragment");
-		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
-
-		var onCreate = Assert.Single (nonCtorMethods, m => m.JniName == "onCreate");
-		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
-
-		var onViewCreated = Assert.Single (nonCtorMethods, m => m.JniName == "onViewCreated");
-		Assert.Equal ("MyApp.BaseFragment", onViewCreated.DeclaringTypeName);
-		Assert.Equal ("TestFixtures", onViewCreated.DeclaringAssemblyName);
-	}
-
-	[Fact]
-	public void GrandchildFragment_ThreeLevelDeepOverride ()
-	{
-		// GrandchildFragment → DerivedFragment → BaseFragment → Activity
-		// OnCreate [Register] is on Activity, 3 levels up
-		var peer = FindFixtureByJavaName ("my/app/GrandchildFragment");
-		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
-		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
+		Assert.Contains (peer.MarshalMethods, m => m.JniName == "onCreate");
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -84,8 +84,8 @@ public class OverrideDetectionTests : FixtureTestBase
 	public void MixedMethods_NoDuplicates ()
 	{
 		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Equal (marshalNames.Count, marshalNames.Distinct ().Count ());
+		var marshalKeys = peer.MarshalMethods.Select (m => $"{m.JniName}:{m.JniSignature}").ToList ();
+		Assert.Equal (marshalKeys.Count, marshalKeys.Distinct ().Count ());
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -23,6 +23,9 @@ public class OverrideDetectionTests : FixtureTestBase
 		Assert.False (onCreate.IsConstructor);
 		// Activity.OnCreate has connector "GetOnCreate_Landroid_os_Bundle_Handler"
 		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
+		// The n_OnCreate callback lives on Activity, not UserActivity
+		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", onCreate.DeclaringAssemblyName);
 
 		// UserActivity has an activation ctor
 		Assert.NotNull (peer.ActivationCtor);
@@ -81,6 +84,9 @@ public class OverrideDetectionTests : FixtureTestBase
 
 		var getMessage = peer.MarshalMethods.First (m => m.JniName == "getMessage");
 		Assert.Equal ("()Ljava/lang/String;", getMessage.JniSignature);
+		// The n_get_Message callback lives on Throwable, not CustomException
+		Assert.Equal ("Java.Lang.Throwable", getMessage.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", getMessage.DeclaringAssemblyName);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -10,43 +10,21 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 public class OverrideDetectionTests : FixtureTestBase
 {
 	[Fact]
-	public void Override_WithoutRegister_IsDetectedAsMarshalMethod ()
+	public void UserActivity_OverrideDetectedWithCorrectRegistration ()
 	{
 		// UserActivity overrides Activity.OnCreate without [Register] on the override
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("onCreate", marshalNames);
-	}
 
-	[Fact]
-	public void Override_HasCorrectJniSignature ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/UserActivity");
 		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
 		Assert.Equal ("(Landroid/os/Bundle;)V", onCreate.JniSignature);
-	}
-
-	[Fact]
-	public void Override_HasCorrectNativeCallbackName ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
 		Assert.Equal ("n_OnCreate", onCreate.NativeCallbackName);
-	}
-
-	[Fact]
-	public void Override_IsNotMarkedAsConstructor ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
 		Assert.False (onCreate.IsConstructor);
-	}
+		// Activity.OnCreate has connector "GetOnCreate_Landroid_os_Bundle_Handler"
+		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
 
-	[Fact]
-	public void Override_ProducesJavaConstructorsFromActivationCtor ()
-	{
-		// UserActivity has an activation ctor → should get JavaConstructors
-		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		// UserActivity has an activation ctor
 		Assert.NotNull (peer.ActivationCtor);
 	}
 
@@ -78,12 +56,8 @@ public class OverrideDetectionTests : FixtureTestBase
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("onCreate", marshalNames);
 		Assert.Contains ("customMethod", marshalNames);
-	}
 
-	[Fact]
-	public void MixedMethods_NoDuplicates ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
+		// No duplicate entries
 		var marshalKeys = peer.MarshalMethods.Select (m => $"{m.JniName}:{m.JniSignature}").ToList ();
 		Assert.Equal (marshalKeys.Count, marshalKeys.Distinct ().Count ());
 	}
@@ -104,12 +78,7 @@ public class OverrideDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/CustomException");
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("getMessage", marshalNames);
-	}
 
-	[Fact]
-	public void PropertyOverride_HasCorrectJniSignature ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/CustomException");
 		var getMessage = peer.MarshalMethods.First (m => m.JniName == "getMessage");
 		Assert.Equal ("()Ljava/lang/String;", getMessage.JniSignature);
 	}
@@ -121,14 +90,5 @@ public class OverrideDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("onCreate", marshalNames);
-	}
-
-	[Fact]
-	public void Override_ConnectorFromBase_IsPreserved ()
-	{
-		var peer = FindFixtureByJavaName ("my/app/UserActivity");
-		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
-		// Activity.OnCreate has connector "GetOnCreate_Landroid_os_Bundle_Handler"
-		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -1,0 +1,134 @@
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+/// <summary>
+/// Tests for override detection: the scanner must find marshal methods on user types
+/// that override registered base methods even when the override has no [Register] attribute.
+/// </summary>
+public class OverrideDetectionTests : FixtureTestBase
+{
+	[Fact]
+	public void Override_WithoutRegister_IsDetectedAsMarshalMethod ()
+	{
+		// UserActivity overrides Activity.OnCreate without [Register] on the override
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", marshalNames);
+	}
+
+	[Fact]
+	public void Override_HasCorrectJniSignature ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
+		Assert.Equal ("(Landroid/os/Bundle;)V", onCreate.JniSignature);
+	}
+
+	[Fact]
+	public void Override_HasCorrectNativeCallbackName ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
+		Assert.Equal ("n_OnCreate", onCreate.NativeCallbackName);
+	}
+
+	[Fact]
+	public void Override_IsNotMarkedAsConstructor ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
+		Assert.False (onCreate.IsConstructor);
+	}
+
+	[Fact]
+	public void Override_ProducesJavaConstructorsFromActivationCtor ()
+	{
+		// UserActivity has an activation ctor → should get JavaConstructors
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		Assert.NotNull (peer.ActivationCtor);
+	}
+
+	[Fact]
+	public void MultipleOverrides_AllDetected ()
+	{
+		// FullActivity overrides both OnCreate and OnStart
+		var peer = FindFixtureByJavaName ("my/app/FullActivity");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", marshalNames);
+		Assert.Contains ("onStart", marshalNames);
+		Assert.Equal (2, marshalNames.Count);
+	}
+
+	[Fact]
+	public void DeepInheritance_OverrideDetectedAcrossMultipleLevels ()
+	{
+		// DeeplyDerived → UserActivity → Activity, [Register] is on Activity.OnCreate
+		var peer = FindFixtureByJavaName ("my/app/DeeplyDerived");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", marshalNames);
+	}
+
+	[Fact]
+	public void MixedMethods_DirectRegisterAndOverrideBothPresent ()
+	{
+		// MixedMethods has direct [Register("customMethod")] AND overrides OnCreate (no [Register])
+		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", marshalNames);
+		Assert.Contains ("customMethod", marshalNames);
+	}
+
+	[Fact]
+	public void MixedMethods_NoDuplicates ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MixedMethods");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Equal (marshalNames.Count, marshalNames.Distinct ().Count ());
+	}
+
+	[Fact]
+	public void NewSlot_NotDetectedAsOverride ()
+	{
+		// NewSlotActivity uses 'new' keyword — should NOT be treated as an override
+		var peer = FindFixtureByJavaName ("my/app/NewSlotActivity");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.DoesNotContain ("onCreate", marshalNames);
+	}
+
+	[Fact]
+	public void PropertyOverride_DetectedFromBaseType ()
+	{
+		// CustomException overrides Throwable.Message which has [Register("getMessage",...)]
+		var peer = FindFixtureByJavaName ("my/app/CustomException");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("getMessage", marshalNames);
+	}
+
+	[Fact]
+	public void PropertyOverride_HasCorrectJniSignature ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/CustomException");
+		var getMessage = peer.MarshalMethods.First (m => m.JniName == "getMessage");
+		Assert.Equal ("()Ljava/lang/String;", getMessage.JniSignature);
+	}
+
+	[Fact]
+	public void DirectRegister_StillWorksForMainActivity ()
+	{
+		// The original test fixture MainActivity has [Register] directly — should still work
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", marshalNames);
+	}
+
+	[Fact]
+	public void Override_ConnectorFromBase_IsPreserved ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/UserActivity");
+		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
+		// Activity.OnCreate has connector "GetOnCreate_Landroid_os_Bundle_Handler"
+		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -70,4 +70,45 @@ public class OverrideDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
 		Assert.Contains (peer.MarshalMethods, m => m.JniName == "onCreate");
 	}
+
+	[Fact]
+	public void DerivedFragment_OnViewCreated_DeclaringTypePointsToBaseFragment ()
+	{
+		// DerivedFragment overrides BaseFragment.OnViewCreated (ACW→ACW chain)
+		var peer = FindFixtureByJavaName ("my/app/DerivedFragment");
+		var onViewCreated = Assert.Single (peer.MarshalMethods, m => m.JniName == "onViewCreated");
+		Assert.Equal ("MyApp.BaseFragment", onViewCreated.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", onViewCreated.DeclaringAssemblyName);
+	}
+
+	[Fact]
+	public void AbstractBaseMethod_OverrideDetected ()
+	{
+		// ConcreteImpl overrides AbstractBase.DoWork which is abstract + [Register]
+		var peer = FindFixtureByJavaName ("my/app/ConcreteImpl");
+		var doWork = Assert.Single (peer.MarshalMethods, m => m.JniName == "doWork");
+		Assert.Equal ("()V", doWork.JniSignature);
+	}
+
+	[Fact]
+	public void MultipleOverloads_PicksCorrectOne ()
+	{
+		// OverloadDerived overrides Process(int) but NOT Process()
+		var peer = FindFixtureByJavaName ("my/app/OverloadDerived");
+		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
+		var processInt = Assert.Single (nonCtorMethods, m => m.JniName == "process" && m.JniSignature == "(I)V");
+		Assert.Equal ("GetProcess_IHandler", processInt.Connector);
+		// Process() should NOT be detected (not overridden)
+		Assert.DoesNotContain (nonCtorMethods, m => m.JniName == "process" && m.JniSignature == "()V");
+	}
+
+	[Fact]
+	public void EmptyConnector_OverrideStillDetected ()
+	{
+		// Activity.OnStart has [Register("onStart", "()V", "")] — empty connector
+		// FullActivity overrides it without [Register]
+		var peer = FindFixtureByJavaName ("my/app/FullActivity");
+		var onStart = Assert.Single (peer.MarshalMethods, m => m.JniName == "onStart");
+		Assert.Equal ("", onStart.Connector);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -55,10 +55,10 @@ public class OverrideDetectionTests : FixtureTestBase
 	{
 		// FullActivity overrides both OnCreate and OnStart
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Contains ("onCreate", marshalNames);
-		Assert.Contains ("onStart", marshalNames);
-		Assert.Equal (2, marshalNames.Count);
+		var nonCtorMarshalNames = peer.MarshalMethods.Where (m => !m.IsConstructor).Select (m => m.JniName).ToList ();
+		Assert.Contains ("onCreate", nonCtorMarshalNames);
+		Assert.Contains ("onStart", nonCtorMarshalNames);
+		Assert.Equal (2, nonCtorMarshalNames.Count);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -34,7 +34,8 @@ public class OverrideDetectionTests : FixtureTestBase
 	[Fact]
 	public void MultipleOverrides_AllDetected ()
 	{
-		// FullActivity overrides both OnCreate and OnStart
+		// FullActivity overrides both OnCreate and OnStart — and nothing else.
+		// Non-registered Object virtuals (ToString, Equals, GetHashCode) must NOT appear.
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
 		var nonCtorMarshalNames = peer.MarshalMethods.Where (m => !m.IsConstructor).Select (m => m.JniName).ToList ();
 		Assert.Equal (2, nonCtorMarshalNames.Count);
@@ -47,8 +48,10 @@ public class OverrideDetectionTests : FixtureTestBase
 	{
 		// DeeplyDerived → UserActivity → Activity, [Register] is on Activity.OnCreate
 		var peer = FindFixtureByJavaName ("my/app/DeeplyDerived");
-		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
-		Assert.Contains ("onCreate", marshalNames);
+		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
+		// DeclaringType must be Activity (where [Register] lives), not UserActivity
+		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", onCreate.DeclaringAssemblyName);
 	}
 
 	[Fact]
@@ -96,5 +99,32 @@ public class OverrideDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
 		var marshalNames = peer.MarshalMethods.Select (m => m.JniName).ToList ();
 		Assert.Contains ("onCreate", marshalNames);
+	}
+
+	[Fact]
+	public void DerivedFragment_DeclaringTypePointsToCorrectBase ()
+	{
+		// DerivedFragment overrides Activity.OnCreate (MCW, 2 levels up) and
+		// BaseFragment.OnViewCreated (user ACW, 1 level up). Each override
+		// must point to the type that owns the [Register].
+		var peer = FindFixtureByJavaName ("my/app/DerivedFragment");
+		var nonCtorMethods = peer.MarshalMethods.Where (m => !m.IsConstructor).ToList ();
+
+		var onCreate = Assert.Single (nonCtorMethods, m => m.JniName == "onCreate");
+		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
+
+		var onViewCreated = Assert.Single (nonCtorMethods, m => m.JniName == "onViewCreated");
+		Assert.Equal ("MyApp.BaseFragment", onViewCreated.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", onViewCreated.DeclaringAssemblyName);
+	}
+
+	[Fact]
+	public void GrandchildFragment_ThreeLevelDeepOverride ()
+	{
+		// GrandchildFragment → DerivedFragment → BaseFragment → Activity
+		// OnCreate [Register] is on Activity, 3 levels up
+		var peer = FindFixtureByJavaName ("my/app/GrandchildFragment");
+		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
+		Assert.Equal ("Android.App.Activity", onCreate.DeclaringTypeName);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -56,9 +56,9 @@ public class OverrideDetectionTests : FixtureTestBase
 		// FullActivity overrides both OnCreate and OnStart
 		var peer = FindFixtureByJavaName ("my/app/FullActivity");
 		var nonCtorMarshalNames = peer.MarshalMethods.Where (m => !m.IsConstructor).Select (m => m.JniName).ToList ();
+		Assert.Equal (2, nonCtorMarshalNames.Count);
 		Assert.Contains ("onCreate", nonCtorMarshalNames);
 		Assert.Contains ("onStart", nonCtorMarshalNames);
-		Assert.Equal (2, nonCtorMarshalNames.Count);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
@@ -122,6 +122,14 @@ namespace Java.Interop
 		public ExportAttribute () { }
 		public ExportAttribute (string name) => Name = name;
 	}
+
+	[AttributeUsage (AttributeTargets.Constructor, AllowMultiple = false)]
+	public sealed class JniConstructorSignatureAttribute : Attribute
+	{
+		public string MemberSignature { get; }
+
+		public JniConstructorSignatureAttribute (string memberSignature) => MemberSignature = memberSignature;
+	}
 }
 
 namespace MyApp

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
@@ -123,6 +123,14 @@ namespace Java.Interop
 		public ExportAttribute (string name) => Name = name;
 	}
 
+	[AttributeUsage (AttributeTargets.Method, AllowMultiple = false)]
+	public sealed class ExportFieldAttribute : Attribute
+	{
+		public string Name { get; set; }
+
+		public ExportFieldAttribute (string name) => Name = name;
+	}
+
 	[AttributeUsage (AttributeTargets.Constructor, AllowMultiple = false)]
 	public sealed class JniConstructorSignatureAttribute : Attribute
 	{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -33,6 +33,7 @@ namespace Android.App
 	[Register ("android/app/Activity", DoNotGenerateAcw = true)]
 	public class Activity : Java.Lang.Object
 	{
+		[Register (".ctor", "()V", "")]
 		public Activity () { }
 		protected Activity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -392,6 +392,39 @@ namespace MyApp
 		// Overrides Throwable.Message which has [Register("getMessage",...)]
 		public override string? Message => "custom";
 	}
+
+	// --- Constructor chaining test types ---
+
+	/// <summary>
+	/// Uses [JniConstructorSignature] instead of [Register] on its constructors.
+	/// Mimics Java.Interop-style binding types (e.g., Java.Base-ref.cs).
+	/// </summary>
+	[Register ("my/app/JiStyleView")]
+	public class JiStyleView : Android.Views.View
+	{
+		protected JiStyleView (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Java.Interop.JniConstructorSignature ("()V")]
+		public JiStyleView () : base (default!, default) { }
+
+		[Java.Interop.JniConstructorSignature ("(Landroid/content/Context;)V")]
+		public JiStyleView (Context context) : base (default!, default) { }
+	}
+
+	/// <summary>
+	/// Has a ctor with a parameter type that doesn't exist on any base registered ctor,
+	/// but since Activity has a registered parameterless ctor, legacy CecilImporter accepts
+	/// this ctor via the parameterless fallback (CecilImporter.cs:394-397).
+	/// </summary>
+	[Register ("my/app/ActivityWithCustomCtor")]
+	public class ActivityWithCustomCtor : Android.App.Activity
+	{
+		protected ActivityWithCustomCtor (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// string param doesn't match any base registered ctor's params,
+		// but Activity has a registered ()V ctor → fallback accepts this.
+		public ActivityWithCustomCtor (string label) { }
+	}
 }
 
 namespace MyApp.Generic

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -308,6 +308,89 @@ namespace MyApp
 		[Java.Interop.Export ("doExportedWork")]
 		public void DoExportedWork () { }
 	}
+
+	// --- Override detection test types ---
+	// These types override registered base methods WITHOUT [Register] on the override,
+	// mimicking real user code where the attribute is only on the base class in Mono.Android.
+
+	/// <summary>
+	/// Overrides Activity.OnCreate without [Register] — the scanner must detect this
+	/// by walking the base type hierarchy and finding [Register] on Activity.OnCreate.
+	/// </summary>
+	[Register ("my/app/UserActivity")]
+	public class UserActivity : Android.App.Activity
+	{
+		protected UserActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// No [Register] here — real user code doesn't have it
+		protected override void OnCreate (object? savedInstanceState) => base.OnCreate (savedInstanceState);
+	}
+
+	/// <summary>
+	/// Overrides multiple registered base methods without [Register].
+	/// </summary>
+	[Register ("my/app/FullActivity")]
+	public class FullActivity : Android.App.Activity
+	{
+		protected FullActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		protected override void OnCreate (object? savedInstanceState) { }
+		protected override void OnStart () { }
+	}
+
+	/// <summary>
+	/// Deep inheritance: overrides a method registered two levels up.
+	/// Activity has [Register("onCreate",...)], UserActivity overrides it (no [Register]),
+	/// DeeplyDerived overrides it again (no [Register]).
+	/// </summary>
+	[Register ("my/app/DeeplyDerived")]
+	public class DeeplyDerived : UserActivity
+	{
+		protected DeeplyDerived (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		protected override void OnCreate (object? savedInstanceState) { }
+	}
+
+	/// <summary>
+	/// Has both a direct [Register] method AND an override of a base registered method.
+	/// The override should be detected; the direct one should not be duplicated.
+	/// </summary>
+	[Register ("my/app/MixedMethods")]
+	public class MixedMethods : Android.App.Activity
+	{
+		protected MixedMethods (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// Override without [Register] — should be detected from base
+		protected override void OnCreate (object? savedInstanceState) { }
+
+		// Direct [Register] — should be collected normally
+		[Register ("customMethod", "()V", "GetCustomMethodHandler")]
+		public virtual void CustomMethod () { }
+	}
+
+	/// <summary>
+	/// Uses 'new' keyword (IsNewSlot) — should NOT be detected as an override.
+	/// </summary>
+	[Register ("my/app/NewSlotActivity")]
+	public class NewSlotActivity : Android.App.Activity
+	{
+		protected NewSlotActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// 'new' hides the base method rather than overriding it
+		protected new void OnCreate (object? savedInstanceState) { }
+	}
+
+	/// <summary>
+	/// Overrides a registered property getter without [Register] on the override.
+	/// </summary>
+	[Register ("my/app/CustomException")]
+	public class CustomException : Java.Lang.Throwable
+	{
+		protected CustomException (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// Overrides Throwable.Message which has [Register("getMessage",...)]
+		public override string? Message => "custom";
+	}
 }
 
 namespace MyApp.Generic

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -425,6 +425,96 @@ namespace MyApp
 		// but Activity has a registered ()V ctor → fallback accepts this.
 		public ActivityWithCustomCtor (string label) { }
 	}
+
+	// --- Additional deep hierarchy test types ---
+
+	/// <summary>
+	/// User ACW base type that adds its own registered method. Used to test
+	/// multi-level user type hierarchies (ACW → ACW → MCW).
+	/// </summary>
+	[Register ("my/app/BaseFragment")]
+	public class BaseFragment : Android.App.Activity
+	{
+		protected BaseFragment (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register ("onViewCreated", "()V", "GetOnViewCreatedHandler")]
+		protected virtual void OnViewCreated () { }
+	}
+
+	/// <summary>
+	/// Overrides both a method registered on a user ACW base (BaseFragment.OnViewCreated)
+	/// and one on an MCW base (Activity.OnCreate). Tests that DeclaringTypeName points
+	/// to the correct type for each.
+	/// </summary>
+	[Register ("my/app/DerivedFragment")]
+	public class DerivedFragment : BaseFragment
+	{
+		protected DerivedFragment (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		protected override void OnCreate (object? savedInstanceState) { }
+		protected override void OnViewCreated () { }
+	}
+
+	/// <summary>
+	/// Three levels deep: GrandchildFragment → DerivedFragment → BaseFragment → Activity.
+	/// OnCreate [Register] is on Activity (3 levels up). Tests deep recursive walk.
+	/// </summary>
+	[Register ("my/app/GrandchildFragment")]
+	public class GrandchildFragment : DerivedFragment
+	{
+		protected GrandchildFragment (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		protected override void OnCreate (object? savedInstanceState) { }
+	}
+
+	// --- Constructor chaining: same-arity type mismatch ---
+
+	/// <summary>
+	/// MCW base with a registered ctor that takes a Context parameter.
+	/// Used to test that ctor parameter type matching is strict (same arity,
+	/// different types should NOT match).
+	/// </summary>
+	[Register ("my/app/DialogBase", DoNotGenerateAcw = true)]
+	public class DialogBase : Java.Lang.Object
+	{
+		[Register (".ctor", "()V", "")]
+		public DialogBase () { }
+
+		[Register (".ctor", "(Landroid/content/Context;)V", "")]
+		public DialogBase (Context context) { }
+
+		protected DialogBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+	}
+
+	/// <summary>
+	/// Derived type with a ctor(string) that has the same arity as
+	/// DialogBase's registered ctor(Context) but a different parameter type.
+	/// The scanner must NOT treat it as "already covered" — it should fall
+	/// through to the parameterless fallback and compute the JNI signature.
+	/// </summary>
+	[Register ("my/app/CustomDialog")]
+	public class CustomDialog : DialogBase
+	{
+		protected CustomDialog (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// Same arity as DialogBase(Context) but different type → not covered.
+		// Parameterless fallback: super() + nctor_N(string).
+		public CustomDialog (string title) { }
+	}
+
+	// --- Constructor chaining: multi-parameter fallback ---
+
+	/// <summary>
+	/// Has a ctor with multiple primitive/string params to test that
+	/// BuildJniCtorSignature correctly handles multi-parameter signatures.
+	/// </summary>
+	[Register ("my/app/ActivityWithMultiParamCtor")]
+	public class ActivityWithMultiParamCtor : Android.App.Activity
+	{
+		protected ActivityWithMultiParamCtor (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public ActivityWithMultiParamCtor (string name, int count, bool enabled) { }
+	}
 }
 
 namespace MyApp.Generic

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -183,10 +183,10 @@ namespace MyApp
 		protected CustomView (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		[Register ("<init>", "()V", "")]
-		public CustomView () : base (default!, default) { }
+		public CustomView () : base (default, default) { }
 
 		[Register ("<init>", "(Landroid/content/Context;)V", "")]
-		public CustomView (Context context) : base (default!, default) { }
+		public CustomView (Context context) : base (default, default) { }
 	}
 
 	[Register ("my/app/Outer")]
@@ -405,10 +405,10 @@ namespace MyApp
 		protected JiStyleView (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		[Java.Interop.JniConstructorSignature ("()V")]
-		public JiStyleView () : base (default!, default) { }
+		public JiStyleView () : base (default, default) { }
 
 		[Java.Interop.JniConstructorSignature ("(Landroid/content/Context;)V")]
-		public JiStyleView (Context context) : base (default!, default) { }
+		public JiStyleView (Context context) : base (default, default) { }
 	}
 
 	/// <summary>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -98,6 +98,16 @@ namespace Android.Views
 		bool OnLongClick (View v);
 	}
 
+	/// <summary>
+	/// Interface with a registered property (for testing interface property implementation detection).
+	/// </summary>
+	[Register ("android/view/View$IHasName", "", "Android.Views.IHasNameInvoker")]
+	public interface IHasName
+	{
+		[Register ("getName", "()Ljava/lang/String;", "GetGetNameHandler:Android.Views.IHasNameInvoker")]
+		string? Name { get; }
+	}
+
 	[Register ("mono/android/view/View_IOnClickListenerImplementor")]
 	public class View_IOnClickListenerImplementor : Java.Lang.Object
 	{
@@ -228,6 +238,34 @@ namespace MyApp
 		public virtual void SetItems (string[]? items) { }
 	}
 
+	// --- Covariant return test types ---
+
+	/// <summary>
+	/// Base type with a method returning Java.Lang.Object.
+	/// </summary>
+	[Register ("my/app/CovariantBase", DoNotGenerateAcw = true)]
+	public class CovariantBase : Java.Lang.Object
+	{
+		protected CovariantBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register ("getResult", "()Ljava/lang/Object;", "GetGetResultHandler")]
+		public virtual Java.Lang.Object? GetResult () => null;
+	}
+
+	/// <summary>
+	/// Derived type that overrides GetResult with a narrower C# return type.
+	/// The JCW should use the base's JNI signature "()Ljava/lang/Object;".
+	/// </summary>
+	[Register ("my/app/CovariantDerived")]
+	public class CovariantDerived : CovariantBase
+	{
+		protected CovariantDerived (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// C# allows covariant returns — return type narrows from Object to string
+		// but no [Register] on the override. The base's JNI sig should be used.
+		public override Java.Lang.Object? GetResult () => null;
+	}
+
 	[Register ("my/app/ExportExample")]
 	public class ExportExample : Java.Lang.Object
 	{
@@ -235,8 +273,39 @@ namespace MyApp
 		public void MyExportedMethod () { }
 	}
 
+	/// <summary>
+	/// Has [Export] methods with different access modifiers.
+	/// The JCW should respect the C# visibility for [Export] methods.
+	/// </summary>
+	[Register ("my/app/ExportAccessTest")]
+	public class ExportAccessTest : Java.Lang.Object
+	{
+		protected ExportAccessTest (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Java.Interop.Export ("publicMethod")]
+		public void PublicMethod () { }
+
+		[Java.Interop.Export ("protectedMethod")]
+		protected void ProtectedMethod () { }
+	}
+
 	[Application (Name = "my.app.MyApplication", BackupAgent = typeof (MyBackupAgent), ManageSpaceActivity = typeof (MyManageSpaceActivity))]
 	public class MyApplication : Java.Lang.Object { }
+
+	/// <summary>
+	/// Has [ExportField] methods that should produce Java field declarations.
+	/// </summary>
+	[Register ("my/app/ExportFieldExample")]
+	public class ExportFieldExample : Java.Lang.Object
+	{
+		protected ExportFieldExample (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Java.Interop.ExportField ("STATIC_INSTANCE")]
+		public static ExportFieldExample GetInstance () => default!;
+
+		[Java.Interop.ExportField ("VALUE")]
+		public string GetValue () => "";
+	}
 
 	[Instrumentation (Name = "my.app.MyInstrumentation")]
 	public class MyInstrumentation : Java.Lang.Object { }
@@ -308,6 +377,78 @@ namespace MyApp
 	{
 		[Java.Interop.Export ("doExportedWork")]
 		public void DoExportedWork () { }
+	}
+
+	// --- Constructor super() argument test types ---
+
+	/// <summary>
+	/// Has a ctor with custom params that don't match any base registered ctor.
+	/// Activity has parameterless [Register(".ctor","()V",...)] so the fallback
+	/// should produce super() (empty super args).
+	/// </summary>
+	[Register ("my/app/CustomParamActivity")]
+	public class CustomParamActivity : Android.App.Activity
+	{
+		protected CustomParamActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// Custom ctor with params that don't match Activity's ()V ctor
+		public CustomParamActivity (string title, int count) : base () { }
+	}
+
+	// --- Interface implementation without [Register] test types ---
+	// These mimic real user code where a class implements a Java interface
+	// but doesn't have [Register] on the implementing method.
+
+	/// <summary>
+	/// Implements IOnClickListener.OnClick without [Register] on the method.
+	/// The scanner must detect this from the interface definition.
+	/// </summary>
+	[Register ("my/app/ImplicitClickListener")]
+	public class ImplicitClickListener : Java.Lang.Object, Android.Views.IOnClickListener
+	{
+		protected ImplicitClickListener (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// No [Register] — real user code doesn't have it
+		public void OnClick (Android.Views.View v) { }
+	}
+
+	/// <summary>
+	/// Implements an interface with a registered property without [Register] on the property.
+	/// </summary>
+	[Register ("my/app/ImplicitPropertyImpl")]
+	public class ImplicitPropertyImpl : Java.Lang.Object, Android.Views.IHasName
+	{
+		protected ImplicitPropertyImpl (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// No [Register] — should be detected from interface property
+		public string? Name => "test";
+	}
+
+	/// <summary>
+	/// Implements multiple interfaces without [Register] on any method.
+	/// </summary>
+	[Register ("my/app/ImplicitMultiListener")]
+	public class ImplicitMultiListener : Java.Lang.Object, Android.Views.IOnClickListener, Android.Views.IOnLongClickListener
+	{
+		protected ImplicitMultiListener (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public void OnClick (Android.Views.View v) { }
+		public bool OnLongClick (Android.Views.View v) => false;
+	}
+
+	/// <summary>
+	/// Has one interface method with [Register] and one without.
+	/// </summary>
+	[Register ("my/app/MixedInterfaceImpl")]
+	public class MixedInterfaceImpl : Java.Lang.Object, Android.Views.IOnClickListener, Android.Views.IOnLongClickListener
+	{
+		protected MixedInterfaceImpl (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register ("onClick", "(Landroid/view/View;)V", "")]
+		public void OnClick (Android.Views.View v) { }
+
+		// No [Register] — should be detected from interface
+		public bool OnLongClick (Android.Views.View v) => false;
 	}
 
 	// --- Override detection test types ---

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -301,7 +301,7 @@ namespace MyApp
 		protected ExportFieldExample (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		[Java.Interop.ExportField ("STATIC_INSTANCE")]
-		public static ExportFieldExample GetInstance () => default!;
+		public static ExportFieldExample? GetInstance () => default;
 
 		[Java.Interop.ExportField ("VALUE")]
 		public string GetValue () => "";

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -108,6 +108,17 @@ namespace Android.Views
 		string? Name { get; }
 	}
 
+	/// <summary>
+	/// Interface that extends another registered interface.
+	/// Tests that implementing types get methods from the parent interface too.
+	/// </summary>
+	[Register ("android/view/View$INamedClickListener", "", "Android.Views.INamedClickListenerInvoker")]
+	public interface INamedClickListener : IOnClickListener
+	{
+		[Register ("getLabel", "()Ljava/lang/String;", "GetGetLabelHandler:Android.Views.INamedClickListenerInvoker")]
+		string? Label { get; }
+	}
+
 	[Register ("mono/android/view/View_IOnClickListenerImplementor")]
 	public class View_IOnClickListenerImplementor : Java.Lang.Object
 	{
@@ -451,6 +462,19 @@ namespace MyApp
 		public bool OnLongClick (Android.Views.View v) => false;
 	}
 
+	/// <summary>
+	/// Implements an interface that extends another registered interface.
+	/// Should get methods from both the child and parent interface.
+	/// </summary>
+	[Register ("my/app/NamedClickListenerImpl")]
+	public class NamedClickListenerImpl : Java.Lang.Object, Android.Views.INamedClickListener
+	{
+		protected NamedClickListenerImpl (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public void OnClick (Android.Views.View v) { }
+		public string? Label => "test";
+	}
+
 	// --- Override detection test types ---
 	// These types override registered base methods WITHOUT [Register] on the override,
 	// mimicking real user code where the attribute is only on the base class in Mono.Android.
@@ -655,6 +679,70 @@ namespace MyApp
 		protected ActivityWithMultiParamCtor (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		public ActivityWithMultiParamCtor (string name, int count, bool enabled) { }
+	}
+
+	// --- Test gap fixtures ---
+
+	/// <summary>
+	/// Has a ctor taking an array of Java peer objects.
+	/// Tests that TryResolveJniObjectDescriptor + array recursion produces [Landroid/view/View;
+	/// </summary>
+	[Register ("my/app/ViewArrayActivity")]
+	public class ViewArrayActivity : Android.App.Activity
+	{
+		protected ViewArrayActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public ViewArrayActivity (Android.Views.View[] views) { }
+	}
+
+	/// <summary>
+	/// Overrides an abstract base method without [Register].
+	/// AbstractBase.DoWork has [Register("doWork", "()V", "")].
+	/// </summary>
+	[Register ("my/app/ConcreteImpl")]
+	public class ConcreteImpl : AbstractBase
+	{
+		protected ConcreteImpl (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public override void DoWork () { }
+	}
+
+	/// <summary>
+	/// MCW base with two overloaded methods — same name, different params.
+	/// Tests that override detection picks the correct overload.
+	/// </summary>
+	[Register ("my/app/OverloadBase", DoNotGenerateAcw = true)]
+	public class OverloadBase : Java.Lang.Object
+	{
+		protected OverloadBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register ("process", "()V", "GetProcessHandler")]
+		public virtual void Process () { }
+
+		[Register ("process", "(I)V", "GetProcess_IHandler")]
+		public virtual void Process (int value) { }
+	}
+
+	/// <summary>
+	/// Overrides only one of two overloads — Process(int) but not Process().
+	/// </summary>
+	[Register ("my/app/OverloadDerived")]
+	public class OverloadDerived : OverloadBase
+	{
+		protected OverloadDerived (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public override void Process (int value) { }
+	}
+
+	/// <summary>
+	/// Has a ctor with unsigned primitive params to test JNI mapping.
+	/// </summary>
+	[Register ("my/app/UnsignedParamActivity")]
+	public class UnsignedParamActivity : Android.App.Activity
+	{
+		protected UnsignedParamActivity (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public UnsignedParamActivity (ushort a, uint b, ulong c) { }
 	}
 }
 


### PR DESCRIPTION
## TL;DR

`JavaPeerScanner` now matches legacy `CecilImporter` output for method overrides, constructor chaining, and interface implementations. The scanner uses a 5-pass approach: direct `[Register]`, property `[Register]`, base class override detection, interface method detection, and constructor chain detection. Also fixes 4 bugs in the integration test harness that were hiding mismatches between legacy and new scanner output. Validated with zero divergence across ~8000 Mono.Android types — no filtering, direct 1:1 comparison.

247 unit tests + 10 integration tests pass.

Part of #10789

## Context

The `JavaPeerScanner` was missing several categories of methods that the legacy `CecilImporter` finds:

1. **Method overrides without `[Register]`** — User types (e.g., `MainActivity`) override `Activity.OnCreate()` without `[Register]` on the override. The attribute is only on the base class method in Mono.Android.

2. **Java constructors via base ctor chaining** — User types have non-activation constructors without `[Register]`. The legacy `CecilImporter` walks the base type hierarchy, seeds registered ctors, and accepts derived ctors with compatible parameters.

3. **Constructor parameter JNI signatures for object types** — Ctors taking Java peer types (e.g., `X509Certificate[]`) need `L<jniName>;` descriptors, not just primitive mappings.

4. **Base JNI name for types without `[Register]`** — Types like `XmlReaderPullParser` have no `[Register]` but are Java peers with auto-computed JNI names. `ResolveBaseJavaName` needs to compute these on demand.

## Scanner architecture

The scanner's `CollectMarshalMethods` now uses a 5-pass approach:

```
CollectMarshalMethods(typeDef, detectBaseOverrides)
│
├─ Pass 1: Direct [Register] / [Export] / [ExportField] on methods
├─ Pass 2: [Register] on properties (getter)
│
│  (Passes 3-5 only for user ACW types: detectBaseOverrides=true)
│
├─ Pass 3: Override detection — walk base hierarchy
│  ├─ Method overrides (FindBaseRegisteredMethodInfo)
│  └─ Property overrides (FindBaseRegisteredProperty)
├─ Pass 4: Interface method implementations
│  └─ CollectInterfaceMethodImplementations
└─ Pass 5: Constructor chaining from base registered ctors
   └─ CollectBaseConstructorChain
      ├─ Seed base registered ctors
      ├─ Match params → already covered
      └─ Fallback → parameterless super() + BuildJniCtorSignature
```

## Changes

### Scanner (`JavaPeerScanner.cs`, `JavaPeerInfo.cs`)

**Pass 3 — Override detection:** For each virtual override without `[Register]`, walks the base hierarchy to find the registered base method and copies its registration info. Also handles property overrides (e.g., `Throwable.Message`). Populates `DeclaringTypeName`/`DeclaringAssemblyName` so UCO wrappers call `n_*` on the correct base type. Walks all base types with no DoNotGenerateAcw boundary — matching legacy `GetBaseDefinition`/`GetBaseRegisteredMethod`.

**Pass 5 — Constructor chain detection:** Mirrors legacy `CecilImporter` behavior:
- Seeds all base registered ctors directly into the type's marshal methods
- Matches derived ctors with compatible parameters against base registered ctors
- Fallback: if a base has a registered `()V` ctor, accepts derived ctors with novel params (generates `super()` call via `SuperArgumentsString=""`)
- Rejects ctors with non-Java parameter types (`System.IntPtr`, `System.Action`, etc.)
- Resolves Java peer object types (e.g., `X509Certificate`) to `L<jniName>;` via assembly cache lookup
- Handles `[JniConstructorSignature]` (Java.Interop-style) in addition to `[Register]`
- Stops base walk at `DoNotGenerateAcw` boundary (matching legacy)

**`ResolveBaseJavaName`** — Now computes auto JNI names for base types without `[Register]` when they haven't been scanned yet (scan order within an assembly is not guaranteed).

**`ManagedTypeToJniDescriptorOrNull`** — Now resolves Java peer object types by looking up their `[Register]` JNI name in the assembly cache.

### Unit tests + fixtures

- **`OverrideDetectionTests`** (10 tests) — overrides without `[Register]`, deep inheritance (3 levels), ACW→ACW→MCW hierarchy, property overrides, mixed methods, new-slot exclusion, DeclaringTypeName verification
- **`ConstructorDetectionTests`** (9 tests) — base ctor chain, implicit default ctor, base ctor seed, `JniConstructorSignature`, parameterless fallback, same-arity type mismatch, multi-parameter signature computation
- Test fixtures: `UserActivity`, `FullActivity`, `DeeplyDerived`, `MixedMethods`, `NewSlotActivity`, `CustomException`, `BaseFragment`, `DerivedFragment`, `GrandchildFragment`, `JiStyleView`, `ActivityWithCustomCtor`, `DialogBase`, `CustomDialog`, `ActivityWithMultiParamCtor`

---

### Integration test harness improvements

_The following changes are not directly related to the scanner features above, but were necessary to properly validate them. The scanner now produces more complete output (interface methods, constructors with object type params, types without `[Register]`), which exposed pre-existing bugs in how the legacy test harness transforms `CecilImporter` output for comparison._

**`GetCecilJavaName`** — Added `JavaNativeTypeManager.ToJniName` fallback for types without `[Register]` (e.g., `ActivityTracker`). Previously returned `null`, silently skipping these types. Now matches what `CecilImporter.CreateType` actually does.

**`ExtractMethodRegistrations`** — Fixed to use `m.JavaName` (JNI name) instead of `m.Name` (managed name) for `[Export]` methods. Now includes constructors from `wrapper.Constructors` so both scanners' constructors are compared directly.

**Removed all filtering** — No more interface method filtering, no phantom entry fallback, no constructor exclusion. Both `RunLegacy` and `RunNew` produce complete unfiltered output compared 1:1 across ~8000 Mono.Android types.

---

### Related issue

Filed #10931 — `JcwJavaSourceGenerator` must skip `registerNatives` in the static block for Application/Instrumentation types.

## Test results

- 247 unit tests pass
- 10 integration tests pass (including `ExactMarshalMethods_MonoAndroid` and `ExactJavaConstructors_MonoAndroid` — no filtering, direct 1:1 comparison)

## Legacy comparison notes

- **Override detection** matches legacy `GetBaseDefinition` → `GetBaseRegisteredMethod`: walks all base types (no DoNotGenerateAcw boundary), checks `Virtual || Abstract`, matches by name + parameter compatibility.
- **Constructor chaining** matches legacy `ctorTypes` loop (CecilImporter.cs:124-160): stops at DoNotGenerateAcw, seeds registered base ctors, checks `AreParametersCompatibleWith`, falls back to parameterless `super()`.
- **Object type resolution** matches legacy `GetJniTypeName`: resolves Java peer types to `L<jniName>;` via `[Register]` lookup, returns null for non-Java types.
- **Parameter compatibility** uses string comparison of decoded S.R.M. signatures — equivalent to Cecil's `a.FullName == b.FullName` for non-generic cases. Validated against ~8000 types with zero divergence.
