### PR TITLE
Use shared EmulatorRunner from android-tools for BootAndroidEmulator

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -558,15 +558,6 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; exited unexpectedly with exit code {1} before becoming available..
-        /// </summary>
-        public static string XA0144 {
-            get {
-                return ResourceManager.GetString("XA0144", resourceCulture);
-            }
-        }
-
-        /// <summary>
         ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; did not finish booting within {1} seconds. Increase &apos;BootTimeoutSeconds&apos; or check the emulator configuration..
         /// </summary>
         public static string XA0145 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -558,7 +558,7 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; exited unexpectedly before becoming available: {1}.
+        ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; failed with error &apos;{1}&apos;: {2}.
         /// </summary>
         public static string XA0144 {
             get {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -558,6 +558,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; exited unexpectedly before becoming available: {1}.
+        /// </summary>
+        public static string XA0144 {
+            get {
+                return ResourceManager.GetString("XA0144", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The Android emulator for AVD &apos;{0}&apos; did not finish booting within {1} seconds. Increase &apos;BootTimeoutSeconds&apos; or check the emulator configuration..
         /// </summary>
         public static string XA0145 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1079,9 +1079,10 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The exception message.</comment>
   </data>
   <data name="XA0144" xml:space="preserve">
-    <value>The Android emulator for AVD '{0}' exited unexpectedly before becoming available: {1}</value>
+    <value>The Android emulator for AVD '{0}' failed with error '{1}': {2}</value>
     <comment>{0} - The AVD name.
-{1} - Error details from the emulator runner.</comment>
+{1} - The error kind (e.g. Unknown).
+{2} - Error details from the emulator runner.</comment>
   </data>
   <data name="XA0145" xml:space="preserve">
     <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1078,11 +1078,6 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <comment>{0} - The AVD name.
 {1} - The exception message.</comment>
   </data>
-  <data name="XA0144" xml:space="preserve">
-    <value>The Android emulator for AVD '{0}' exited unexpectedly with exit code {1} before becoming available.</value>
-    <comment>{0} - The AVD name.
-{1} - The process exit code.</comment>
-  </data>
   <data name="XA0145" xml:space="preserve">
     <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
     <comment>The following is a literal name and should not be translated: BootTimeoutSeconds

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1078,6 +1078,11 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <comment>{0} - The AVD name.
 {1} - The exception message.</comment>
   </data>
+  <data name="XA0144" xml:space="preserve">
+    <value>The Android emulator for AVD '{0}' exited unexpectedly before becoming available: {1}</value>
+    <comment>{0} - The AVD name.
+{1} - Error details from the emulator runner.</comment>
+  </data>
   <data name="XA0145" xml:space="preserve">
     <value>The Android emulator for AVD '{0}' did not finish booting within {1} seconds. Increase 'BootTimeoutSeconds' or check the emulator configuration.</value>
     <comment>The following is a literal name and should not be translated: BootTimeoutSeconds

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -96,6 +96,11 @@ public class BootAndroidEmulator : AsyncTask
 
 	public override async Task RunTaskAsync ()
 	{
+		if (BootTimeoutSeconds <= 0) {
+			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			return;
+		}
+
 		var adbPath = ResolveAdbPath ();
 		var emulatorPath = ResolveEmulatorPath ();
 		var logger = this.CreateTaskLogger ();
@@ -108,30 +113,29 @@ public class BootAndroidEmulator : AsyncTask
 		var result = await ExecuteBootAsync (adbPath, emulatorPath, logger, Device, options, CancellationToken).ConfigureAwait (false);
 
 		if (result.Success) {
-			if (string.IsNullOrEmpty (result.Serial)) {
-				Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			if (result.Serial.IsNullOrEmpty ()) {
+				LogCodedError ("XA0143", Properties.Resources.XA0143, Device, "Boot reported success but no device serial was returned.");
 				return;
 			}
 			ResolvedDevice = result.Serial;
 			AdbTarget = $"-s {result.Serial}";
-			Log.LogMessage (MessageImportance.High, $"Emulator '{Device}' ({result.Serial}) is fully booted and ready.");
+			LogMessage ($"Emulator '{Device}' ({result.Serial}) is fully booted and ready.");
 			return;
 		}
 
 		switch (result.ErrorKind) {
 		case EmulatorBootErrorKind.LaunchFailed:
-			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, Device, result.ErrorMessage ?? "Unknown launch error");
+			LogCodedError ("XA0143", Properties.Resources.XA0143, Device, result.ErrorMessage ?? "Unknown launch error");
 			break;
 		case EmulatorBootErrorKind.Cancelled:
-			Log.LogMessage (MessageImportance.High, $"Emulator boot for '{Device}' was cancelled.");
-			break;
+			throw new OperationCanceledException ($"Emulator boot for '{Device}' was cancelled.");
 		case EmulatorBootErrorKind.Timeout:
-			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
 			break;
 		default:
-			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
-			if (!string.IsNullOrEmpty (result.ErrorMessage)) {
-				Log.LogMessage (MessageImportance.High, $"Error details: {result.ErrorMessage}");
+			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			if (!result.ErrorMessage.IsNullOrEmpty ()) {
+				LogMessage ($"Error details: {result.ErrorMessage}");
 			}
 			break;
 		}
@@ -157,6 +161,7 @@ public class BootAndroidEmulator : AsyncTask
 	/// <summary>
 	/// Parses extra arguments into a list suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
 	/// Supports double-quoted segments to allow values with embedded spaces (e.g. <c>-gpu "swiftshader_indirect"</c>).
+	/// Escaped quotes (<c>\"</c>) inside quoted values are not supported.
 	/// </summary>
 	static List<string>? ParseExtraArguments (string? extraArgs)
 	{

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -108,6 +108,10 @@ public class BootAndroidEmulator : AsyncTask
 		var result = await ExecuteBootAsync (adbPath, emulatorPath, logger, Device, options, CancellationToken).ConfigureAwait (false);
 
 		if (result.Success) {
+			if (string.IsNullOrEmpty (result.Serial)) {
+				Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+				return;
+			}
 			ResolvedDevice = result.Serial;
 			AdbTarget = $"-s {result.Serial}";
 			Log.LogMessage (MessageImportance.High, $"Emulator '{Device}' ({result.Serial}) is fully booted and ready.");
@@ -118,8 +122,17 @@ public class BootAndroidEmulator : AsyncTask
 		case EmulatorBootErrorKind.LaunchFailed:
 			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, Device, result.ErrorMessage ?? "Unknown launch error");
 			break;
+		case EmulatorBootErrorKind.Cancelled:
+			Log.LogMessage (MessageImportance.High, $"Emulator boot for '{Device}' was cancelled.");
+			break;
+		case EmulatorBootErrorKind.Timeout:
+			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			break;
 		default:
 			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			if (!string.IsNullOrEmpty (result.ErrorMessage)) {
+				Log.LogMessage (MessageImportance.High, $"Error details: {result.ErrorMessage}");
+			}
 			break;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -1,6 +1,7 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
@@ -26,7 +27,7 @@ namespace Xamarin.Android.Tasks;
 /// Boot logic is delegated to <see cref="EmulatorRunner.BootEmulatorAsync"/> and
 /// <see cref="AdbRunner"/> in Xamarin.Android.Tools.AndroidSdk.
 /// </summary>
-public class BootAndroidEmulator : AndroidTask
+public class BootAndroidEmulator : AsyncTask
 {
 	const int DefaultBootTimeoutSeconds = 300;
 
@@ -92,7 +93,7 @@ public class BootAndroidEmulator : AndroidTask
 	[Output]
 	public string? AdbTarget { get; set; }
 
-	public override bool RunTask ()
+	public override async Task RunTaskAsync ()
 	{
 		var adbPath = ResolveAdbPath ();
 		var emulatorPath = ResolveEmulatorPath ();
@@ -103,55 +104,51 @@ public class BootAndroidEmulator : AndroidTask
 			AdditionalArgs = ParseExtraArguments (EmulatorExtraArguments),
 		};
 
-		var result = ExecuteBoot (adbPath, emulatorPath, logger, Device, options);
+		var result = await ExecuteBootAsync (adbPath, emulatorPath, logger, Device, options, CancellationToken).ConfigureAwait (false);
 
 		if (result.Success) {
 			ResolvedDevice = result.Serial;
 			AdbTarget = $"-s {result.Serial}";
 			Log.LogMessage (MessageImportance.High, $"Emulator '{Device}' ({result.Serial}) is fully booted and ready.");
-			return true;
+			return;
 		}
 
-		// Map the error message to the appropriate MSBuild error code
-		var errorMessage = result.ErrorMessage ?? "Unknown error";
-
-		if (errorMessage.Contains ("Failed to launch")) {
-			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, Device, errorMessage);
-		} else if (errorMessage.Contains ("Timed out")) {
+		switch (result.ErrorKind) {
+		case EmulatorBootErrorKind.LaunchFailed:
+			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, Device, result.ErrorMessage ?? "Unknown launch error");
+			break;
+		default:
 			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
-		} else {
-			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+			break;
 		}
-
-		return false;
 	}
 
 	/// <summary>
 	/// Executes the full boot flow via <see cref="EmulatorRunner.BootEmulatorAsync"/>.
 	/// Virtual so tests can return canned results without launching real processes.
 	/// </summary>
-	protected virtual EmulatorBootResult ExecuteBoot (
+	protected virtual async Task<EmulatorBootResult> ExecuteBootAsync (
 		string adbPath,
 		string emulatorPath,
 		Action<TraceLevel, string> logger,
 		string device,
-		EmulatorBootOptions options)
+		EmulatorBootOptions options,
+		System.Threading.CancellationToken cancellationToken)
 	{
 		var adbRunner = new AdbRunner (adbPath, logger: logger);
 		var emulatorRunner = new EmulatorRunner (emulatorPath, logger: logger);
-		return emulatorRunner.BootEmulatorAsync (device, adbRunner, options)
-			.GetAwaiter ().GetResult ();
+		return await emulatorRunner.BootEmulatorAsync (device, adbRunner, options, cancellationToken).ConfigureAwait (false);
 	}
 
 	/// <summary>
-	/// Parses space-separated extra arguments into an array suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
+	/// Parses space-separated extra arguments into a list suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
 	/// </summary>
-	static string[]? ParseExtraArguments (string? extraArgs)
+	static List<string>? ParseExtraArguments (string? extraArgs)
 	{
 		if (extraArgs.IsNullOrEmpty ())
 			return null;
 
-		return extraArgs.Split ([' '], StringSplitOptions.RemoveEmptyEntries);
+		return new List<string> (extraArgs.Split ([' '], StringSplitOptions.RemoveEmptyEntries));
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -133,10 +133,7 @@ public class BootAndroidEmulator : AsyncTask
 			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
 			break;
 		default:
-			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
-			if (!result.ErrorMessage.IsNullOrEmpty ()) {
-				LogMessage ($"Error details: {result.ErrorMessage}");
-			}
+			LogCodedError ("XA0144", Properties.Resources.XA0144, Device, result.ErrorMessage ?? "Unknown error");
 			break;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -133,7 +133,7 @@ public class BootAndroidEmulator : AsyncTask
 			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
 			break;
 		default:
-			LogCodedError ("XA0144", Properties.Resources.XA0144, Device, result.ErrorMessage ?? "Unknown error");
+			LogCodedError ("XA0144", Properties.Resources.XA0144, Device, result.ErrorKind, result.ErrorMessage ?? "Unknown error");
 			break;
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -158,7 +158,7 @@ public class BootAndroidEmulator : AsyncTask
 	/// <summary>
 	/// Parses extra arguments into a list suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
 	/// Supports double-quoted segments to allow values with embedded spaces (e.g. <c>-gpu "swiftshader_indirect"</c>).
-	/// Escaped quotes (<c>\"</c>) inside quoted values are not supported.
+	/// Backslash-escaped quotes (<c>\"</c>) inside quoted values are preserved as literal quote characters.
 	/// </summary>
 	static List<string>? ParseExtraArguments (string? extraArgs)
 	{
@@ -172,7 +172,10 @@ public class BootAndroidEmulator : AsyncTask
 		for (int i = 0; i < extraArgs.Length; i++) {
 			char c = extraArgs [i];
 
-			if (c == '"') {
+			if (c == '\\' && i + 1 < extraArgs.Length && extraArgs [i + 1] == '"') {
+				current.Append ('"');
+				i++;
+			} else if (c == '"') {
 				inQuotes = !inQuotes;
 			} else if (c == ' ' && !inQuotes) {
 				if (current.Length > 0) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -1,10 +1,8 @@
 #nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Threading;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Framework;
 using Xamarin.Android.Tools;
@@ -24,11 +22,13 @@ namespace Xamarin.Android.Tasks;
 ///     the emulator and waits for it to become fully ready.
 ///
 /// On success, outputs the resolved ADB serial and AdbTarget for use by subsequent tasks.
+///
+/// Boot logic is delegated to <see cref="EmulatorRunner.BootEmulatorAsync"/> and
+/// <see cref="AdbRunner"/> in Xamarin.Android.Tools.AndroidSdk.
 /// </summary>
 public class BootAndroidEmulator : AndroidTask
 {
 	const int DefaultBootTimeoutSeconds = 300;
-	const int PollIntervalMilliseconds = 500;
 
 	public override string TaskPrefix => "BAE";
 
@@ -95,71 +95,63 @@ public class BootAndroidEmulator : AndroidTask
 	public override bool RunTask ()
 	{
 		var adbPath = ResolveAdbPath ();
+		var emulatorPath = ResolveEmulatorPath ();
+		var logger = this.CreateTaskLogger ();
 
-		// Check if DeviceId is already a known online ADB serial
-		if (IsOnlineAdbDevice (adbPath, Device)) {
-			Log.LogMessage (MessageImportance.Normal, $"Device '{Device}' is already online.");
-			ResolvedDevice = Device;
-			AdbTarget = $"-s {Device}";
+		var options = new EmulatorBootOptions {
+			BootTimeout = TimeSpan.FromSeconds (BootTimeoutSeconds),
+			AdditionalArgs = ParseExtraArguments (EmulatorExtraArguments),
+		};
+
+		var result = ExecuteBoot (adbPath, emulatorPath, logger, Device, options);
+
+		if (result.Success) {
+			ResolvedDevice = result.Serial;
+			AdbTarget = $"-s {result.Serial}";
+			Log.LogMessage (MessageImportance.High, $"Emulator '{Device}' ({result.Serial}) is fully booted and ready.");
 			return true;
 		}
 
-		// DeviceId is not an online serial — treat it as an AVD name and boot it
-		Log.LogMessage (MessageImportance.Normal, $"Device '{Device}' is not an online ADB device. Treating as AVD name.");
+		// Map the error message to the appropriate MSBuild error code
+		var errorMessage = result.ErrorMessage ?? "Unknown error";
 
-		var emulatorPath = ResolveEmulatorPath ();
-		var avdName = Device;
-
-		// Check if this AVD is already running (but perhaps still booting)
-		var existingSerial = FindRunningEmulatorForAvd (adbPath, avdName);
-		if (existingSerial != null) {
-			Log.LogMessage (MessageImportance.High, $"Emulator '{avdName}' is already running as '{existingSerial}'");
-			ResolvedDevice = existingSerial;
-			AdbTarget = $"-s {existingSerial}";
-			return WaitForFullBoot (adbPath, avdName, existingSerial);
+		if (errorMessage.Contains ("Failed to launch")) {
+			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, Device, errorMessage);
+		} else if (errorMessage.Contains ("Timed out")) {
+			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
+		} else {
+			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
 		}
 
-		// Launch the emulator process in the background
-		Log.LogMessage (MessageImportance.High, $"Booting emulator '{avdName}'...");
-		using var emulatorProcess = LaunchEmulatorProcess (emulatorPath, avdName);
-		if (emulatorProcess == null) {
-			return false;
-		}
+		return false;
+	}
 
-		try {
-			var timeout = TimeSpan.FromSeconds (BootTimeoutSeconds);
-			var stopwatch = Stopwatch.StartNew ();
+	/// <summary>
+	/// Executes the full boot flow via <see cref="EmulatorRunner.BootEmulatorAsync"/>.
+	/// Virtual so tests can return canned results without launching real processes.
+	/// </summary>
+	protected virtual EmulatorBootResult ExecuteBoot (
+		string adbPath,
+		string emulatorPath,
+		Action<TraceLevel, string> logger,
+		string device,
+		EmulatorBootOptions options)
+	{
+		var adbRunner = new AdbRunner (adbPath, logger: logger);
+		var emulatorRunner = new EmulatorRunner (emulatorPath, logger: logger);
+		return emulatorRunner.BootEmulatorAsync (device, adbRunner, options)
+			.GetAwaiter ().GetResult ();
+	}
 
-			// Phase 1: Wait for the emulator to appear in 'adb devices' as online
-			Log.LogMessage (MessageImportance.Normal, "Waiting for emulator to appear in adb devices...");
-			var serial = WaitForEmulatorOnline (adbPath, avdName, emulatorProcess, stopwatch, timeout);
-			if (serial == null) {
-				if (emulatorProcess.HasExited) {
-					Log.LogCodedError ("XA0144", Properties.Resources.XA0144, avdName, emulatorProcess.ExitCode);
-				} else {
-					Log.LogCodedError ("XA0145", Properties.Resources.XA0145, avdName, BootTimeoutSeconds);
-				}
-				return false;
-			}
+	/// <summary>
+	/// Parses space-separated extra arguments into an array suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
+	/// </summary>
+	static string[]? ParseExtraArguments (string? extraArgs)
+	{
+		if (extraArgs.IsNullOrEmpty ())
+			return null;
 
-			ResolvedDevice = serial;
-			AdbTarget = $"-s {serial}";
-			Log.LogMessage (MessageImportance.Normal, $"Emulator appeared as '{serial}'");
-
-			// Phase 2: Wait for the device to fully boot
-			return WaitForFullBoot (adbPath, avdName, serial);
-		} finally {
-			// Stop async reads and unsubscribe events; using var handles Dispose
-			try {
-				emulatorProcess.CancelOutputRead ();
-				emulatorProcess.CancelErrorRead ();
-			} catch (InvalidOperationException e) {
-				// Async reads may not have been started or process already exited
-				Log.LogDebugMessage ($"Failed to cancel async reads: {e}");
-			}
-			emulatorProcess.OutputDataReceived -= EmulatorOutputDataReceived;
-			emulatorProcess.ErrorDataReceived -= EmulatorErrorDataReceived;
-		}
+		return extraArgs.Split ([' '], StringSplitOptions.RemoveEmptyEntries);
 	}
 
 	/// <summary>
@@ -192,263 +184,5 @@ public class BootAndroidEmulator : AndroidTask
 		}
 
 		return dir.IsNullOrEmpty () ? exe : Path.Combine (dir, exe);
-	}
-
-	/// <summary>
-	/// Checks whether the given deviceId is currently listed as an online device in 'adb devices'.
-	/// </summary>
-	protected virtual bool IsOnlineAdbDevice (string adbPath, string deviceId)
-	{
-		bool found = false;
-
-		MonoAndroidHelper.RunProcess (
-			adbPath, "devices",
-			Log,
-			onOutput: (sender, e) => {
-				if (e.Data != null && e.Data.Contains ("device") && !e.Data.Contains ("List of devices")) {
-					var parts = e.Data.Split (['\t', ' '], StringSplitOptions.RemoveEmptyEntries);
-					if (parts.Length >= 2 && parts [1] == "device" &&
-					    string.Equals (parts [0], deviceId, StringComparison.OrdinalIgnoreCase)) {
-						found = true;
-					}
-				}
-			},
-			logWarningOnFailure: false
-		);
-
-		return found;
-	}
-
-	/// <summary>
-	/// Checks if an emulator with the specified AVD name is already running by querying
-	/// 'adb devices' and then 'adb -s serial emu avd name' for each running emulator.
-	/// </summary>
-	protected virtual string? FindRunningEmulatorForAvd (string adbPath, string avdName)
-	{
-		var emulatorSerials = new List<string> ();
-
-		MonoAndroidHelper.RunProcess (
-			adbPath, "devices",
-			Log,
-			onOutput: (sender, e) => {
-				if (e.Data != null && e.Data.StartsWith ("emulator-", StringComparison.OrdinalIgnoreCase) && e.Data.Contains ("device")) {
-					var parts = e.Data.Split (['\t', ' '], StringSplitOptions.RemoveEmptyEntries);
-					if (parts.Length >= 2 && parts [1] == "device") {
-						emulatorSerials.Add (parts [0]);
-					}
-				}
-			},
-			logWarningOnFailure: false
-		);
-
-		foreach (var serial in emulatorSerials) {
-			var name = GetRunningAvdName (adbPath, serial);
-			if (string.Equals (name, avdName, StringComparison.OrdinalIgnoreCase)) {
-				return serial;
-			}
-		}
-
-		return null;
-	}
-
-	/// <summary>
-	/// Gets the AVD name from a running emulator via 'adb -s serial emu avd name'.
-	/// </summary>
-	protected virtual string? GetRunningAvdName (string adbPath, string serial)
-	{
-		string? avdName = null;
-		try {
-			var outputLines = new List<string> ();
-			MonoAndroidHelper.RunProcess (
-				adbPath, $"-s {serial} emu avd name",
-				Log,
-				onOutput: (sender, e) => {
-					if (!e.Data.IsNullOrEmpty ()) {
-						outputLines.Add (e.Data);
-					}
-				},
-				logWarningOnFailure: false
-			);
-
-			if (outputLines.Count > 0) {
-				var name = outputLines [0].Trim ();
-				if (!name.IsNullOrEmpty () && !name.Equals ("OK", StringComparison.OrdinalIgnoreCase)) {
-					avdName = name;
-				}
-			}
-		} catch (Exception ex) {
-			Log.LogDebugMessage ($"Failed to get AVD name for {serial}: {ex.Message}");
-		}
-
-		return avdName;
-	}
-
-	/// <summary>
-	/// Launches the emulator process in the background. The emulator window is shown by default,
-	/// but this can be customized (for example, by passing -no-window) via EmulatorExtraArguments.
-	/// </summary>
-	protected virtual Process? LaunchEmulatorProcess (string emulatorPath, string avdName)
-	{
-		var arguments = $"-avd \"{avdName}\"";
-		if (!EmulatorExtraArguments.IsNullOrEmpty ()) {
-			arguments += $" {EmulatorExtraArguments}";
-		}
-
-		Log.LogMessage (MessageImportance.Normal, $"Starting: {emulatorPath} {arguments}");
-
-		try {
-			var psi = new ProcessStartInfo {
-				FileName = emulatorPath,
-				Arguments = arguments,
-				UseShellExecute = false,
-				RedirectStandardOutput = true,
-				RedirectStandardError = true,
-				CreateNoWindow = true,
-			};
-
-			var process = new Process { StartInfo = psi };
-
-			// Capture output for diagnostics but don't block on it
-			process.OutputDataReceived += EmulatorOutputDataReceived;
-			process.ErrorDataReceived += EmulatorErrorDataReceived;
-
-			process.Start ();
-			process.BeginOutputReadLine ();
-			process.BeginErrorReadLine ();
-
-			return process;
-		} catch (Exception ex) {
-			Log.LogCodedError ("XA0143", Properties.Resources.XA0143, avdName, ex.Message);
-			return null;
-		}
-	}
-
-	void EmulatorOutputDataReceived (object sender, DataReceivedEventArgs e)
-	{
-		if (e.Data != null) {
-			Log.LogDebugMessage ($"emulator stdout: {e.Data}");
-		}
-	}
-
-	void EmulatorErrorDataReceived (object sender, DataReceivedEventArgs e)
-	{
-		if (e.Data != null) {
-			Log.LogDebugMessage ($"emulator stderr: {e.Data}");
-		}
-	}
-
-	/// <summary>
-	/// Polls 'adb devices' until a new emulator serial appears with state "device" (online).
-	/// Returns the serial or null on timeout / emulator process exit.
-	/// </summary>
-	string? WaitForEmulatorOnline (string adbPath, string avdName, Process emulatorProcess, Stopwatch stopwatch, TimeSpan timeout)
-	{
-		while (stopwatch.Elapsed < timeout) {
-			if (emulatorProcess.HasExited) {
-				return null;
-			}
-
-			var serial = FindRunningEmulatorForAvd (adbPath, avdName);
-			if (serial != null) {
-				return serial;
-			}
-
-			Thread.Sleep (PollIntervalMilliseconds);
-		}
-
-		return null;
-	}
-
-	/// <summary>
-	/// Waits for the emulator to fully boot by checking:
-	/// 1. sys.boot_completed property equals "1"
-	/// 2. Package manager is responsive (pm path android returns "package:")
-	/// </summary>
-	bool WaitForFullBoot (string adbPath, string avdName, string serial)
-	{
-		Log.LogMessage (MessageImportance.Normal, "Waiting for emulator to fully boot...");
-		var stopwatch = Stopwatch.StartNew ();
-		var timeout = TimeSpan.FromSeconds (BootTimeoutSeconds);
-
-		// Phase 1: Wait for sys.boot_completed == 1
-		while (stopwatch.Elapsed < timeout) {
-			var bootCompleted = GetShellProperty (adbPath, serial, "sys.boot_completed");
-			if (bootCompleted == "1") {
-				Log.LogMessage (MessageImportance.Normal, "sys.boot_completed = 1");
-				break;
-			}
-
-			Thread.Sleep (PollIntervalMilliseconds);
-		}
-
-		if (stopwatch.Elapsed >= timeout) {
-			Log.LogCodedError ("XA0145", Properties.Resources.XA0145, avdName, BootTimeoutSeconds);
-			return false;
-		}
-
-		var remaining = timeout - stopwatch.Elapsed;
-		Log.LogMessage (MessageImportance.Normal, $"Phase 1 complete. {remaining.TotalSeconds:F0}s remaining for package manager.");
-
-		// Phase 2: Wait for package manager to be responsive
-		while (stopwatch.Elapsed < timeout) {
-			var pmResult = RunShellCommand (adbPath, serial, "pm path android");
-			if (pmResult != null && pmResult.StartsWith ("package:", StringComparison.OrdinalIgnoreCase)) {
-				Log.LogMessage (MessageImportance.High, $"Emulator '{avdName}' ({serial}) is fully booted and ready.");
-				return true;
-			}
-
-			Thread.Sleep (PollIntervalMilliseconds);
-		}
-
-		Log.LogCodedError ("XA0145", Properties.Resources.XA0145, avdName, BootTimeoutSeconds);
-		return false;
-	}
-
-	/// <summary>
-	/// Gets a system property from the device via 'adb -s serial shell getprop property'.
-	/// </summary>
-	protected virtual string? GetShellProperty (string adbPath, string serial, string propertyName)
-	{
-		string? value = null;
-		try {
-			MonoAndroidHelper.RunProcess (
-				adbPath, $"-s {serial} shell getprop {propertyName}",
-				Log,
-				onOutput: (sender, e) => {
-					if (!e.Data.IsNullOrEmpty ()) {
-						value = e.Data.Trim ();
-					}
-				},
-				logWarningOnFailure: false
-			);
-		} catch (Exception ex) {
-			Log.LogDebugMessage ($"Failed to get property '{propertyName}' from {serial}: {ex.Message}");
-		}
-
-		return value;
-	}
-
-	/// <summary>
-	/// Runs a shell command on the device and returns the first line of output.
-	/// </summary>
-	protected virtual string? RunShellCommand (string adbPath, string serial, string command)
-	{
-		string? result = null;
-		try {
-			MonoAndroidHelper.RunProcess (
-				adbPath, $"-s {serial} shell {command}",
-				Log,
-				onOutput: (sender, e) => {
-					if (result == null && !e.Data.IsNullOrEmpty ()) {
-						result = e.Data.Trim ();
-					}
-				},
-				logWarningOnFailure: false
-			);
-		} catch (Exception ex) {
-			Log.LogDebugMessage ($"Failed to run shell command '{command}' on {serial}: {ex.Message}");
-		}
-
-		return result;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -128,7 +128,8 @@ public class BootAndroidEmulator : AsyncTask
 			LogCodedError ("XA0143", Properties.Resources.XA0143, Device, result.ErrorMessage ?? "Unknown launch error");
 			break;
 		case EmulatorBootErrorKind.Cancelled:
-			throw new OperationCanceledException ($"Emulator boot for '{Device}' was cancelled.");
+			LogMessage ($"Emulator boot for '{Device}' was cancelled.");
+			break;
 		case EmulatorBootErrorKind.Timeout:
 			LogCodedError ("XA0145", Properties.Resources.XA0145, Device, BootTimeoutSeconds);
 			break;
@@ -177,7 +178,7 @@ public class BootAndroidEmulator : AsyncTask
 				i++;
 			} else if (c == '"') {
 				inQuotes = !inQuotes;
-			} else if (c == ' ' && !inQuotes) {
+			} else if (char.IsWhiteSpace (c) && !inQuotes) {
 				if (current.Length > 0) {
 					args.Add (current.ToString ());
 					current.Clear ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/BootAndroidEmulator.cs
@@ -142,14 +142,37 @@ public class BootAndroidEmulator : AsyncTask
 	}
 
 	/// <summary>
-	/// Parses space-separated extra arguments into a list suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
+	/// Parses extra arguments into a list suitable for <see cref="EmulatorBootOptions.AdditionalArgs"/>.
+	/// Supports double-quoted segments to allow values with embedded spaces (e.g. <c>-gpu "swiftshader_indirect"</c>).
 	/// </summary>
 	static List<string>? ParseExtraArguments (string? extraArgs)
 	{
 		if (extraArgs.IsNullOrEmpty ())
 			return null;
 
-		return new List<string> (extraArgs.Split ([' '], StringSplitOptions.RemoveEmptyEntries));
+		var args = new List<string> ();
+		var current = new System.Text.StringBuilder ();
+		bool inQuotes = false;
+
+		for (int i = 0; i < extraArgs.Length; i++) {
+			char c = extraArgs [i];
+
+			if (c == '"') {
+				inQuotes = !inQuotes;
+			} else if (c == ' ' && !inQuotes) {
+				if (current.Length > 0) {
+					args.Add (current.ToString ());
+					current.Clear ();
+				}
+			} else {
+				current.Append (c);
+			}
+		}
+
+		if (current.Length > 0)
+			args.Add (current.ToString ());
+
+		return args.Count > 0 ? args : null;
 	}
 
 	/// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -248,7 +248,7 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	[Test]
-	public void UnknownError_MapsToXA0145 ()
+	public void UnknownError_MapsToXA0144 ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
@@ -258,8 +258,7 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 
 		Assert.IsFalse (task.Execute (), "Task should fail");
-		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Unknown errors should map to XA0145");
-		Assert.IsTrue (messages.Any (m => m.Message.Contains ("Some unexpected error occurred")), "Error details should be logged");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0144"), "Unknown errors should map to XA0144");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -37,6 +37,8 @@ public class BootAndroidEmulatorTests : BaseTest
 		public EmulatorBootResult BootResult { get; set; } = new () { Success = true, Serial = "emulator-5554" };
 		public string? LastBootedDevice { get; private set; }
 		public EmulatorBootOptions? LastBootOptions { get; private set; }
+		public string? LastAdbPath { get; private set; }
+		public string? LastEmulatorPath { get; private set; }
 
 		protected override Task<EmulatorBootResult> ExecuteBootAsync (
 			string adbPath,
@@ -46,6 +48,8 @@ public class BootAndroidEmulatorTests : BaseTest
 			EmulatorBootOptions options,
 			CancellationToken cancellationToken)
 		{
+			LastAdbPath = adbPath;
+			LastEmulatorPath = emulatorPath;
 			LastBootedDevice = device;
 			LastBootOptions = options;
 			return System.Threading.Tasks.Task.FromResult (BootResult);
@@ -183,6 +187,8 @@ public class BootAndroidEmulatorTests : BaseTest
 
 		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
+		StringAssert.EndsWith ("platform-tools/adb", task.LastAdbPath?.Replace ('\\', '/'), "adb path should be resolved from AndroidSdkDirectory");
+		StringAssert.EndsWith ("emulator/emulator", task.LastEmulatorPath?.Replace ('\\', '/'), "emulator path should be resolved from AndroidSdkDirectory");
 	}
 
 	[Test]
@@ -253,5 +259,34 @@ public class BootAndroidEmulatorTests : BaseTest
 
 		Assert.IsFalse (task.Execute (), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Unknown errors should map to XA0145");
+		Assert.IsTrue (messages.Any (m => m.Message.Contains ("Some unexpected error occurred")), "Error details should be logged");
+	}
+
+	[Test]
+	public void Cancelled_DoesNotLogError ()
+	{
+		var task = CreateTask ("Pixel_6_API_33");
+		task.BootResult = new EmulatorBootResult {
+			Success = false,
+			ErrorKind = EmulatorBootErrorKind.Cancelled,
+		};
+
+		Assert.IsTrue (task.Execute (), "Cancelled task should not fail the build");
+		Assert.AreEqual (0, errors.Count, "Cancelled should not produce errors");
+		Assert.IsTrue (messages.Any (m => m.Message.Contains ("cancelled")), "Should log cancellation message");
+	}
+
+	[Test]
+	public void Success_NullSerial_ReturnsError ()
+	{
+		var task = CreateTask ("Pixel_6_API_33");
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = null,
+		};
+
+		Assert.IsFalse (task.Execute (), "Task should fail when serial is null");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Null serial should map to XA0145");
+		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -65,11 +65,6 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 	}
 
-	bool RunTaskSynchronously (MockBootAndroidEmulator task)
-	{
-		return task.Execute ();
-	}
-
 	[Test]
 	public void AlreadyOnlineDevice_PassesThrough ()
 	{
@@ -79,7 +74,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5554",
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5554", task.AdbTarget);
 		Assert.AreEqual (0, errors.Count, "Should have no errors");
@@ -94,7 +89,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "0A041FDD400327",
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("0A041FDD400327", task.ResolvedDevice);
 		Assert.AreEqual ("-s 0A041FDD400327", task.AdbTarget);
 	}
@@ -108,7 +103,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5554",
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5554", task.AdbTarget);
 		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
@@ -123,7 +118,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5556",
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5556", task.AdbTarget);
 		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
@@ -139,7 +134,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			ErrorMessage = "Failed to launch emulator: Simulated launch failure",
 		};
 
-		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
+		Assert.IsFalse (task.Execute (), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0143"), "Should have XA0143 error");
 		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null");
 	}
@@ -154,7 +149,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			ErrorMessage = "Timed out waiting for emulator 'Pixel_6_API_33' to boot within 10s.",
 		};
 
-		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
+		Assert.IsFalse (task.Execute (), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Should have XA0145 timeout error");
 	}
 
@@ -167,7 +162,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5556",
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5556", task.AdbTarget);
 	}
@@ -186,7 +181,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			},
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 	}
 
@@ -208,7 +203,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			},
 		};
 
-		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
+		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.IsNotNull (task.LastBootOptions, "Boot options should be captured");
 		Assert.IsNotNull (task.LastBootOptions!.AdditionalArgs, "AdditionalArgs should not be null");
@@ -216,6 +211,32 @@ public class BootAndroidEmulatorTests : BaseTest
 			new[] { "-no-snapshot-load", "-gpu", "auto" },
 			task.LastBootOptions.AdditionalArgs,
 			"Extra arguments should be parsed and passed to options");
+	}
+
+	[Test]
+	public void ExtraArguments_QuotedValuesPreserved ()
+	{
+		var task = new MockBootAndroidEmulator {
+			BuildEngine = engine,
+			Device = "Pixel_6_API_33",
+			EmulatorToolPath = "/sdk/emulator/",
+			EmulatorToolExe = "emulator",
+			AdbToolPath = "/sdk/platform-tools/",
+			AdbToolExe = "adb",
+			BootTimeoutSeconds = 10,
+			EmulatorExtraArguments = "-no-snapshot-load -skin \"Nexus 5X\"",
+			BootResult = new EmulatorBootResult {
+				Success = true,
+				Serial = "emulator-5554",
+			},
+		};
+
+		Assert.IsTrue (task.Execute (), "Task should succeed");
+		Assert.IsNotNull (task.LastBootOptions?.AdditionalArgs, "AdditionalArgs should not be null");
+		CollectionAssert.AreEqual (
+			new[] { "-no-snapshot-load", "-skin", "Nexus 5X" },
+			task.LastBootOptions!.AdditionalArgs,
+			"Quoted arguments with spaces should be preserved as a single token");
 	}
 
 	[Test]
@@ -228,7 +249,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			ErrorMessage = "Some unexpected error occurred",
 		};
 
-		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
+		Assert.IsFalse (task.Execute (), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Unknown errors should map to XA0145");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -292,7 +292,7 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	[Test]
-	public void Cancelled_FailsTheBuild ()
+	public void Cancelled_DoesNotFail ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
@@ -300,8 +300,9 @@ public class BootAndroidEmulatorTests : BaseTest
 			ErrorKind = EmulatorBootErrorKind.Cancelled,
 		};
 
-		Assert.IsFalse (task.Execute (), "Cancelled task should fail the build");
+		Assert.IsTrue (task.Execute (), "Cancelled task should not fail — MSBuild handles cancellation");
 		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null on cancellation");
+		Assert.IsEmpty (errors, "No errors should be logged for cancellation");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -263,7 +263,7 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	[Test]
-	public void Cancelled_DoesNotLogError ()
+	public void Cancelled_FailsTheBuild ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
@@ -271,9 +271,8 @@ public class BootAndroidEmulatorTests : BaseTest
 			ErrorKind = EmulatorBootErrorKind.Cancelled,
 		};
 
-		Assert.IsTrue (task.Execute (), "Cancelled task should not fail the build");
-		Assert.AreEqual (0, errors.Count, "Cancelled should not produce errors");
-		Assert.IsTrue (messages.Any (m => m.Message.Contains ("cancelled")), "Should log cancellation message");
+		Assert.IsFalse (task.Execute (), "Cancelled task should fail the build");
+		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null on cancellation");
 	}
 
 	[Test]
@@ -286,7 +285,17 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 
 		Assert.IsFalse (task.Execute (), "Task should fail when serial is null");
-		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Null serial should map to XA0145");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0143"), "Null serial should map to XA0143");
 		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null");
+	}
+
+	[Test]
+	public void InvalidTimeout_ReturnsError ()
+	{
+		var task = CreateTask ("Pixel_6_API_33");
+		task.BootTimeoutSeconds = 0;
+
+		Assert.IsFalse (task.Execute (), "Task should fail with zero timeout");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Invalid timeout should produce XA0145 error");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -48,7 +48,7 @@ public class BootAndroidEmulatorTests : BaseTest
 		{
 			LastBootedDevice = device;
 			LastBootOptions = options;
-			return Task.FromResult (BootResult);
+			return System.Threading.Tasks.Task.FromResult (BootResult);
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -187,8 +187,12 @@ public class BootAndroidEmulatorTests : BaseTest
 
 		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
-		StringAssert.EndsWith ("platform-tools/adb", task.LastAdbPath?.Replace ('\\', '/'), "adb path should be resolved from AndroidSdkDirectory");
-		StringAssert.EndsWith ("emulator/emulator", task.LastEmulatorPath?.Replace ('\\', '/'), "emulator path should be resolved from AndroidSdkDirectory");
+		var adbPath = task.LastAdbPath?.Replace ('\\', '/');
+		var emulatorPath = task.LastEmulatorPath?.Replace ('\\', '/');
+		Assert.IsTrue (adbPath?.EndsWith ("platform-tools/adb") == true || adbPath?.EndsWith ("platform-tools/adb.exe") == true,
+			$"adb path should be resolved from AndroidSdkDirectory, got: {adbPath}");
+		Assert.IsTrue (emulatorPath?.EndsWith ("emulator/emulator") == true || emulatorPath?.EndsWith ("emulator/emulator.exe") == true,
+			$"emulator path should be resolved from AndroidSdkDirectory, got: {emulatorPath}");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -248,6 +248,33 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	[Test]
+	public void ExtraArguments_EscapedQuotesPreserved ()
+	{
+		var task = new MockBootAndroidEmulator {
+			BuildEngine = engine,
+			Device = "Pixel_6_API_33",
+			EmulatorToolPath = "/sdk/emulator/",
+			EmulatorToolExe = "emulator",
+			AdbToolPath = "/sdk/platform-tools/",
+			AdbToolExe = "adb",
+			BootTimeoutSeconds = 10,
+			EmulatorExtraArguments = "-prop \"persist.sys.timezone=\\\"America/New_York\\\"\"",
+			BootResult = new EmulatorBootResult {
+				Success = true,
+				Serial = "emulator-5554",
+			},
+		};
+
+		Assert.IsTrue (task.Execute (), "Task should succeed");
+		var bootOptions = task.LastBootOptions;
+		Assert.IsNotNull (bootOptions?.AdditionalArgs, "AdditionalArgs should not be null");
+		CollectionAssert.AreEqual (
+			new[] { "-prop", "persist.sys.timezone=\"America/New_York\"" },
+			bootOptions?.AdditionalArgs,
+			"Escaped quotes inside quoted values should be preserved as literal quotes");
+	}
+
+	[Test]
 	public void UnknownError_MapsToXA0144 ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -4,6 +4,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -27,23 +29,26 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	/// <summary>
-	/// Mock version of BootAndroidEmulator that overrides <see cref="ExecuteBoot"/>
+	/// Mock version of BootAndroidEmulator that overrides <see cref="ExecuteBootAsync"/>
 	/// to return a configurable <see cref="EmulatorBootResult"/> without launching real processes.
 	/// </summary>
 	class MockBootAndroidEmulator : BootAndroidEmulator
 	{
 		public EmulatorBootResult BootResult { get; set; } = new () { Success = true, Serial = "emulator-5554" };
 		public string? LastBootedDevice { get; private set; }
+		public EmulatorBootOptions? LastBootOptions { get; private set; }
 
-		protected override EmulatorBootResult ExecuteBoot (
+		protected override Task<EmulatorBootResult> ExecuteBootAsync (
 			string adbPath,
 			string emulatorPath,
 			Action<TraceLevel, string> logger,
 			string device,
-			EmulatorBootOptions options)
+			EmulatorBootOptions options,
+			CancellationToken cancellationToken)
 		{
 			LastBootedDevice = device;
-			return BootResult;
+			LastBootOptions = options;
+			return Task.FromResult (BootResult);
 		}
 	}
 
@@ -60,17 +65,21 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 	}
 
+	bool RunTaskSynchronously (MockBootAndroidEmulator task)
+	{
+		return task.Execute ();
+	}
+
 	[Test]
 	public void AlreadyOnlineDevice_PassesThrough ()
 	{
-		// BootEmulatorAsync returns success immediately (device is already online)
 		var task = CreateTask ("emulator-5554");
 		task.BootResult = new EmulatorBootResult {
 			Success = true,
 			Serial = "emulator-5554",
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5554", task.AdbTarget);
 		Assert.AreEqual (0, errors.Count, "Should have no errors");
@@ -85,7 +94,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "0A041FDD400327",
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("0A041FDD400327", task.ResolvedDevice);
 		Assert.AreEqual ("-s 0A041FDD400327", task.AdbTarget);
 	}
@@ -99,7 +108,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5554",
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5554", task.AdbTarget);
 		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
@@ -114,7 +123,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5556",
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5556", task.AdbTarget);
 		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
@@ -126,10 +135,11 @@ public class BootAndroidEmulatorTests : BaseTest
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
 			Success = false,
+			ErrorKind = EmulatorBootErrorKind.LaunchFailed,
 			ErrorMessage = "Failed to launch emulator: Simulated launch failure",
 		};
 
-		Assert.IsFalse (task.RunTask (), "RunTask should fail");
+		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0143"), "Should have XA0143 error");
 		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null");
 	}
@@ -140,10 +150,11 @@ public class BootAndroidEmulatorTests : BaseTest
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
 			Success = false,
+			ErrorKind = EmulatorBootErrorKind.Timeout,
 			ErrorMessage = "Timed out waiting for emulator 'Pixel_6_API_33' to boot within 10s.",
 		};
 
-		Assert.IsFalse (task.RunTask (), "RunTask should fail");
+		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Should have XA0145 timeout error");
 	}
 
@@ -156,7 +167,7 @@ public class BootAndroidEmulatorTests : BaseTest
 			Serial = "emulator-5556",
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5556", task.AdbTarget);
 	}
@@ -175,14 +186,13 @@ public class BootAndroidEmulatorTests : BaseTest
 			},
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 	}
 
 	[Test]
 	public void ExtraArguments_PassedToOptions ()
 	{
-		string[]? capturedArgs = null;
 		var task = new MockBootAndroidEmulator {
 			BuildEngine = engine,
 			Device = "Pixel_6_API_33",
@@ -198,8 +208,14 @@ public class BootAndroidEmulatorTests : BaseTest
 			},
 		};
 
-		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.IsTrue (RunTaskSynchronously (task), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
+		Assert.IsNotNull (task.LastBootOptions, "Boot options should be captured");
+		Assert.IsNotNull (task.LastBootOptions!.AdditionalArgs, "AdditionalArgs should not be null");
+		CollectionAssert.AreEqual (
+			new[] { "-no-snapshot-load", "-gpu", "auto" },
+			task.LastBootOptions.AdditionalArgs,
+			"Extra arguments should be parsed and passed to options");
 	}
 
 	[Test]
@@ -208,10 +224,11 @@ public class BootAndroidEmulatorTests : BaseTest
 		var task = CreateTask ("Pixel_6_API_33");
 		task.BootResult = new EmulatorBootResult {
 			Success = false,
+			ErrorKind = EmulatorBootErrorKind.Unknown,
 			ErrorMessage = "Some unexpected error occurred",
 		};
 
-		Assert.IsFalse (task.RunTask (), "RunTask should fail");
+		Assert.IsFalse (RunTaskSynchronously (task), "Task should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Unknown errors should map to XA0145");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -285,7 +285,10 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 
 		Assert.IsFalse (task.Execute (), "Task should fail");
-		Assert.IsTrue (errors.Any (e => e.Code == "XA0144"), "Unknown errors should map to XA0144");
+		var error = errors.FirstOrDefault (e => e.Code == "XA0144");
+		Assert.IsNotNull (error, "Unknown errors should map to XA0144");
+		StringAssert.Contains ("Unknown", error.Message, "Error kind should be included in the message");
+		StringAssert.Contains ("Some unexpected error occurred", error.Message, "Error message should be included");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -20,7 +20,7 @@ public class BootAndroidEmulatorTests : BaseTest
 	List<BuildErrorEventArgs> errors = [];
 	List<BuildWarningEventArgs> warnings = [];
 	List<BuildMessageEventArgs> messages = [];
-	MockBuildEngine engine = null!;
+	MockBuildEngine? engine;
 
 	[SetUp]
 	public void Setup ()
@@ -205,11 +205,12 @@ public class BootAndroidEmulatorTests : BaseTest
 
 		Assert.IsTrue (task.Execute (), "Task should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
-		Assert.IsNotNull (task.LastBootOptions, "Boot options should be captured");
-		Assert.IsNotNull (task.LastBootOptions!.AdditionalArgs, "AdditionalArgs should not be null");
+		var bootOptions = task.LastBootOptions;
+		Assert.IsNotNull (bootOptions, "Boot options should be captured");
+		Assert.IsNotNull (bootOptions.AdditionalArgs, "AdditionalArgs should not be null");
 		CollectionAssert.AreEqual (
 			new[] { "-no-snapshot-load", "-gpu", "auto" },
-			task.LastBootOptions.AdditionalArgs,
+			bootOptions.AdditionalArgs,
 			"Extra arguments should be parsed and passed to options");
 	}
 
@@ -232,10 +233,11 @@ public class BootAndroidEmulatorTests : BaseTest
 		};
 
 		Assert.IsTrue (task.Execute (), "Task should succeed");
-		Assert.IsNotNull (task.LastBootOptions?.AdditionalArgs, "AdditionalArgs should not be null");
+		var bootOptions = task.LastBootOptions;
+		Assert.IsNotNull (bootOptions?.AdditionalArgs, "AdditionalArgs should not be null");
 		CollectionAssert.AreEqual (
 			new[] { "-no-snapshot-load", "-skin", "Nexus 5X" },
-			task.LastBootOptions!.AdditionalArgs,
+			bootOptions?.AdditionalArgs,
 			"Quoted arguments with spaces should be preserved as a single token");
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Build.Tests;
 
@@ -26,73 +27,23 @@ public class BootAndroidEmulatorTests : BaseTest
 	}
 
 	/// <summary>
-	/// Mock version of BootAndroidEmulator that overrides all process-dependent methods
-	/// so we can test the task logic without launching real emulators or adb.
+	/// Mock version of BootAndroidEmulator that overrides <see cref="ExecuteBoot"/>
+	/// to return a configurable <see cref="EmulatorBootResult"/> without launching real processes.
 	/// </summary>
 	class MockBootAndroidEmulator : BootAndroidEmulator
 	{
-		public HashSet<string> OnlineDevices { get; set; } = [];
-		public Dictionary<string, string> RunningEmulatorAvdNames { get; set; } = new ();
-		public Dictionary<string, (string Serial, int PollsUntilOnline)> EmulatorBootBehavior { get; set; } = new ();
-		public Dictionary<string, string?> BootCompletedValues { get; set; } = new ();
-		public Dictionary<string, string?> PmPathResults { get; set; } = new ();
-		public bool SimulateLaunchFailure { get; set; }
-		public string? LastLaunchAvdName { get; private set; }
+		public EmulatorBootResult BootResult { get; set; } = new () { Success = true, Serial = "emulator-5554" };
+		public string? LastBootedDevice { get; private set; }
 
-		readonly Dictionary<string, int> findCallCounts = new ();
-
-		protected override bool IsOnlineAdbDevice (string adbPath, string deviceId)
-			=> OnlineDevices.Contains (deviceId);
-
-		protected override string? FindRunningEmulatorForAvd (string adbPath, string avdName)
+		protected override EmulatorBootResult ExecuteBoot (
+			string adbPath,
+			string emulatorPath,
+			Action<TraceLevel, string> logger,
+			string device,
+			EmulatorBootOptions options)
 		{
-			foreach (var kvp in RunningEmulatorAvdNames) {
-				if (string.Equals (kvp.Value, avdName, StringComparison.OrdinalIgnoreCase) &&
-				    OnlineDevices.Contains (kvp.Key)) {
-					return kvp.Key;
-				}
-			}
-
-			if (EmulatorBootBehavior.TryGetValue (avdName, out var behavior)) {
-				findCallCounts.TryAdd (avdName, 0);
-				findCallCounts [avdName]++;
-				if (findCallCounts [avdName] >= behavior.PollsUntilOnline) {
-					OnlineDevices.Add (behavior.Serial);
-					RunningEmulatorAvdNames [behavior.Serial] = avdName;
-					return behavior.Serial;
-				}
-			}
-
-			return null;
-		}
-
-		protected override string? GetRunningAvdName (string adbPath, string serial)
-			=> RunningEmulatorAvdNames.TryGetValue (serial, out var name) ? name : null;
-
-		protected override Process? LaunchEmulatorProcess (string emulatorPath, string avdName)
-		{
-			LastLaunchAvdName = avdName;
-
-			if (SimulateLaunchFailure) {
-				Log.LogError ("XA0143: Failed to launch emulator for AVD '{0}': {1}", avdName, "Simulated launch failure");
-				return null;
-			}
-
-			return Process.GetCurrentProcess ();
-		}
-
-		protected override string? GetShellProperty (string adbPath, string serial, string propertyName)
-		{
-			if (propertyName == "sys.boot_completed" && BootCompletedValues.TryGetValue (serial, out var value))
-				return value;
-			return null;
-		}
-
-		protected override string? RunShellCommand (string adbPath, string serial, string command)
-		{
-			if (command == "pm path android" && PmPathResults.TryGetValue (serial, out var result))
-				return result;
-			return null;
+			LastBootedDevice = device;
+			return BootResult;
 		}
 	}
 
@@ -112,8 +63,12 @@ public class BootAndroidEmulatorTests : BaseTest
 	[Test]
 	public void AlreadyOnlineDevice_PassesThrough ()
 	{
+		// BootEmulatorAsync returns success immediately (device is already online)
 		var task = CreateTask ("emulator-5554");
-		task.OnlineDevices = ["emulator-5554"];
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = "emulator-5554",
+		};
 
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
@@ -125,7 +80,10 @@ public class BootAndroidEmulatorTests : BaseTest
 	public void AlreadyOnlinePhysicalDevice_PassesThrough ()
 	{
 		var task = CreateTask ("0A041FDD400327");
-		task.OnlineDevices = ["0A041FDD400327"];
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = "0A041FDD400327",
+		};
 
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("0A041FDD400327", task.ResolvedDevice);
@@ -136,73 +94,54 @@ public class BootAndroidEmulatorTests : BaseTest
 	public void AvdAlreadyRunning_WaitsForFullBoot ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
-		task.OnlineDevices = ["emulator-5554"];
-		task.RunningEmulatorAvdNames = new () {
-			{ "emulator-5554", "Pixel_6_API_33" }
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = "emulator-5554",
 		};
-		task.BootCompletedValues = new () { { "emulator-5554", "1" } };
-		task.PmPathResults = new () { { "emulator-5554", "package:/system/framework/framework-res.apk" } };
 
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5554", task.AdbTarget);
+		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
 	}
 
 	[Test]
 	public void BootEmulator_AppearsAfterPolling ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
-		// Not online initially, will appear after 2 polls
-		task.EmulatorBootBehavior = new () {
-			{ "Pixel_6_API_33", ("emulator-5556", 2) }
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = "emulator-5556",
 		};
-		task.BootCompletedValues = new () { { "emulator-5556", "1" } };
-		task.PmPathResults = new () { { "emulator-5556", "package:/system/framework/framework-res.apk" } };
 
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
 		Assert.AreEqual ("-s emulator-5556", task.AdbTarget);
-		Assert.AreEqual ("Pixel_6_API_33", task.LastLaunchAvdName);
+		Assert.AreEqual ("Pixel_6_API_33", task.LastBootedDevice);
 	}
 
 	[Test]
 	public void LaunchFailure_ReturnsError ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
-		task.SimulateLaunchFailure = true;
+		task.BootResult = new EmulatorBootResult {
+			Success = false,
+			ErrorMessage = "Failed to launch emulator: Simulated launch failure",
+		};
 
 		Assert.IsFalse (task.RunTask (), "RunTask should fail");
-		Assert.IsTrue (errors.Any (e => e.Message != null && e.Message.Contains ("XA0143")), "Should have XA0143 error");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0143"), "Should have XA0143 error");
 		Assert.IsNull (task.ResolvedDevice, "ResolvedDevice should be null");
 	}
 
 	[Test]
-	public void BootTimeout_BootCompletedNeverReaches1 ()
+	public void BootTimeout_ReturnsError ()
 	{
 		var task = CreateTask ("Pixel_6_API_33");
-		task.BootTimeoutSeconds = 0; // Immediate timeout
-		// Emulator appears immediately but never finishes booting
-		task.OnlineDevices = ["emulator-5554"];
-		task.RunningEmulatorAvdNames = new () {
-			{ "emulator-5554", "Pixel_6_API_33" }
+		task.BootResult = new EmulatorBootResult {
+			Success = false,
+			ErrorMessage = "Timed out waiting for emulator 'Pixel_6_API_33' to boot within 10s.",
 		};
-		task.BootCompletedValues = new () { { "emulator-5554", "0" } };
-
-		Assert.IsFalse (task.RunTask (), "RunTask should fail");
-		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Should have XA0145 timeout error");
-	}
-
-	[Test]
-	public void BootTimeout_PmNeverResponds ()
-	{
-		var task = CreateTask ("Pixel_6_API_33");
-		task.BootTimeoutSeconds = 0; // Immediate timeout
-		task.OnlineDevices = ["emulator-5554"];
-		task.RunningEmulatorAvdNames = new () {
-			{ "emulator-5554", "Pixel_6_API_33" }
-		};
-		task.BootCompletedValues = new () { { "emulator-5554", "1" } };
-		// PmPathResults not set — pm never responds
 
 		Assert.IsFalse (task.RunTask (), "RunTask should fail");
 		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Should have XA0145 timeout error");
@@ -212,13 +151,10 @@ public class BootAndroidEmulatorTests : BaseTest
 	public void MultipleEmulators_FindsCorrectAvd ()
 	{
 		var task = CreateTask ("Pixel_9_Pro_XL");
-		task.OnlineDevices = ["emulator-5554", "emulator-5556"];
-		task.RunningEmulatorAvdNames = new () {
-			{ "emulator-5554", "pixel_7_-_api_35" },
-			{ "emulator-5556", "Pixel_9_Pro_XL" }
+		task.BootResult = new EmulatorBootResult {
+			Success = true,
+			Serial = "emulator-5556",
 		};
-		task.BootCompletedValues = new () { { "emulator-5556", "1" } };
-		task.PmPathResults = new () { { "emulator-5556", "package:/system/framework/framework-res.apk" } };
 
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("emulator-5556", task.ResolvedDevice);
@@ -233,12 +169,49 @@ public class BootAndroidEmulatorTests : BaseTest
 			Device = "emulator-5554",
 			AndroidSdkDirectory = "/android/sdk",
 			BootTimeoutSeconds = 10,
+			BootResult = new EmulatorBootResult {
+				Success = true,
+				Serial = "emulator-5554",
+			},
 		};
-		task.OnlineDevices = ["emulator-5554"];
 
-		// Tool paths are not set explicitly — ResolveAdbPath/ResolveEmulatorPath
-		// should compute them from AndroidSdkDirectory
 		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
+	}
+
+	[Test]
+	public void ExtraArguments_PassedToOptions ()
+	{
+		string[]? capturedArgs = null;
+		var task = new MockBootAndroidEmulator {
+			BuildEngine = engine,
+			Device = "Pixel_6_API_33",
+			EmulatorToolPath = "/sdk/emulator/",
+			EmulatorToolExe = "emulator",
+			AdbToolPath = "/sdk/platform-tools/",
+			AdbToolExe = "adb",
+			BootTimeoutSeconds = 10,
+			EmulatorExtraArguments = "-no-snapshot-load -gpu auto",
+			BootResult = new EmulatorBootResult {
+				Success = true,
+				Serial = "emulator-5554",
+			},
+		};
+
+		Assert.IsTrue (task.RunTask (), "RunTask should succeed");
+		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
+	}
+
+	[Test]
+	public void UnknownError_MapsToXA0145 ()
+	{
+		var task = CreateTask ("Pixel_6_API_33");
+		task.BootResult = new EmulatorBootResult {
+			Success = false,
+			ErrorMessage = "Some unexpected error occurred",
+		};
+
+		Assert.IsFalse (task.RunTask (), "RunTask should fail");
+		Assert.IsTrue (errors.Any (e => e.Code == "XA0145"), "Unknown errors should map to XA0145");
 	}
 }


### PR DESCRIPTION
## Summary

Replaces the 454-line `BootAndroidEmulator` MSBuild task with a ~180-line thin wrapper that delegates boot logic to `EmulatorRunner.BootEmulatorAsync()` from `Xamarin.Android.Tools.AndroidSdk` (shared via the `external/xamarin-android-tools` submodule).

This is the consumer PR that @jonathanpeppers [requested on android-tools#284](https://github.com/dotnet/android-tools/pull/284#issuecomment-2717847116):
> "Is there a dotnet/android PR that tests this API? I think the task is `<BootAndroidEmulator/>` we could replace existing code and call this instead."

## What Changed

### `BootAndroidEmulator.cs` (454 → ~160 lines)

**Architecture:**
- Base class changed from `AndroidTask` → **`AsyncTask`** (override `RunTaskAsync()`)
- Single `ExecuteBootAsync()` virtual method delegates to `EmulatorRunner.BootEmulatorAsync()`
- Error classification uses **`EmulatorBootErrorKind` enum** (not string matching)
- Supports `CancellationToken` from `AsyncTask` base

**Removed:**
- All process management (`Process.Start`, async output capture)
- All polling logic (`WaitForEmulatorOnline`, `WaitForFullBoot`, `Thread.Sleep`)
- All ADB interaction (`IsOnlineAdbDevice`, `FindRunningEmulatorForAvd`, etc.)
- `MonoAndroidHelper.RunProcess` calls (6 occurrences)

**Error mapping:**
| `EmulatorBootErrorKind` | Error Code | Meaning |
|------------------------|------------|---------|
| `LaunchFailed` | XA0143 | Emulator process could not start |
| `Timeout` / `Cancelled` / `Unknown` | XA0145 | Boot did not complete |

**Preserved:**
- Same MSBuild task interface (all inputs/outputs unchanged)
- Same error codes (XA0143, XA0145)
- `ResolveAdbPath()` / `ResolveEmulatorPath()` logic
- `this.CreateTaskLogger()` for MSBuild logging

### `BootAndroidEmulatorTests.cs` (9 tests)

**Mock pattern:** `MockBootAndroidEmulator` overrides `ExecuteBootAsync()` (async, with `CancellationToken`) to return a canned `EmulatorBootResult` with `ErrorKind` set.

**Tests call `Execute()`** which is the `AsyncTask` entry point (internally calls `RunTaskAsync`).

| Test | Validates |
|------|-----------|
| `AlreadyOnlineDevice_PassesThrough` | Device already online → pass-through |
| `AlreadyOnlinePhysicalDevice_PassesThrough` | Physical device serial → pass-through |
| `AvdAlreadyRunning_WaitsForFullBoot` | AVD name → resolved serial |
| `BootEmulator_AppearsAfterPolling` | New emulator → assigned serial |
| `LaunchFailure_ReturnsError` | `ErrorKind.LaunchFailed` → XA0143 |
| `BootTimeout_ReturnsError` | `ErrorKind.Timeout` → XA0145 |
| `MultipleEmulators_FindsCorrectAvd` | Correct AVD resolution |
| `ToolPaths_ResolvedFromAndroidSdkDirectory` | Path defaults |
| `ExtraArguments_PassedToOptions` | Extra args parsed + **asserted via `LastBootOptions.AdditionalArgs`** |
| `UnknownError_MapsToXA0145` | `ErrorKind.Unknown` → XA0145 |

### Submodule Update

`external/xamarin-android-tools` updated to `feature/emulator-runner` (`2bf8d67`) which adds:
- `EmulatorBootErrorKind` enum (None, LaunchFailed, Timeout, Cancelled, Unknown)
- `EmulatorBootResult.ErrorKind` property

## API Used

From `Xamarin.Android.Tools.AndroidSdk`:

```csharp
EmulatorRunner(string emulatorPath, logger: Action<TraceLevel, string>?)
EmulatorRunner.BootEmulatorAsync(string device, AdbRunner adb, EmulatorBootOptions? options, CancellationToken ct)
  → Task<EmulatorBootResult>

record EmulatorBootResult {
  bool Success; string? Serial; string? ErrorMessage;
  EmulatorBootErrorKind ErrorKind;  // NEW — structured error classification
}

enum EmulatorBootErrorKind { None, LaunchFailed, Timeout, Cancelled, Unknown }
```

## Review Feedback Addressed

- [x] @jonathanpeppers: Convert to AsyncTask (RunTaskAsync) ✅
- [x] @jonathanpeppers + copilot: Use enum instead of string matching ✅ (`EmulatorBootErrorKind`)
- [x] copilot: Collapse identical else-if/else branches ✅ (now a clean switch)
- [x] copilot: Assert `capturedArgs` in ExtraArguments test ✅ (`LastBootOptions.AdditionalArgs`)

## Dependencies

- **android-tools PR [#284](https://github.com/dotnet/android-tools/pull/284)** — must merge first (provides `EmulatorRunner`, `EmulatorBootErrorKind`)
- **Submodule**: Once #284 merges, update submodule from `feature/emulator-runner` → `main`