### PR TITLE
[TrimmableTypeMap] Generate per-assembly acw-map.txt from scanner results

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -22,8 +22,9 @@ public static class AcwMapWriter
 {
 	/// <summary>
 	/// Writes acw-map lines for the given <paramref name="peers"/> to the <paramref name="writer"/>.
-	/// Conflict detection is NOT performed here — it happens at merge time when all per-assembly
-	/// maps are combined. Per-assembly maps write all 3 line variants unconditionally.
+	/// Per-assembly maps write all 3 line variants unconditionally. No conflict detection
+	/// is performed — the merged acw-map.txt is a simple concatenation consumed by
+	/// LoadMapFile which uses first-entry-wins semantics for duplicate keys.
 	/// </summary>
 	public static void Write (TextWriter writer, IEnumerable<JavaPeerInfo> peers)
 	{

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -51,33 +51,4 @@ public static class AcwMapWriter
 		}
 	}
 
-	/// <summary>
-	/// Writes acw-map lines to a file, only updating the file if the content has changed.
-	/// Returns true if the file was written (content changed or file didn't exist).
-	/// </summary>
-	public static bool WriteToFile (string filePath, IEnumerable<JavaPeerInfo> peers)
-	{
-		using var memoryStream = new MemoryStream ();
-		using (var writer = new StreamWriter (memoryStream, new System.Text.UTF8Encoding (encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: true)) {
-			Write (writer, peers);
-		}
-
-		memoryStream.Position = 0;
-		byte[] newContent = memoryStream.ToArray ();
-
-		if (File.Exists (filePath)) {
-			byte[] existingContent = File.ReadAllBytes (filePath);
-			if (existingContent.AsSpan ().SequenceEqual (newContent)) {
-				return false;
-			}
-		}
-
-		string? directory = Path.GetDirectoryName (filePath);
-		if (directory != null) {
-			Directory.CreateDirectory (directory);
-		}
-
-		File.WriteAllBytes (filePath, newContent);
-		return true;
-	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -50,5 +50,4 @@ public static class AcwMapWriter
 			writer.WriteLine (javaKey);
 		}
 	}
-
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AcwMapWriter.cs
@@ -1,0 +1,82 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// Generates per-assembly acw-map.txt content from <see cref="JavaPeerInfo"/> records.
+/// The acw-map.txt file maps managed type names to Java/ACW type names, consumed by
+/// <c>_ConvertCustomView</c> to fix up custom view names in layout XMLs.
+///
+/// Format per type (3 lines):
+///   Line 1: PartialAssemblyQualifiedName;JavaKey  (always written)
+///   Line 2: ManagedKey;JavaKey
+///   Line 3: CompatJniName;JavaKey
+///
+/// Java keys use dots (not slashes): e.g., "android.app.Activity"
+/// </summary>
+public static class AcwMapWriter
+{
+	/// <summary>
+	/// Writes acw-map lines for the given <paramref name="peers"/> to the <paramref name="writer"/>.
+	/// Conflict detection is NOT performed here — it happens at merge time when all per-assembly
+	/// maps are combined. Per-assembly maps write all 3 line variants unconditionally.
+	/// </summary>
+	public static void Write (TextWriter writer, IEnumerable<JavaPeerInfo> peers)
+	{
+		foreach (var peer in peers.OrderBy (p => p.ManagedTypeName, StringComparer.Ordinal)) {
+			string javaKey = peer.JavaName.Replace ('/', '.');
+			string managedKey = peer.ManagedTypeName;
+			string partialAsmQualifiedName = $"{managedKey}, {peer.AssemblyName}";
+			string compatJniName = peer.CompatJniName.Replace ('/', '.');
+
+			// Line 1: PartialAssemblyQualifiedName;JavaKey
+			writer.Write (partialAsmQualifiedName);
+			writer.Write (';');
+			writer.WriteLine (javaKey);
+
+			// Line 2: ManagedKey;JavaKey
+			writer.Write (managedKey);
+			writer.Write (';');
+			writer.WriteLine (javaKey);
+
+			// Line 3: CompatJniName;JavaKey
+			writer.Write (compatJniName);
+			writer.Write (';');
+			writer.WriteLine (javaKey);
+		}
+	}
+
+	/// <summary>
+	/// Writes acw-map lines to a file, only updating the file if the content has changed.
+	/// Returns true if the file was written (content changed or file didn't exist).
+	/// </summary>
+	public static bool WriteToFile (string filePath, IEnumerable<JavaPeerInfo> peers)
+	{
+		using var memoryStream = new MemoryStream ();
+		using (var writer = new StreamWriter (memoryStream, new System.Text.UTF8Encoding (encoderShouldEmitUTF8Identifier: false), bufferSize: 1024, leaveOpen: true)) {
+			Write (writer, peers);
+		}
+
+		memoryStream.Position = 0;
+		byte[] newContent = memoryStream.ToArray ();
+
+		if (File.Exists (filePath)) {
+			byte[] existingContent = File.ReadAllBytes (filePath);
+			if (existingContent.AsSpan ().SequenceEqual (newContent)) {
+				return false;
+			}
+		}
+
+		string? directory = Path.GetDirectoryName (filePath);
+		if (directory != null) {
+			Directory.CreateDirectory (directory);
+		}
+
+		File.WriteAllBytes (filePath, newContent);
+		return true;
+	}
+}

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -1,6 +1,6 @@
 <!-- Trimmable typemap: managed type mapping instead of native binary typemaps.
      Generates per-assembly TypeMap .dll assemblies, a root _Microsoft.Android.TypeMaps.dll,
-     and JCW .java source files with registerNatives. -->
+     JCW .java source files with registerNatives, and per-assembly acw-map files. -->
 <Project>
 
   <UsingTask TaskName="Xamarin.Android.Tasks.GenerateTrimmableTypeMap" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
@@ -14,6 +14,7 @@
     <_TypeMapAssemblyName>_Microsoft.Android.TypeMaps</_TypeMapAssemblyName>
     <_TypeMapOutputDirectory>$(IntermediateOutputPath)typemap\</_TypeMapOutputDirectory>
     <_TypeMapJavaOutputDirectory>$(IntermediateOutputPath)typemap\java</_TypeMapJavaOutputDirectory>
+    <_PerAssemblyAcwMapDirectory>$(IntermediateOutputPath)acw-maps\</_PerAssemblyAcwMapDirectory>
   </PropertyGroup>
 
   <!-- Tell the runtime which assembly contains the TypeMap attributes -->
@@ -41,18 +42,54 @@
         ResolvedAssemblies="@(_ResolvedAssemblies)"
         OutputDirectory="$(_TypeMapOutputDirectory)"
         JavaSourceOutputDirectory="$(_TypeMapJavaOutputDirectory)"
+        AcwMapDirectory="$(_PerAssemblyAcwMapDirectory)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)">
       <Output TaskParameter="GeneratedAssemblies" ItemName="_GeneratedTypeMapAssemblies" />
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_GeneratedJavaFiles" />
+      <Output TaskParameter="PerAssemblyAcwMapFiles" ItemName="_PerAssemblyAcwMapFiles" />
     </GenerateTrimmableTypeMap>
 
     <ItemGroup>
       <FileWrites Include="@(_GeneratedTypeMapAssemblies)" />
       <FileWrites Include="@(_GeneratedJavaFiles)" />
+      <FileWrites Include="@(_PerAssemblyAcwMapFiles)" />
     </ItemGroup>
 
     <MakeDir Directories="$(_AndroidStampDirectory)" Condition=" !Exists('$(_AndroidStampDirectory)') " />
     <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <!--
+    Merge per-assembly acw-map files into a single acw-map.txt.
+    Consumed by _ConvertCustomView (layout XML custom view fixups) and R8.
+    Runs after _GenerateJavaStubs produces the per-assembly files;
+    skipped on incremental builds when no *.txt is newer than acw-map.txt.
+  -->
+  <Target Name="_CollectPerAssemblyAcwMaps"
+      AfterTargets="_GenerateJavaStubs">
+    <ItemGroup>
+      <_PerAssemblyAcwMapFiles Include="$(_PerAssemblyAcwMapDirectory)*.txt" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_MergeAcwMaps"
+      AfterTargets="_CollectPerAssemblyAcwMaps"
+      Inputs="@(_PerAssemblyAcwMapFiles)"
+      Outputs="$(_AcwMapFile)">
+
+    <ReadLinesFromFile File="%(_PerAssemblyAcwMapFiles.Identity)">
+      <Output TaskParameter="Lines" ItemName="_AcwMapLines" />
+    </ReadLinesFromFile>
+
+    <WriteLinesToFile
+        File="$(_AcwMapFile)"
+        Lines="@(_AcwMapLines)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_AcwMapFile)" />
+    </ItemGroup>
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -60,20 +60,30 @@
   </Target>
 
   <!--
-    Merge per-assembly acw-map files into a single acw-map.txt.
-    Consumed by _ConvertCustomView (layout XML custom view fixups) and R8.
-    Runs after _GenerateJavaStubs produces the per-assembly files;
-    skipped on incremental builds when no *.txt is newer than acw-map.txt.
+    Collect per-assembly acw-map files from disk.  On a clean build _GenerateJavaStubs
+    already populated @(_PerAssemblyAcwMapFiles) via its task Output; on an incremental
+    build where that target was skipped the item group is empty.  Either way we clear it
+    and re-glob so there is exactly one authoritative copy of each item.
   -->
   <Target Name="_CollectPerAssemblyAcwMaps"
-      AfterTargets="_GenerateJavaStubs">
+      DependsOnTargets="_GenerateJavaStubs">
     <ItemGroup>
+      <_PerAssemblyAcwMapFiles Remove="@(_PerAssemblyAcwMapFiles)" />
       <_PerAssemblyAcwMapFiles Include="$(_PerAssemblyAcwMapDirectory)*.txt" />
     </ItemGroup>
   </Target>
 
+  <!--
+    Merge per-assembly acw-map files into a single acw-map.txt.
+    Consumed by _ConvertCustomView (layout XML custom view fixups) and R8.
+    AfterTargets hooks this into the build after _GenerateJavaStubs;
+    DependsOnTargets ensures _CollectPerAssemblyAcwMaps runs first so that
+    @(_PerAssemblyAcwMapFiles) is populated for the Inputs/Outputs check.
+    Skipped on incremental builds when no *.txt is newer than acw-map.txt.
+  -->
   <Target Name="_MergeAcwMaps"
-      AfterTargets="_CollectPerAssemblyAcwMaps"
+      AfterTargets="_GenerateJavaStubs"
+      DependsOnTargets="_CollectPerAssemblyAcwMaps"
       Inputs="@(_PerAssemblyAcwMapFiles)"
       Outputs="$(_AcwMapFile)">
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -180,7 +180,13 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		foreach (var group in peersByAssembly) {
 			var peers = group.ToList ();
 			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
-			bool written = AcwMapWriter.WriteToFile (outputFile, peers);
+
+			bool written;
+			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
+				AcwMapWriter.Write (sw, peers);
+				sw.Flush ();
+				written = Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
+			}
 
 			Log.LogDebugMessage (written
 				? $"  acw-map.{group.Key}.txt: {peers.Count} types"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -12,9 +12,9 @@ using Microsoft.Build.Utilities;
 namespace Xamarin.Android.Tasks;
 
 /// <summary>
-/// Generates trimmable TypeMap assemblies and JCW Java source files from resolved assemblies.
-/// Runs before the trimmer to produce per-assembly typemap .dll files and a root
-/// _Microsoft.Android.TypeMaps.dll, plus .java files for ACW types with registerNatives.
+/// Generates trimmable TypeMap assemblies, JCW Java source files, and per-assembly
+/// acw-map files from resolved assemblies. The acw-map files are later merged into
+/// a single acw-map.txt consumed by _ConvertCustomView for layout XML fixups.
 /// </summary>
 public class GenerateTrimmableTypeMap : AndroidTask
 {
@@ -30,6 +30,12 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public string JavaSourceOutputDirectory { get; set; } = "";
 
 	/// <summary>
+	/// Directory for per-assembly acw-map.{AssemblyName}.txt files.
+	/// </summary>
+	[Required]
+	public string AcwMapDirectory { get; set; } = "";
+
+	/// <summary>
 	/// The .NET target framework version (e.g., "v11.0"). Used to set the System.Runtime
 	/// assembly reference version in generated typemap assemblies.
 	/// </summary>
@@ -42,6 +48,13 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	[Output]
 	public ITaskItem []? GeneratedJavaFiles { get; set; }
 
+	/// <summary>
+	/// Per-assembly acw-map files produced during scanning. Each file contains
+	/// ManagedName;JavaName lines for types in that assembly.
+	/// </summary>
+	[Output]
+	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
+
 	public override bool RunTask ()
 	{
 		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
@@ -49,6 +62,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 		Directory.CreateDirectory (OutputDirectory);
 		Directory.CreateDirectory (JavaSourceOutputDirectory);
+		Directory.CreateDirectory (AcwMapDirectory);
 
 		var allPeers = ScanAssemblies (assemblyPaths);
 		if (allPeers.Count == 0) {
@@ -58,6 +72,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 		GeneratedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, assemblyPaths);
 		GeneratedJavaFiles = GenerateJcwJavaSources (allPeers);
+		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (allPeers);
 
 		return !Log.HasLoggedErrors;
 	}
@@ -151,6 +166,32 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			items [i] = new TaskItem (files [i]);
 		}
 		return items;
+	}
+
+	ITaskItem [] GeneratePerAssemblyAcwMaps (List<JavaPeerInfo> allPeers)
+	{
+		var peersByAssembly = allPeers
+			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
+			.OrderBy (g => g.Key, StringComparer.Ordinal);
+
+		var outputFiles = new List<ITaskItem> ();
+
+		foreach (var group in peersByAssembly) {
+			var peers = group.ToList ();
+			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
+			bool written = AcwMapWriter.WriteToFile (outputFile, peers);
+
+			Log.LogDebugMessage (written
+				? $"  acw-map.{group.Key}.txt: {peers.Count} types"
+				: $"  acw-map.{group.Key}.txt: unchanged");
+
+			var item = new TaskItem (outputFile);
+			item.SetMetadata ("AssemblyName", group.Key);
+			outputFiles.Add (item);
+		}
+
+		Log.LogDebugMessage ($"Generated {outputFiles.Count} per-assembly ACW map files.");
+		return outputFiles.ToArray ();
 	}
 
 	static Version ParseTargetFrameworkVersion (string tfv)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -50,7 +50,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 	/// <summary>
 	/// Per-assembly acw-map files produced during scanning. Each file contains
-	/// ManagedName;JavaName lines for types in that assembly.
+	/// three lines per type: PartialAssemblyQualifiedName;JavaKey,
+	/// ManagedKey;JavaKey, and CompatJniName;JavaKey.
 	/// </summary>
 	[Output]
 	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -158,6 +158,7 @@ namespace Xamarin.Android.Build.Tests {
 				ResolvedAssemblies = [],
 				OutputDirectory = outputDir,
 				JavaSourceOutputDirectory = javaDir,
+				AcwMapDirectory = Path.Combine (Root, path, "acw-maps"),
 				TargetFrameworkVersion = "not-a-version",
 			};
 
@@ -211,6 +212,7 @@ namespace Xamarin.Android.Build.Tests {
 				ResolvedAssemblies = assemblies,
 				OutputDirectory = outputDir,
 				JavaSourceOutputDirectory = javaDir,
+				AcwMapDirectory = Path.Combine (outputDir, "..", "acw-maps"),
 				TargetFrameworkVersion = tfv,
 			};
 		}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+public class AcwMapWriterTests : FixtureTestBase
+{
+	static string WriteToString (IEnumerable<JavaPeerInfo> peers)
+	{
+		using var writer = new StringWriter ();
+		AcwMapWriter.Write (writer, peers);
+		return writer.ToString ();
+	}
+
+	[Fact]
+	public void Write_SingleMcwType_ProducesThreeLines ()
+	{
+		var peer = MakeMcwPeer ("android/app/Activity", "Android.App.Activity", "Mono.Android");
+
+		var output = WriteToString (new [] { peer });
+		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+
+		Assert.Equal (3, lines.Length);
+		// Line 1: PartialAssemblyQualifiedName;JavaKey
+		Assert.Equal ("Android.App.Activity, Mono.Android;android.app.Activity", lines [0]);
+		// Line 2: ManagedKey;JavaKey
+		Assert.Equal ("Android.App.Activity;android.app.Activity", lines [1]);
+		// Line 3: CompatJniName;JavaKey
+		Assert.Equal ("android.app.Activity;android.app.Activity", lines [2]);
+	}
+
+	[Fact]
+	public void Write_UserType_SlashesConvertedToDots ()
+	{
+		var peer = new JavaPeerInfo {
+			JavaName = "crc64abcdef/MyActivity",
+			CompatJniName = "my.namespace/MyActivity",
+			ManagedTypeName = "My.Namespace.MyActivity",
+			ManagedTypeNamespace = "My.Namespace",
+			ManagedTypeShortName = "MyActivity",
+			AssemblyName = "MyApp",
+		};
+
+		var output = WriteToString (new [] { peer });
+		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+
+		Assert.Equal (3, lines.Length);
+		Assert.Equal ("My.Namespace.MyActivity, MyApp;crc64abcdef.MyActivity", lines [0]);
+		Assert.Equal ("My.Namespace.MyActivity;crc64abcdef.MyActivity", lines [1]);
+		Assert.Equal ("my.namespace.MyActivity;crc64abcdef.MyActivity", lines [2]);
+	}
+
+	[Fact]
+	public void Write_MultipleTypes_OrderedByManagedName ()
+	{
+		var peers = new [] {
+			MakeMcwPeer ("android/widget/TextView", "Android.Widget.TextView", "Mono.Android"),
+			MakeMcwPeer ("android/app/Activity", "Android.App.Activity", "Mono.Android"),
+			MakeMcwPeer ("android/content/Context", "Android.Content.Context", "Mono.Android"),
+		};
+
+		var output = WriteToString (peers);
+		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+
+		// 3 types × 3 lines each = 9 lines
+		Assert.Equal (9, lines.Length);
+
+		// First type alphabetically: Android.App.Activity
+		Assert.StartsWith ("Android.App.Activity, Mono.Android;", lines [0]);
+		// Second: Android.Content.Context
+		Assert.StartsWith ("Android.Content.Context, Mono.Android;", lines [3]);
+		// Third: Android.Widget.TextView
+		Assert.StartsWith ("Android.Widget.TextView, Mono.Android;", lines [6]);
+	}
+
+	[Fact]
+	public void Write_EmptyList_ProducesEmptyOutput ()
+	{
+		var output = WriteToString (Array.Empty<JavaPeerInfo> ());
+		Assert.Equal ("", output);
+	}
+
+	[Fact]
+	public void Write_MatchesExpectedAcwMapFormat ()
+	{
+		// Verify the format matches what LoadMapFile expects:
+		// each line is "key;value" where LoadMapFile splits on ';'
+		var peer = MakeMcwPeer ("android/app/Activity", "Android.App.Activity", "Mono.Android");
+
+		var output = WriteToString (new [] { peer });
+
+		foreach (var line in output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None)) {
+			var parts = line.Split (new [] { ';' }, count: 2);
+			Assert.Equal (2, parts.Length);
+			Assert.False (string.IsNullOrWhiteSpace (parts [0]), "Key should not be empty");
+			Assert.False (string.IsNullOrWhiteSpace (parts [1]), "Value should not be empty");
+		}
+	}
+
+	[Fact]
+	public void Write_FromScannedFixtures_ProducesValidOutput ()
+	{
+		var peers = ScanFixtures ();
+		Assert.NotEmpty (peers);
+
+		var output = WriteToString (peers);
+
+		foreach (var line in output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None)) {
+			var parts = line.Split (new [] { ';' }, count: 2);
+			Assert.Equal (2, parts.Length);
+			// No slashes in the output — they should all be converted to dots
+			Assert.DoesNotContain ("/", parts [1]);
+		}
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/AcwMapWriterTests.cs
@@ -7,11 +7,15 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
 public class AcwMapWriterTests : FixtureTestBase
 {
-	static string WriteToString (IEnumerable<JavaPeerInfo> peers)
+	static string [] WriteLines (IEnumerable<JavaPeerInfo> peers)
 	{
 		using var writer = new StringWriter ();
 		AcwMapWriter.Write (writer, peers);
-		return writer.ToString ();
+		var output = writer.ToString ().TrimEnd ();
+		if (output.Length == 0) {
+			return Array.Empty<string> ();
+		}
+		return output.Split (new [] { Environment.NewLine }, StringSplitOptions.None);
 	}
 
 	[Fact]
@@ -19,8 +23,7 @@ public class AcwMapWriterTests : FixtureTestBase
 	{
 		var peer = MakeMcwPeer ("android/app/Activity", "Android.App.Activity", "Mono.Android");
 
-		var output = WriteToString (new [] { peer });
-		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+		var lines = WriteLines (new [] { peer });
 
 		Assert.Equal (3, lines.Length);
 		// Line 1: PartialAssemblyQualifiedName;JavaKey
@@ -43,8 +46,7 @@ public class AcwMapWriterTests : FixtureTestBase
 			AssemblyName = "MyApp",
 		};
 
-		var output = WriteToString (new [] { peer });
-		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+		var lines = WriteLines (new [] { peer });
 
 		Assert.Equal (3, lines.Length);
 		Assert.Equal ("My.Namespace.MyActivity, MyApp;crc64abcdef.MyActivity", lines [0]);
@@ -61,8 +63,7 @@ public class AcwMapWriterTests : FixtureTestBase
 			MakeMcwPeer ("android/content/Context", "Android.Content.Context", "Mono.Android"),
 		};
 
-		var output = WriteToString (peers);
-		var lines = output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None);
+		var lines = WriteLines (peers);
 
 		// 3 types × 3 lines each = 9 lines
 		Assert.Equal (9, lines.Length);
@@ -78,8 +79,8 @@ public class AcwMapWriterTests : FixtureTestBase
 	[Fact]
 	public void Write_EmptyList_ProducesEmptyOutput ()
 	{
-		var output = WriteToString (Array.Empty<JavaPeerInfo> ());
-		Assert.Equal ("", output);
+		var lines = WriteLines (Array.Empty<JavaPeerInfo> ());
+		Assert.Empty (lines);
 	}
 
 	[Fact]
@@ -89,9 +90,9 @@ public class AcwMapWriterTests : FixtureTestBase
 		// each line is "key;value" where LoadMapFile splits on ';'
 		var peer = MakeMcwPeer ("android/app/Activity", "Android.App.Activity", "Mono.Android");
 
-		var output = WriteToString (new [] { peer });
+		var lines = WriteLines (new [] { peer });
 
-		foreach (var line in output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None)) {
+		foreach (var line in lines) {
 			var parts = line.Split (new [] { ';' }, count: 2);
 			Assert.Equal (2, parts.Length);
 			Assert.False (string.IsNullOrWhiteSpace (parts [0]), "Key should not be empty");
@@ -105,9 +106,9 @@ public class AcwMapWriterTests : FixtureTestBase
 		var peers = ScanFixtures ();
 		Assert.NotEmpty (peers);
 
-		var output = WriteToString (peers);
+		var lines = WriteLines (peers);
 
-		foreach (var line in output.TrimEnd ().Split (new [] { '\n' }, StringSplitOptions.None)) {
+		foreach (var line in lines) {
 			var parts = line.Split (new [] { ';' }, count: 2);
 			Assert.Equal (2, parts.Length);
 			// No slashes in the output — they should all be converted to dots


### PR DESCRIPTION
Part of https://github.com/dotnet/android/issues/10807
Follows #10924 (merged).

## Summary

Adds per-assembly `acw-map.{AssemblyName}.txt` generation to the trimmable typemap path, enabling `_ConvertCustomView` and R8 to work with the trimmable build flow.

## Background: What is acw-map.txt?

The `acw-map.txt` file maps .NET managed type names to their corresponding Java/ACW (Android Callable Wrapper) names. It is consumed by:
- **`_ConvertCustomView`** — replaces managed type names with ACW names in layout XML files (e.g., `<My.Custom.View>` → `<crc64.../MyCustomView>`)
- **R8/ProGuard** — uses the mapping during code shrinking

### Legacy format (from `ACWMapGenerator`)

The legacy `ACWMapGenerator` (in `ACWMapGenerator.cs`) uses Cecil to scan `TypeDefinition` objects and writes 3 lines per type:

```
PartialAssemblyQualifiedName;JavaKey    e.g., "Android.App.Activity, Mono.Android;android.app.Activity"
ManagedKey;JavaKey                       e.g., "Android.App.Activity;android.app.Activity"
CompatJniName;JavaKey                    e.g., "android.app.Activity;android.app.Activity"
```

- Java keys use **dots** (not slashes) — `Replace('/"', '".')` is applied
- Encoding is **UTF-8 without BOM** (via `MemoryStreamPool.CreateStreamWriter()` which uses `UTF8withoutBOM`)
- Types are sorted by managed name (ordinal)
- The file is written only when content changes (`Files.CopyIfStreamChanged`)
- The consumer `LoadMapFile` reads lines, splits on `;`, and populates a `Dictionary<string, string>` (first entry wins for duplicates)

### Trimmable path: `AcwMapWriter`

The trimmable path replaces Cecil-based scanning with `JavaPeerScanner` (SRM-based). `JavaPeerInfo` already contains all the data needed:
- `ManagedTypeName` → managed key
- `JavaName` → java key (with `/` → `.` conversion)
- `CompatJniName` → compat JNI key (with `/` → `.` conversion)
- `AssemblyName` → for partial assembly-qualified name

`AcwMapWriter` writes the **exact same 3-line format** as the legacy generator, ensuring `LoadMapFile` consumers see no difference.

## Approach

Instead of a separate scanning task, acw-map generation is a **side-output** of `GenerateTrimmableTypeMap` — the task already has all `JavaPeerInfo` records from scanning, so no extra scan pass is needed.

### Changes

- **`AcwMapWriter`** — pure formatting logic: `JavaPeerInfo` → acw-map.txt lines (UTF-8 without BOM, ordinal sort, content-comparison write)
- **`GenerateTrimmableTypeMap`** — new `AcwMapDirectory` input + `PerAssemblyAcwMapFiles` output. Groups peers by assembly and writes per-assembly files.
- **`_CollectPerAssemblyAcwMaps` target** — globs per-assembly `*.txt` files into an item group after `_GenerateJavaStubs` runs
- **`_MergeAcwMaps` target** — concatenates per-assembly files into the single `acw-map.txt`. Uses `Inputs/Outputs` for incrementality and `WriteOnlyWhenDifferent` to avoid unnecessary downstream rebuilds.
- **6 unit tests** for `AcwMapWriter` format correctness (261 total tests pass)

### Build flow

```
_GenerateJavaStubs
  └─ GenerateTrimmableTypeMap  → typemap .dlls + JCW .java + acw-map.*.txt
_CollectPerAssemblyAcwMaps     → globs *.txt into @(_PerAssemblyAcwMapFiles)
_MergeAcwMaps                  → concatenates → acw-map.txt
_ConvertCustomView             → reads acw-map.txt (unchanged consumer)
```

### Incrementality

- **`_GenerateJavaStubs`**: stamp-based — skipped when assemblies unchanged
- **`AcwMapWriter.WriteToFile`**: content comparison — unchanged assemblies produce identical files (no timestamp update)
- **`_MergeAcwMaps`**: `Inputs="@(_PerAssemblyAcwMapFiles)"` / `Outputs="$(_AcwMapFile)"` — skipped when no per-assembly file is newer
- **`WriteOnlyWhenDifferent`**: merged `acw-map.txt` only updated when content changes

### Future: per-assembly incremental optimization

Per-assembly acw-map files lay the groundwork for #10958 (build time optimizations). When the scan step gains per-assembly `Inputs/Outputs` incrementality, unchanged assemblies will skip scanning entirely — and their acw-map files will remain untouched, so the merge step will also be skipped.