### PR TITLE
[xabt] Validate CustomJniInitFunctions names are valid C identifiers

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeAotLibraryLoadAssemblerSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeAotLibraryLoadAssemblerSources.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
@@ -16,6 +17,8 @@ public class GenerateNativeAotLibraryLoadAssemblerSources : AndroidTask
 		".dll",
 		".dylib",
 	};
+
+	static readonly Regex ValidCIdentifier = new Regex (@"^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.Compiled);
 
 	static readonly HashSet<string> LibraryNamesToIgnore = new (StringComparer.OrdinalIgnoreCase) {
 		"*",
@@ -128,6 +131,12 @@ public class GenerateNativeAotLibraryLoadAssemblerSources : AndroidTask
 				string name = func.ItemSpec;
 				if (seen.Contains (name)) {
 					continue;
+				}
+				// Reject names containing newlines or non-identifier characters: they would break out of
+				// the LLVM IR function declaration context and inject arbitrary IR directives (CWE-74).
+				if (name.IndexOfAny (['\n', '\r']) >= 0 ||
+				    !ValidCIdentifier.IsMatch (name)) {
+					throw new InvalidOperationException ($"CustomJniInitFunctions item '{name}' is not a valid C identifier and cannot be used as a JNI init function name.");
 				}
 				seen.Add (name);
 				customInitFunctions.Add (name);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -2219,5 +2219,30 @@ namespace App1
 			Assert.NotNull (method, $"Failed to find the '{MethodName}' method in type '{TypeName}'");
 			Assert.IsTrue (method.IsPublic, $"Method '{MethodName}' should be public");
 		}
+
+		[Test]
+		public void InvalidCustomJniInitFunctionName ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.NativeAOT, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+
+			// A malicious NuGet package could inject LLVM IR via a function name containing
+			// newlines or non-identifier characters (VULN-341/342).  The build must reject
+			// names that are not valid C identifiers.
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidStaticJniInitFunction", "valid_name"));
+			proj.OtherBuildItems.Add (new BuildItem ("AndroidStaticJniInitFunction", "evil\ndefine void @injected()"));
+
+			using (var b = CreateApkBuilder ()) {
+				b.ThrowOnBuildFailure = false;
+				Assert.IsFalse (b.Build (proj), "Build should have failed due to invalid CustomJniInitFunctions names.");
+				StringAssertEx.ContainsRegex (@"is not a valid C identifier", b.LastBuildOutput, "Expected an error about invalid C identifier");
+			}
+		}
 	}
 }


### PR DESCRIPTION
Reject AndroidStaticJniInitFunction items that are not valid C identifiers before they reach the LLVM IR generator. A malicious NuGet package could inject arbitrary LLVM IR directives via newlines or special characters in function names (CWE-74).