### PR TITLE
[xaprepare] Retry runtime pack restore up to 3 times

### DIFF
--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -47,11 +47,13 @@ namespace Xamarin.Android.Prepare
 
 			// Install runtime packs associated with the SDK previously installed.
 			var packageDownloadProj = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "build-tools", "xaprepare", "xaprepare", "package-download.proj");
-			var logPath = Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{context.BuildTimeStamp}-download-runtime-packs.binlog");
+			var logPathBase = Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{context.BuildTimeStamp}-download-runtime-packs");
 
 			const int maxAttempts = 3;
+			const int initialBackoffDelayMilliseconds = 2000;
 			bool restoreSucceeded = false;
 			for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+				var logPath = $"{logPathBase}-attempt{attempt}.binlog";
 				var runner = new ProcessRunner (Configurables.Paths.DotNetPreviewTool, "restore",
 					ProcessRunner.QuoteArgument (packageDownloadProj),
 					"--configfile", Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "NuGet.config"),
@@ -67,6 +69,8 @@ namespace Xamarin.Android.Prepare
 				}
 				if (attempt < maxAttempts) {
 					Log.WarningLine ($"Failed to restore runtime packs (attempt {attempt}/{maxAttempts}), retrying...");
+					var delayMilliseconds = initialBackoffDelayMilliseconds * (1 << (attempt - 1));
+					await Task.Delay (delayMilliseconds);
 				}
 			}
 			if (!restoreSucceeded) {

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -48,17 +48,29 @@ namespace Xamarin.Android.Prepare
 			// Install runtime packs associated with the SDK previously installed.
 			var packageDownloadProj = Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "build-tools", "xaprepare", "xaprepare", "package-download.proj");
 			var logPath = Path.Combine (Configurables.Paths.BuildBinDir, $"msbuild-{context.BuildTimeStamp}-download-runtime-packs.binlog");
-			var runner = new ProcessRunner (Configurables.Paths.DotNetPreviewTool, "restore",
-				ProcessRunner.QuoteArgument (packageDownloadProj),
-				"--configfile", Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "NuGet.config"),
-				ProcessRunner.QuoteArgument ($"-bl:{logPath}"),
-				"--verbosity", "normal"
-			) {
-				EchoStandardOutput = true,
-				EchoStandardError = true,
-			};
-			if (!runner.Run ()) {
-				Log.ErrorLine ($"Failed to restore runtime packs using '{packageDownloadProj}'.");
+
+			const int maxAttempts = 3;
+			bool restoreSucceeded = false;
+			for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+				var runner = new ProcessRunner (Configurables.Paths.DotNetPreviewTool, "restore",
+					ProcessRunner.QuoteArgument (packageDownloadProj),
+					"--configfile", Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "NuGet.config"),
+					ProcessRunner.QuoteArgument ($"-bl:{logPath}"),
+					"--verbosity", "normal"
+				) {
+					EchoStandardOutput = true,
+					EchoStandardError = true,
+				};
+				if (runner.Run ()) {
+					restoreSucceeded = true;
+					break;
+				}
+				if (attempt < maxAttempts) {
+					Log.WarningLine ($"Failed to restore runtime packs (attempt {attempt}/{maxAttempts}), retrying...");
+				}
+			}
+			if (!restoreSucceeded) {
+				Log.ErrorLine ($"Failed to restore runtime packs using '{packageDownloadProj}' after {maxAttempts} attempts.");
 				return false;
 			}
 


### PR DESCRIPTION
The dotnet restore for runtime packs in Step_InstallDotNetPreview can time out (10-minute default) due to transient NuGet feed issues, causing the entire macOS build to fail and require manual reruns.

Add retry logic (up to 3 attempts) so transient restore failures self-heal without manual intervention.