### PR TITLE
[tests] Treat IOException as transient network error in DownloadedCache

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DownloadedCache.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/DownloadedCache.cs
@@ -80,6 +80,11 @@ namespace Xamarin.ProjectTools
 				return true;
 			}
 
+			// Check for SSL/TLS errors (e.g., "Received an unexpected EOF or 0 bytes from the transport stream")
+			if (ex.InnerException is IOException) {
+				return true;
+			}
+
 			return false;
 		}
 	}


### PR DESCRIPTION
Add IOException check to IsTransientError to handle SSL/TLS failures (e.g. 'Received an unexpected EOF or 0 bytes from the transport stream') that surface as HttpRequestException wrapping IOException.