### PR TITLE
[build] Fix BinSkim `analyzeTargetGlob` pattern

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -61,7 +61,7 @@ extends:
       binskim:
         scanOutputDirectoryOnly: true
         # Only scan actual build output, not test assemblies under bin/Test*
-        analyzeTargetGlob: +|bin\Build*\**
+        analyzeTargetGlob: bin\Build*\**
       codeql:
         compiled:
           enabled: false


### PR DESCRIPTION
The `+|` prefix is BinSkim CLI syntax that the 1ES Guardian wrapper
cannot parse: 'Could not parse glob pattern'. Remove the `+|` prefix
and keep the glob pattern for Guardian compatibility.