### PR TITLE
[xabt] Filter non-Android .so files from _ResolvedNativeLibraries

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -248,6 +248,16 @@ _ResolveAssemblies MSBuild target.
     </PropertyGroup>
     <ItemGroup>
       <_ResolvedNativeLibraries Include="@(ResolvedFileToPublish)" Condition=" '%(ResolvedFileToPublish.Extension)' == '.so' " />
+      <!-- Exclude native libraries from non-Android RIDs (e.g. runtimes/linux-x64/native/).
+           The .NET SDK sets RuntimeIdentifier metadata to the current Android RID on all
+           ResolvedFileToPublish items, causing non-Android .so files to pass ABI checks
+           downstream. Use %(PathInPackage) metadata to detect the actual source RID.
+           Note: both 'android-*' and 'linux-bionic-*' RIDs are valid Android targets. -->
+      <_ResolvedNativeLibraries Remove="@(_ResolvedNativeLibraries)"
+          Condition=" '%(PathInPackage)' != '' And
+                      $([System.String]::new('%(PathInPackage)').StartsWith('runtimes/')) And
+                      !$([System.String]::new('%(PathInPackage)').StartsWith('runtimes/android')) And
+                      !$([System.String]::new('%(PathInPackage)').StartsWith('runtimes/linux-bionic')) " />
     </ItemGroup>
     <ItemGroup>
       <_MonoComponent Condition=" '$(AndroidEnableProfiler)' == 'true' " Include="diagnostics_tracing" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -251,13 +251,12 @@ _ResolveAssemblies MSBuild target.
       <!-- Exclude native libraries from non-Android RIDs (e.g. runtimes/linux-x64/native/).
            The .NET SDK sets RuntimeIdentifier metadata to the current Android RID on all
            ResolvedFileToPublish items, causing non-Android .so files to pass ABI checks
-           downstream. Use %(PathInPackage) metadata to detect the actual source RID.
+           downstream. Check the file path for non-Android runtimes/ directories.
            Note: both 'android-*' and 'linux-bionic-*' RIDs are valid Android targets. -->
       <_ResolvedNativeLibraries Remove="@(_ResolvedNativeLibraries)"
-          Condition=" '%(PathInPackage)' != '' And
-                      $([System.String]::new('%(PathInPackage)').StartsWith('runtimes/')) And
-                      !$([System.String]::new('%(PathInPackage)').StartsWith('runtimes/android')) And
-                      !$([System.String]::new('%(PathInPackage)').StartsWith('runtimes/linux-bionic')) " />
+          Condition=" $([System.String]::new('%(Identity)').Replace('\','/').Contains('/runtimes/')) And
+                      !$([System.String]::new('%(Identity)').Replace('\','/').Contains('/runtimes/android')) And
+                      !$([System.String]::new('%(Identity)').Replace('\','/').Contains('/runtimes/linux-bionic')) " />
     </ItemGroup>
     <ItemGroup>
       <_MonoComponent Condition=" '$(AndroidEnableProfiler)' == 'true' " Include="diagnostics_tracing" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -629,6 +629,38 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		[Test]
+		public void NonAndroidNativeLibrariesDoNotProduceWarnings ()
+		{
+			var proj = new XamarinAndroidApplicationProject ();
+			// Create a dummy .so at a path mimicking a non-Android NuGet native library
+			proj.OtherBuildItems.Add (new BuildItem ("None", "runtimes/linux-x64/native/libFake.so") {
+				BinaryContent = () => new byte [128],
+			});
+			// Inject it into ResolvedFileToPublish with RuntimeIdentifier=android-arm64,
+			// simulating what the .NET SDK does for packages like Microsoft.Testing.Extensions.CodeCoverage
+			proj.Imports.Add (new Import ("non-android-so.targets") {
+				TextContent = () =>
+					"""
+					<?xml version="1.0" encoding="utf-8"?>
+					<Project>
+					  <Target Name="_InjectFakeLinuxSo" BeforeTargets="_IncludeNativeSystemLibraries">
+					    <ItemGroup>
+					      <ResolvedFileToPublish Include="$(MSBuildProjectDirectory)/runtimes/linux-x64/native/libFake.so">
+					        <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
+					        <NuGetPackageId>FakePackage</NuGetPackageId>
+					        <NuGetPackageVersion>1.0.0</NuGetPackageVersion>
+					      </ResolvedFileToPublish>
+					    </ItemGroup>
+					  </Target>
+					</Project>
+					""",
+			});
+			using var b = CreateApkBuilder ();
+			Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+			b.AssertHasNoWarnings ();
+		}
+
 		static IEnumerable<object[]> Get_XA1037PropertyDeprecatedWarningData ()
 		{
 			var ret = new List<object[]> ();


### PR DESCRIPTION
NuGet packages like Microsoft.Testing.Extensions.CodeCoverage ship native .so files under runtimes/linux-x64/native/. The .NET SDK stamps RuntimeIdentifier=android-arm64 metadata on all ResolvedFileToPublish items during inner builds, causing ProcessNativeLibraries to treat these non-Android libraries as valid Android native libs. This leads to spurious XA0141 warnings about 16 KB page alignment.

Use %(PathInPackage) metadata to detect the actual source RID and exclude .so files from non-Android runtimes (linux-x64, linux-musl-x64, osx-x64, win-x64, etc.) while preserving android-* and linux-bionic-* RIDs which are valid Android targets.