### PR TITLE
[build] Fix BinSkim failure in 'Convert NuGet to MSI' job

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -60,8 +60,12 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-        # Only scan actual build output, not test assemblies under bin/Test*
-        analyzeTargetGlob: bin\Build*\**
+        # Scan build output and MSI conversion output, but not test assemblies
+        # under bin/Test* which produce BA2021 false positives.
+        # Both patterns are needed because the 1ES template applies sdl config
+        # globally: build/test jobs produce bin\Build*\ output, while the
+        # "Convert NuGet to MSI" job only produces bin\msi-nupkgs\ output.
+        analyzeTargetGlob: bin\Build*\**;bin\msi-nupkgs\**
       codeql:
         compiled:
           enabled: false


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13575957&view=logs&j=5b07041f-3ad2-50e1-dcc0-0b413b70a215&t=033d44a8-e06e-5493-047f-4acab20a6c86

The "Convert NuGet to MSI" job fails with:

```
##[warning]Could not parse glob pattern D:\a\_work\1\s\bin\Build*\** for argument Target. The value will be passed to the tool without resolution.
BINSKIM : error ERR997.NoValidAnalysisTargets : No valid analysis targets were specified.
##[error]GuardianErrorExitCodeException: binskim completed with an Error exit code: 1. BinSkim failed. Verify the target(s) to be scanned.
```

This happens because the 1ES template applies `sdl.binskim` config globally to all jobs with no per-job override mechanism. The `analyzeTargetGlob` pattern `bin\Build*\**` (added in #10940, fixed in #10953) only matches build/test job output directories, but the MSI conversion job has no `bin\Build*\` directory — it produces output under `bin\msi-nupkgs\` instead.

Add `bin\msi-nupkgs\**` to the glob so the MSI conversion job has valid scan targets.