### PR TITLE
[Mono.Android] Fix UnhandledExceptionRaiser not firing in .NET 10

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidEnvironment.cs
@@ -111,17 +111,25 @@ namespace Android.Runtime {
 
 		internal static void UnhandledException (Exception e)
 		{
-			var raisers         = UnhandledExceptionRaiser;
+			if (TryRaiseUnhandledException (e))
+				return;
+
+			RaiseThrowable (Java.Lang.Throwable.FromException (e));
+		}
+
+		// Returns true if the exception was handled by a subscriber.
+		internal static bool TryRaiseUnhandledException (Exception e)
+		{
+			var raisers          = UnhandledExceptionRaiser;
 			if (raisers != null) {
 				var info    = new RaiseThrowableEventArgs (e);
 				foreach (EventHandler<RaiseThrowableEventArgs> handler in raisers.GetInvocationList ()) {
 					handler (null, info);
 					if (info.Handled)
-						return;
+						return true;
 				}
 			}
-
-			RaiseThrowable (Java.Lang.Throwable.FromException (e));
+			return false;
 		}
 
 		// This is invoked by

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -73,6 +73,19 @@ namespace Android.Runtime {
 			return peekedExc;
 		}
 
+		public override void OnUserUnhandledException (ref JniTransition transition, Exception e)
+		{
+			// Raise the UnhandledExceptionRaiser event via AndroidEnvironment.UnhandledException().
+			// If a subscriber sets Handled = true, UnhandledException() returns without calling
+			// RaiseThrowable() and we should not transition to JNI.
+			// See: https://github.com/dotnet/android/issues/10654
+			if (AndroidEnvironment.TryRaiseUnhandledException (e)) {
+				return;
+			}
+
+			base.OnUserUnhandledException (ref transition, e);
+		}
+
 		public override void RaisePendingException (Exception pendingException)
 		{
 			var je  = pendingException as JavaException;

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -75,9 +75,9 @@ namespace Android.Runtime {
 
 		public override void OnUserUnhandledException (ref JniTransition transition, Exception e)
 		{
-			// Raise the UnhandledExceptionRaiser event via AndroidEnvironment.UnhandledException().
-			// If a subscriber sets Handled = true, UnhandledException() returns without calling
-			// RaiseThrowable() and we should not transition to JNI.
+			// Raise the UnhandledExceptionRaiser event via TryRaiseUnhandledException().
+			// If a subscriber sets Handled = true, the exception is considered handled
+			// and we return without transitioning to JNI.
 			// See: https://github.com/dotnet/android/issues/10654
 			if (AndroidEnvironment.TryRaiseUnhandledException (e)) {
 				return;

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -435,15 +435,11 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			proj.SetRuntime (runtime);
 			proj.SetAndroidSupportedAbis (DeviceAbi);
 
-			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", """
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
+"""
 				Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => {
 					Android.Util.Log.Error ("UnhandledTest", $"UnhandledExceptionRaiser: {e.Exception}");
 					e.Handled = true;
-				};
-
-				AppDomain.CurrentDomain.UnhandledException += (sender, e) => {
-					Android.Util.Log.Error ("UnhandledTest",
-						$"AppDomain.UnhandledException: {e.ExceptionObject}, IsTerminating: {e.IsTerminating}");
 				};
 
 				button!.Click += (sender, e) => {
@@ -454,17 +450,17 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			builder = CreateApkBuilder ();
 			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
 			AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
-			WaitForActivityToStart (proj.PackageName, "MainActivity",
-				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"));
+			Assert.IsTrue (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log")), "Activity should have started.");
 			ClearAdbLogcat ();
 			ClearBlockingDialogs ();
 			ClickButton (proj.PackageName, "myButton", "MY BUTTON");
 
-			string expectedLogcatOutput = "UnhandledExceptionRaiser: System.Exception: Unhandled exception test";
+			string expectedRaiser = "UnhandledExceptionRaiser: System.Exception: Unhandled exception test";
 			Assert.IsTrue (
-				MonitorAdbLogcat (CreateLineChecker (expectedLogcatOutput),
+				MonitorAdbLogcat (CreateLineChecker (expectedRaiser),
 					logcatFilePath: Path.Combine (Root, builder.ProjectDirectory, "unhandled-logcat.log"), timeout: 60),
-				$"Output did not contain {expectedLogcatOutput}!");
+				$"Output did not contain {expectedRaiser}!");
 		}
 
 		[Test]

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -429,6 +429,45 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 		}
 
 		[Test]
+		public void UnhandledExceptionFromButtonClick ([Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
+		{
+			proj = new XamarinAndroidApplicationProject ();
+			proj.SetRuntime (runtime);
+			proj.SetAndroidSupportedAbis (DeviceAbi);
+
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", """
+				Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => {
+					Android.Util.Log.Error ("UnhandledTest", $"UnhandledExceptionRaiser: {e.Exception}");
+					e.Handled = true;
+				};
+
+				AppDomain.CurrentDomain.UnhandledException += (sender, e) => {
+					Android.Util.Log.Error ("UnhandledTest",
+						$"AppDomain.UnhandledException: {e.ExceptionObject}, IsTerminating: {e.IsTerminating}");
+				};
+
+				button!.Click += (sender, e) => {
+					throw new Exception ("Unhandled exception test");
+				};
+			""");
+
+			builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Install (proj), "Install should have succeeded.");
+			AdbStartActivity ($"{proj.PackageName}/{proj.JavaPackageName}.MainActivity");
+			WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"));
+			ClearAdbLogcat ();
+			ClearBlockingDialogs ();
+			ClickButton (proj.PackageName, "myButton", "MY BUTTON");
+
+			string expectedLogcatOutput = "UnhandledExceptionRaiser: System.Exception: Unhandled exception test";
+			Assert.IsTrue (
+				MonitorAdbLogcat (CreateLineChecker (expectedLogcatOutput),
+					logcatFilePath: Path.Combine (Root, builder.ProjectDirectory, "unhandled-logcat.log"), timeout: 60),
+				$"Output did not contain {expectedLogcatOutput}!");
+		}
+
+		[Test]
 		[Category ("UsesDevice")]
 		[TestCase ("テスト")]
 		[TestCase ("随机生成器")]

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -435,8 +435,7 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 			proj.SetRuntime (runtime);
 			proj.SetAndroidSupportedAbis (DeviceAbi);
 
-			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}",
-"""
+			proj.MainActivity = proj.DefaultMainActivity.Replace ("//${AFTER_ONCREATE}", """
 				Android.Runtime.AndroidEnvironment.UnhandledExceptionRaiser += (sender, e) => {
 					Android.Util.Log.Error ("UnhandledTest", $"UnhandledExceptionRaiser: {e.Exception}");
 					e.Handled = true;


### PR DESCRIPTION
Context: https://github.com/dotnet/java-interop/pull/1275
Fixes: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2842209

dotnet/java-interop#1275 eliminated `JNINativeWrapper.CreateDelegate()` from generated binding marshal methods. The old code path routed exceptions through `AndroidEnvironment.UnhandledException()`, which fires the `UnhandledExceptionRaiser` event. The new code path calls `JniRuntime.OnUserUnhandledException()`, which only calls `SetPendingException()` and never invokes `AndroidEnvironment.UnhandledException()`.

Fix by overriding `OnUserUnhandledException()` in `AndroidRuntime` to call `AndroidEnvironment.TryRaiseUnhandledException()` before delegating to the base implementation. If a subscriber sets `Handled = true`, the exception is swallowed and not transitioned to JNI.

Refactor `AndroidEnvironment.UnhandledException()` to extract the event- raising logic into `TryRaiseUnhandledException()` so it can be called from both the old and new code paths.

### Tests ###

Add a test that verifies both `UnhandledExceptionRaiser` and `AppDomain.UnhandledException` fire when an unhandled exception is thrown from a button click handler.

The test:

1. Registers both `UnhandledExceptionRaiser` (with `e.Handled = true`) and `AppDomain.UnhandledException` handlers
2. Throws from the button click delegate
3. Asserts `UnhandledExceptionRaiser` fires via logcat