### PR TITLE
Fix `dotnet run` failing with multiple AVDs present

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Android.Tasks;
 
 /// <summary>
 /// MSBuild task that queries available Android devices and emulators using 'adb devices -l'
-/// and 'emulator -list-avds'. Merges the results to provide a complete list of available
-/// devices including emulators that are not currently running.
+/// and 'emulator -list-avds'. Merges the results and filters them for device selection:
+/// when any online devices exist, only online devices are returned (enabling auto-selection
+/// when a single device is running). When no online devices exist, all devices are returned
+/// including non-running emulators (allowing the user to pick one to boot).
 /// Returns a list of devices with metadata for device selection in dotnet run.
 ///
 /// Parsing and merging logic is delegated to <see cref="AdbRunner"/> in Xamarin.Android.Tools.AndroidSdk.
@@ -74,12 +76,38 @@ public class GetAvailableAndroidDevices : AndroidAdb
         // Merge using shared logic
         var mergedDevices = AdbRunner.MergeDevicesAndEmulators (adbDevices, availableEmulators, logger);
 
-        // Convert to ITaskItem array
-        Devices = ConvertToTaskItems (mergedDevices);
+        // Filter: if any online devices exist, return only those so auto-selection works
+        // when a single device is running. If none are online, return all (including
+        // non-running emulators) so the user can pick one to boot.
+        var filteredDevices = FilterDevicesForSelection (mergedDevices);
+        Log.LogDebugMessage ($"Filtered from {mergedDevices.Count} to {filteredDevices.Count} device(s) (online devices take priority)");
 
-        Log.LogDebugMessage ($"Total {Devices.Length} Android device(s)/emulator(s) after merging");
+        // Convert to ITaskItem array
+        Devices = ConvertToTaskItems (filteredDevices);
+
+        Log.LogDebugMessage ($"Total {Devices.Length} Android device(s)/emulator(s) after filtering");
 
         return !Log.HasLoggedErrors;
+    }
+
+    /// <summary>
+    /// Filters the merged device list for device selection:
+    /// - If any online devices exist, returns only those (so auto-selection works with a single running device)
+    /// - If no online devices exist, returns all (including non-running emulators for user selection)
+    /// </summary>
+    internal static IReadOnlyList<AdbDeviceInfo> FilterDevicesForSelection (IReadOnlyList<AdbDeviceInfo> devices)
+    {
+        var onlineDevices = new List<AdbDeviceInfo> (devices.Count);
+        foreach (var device in devices) {
+            if (device.Status == AdbDeviceStatus.Online) {
+                onlineDevices.Add (device);
+            }
+        }
+
+        if (onlineDevices.Count == 0)
+            return devices;
+
+        return onlineDevices;
     }
 
     /// <summary>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
@@ -97,36 +97,15 @@ public class GetAvailableAndroidDevices : AndroidAdb
     /// </summary>
     internal static IReadOnlyList<AdbDeviceInfo> FilterDevicesForSelection (IReadOnlyList<AdbDeviceInfo> devices)
     {
-        bool anyOnline = false;
-        bool anyOffline = false;
-        int onlineCount = 0;
-
-        for (int i = 0; i < devices.Count; i++) {
-            var device = devices [i];
-            if (device.Status == AdbDeviceStatus.Online) {
-                anyOnline = true;
-                onlineCount++;
-            } else {
-                anyOffline = true;
-            }
-        }
-
-        // No online devices: return all devices (including non-running emulators)
-        if (!anyOnline)
-            return devices;
-
-        // All devices are online: no filtering needed, return original list
-        if (!anyOffline)
-            return devices;
-
-        // Mixed online and offline: return only online devices
-        var onlineDevices = new List<AdbDeviceInfo> (onlineCount);
-        for (int i = 0; i < devices.Count; i++) {
-            var device = devices [i];
+        var onlineDevices = new List<AdbDeviceInfo> (devices.Count);
+        foreach (var device in devices) {
             if (device.Status == AdbDeviceStatus.Online) {
                 onlineDevices.Add (device);
             }
         }
+
+        if (onlineDevices.Count == 0)
+            return devices;
 
         return onlineDevices;
     }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GetAvailableAndroidDevices.cs
@@ -97,15 +97,36 @@ public class GetAvailableAndroidDevices : AndroidAdb
     /// </summary>
     internal static IReadOnlyList<AdbDeviceInfo> FilterDevicesForSelection (IReadOnlyList<AdbDeviceInfo> devices)
     {
-        var onlineDevices = new List<AdbDeviceInfo> (devices.Count);
-        foreach (var device in devices) {
+        bool anyOnline = false;
+        bool anyOffline = false;
+        int onlineCount = 0;
+
+        for (int i = 0; i < devices.Count; i++) {
+            var device = devices [i];
+            if (device.Status == AdbDeviceStatus.Online) {
+                anyOnline = true;
+                onlineCount++;
+            } else {
+                anyOffline = true;
+            }
+        }
+
+        // No online devices: return all devices (including non-running emulators)
+        if (!anyOnline)
+            return devices;
+
+        // All devices are online: no filtering needed, return original list
+        if (!anyOffline)
+            return devices;
+
+        // Mixed online and offline: return only online devices
+        var onlineDevices = new List<AdbDeviceInfo> (onlineCount);
+        for (int i = 0; i < devices.Count; i++) {
+            var device = devices [i];
             if (device.Status == AdbDeviceStatus.Online) {
                 onlineDevices.Add (device);
             }
         }
-
-        if (onlineDevices.Count == 0)
-            return devices;
 
         return onlineDevices;
     }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAvailableAndroidDevicesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GetAvailableAndroidDevicesTests.cs
@@ -706,6 +706,106 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual ("Pixel 7 Pro API 35 (Not Running)", result [0].GetMetadata ("Description"), "Description should be formatted with (Not Running) suffix");
 		}
 
+		[Test]
+		public void FilterDevicesForSelection_SingleOnlineDevice_WithNonRunningEmulators_ReturnsOnlyOnline ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("emulator-5554", "Pixel 8 API 36 X64", AdbDeviceType.Emulator, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("pixel_3_xl_api_22_arm", "Pixel 3 XL API 22 Arm (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+				CreateDeviceInfo ("pixel_3_xl_api_22_x86", "Pixel 3 XL API 22 X86 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+				CreateDeviceInfo ("pixel_4_api_30_amd64", "Pixel 4 API 30 Amd64 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (1, filtered.Count, "Should return only the single running device");
+			Assert.AreEqual ("emulator-5554", filtered [0].Serial);
+			Assert.AreEqual (AdbDeviceStatus.Online, filtered [0].Status);
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_SinglePhysicalDevice_WithNonRunningEmulators_ReturnsOnlyOnline ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("0A041FDD400327", "Pixel 5", AdbDeviceType.Device, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("pixel_7_api_35", "Pixel 7 API 35 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+				CreateDeviceInfo ("pixel_9_api_36", "Pixel 9 API 36 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (1, filtered.Count, "Should return only the single running physical device");
+			Assert.AreEqual ("0A041FDD400327", filtered [0].Serial);
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_MultipleOnlineDevices_ReturnsOnlyOnline ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("0A041FDD400327", "Pixel 5", AdbDeviceType.Device, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("emulator-5554", "Pixel 8 API 36", AdbDeviceType.Emulator, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("pixel_7_api_35", "Pixel 7 API 35 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (2, filtered.Count, "Should return only the 2 online devices");
+			Assert.IsTrue (filtered.All (d => d.Status == AdbDeviceStatus.Online), "All returned devices should be online");
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_NoOnlineDevices_ReturnsAll ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("pixel_7_api_35", "Pixel 7 API 35 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+				CreateDeviceInfo ("pixel_9_api_36", "Pixel 9 API 36 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (2, filtered.Count, "Should return all devices when none are online");
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_EmptyList_ReturnsEmpty ()
+		{
+			var devices = new List<AdbDeviceInfo> ();
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (0, filtered.Count, "Should return empty list");
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_OnlineDeviceWithOfflineDevice_ReturnsOnlyOnline ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("0A041FDD400327", "Pixel 5", AdbDeviceType.Device, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("DEADBEEF123456", "Pixel 3", AdbDeviceType.Device, AdbDeviceStatus.Offline),
+				CreateDeviceInfo ("pixel_7_api_35", "Pixel 7 API 35 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (1, filtered.Count, "Should return only the online device, filtering offline and non-running");
+			Assert.AreEqual ("0A041FDD400327", filtered [0].Serial);
+		}
+
+		[Test]
+		public void FilterDevicesForSelection_OnlineDeviceWithUnauthorizedDevice_ReturnsOnlyOnline ()
+		{
+			var devices = new List<AdbDeviceInfo> {
+				CreateDeviceInfo ("0A041FDD400327", "Pixel 5", AdbDeviceType.Device, AdbDeviceStatus.Online),
+				CreateDeviceInfo ("UNAUTHORIZED001", "Unknown", AdbDeviceType.Device, AdbDeviceStatus.Unauthorized),
+				CreateDeviceInfo ("pixel_7_api_35", "Pixel 7 API 35 (Not Running)", AdbDeviceType.Emulator, AdbDeviceStatus.NotRunning),
+			};
+
+			var filtered = GetAvailableAndroidDevices.FilterDevicesForSelection (devices);
+
+			Assert.AreEqual (1, filtered.Count, "Should return only the online device, filtering unauthorized and non-running");
+			Assert.AreEqual ("0A041FDD400327", filtered [0].Serial);
+		}
+
 		/// <summary>
 		/// Helper method to create an AdbDeviceInfo for testing
 		/// </summary>


### PR DESCRIPTION
## Summary

When multiple AVD emulator images are defined but only one device is running, `dotnet run` incorrectly considers all AVDs (including non-running ones) as available targets, causing a device selection prompt or error in non-interactive mode.

## Changes

Added `FilterDevicesForSelection()` to `GetAvailableAndroidDevices` that filters the merged device list after the merge step:

- **Any online devices exist** → return only online devices (enables auto-selection when a single device is running)
- **No online devices exist** → return all including non-running emulators (so the user can pick one to boot)

This means:
| Scenario | Result |
|----------|--------|
| 1 running device + N non-running emulators | Auto-selects the running device |
| 2+ running devices | Prompts user to choose between running devices |
| 0 running devices + N non-running emulators | Prompts user to pick an emulator to boot |
| 0 devices at all | Error |

## Tests

Added 8 unit tests covering:
- Single online device with non-running emulators (the exact bug scenario)
- Single physical device with non-running emulators
- Multiple online devices (filters out non-running)
- No online devices (returns all for selection)
- Empty device list
- Online + offline device
- Online + unauthorized device

Fixes #10998