### PR TITLE
[TrimmableTypeMap] Normalize dots to slashes in [Register] attribute JNI names

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -93,6 +93,7 @@ sealed class AssemblyIndex : IDisposable
 
 			if (attrName == "RegisterAttribute") {
 				registerInfo = ParseRegisterAttribute (ca);
+				registerInfo = registerInfo with { JniName = registerInfo.JniName.Replace ('.', '/') };
 			} else if (attrName == "ExportAttribute") {
 				// [Export] is a method-level attribute; it is parsed at scan time by JavaPeerScanner
 			} else if (IsKnownComponentAttribute (attrName)) {
@@ -215,7 +216,7 @@ sealed class AssemblyIndex : IDisposable
 		}
 
 		return new RegisterInfo {
-			JniName = jniName.Replace ('.', '/'),
+			JniName = jniName,
 			Signature = signature,
 			Connector = connector,
 			DoNotGenerateAcw = doNotGenerateAcw,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -215,7 +215,7 @@ sealed class AssemblyIndex : IDisposable
 		}
 
 		return new RegisterInfo {
-			JniName = jniName,
+			JniName = jniName.Replace ('.', '/'),
 			Signature = signature,
 			Connector = connector,
 			DoNotGenerateAcw = doNotGenerateAcw,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -73,4 +73,14 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 			Assert.False (string.IsNullOrEmpty (peer.AssemblyName),
 				$"Type {peer.ManagedTypeName} should have assembly name"));
 	}
+
+	[Fact]
+	public void Scan_RegisterAttribute_DotFormat_NormalizedToSlashes ()
+	{
+		// [Register ("com.example.dotformat.DotActivity")] uses dots — scanner should normalize to slashes
+		var peer = FindFixtureByJavaName ("com/example/dotformat/DotActivity");
+		Assert.Equal ("com/example/dotformat/DotActivity", peer.JavaName);
+		Assert.Equal ("com/example/dotformat/DotActivity", peer.CompatJniName);
+		Assert.False (peer.DoNotGenerateAcw);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -77,10 +77,14 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 	[Fact]
 	public void Scan_RegisterAttribute_DotFormat_NormalizedToSlashes ()
 	{
-		// [Register ("com.example.dotformat.DotActivity")] uses dots — scanner should normalize to slashes
-		var peer = FindFixtureByJavaName ("com/example/dotformat/DotActivity");
-		Assert.Equal ("com/example/dotformat/DotActivity", peer.JavaName);
-		Assert.Equal ("com/example/dotformat/DotActivity", peer.CompatJniName);
+		// [Register ("com.example.dotformat.MainActivity")] uses dots (Java class name format)
+		// — the scanner must normalize to slashes (JNI format).
+		// Reproduces the crash from Tests/Xamarin.ProjectTools/Resources/DotNet/MainActivity.cs
+		// where the template expands to [Register ("${JAVA_PACKAGENAME}.MainActivity"), Activity (...)].
+		var peer = FindFixtureByJavaName ("com/example/dotformat/MainActivity");
+		Assert.Equal ("com/example/dotformat/MainActivity", peer.JavaName);
+		Assert.Equal ("com/example/dotformat/MainActivity", peer.CompatJniName);
 		Assert.False (peer.DoNotGenerateAcw);
+		Assert.True (peer.IsUnconditional, "Should be unconditional due to [Activity]");
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -363,3 +363,10 @@ public class GlobalType : Java.Lang.Object
 	protected GlobalType (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
 }
 public class GlobalUnregisteredType : Java.Lang.Object { }
+
+// Type with dot-format [Register] name (matches Android app project template pattern)
+[Register ("com.example.dotformat.DotActivity")]
+public class DotFormatActivity : Android.App.Activity
+{
+	protected DotFormatActivity (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -364,8 +364,10 @@ public class GlobalType : Java.Lang.Object
 }
 public class GlobalUnregisteredType : Java.Lang.Object { }
 
-// Type with dot-format [Register] name (matches Android app project template pattern)
-[Register ("com.example.dotformat.DotActivity")]
+// Matches the Android app project template pattern from
+// Tests/Xamarin.ProjectTools/Resources/DotNet/MainActivity.cs:
+//   [Register ("${JAVA_PACKAGENAME}.MainActivity"), Activity (Label = "...", MainLauncher = true, Icon = "@drawable/icon")]
+[Register ("com.example.dotformat.MainActivity"), Activity (Label = "DotFormat", MainLauncher = true)]
 public class DotFormatActivity : Android.App.Activity
 {
 	protected DotFormatActivity (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }


### PR DESCRIPTION
Fixes #10946
Part of #10800

## Summary

The `[Register]` attribute on types in Android app project templates uses Java class name format with dots (e.g., `com.xamarin.myapp.MainActivity`) but the JCW generator expects JNI format with slashes (`com/xamarin/myapp/MainActivity`). This caused `JcwJavaSourceGenerator.GetOutputFilePath` to throw `ArgumentException` when building apps with `_AndroidTypeMapImplementation=trimmable`.

## Fix

Normalize dots to slashes in `AssemblyIndex.ParseRegisterInfo()` when reading the `[Register]` attribute's JNI name. This matches how component attribute `Name` properties are already normalized in the same file (lines 102, 113).

**One-line change:** `JniName = jniName` → `JniName = jniName.Replace ('.', '/')`

## Test

Added a test fixture type `DotFormatActivity` with `[Register ("com.example.dotformat.DotActivity")]` and a test that verifies the scanner normalizes it to `com/example/dotformat/DotActivity`.