### PR TITLE
[TrimmableTypeMap] Skip registerNatives for Application/Instrumentation types

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -139,6 +139,13 @@ sealed class JcwJavaSourceGenerator
 
 	static void WriteStaticInitializer (JavaPeerInfo type, TextWriter writer)
 	{
+		// Application and Instrumentation types cannot call registerNatives in their
+		// static initializer — the native library isn't loaded yet at that point.
+		// Their registration is deferred to ApplicationRegistration.registerApplications().
+		if (type.CannotRegisterInStaticConstructor) {
+			return;
+		}
+
 		string className = JniSignatureHelper.GetJavaSimpleName (type.JavaName);
 		writer.Write ($$"""
 	static {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -128,12 +128,11 @@ sealed class AssemblyIndex : IDisposable
 		"InstrumentationAttribute",
 	};
 
-	static TypeAttributeInfo CreateTypeAttributeInfo (string attrName)
-	{
-		return attrName == "ApplicationAttribute"
-			? new ApplicationAttributeInfo ()
-			: new TypeAttributeInfo (attrName);
-	}
+	static TypeAttributeInfo CreateTypeAttributeInfo (string attrName) => attrName switch {
+		"ApplicationAttribute" => new ApplicationAttributeInfo (),
+		"InstrumentationAttribute" => new InstrumentationAttributeInfo (),
+		_ => new TypeAttributeInfo (attrName),
+	};
 
 	static bool IsKnownComponentAttribute (string attrName) => KnownComponentAttributes.Contains (attrName);
 
@@ -298,3 +297,5 @@ sealed class ApplicationAttributeInfo () : TypeAttributeInfo ("ApplicationAttrib
 	public string? BackupAgent { get; set; }
 	public string? ManageSpaceActivity { get; set; }
 }
+
+sealed class InstrumentationAttributeInfo () : TypeAttributeInfo ("InstrumentationAttribute") { }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -73,6 +73,14 @@ sealed record JavaPeerInfo
 	public bool IsUnconditional { get; init; }
 
 	/// <summary>
+	/// True for Application and Instrumentation types. These types cannot call
+	/// <c>registerNatives</c> in their static initializer because the native library
+	/// (<c>libmonodroid.so</c>) is not loaded until after the Application class is instantiated.
+	/// Registration is deferred to <c>ApplicationRegistration.registerApplications()</c>.
+	/// </summary>
+	public bool CannotRegisterInStaticConstructor { get; init; }
+
+	/// <summary>
 	/// Marshal methods: methods with [Register(name, sig, connector)], [Export], or
 	/// constructor registrations ([Register(".ctor", sig, "")] / [JniConstructorSignature]).
 	/// Constructors are identified by <see cref="MarshalMethodInfo.IsConstructor"/>.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -195,6 +195,8 @@ sealed class JavaPeerScanner : IDisposable
 			var isGenericDefinition = typeDef.GetGenericParameters ().Count > 0;
 
 			var isUnconditional = attrInfo is not null;
+			var cannotRegisterInStaticConstructor = attrInfo is ApplicationAttributeInfo
+				|| attrInfo?.AttributeName == "InstrumentationAttribute";
 			string? invokerTypeName = null;
 
 			// Resolve base Java type name
@@ -230,6 +232,7 @@ sealed class JavaPeerScanner : IDisposable
 				IsAbstract = isAbstract,
 				DoNotGenerateAcw = doNotGenerateAcw,
 				IsUnconditional = isUnconditional,
+				CannotRegisterInStaticConstructor = cannotRegisterInStaticConstructor,
 				MarshalMethods = marshalMethods,
 				JavaConstructors = BuildJavaConstructors (marshalMethods),
 				JavaFields = exportFields,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -195,8 +195,7 @@ sealed class JavaPeerScanner : IDisposable
 			var isGenericDefinition = typeDef.GetGenericParameters ().Count > 0;
 
 			var isUnconditional = attrInfo is not null;
-			var cannotRegisterInStaticConstructor = attrInfo is ApplicationAttributeInfo
-				|| attrInfo?.AttributeName == "InstrumentationAttribute";
+			var cannotRegisterInStaticConstructor = attrInfo is ApplicationAttributeInfo or InstrumentationAttributeInfo;
 			string? invokerTypeName = null;
 
 			// Resolve base Java type name

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -126,6 +126,22 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			AssertContainsLine ("mono.android.Runtime.registerNatives (MainActivity.class);\n", java);
 		}
 
+		[Fact]
+		public void Generate_ApplicationType_SkipsRegisterNatives ()
+		{
+			var java = GenerateFixture ("my/app/MyApplication");
+			Assert.DoesNotContain ("registerNatives", java);
+			Assert.DoesNotContain ("static {", java);
+		}
+
+		[Fact]
+		public void Generate_InstrumentationType_SkipsRegisterNatives ()
+		{
+			var java = GenerateFixture ("my/app/MyInstrumentation");
+			Assert.DoesNotContain ("registerNatives", java);
+			Assert.DoesNotContain ("static {", java);
+		}
+
 	}
 
 	public class Constructor

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
@@ -119,4 +119,25 @@ public partial class JavaPeerScannerTests
 	{
 		Assert.Equal (managedName, FindFixtureByJavaName (javaName).ManagedTypeName);
 	}
+
+	[Fact]
+	public void Scan_ApplicationType_HasCannotRegisterInStaticConstructor ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MyApplication");
+		Assert.True (peer.CannotRegisterInStaticConstructor);
+	}
+
+	[Fact]
+	public void Scan_InstrumentationType_HasCannotRegisterInStaticConstructor ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MyInstrumentation");
+		Assert.True (peer.CannotRegisterInStaticConstructor);
+	}
+
+	[Fact]
+	public void Scan_ActivityType_DoesNotHaveCannotRegisterInStaticConstructor ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/MainActivity");
+		Assert.False (peer.CannotRegisterInStaticConstructor);
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/dotnet/android/issues/10931

## Summary

Application and Instrumentation types cannot call `registerNatives` in their static initializer because the native library (`libmonodroid.so`) is not loaded until after the Application class is instantiated. Their registration is deferred to `ApplicationRegistration.registerApplications()`.

### Changes

- Add `CannotRegisterInStaticConstructor` flag to `JavaPeerInfo`
- Set the flag in `JavaPeerScanner` when `[Application]` or `[Instrumentation]` attribute is detected
- Skip emitting `static { registerNatives(...) }` block in `JcwJavaSourceGenerator` when the flag is set

### Tests

5 new tests:
- Scanner correctly sets flag for Application and Instrumentation types
- Scanner does NOT set flag for Activity types
- JCW generator skips static block for Application types
- JCW generator skips static block for Instrumentation types

All 260 unit tests pass.