### PR TITLE
Update copilot-instructions.md with learnings from recent PRs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,6 +7,7 @@
 - `src/Xamarin.Android.Build.Tasks/` - MSBuild tasks for Android apps  
 - `src/native/` - Native runtime (MonoVM/CoreCLR/NativeAOT)
 - `external/Java.Interop/` - JNI bindings and Java-to-.NET interop
+- `external/xamarin-android-tools/` - Shared SDK tooling: `AndroidTask`/`AsyncTask` base classes, `AdbRunner`, `EmulatorRunner`, NRT extensions (`IsNullOrEmpty()`, `IsNullOrWhiteSpace()`), `CreateTaskLogger`, and SDK info utilities
 - `tests/` - NUnit tests, integration tests, device tests
 
 **Build System:** MSBuild + .NET Arcade SDK + CMake (native)
@@ -32,7 +33,7 @@ Reference official Android documentation where helpful:
 
 **Use Microsoft docs:** Search MS Learn before making .NET, Windows, or Microsoft features, APIs, or integrations. Use the `microsoft_docs_search` tool.
 
-**MSBuild Tasks:** Extend `AndroidTask` base class, use `XA####` error codes, test in isolation.
+**MSBuild Tasks:** Extend `AndroidTask` base class, use `XA####` error codes, test in isolation. Use `AsyncTask` for tasks that need `async`/`await` — it handles `Yield()`, `try`/`finally`, and `Reacquire()` automatically.
 
 **Internal build `<UsingTask/>` elements:** For `xa-prep-tasks` and `BootstrapTasks` (internal build-time tasks, not shipped to customers), always use `TaskFactory="TaskHostFactory"` and `Runtime="NET"` attributes on `<UsingTask/>` elements. This runs the task in a separate process to avoid Windows file locking issues and ensures the task runs on .NET (even when MSBuild.exe in Visual Studio uses .NET Framework). Example:
 
@@ -56,6 +57,10 @@ When opting C# code into nullable reference types:
 * Add `#nullable enable` at the top of the file without any preceding blank lines.
 
 * Don't *ever* use `!` (null-forgiving operator) to handle `null`! Always check for null explicitly and throw appropriate exceptions.
+
+* **In test code**, avoid `!` too. Common workarounds:
+  - `[SetUp]`-initialized fields: declare as nullable (`MockBuildEngine? engine;`) instead of `MockBuildEngine engine = null!;`
+  - After `Assert.IsNotNull`: extract into a local variable (`var opts = task.Options; Assert.IsNotNull (opts); opts.Foo...`) instead of using `task.Options!.Foo`
 
 * Declare variables non-nullable, and check for `null` at entry points.
 
@@ -181,7 +186,9 @@ This pattern ensures proper encoding, timestamps, and file attributes are handle
 
 ## Error Patterns
 - **MSBuild Errors:** `XA####` (errors), `XA####` (warnings), `APT####` (Android tools)
-- **Logging:** Use `Log.LogError`, `Log.LogWarning` with error codes and context
+- **Error messages:** Must come from `Properties.Resources` (e.g., `Properties.Resources.XA0143`) for localization support. Add new messages to the English `Resources.resx` file.
+- **Error code lifecycle:** When removing functionality that used an `XA####` code, either repurpose the code or remove it from `Resources.resx` and `Resources.Designer.cs`. Don't leave orphaned codes.
+- **Logging in `AsyncTask`:** Use the thread-safe helpers (`LogCodedError()`, `LogMessage()`, `LogCodedWarning()`, `LogDebugMessage()`) instead of `Log.*`. The `Log` property is marked `[Obsolete]` on `AsyncTask` because calling `Log.LogMessage` directly from a background thread can hang Visual Studio.
 
 ## Troubleshooting
 - **Build:** Clean `bin/`+`obj/`, check Android SDK/NDK, `make clean`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -195,3 +195,4 @@ This pattern ensures proper encoding, timestamps, and file attributes are handle
 - **MSBuild:** Test in isolation, validate inputs
 - **Device:** Use update directories for rapid Debug iteration
 - **Performance:** See `../Documentation/guides/profiling.md` and `../Documentation/guides/tracing.md`
+- **Emulator black screen on macOS:** If the Android emulator launches but shows only a black screen, the emulator tools are likely outdated. Update via `sdkmanager --install "emulator"` or Android Studio SDK Manager. Versions older than ~35.x are known to render incorrectly on Apple Silicon Macs.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -195,4 +195,3 @@ This pattern ensures proper encoding, timestamps, and file attributes are handle
 - **MSBuild:** Test in isolation, validate inputs
 - **Device:** Use update directories for rapid Debug iteration
 - **Performance:** See `../Documentation/guides/profiling.md` and `../Documentation/guides/tracing.md`
-- **Emulator black screen on macOS:** If the Android emulator launches but shows only a black screen, the emulator tools are likely outdated. Update via `sdkmanager --install "emulator"` or Android Studio SDK Manager. Versions older than ~35.x are known to render incorrectly on Apple Silicon Macs.


### PR DESCRIPTION
## Summary

Updates `.github/copilot-instructions.md` with learnings from recent PRs (#10949, #10969, #10971 and dotnet/android-tools#312).

## Changes

### Architecture
- Document `external/xamarin-android-tools/` submodule — it contains key shared infrastructure (`AndroidTask`/`AsyncTask` base classes, `AdbRunner`, `EmulatorRunner`, NRT extensions, `CreateTaskLogger`)

### MSBuild Tasks
- Clarify that `AsyncTask` should be used for tasks needing `async`/`await` (not just `AndroidTask`)

### Error Patterns (expanded section)
- **Error messages must come from `Properties.Resources`** — previously not documented, led to hardcoded strings in AI-generated code
- **Error code lifecycle** — when removing functionality, clean up or repurpose the `XA####` code; don't leave orphaned entries in `Resources.resx`
- **AsyncTask logging** — use thread-safe `LogCodedError()`/`LogMessage()` helpers instead of `Log.*` which is `[Obsolete]` on `AsyncTask` and can hang Visual Studio

### Nullable Reference Types
- **`!` workarounds for test code** — document how to avoid `null!` in `[SetUp]` fields (use nullable types) and after `Assert.IsNotNull` (extract to local variable)

## Context

These gaps caused real issues during PR development:
- Using `Log.LogCodedError` from `AsyncTask` async context (should use `LogCodedError`)
- Orphaned XA0144 error code after refactoring
- `null!` pattern in test fields flagged by all 4 AI models during multi-model code review
- Hardcoded error strings instead of `Properties.Resources`
