### PR TITLE
[build] Add `build-summary` stage to `Xamarin.Android-PR` pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/dev/peppers/build-summary
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support
@@ -456,3 +456,18 @@ extends:
         policheckPtbScanFolder: $(Build.SourcesDirectory)\Localize\loc\pt-BR
         policheckRusScanFolder: $(Build.SourcesDirectory)\Localize\loc\ru
         policheckTrkScanFolder: $(Build.SourcesDirectory)\Localize\loc\tr
+
+    - ${{ if eq(variables['Build.DefinitionName'], 'Xamarin.Android-PR') }}:
+      - stage: BuildSummary
+        dependsOn:
+        - mac_build
+        - win_build_test
+        - linux_build
+        - smoke_tests
+        - linux_tests
+        - msbuild_dotnet
+        - msbuilddevice_tests
+        - maui_tests
+        condition: failed()
+        jobs:
+        - template: build-summary/v1.yml@yaml-templates

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/dev/peppers/build-summary
+    ref: refs/heads/main
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -7,9 +7,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 -->
 <Project>
 
-  <!-- Deliberate invalid XML to test build-summary template -->
-  <This is not valid XML>
-
   <UsingTask TaskName="Xamarin.Android.Tasks.SetNdkPathForIlc" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GenerateNativeAotLibraryLoadAssemblerSources" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GenerateNativeAotEnvironmentAssemblerSources" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -7,6 +7,9 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
 -->
 <Project>
 
+  <!-- Deliberate invalid XML to test build-summary template -->
+  <This is not valid XML>
+
   <UsingTask TaskName="Xamarin.Android.Tasks.SetNdkPathForIlc" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GenerateNativeAotLibraryLoadAssemblerSources" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
   <UsingTask TaskName="Xamarin.Android.Tasks.GenerateNativeAotEnvironmentAssemblerSources" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />


### PR DESCRIPTION
Context: https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/720277

Points yaml-templates at `dev/peppers/build-summary` to test the new `build-summary` template. Only runs on `Xamarin.Android-PR` pipeline for non-fork PRs.

For testing:

* Add invalid XML to NativeAOT.targets to trigger test failures