### PR TITLE
[build] Revert BinSkim analyzeTargetGlob customization

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -60,10 +60,6 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-        # Only scan actual build output, not test assemblies under bin/Test*
-        # which produce BA2021 false positives. The "Convert NuGet to MSI" job
-        # overrides this glob in its own templateContext (in Xamarin.yaml-templates).
-        analyzeTargetGlob: bin\Build*\**
       codeql:
         compiled:
           enabled: false

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/dev/jopepper/revert-binskim-sdl
+    ref: refs/heads/main
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -60,12 +60,10 @@ extends:
         enableAllTools: false
       binskim:
         scanOutputDirectoryOnly: true
-        # Scan build output and MSI conversion output, but not test assemblies
-        # under bin/Test* which produce BA2021 false positives.
-        # Both patterns are needed because the 1ES template applies sdl config
-        # globally: build/test jobs produce bin\Build*\ output, while the
-        # "Convert NuGet to MSI" job only produces bin\msi-nupkgs\ output.
-        analyzeTargetGlob: bin\Build*\**;bin\msi-nupkgs\**
+        # Only scan actual build output, not test assemblies under bin/Test*
+        # which produce BA2021 false positives. The "Convert NuGet to MSI" job
+        # overrides this glob in its own templateContext (in Xamarin.yaml-templates).
+        analyzeTargetGlob: bin\Build*\**
       codeql:
         compiled:
           enabled: false

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -295,6 +295,7 @@ extends:
           artifactPatterns: |
             !*Darwin*
           propsArtifactName: $(NuGetArtifactName)
+          binskimTargetGlob: $(Build.StagingDirectory)\bin\msi-nupkgs\**
           ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android')) }}:
             signType: Real
           ${{ else }}:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/jopepper/revert-binskim-sdl
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -295,7 +295,6 @@ extends:
           artifactPatterns: |
             !*Darwin*
           propsArtifactName: $(NuGetArtifactName)
-          binskimTargetGlob: $(Build.StagingDirectory)\bin\msi-nupkgs\**
           ${{ if and(startsWith(variables['Build.SourceBranch'], 'refs/heads/release/'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.DefinitionName'], 'Xamarin.Android')) }}:
             signType: Real
           ${{ else }}:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -300,6 +300,11 @@ extends:
           ${{ else }}:
             signType: Test
           preConvertSteps:
+          # The global sdl.binskim.analyzeTargetGlob (bin\Build*\**) doesn't match
+          # any directory in this job. Create an empty one so BinSkim doesn't fail
+          # with ERR997.NoValidAnalysisTargets.
+          - pwsh: New-Item -ItemType Directory -Path "$(Build.SourcesDirectory)\bin\Build$(XA.Build.Configuration)" -Force
+            displayName: create bin\Build$(XA.Build.Configuration) for BinSkim
           - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: nuget-signed

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -300,11 +300,6 @@ extends:
           ${{ else }}:
             signType: Test
           preConvertSteps:
-          # The global sdl.binskim.analyzeTargetGlob (bin\Build*\**) doesn't match
-          # any directory in this job. Create an empty one so BinSkim doesn't fail
-          # with ERR997.NoValidAnalysisTargets.
-          - pwsh: New-Item -ItemType Directory -Path "$(Build.SourcesDirectory)\bin\Build$(XA.Build.Configuration)" -Force
-            displayName: create bin\Build$(XA.Build.Configuration) for BinSkim
           - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: nuget-signed


### PR DESCRIPTION
Revert the `analyzeTargetGlob` customization added in PRs #10940, #10953, and #10961.

The custom glob patterns caused more problems than they solved:

- `+|bin\Build*\**` — Guardian can't parse `+|` prefix (#10953)
- `bin\Build*\**` — breaks the 'Convert NuGet to MSI' job which has no `bin\Build*\` directory (#10961)
- `bin\Build*\**;bin\msi-nupkgs\**` — Guardian can't parse semicolons, breaks every job

Remove `analyzeTargetGlob` entirely and keep only `scanOutputDirectoryOnly: true`, which is the default configuration that worked before #10940.