### PR TITLE
[build] Scope BinSkim scanning to build output only

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -60,6 +60,8 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
+        # Only scan actual build output, not test assemblies under bin/Test*
+        analyzeTargetGlob: +|bin\Build*\**
       codeql:
         compiled:
           enabled: false


### PR DESCRIPTION
Add analyzeTargetGlob to restrict BinSkim to bin\Build*\ directories, excluding bin\Test*\ test assemblies. Test-built debug assemblies produce BA2021 (DoNotMarkWritableSectionsAsExecutable) false positives that add noise to every failing PR build.

The 1ES template applies sdl config globally to all jobs with no per-job override mechanism, so analyzeTargetGlob is the most targeted way to exclude test output from scanning.