### PR TITLE
Bump `$(AndroidPackVersion)` to 36.99.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>36.1.99</AndroidPackVersion>
+    <AndroidPackVersion>36.99.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.3</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>


### PR DESCRIPTION
Since main/.NET 11 now contains preview bindings for API-37.

We normally bump the product version to signal this: 36.99.x

When API-37 goes stable, we will change to 37.x.

This is also good to move ahead of 36.1.99, as our stable builds are at 36.1.43 and this will prevent a collision.