### PR TITLE
Track AndroidManifestOverlay changes in _ManifestMerger

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -205,7 +205,7 @@ namespace Bug12935
 </manifest>
 "
 			});
-			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
+			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: true, cleanupOnDispose: false)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var manifestFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				var text = File.ReadAllText (manifestFile);
@@ -238,7 +238,7 @@ namespace Bug12935
 "
 			};
 			proj.OtherBuildItems.Add (overlay);
-			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: true, cleanupOnDispose: false)) {
+			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
 				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
 				var text = b.Output.GetIntermediaryAsText ("android/AndroidManifest.xml");
 				StringAssert.Contains ("android.permission.CAMERA", text, "Merged manifest should contain the initial overlay permission.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -205,7 +205,7 @@ namespace Bug12935
 </manifest>
 "
 			});
-			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: true, cleanupOnDispose: false)) {
+			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: false, cleanupOnDispose: false)) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 				var manifestFile = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "AndroidManifest.xml");
 				var text = File.ReadAllText (manifestFile);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -253,7 +253,7 @@ namespace Bug12935
 	<uses-permission android:name=""android.permission.RECORD_AUDIO"" />
 </manifest>
 ";
-				overlay.Timestamp = null;
+				proj.Touch ("ManifestOverlay.xml");
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Third build should have succeeded.");
 				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -214,6 +214,56 @@ namespace Bug12935
 		}
 
 		[Test]
+		public void OverlayManifestIncrementalBuildTest ([Values] AndroidRuntime runtime)
+		{
+			const bool isRelease = true;
+			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
+				return;
+			}
+			var proj = new XamarinAndroidApplicationProject () {
+				IsRelease = isRelease,
+				ManifestMerger = "manifestmerger.jar",
+			};
+			proj.SetRuntime (runtime);
+			proj.AndroidManifest = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"" android:versionCode=""1"" android:versionName=""1.0"" package=""foo.foo"">
+	<application android:label=""foo"">
+	</application>
+</manifest>";
+			var overlay = new BuildItem ("AndroidManifestOverlay", "ManifestOverlay.xml") {
+				TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"">
+	<uses-permission android:name=""android.permission.CAMERA"" />
+</manifest>
+"
+			};
+			proj.OtherBuildItems.Add (overlay);
+			using (var b = CreateApkBuilder (cleanupAfterSuccessfulBuild: true, cleanupOnDispose: false)) {
+				Assert.IsTrue (b.Build (proj), "First build should have succeeded.");
+				var text = b.Output.GetIntermediaryAsText ("android/AndroidManifest.xml");
+				StringAssert.Contains ("android.permission.CAMERA", text, "Merged manifest should contain the initial overlay permission.");
+				StringAssert.DoesNotContain ("android.permission.RECORD_AUDIO", text, "Merged manifest should not contain the updated overlay permission yet.");
+
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
+				b.Output.AssertTargetIsSkipped ("_ManifestMerger");
+
+				overlay.TextContent = () => @"<?xml version=""1.0"" encoding=""utf-8""?>
+<manifest xmlns:android=""http://schemas.android.com/apk/res/android"">
+	<uses-permission android:name=""android.permission.CAMERA"" />
+	<uses-permission android:name=""android.permission.RECORD_AUDIO"" />
+</manifest>
+";
+				overlay.Timestamp = null;
+
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Third build should have succeeded.");
+				b.Output.AssertTargetIsNotSkipped ("_ManifestMerger");
+
+				text = b.Output.GetIntermediaryAsText ("android/AndroidManifest.xml");
+				StringAssert.Contains ("android.permission.RECORD_AUDIO", text, "Merged manifest should include permissions from the updated overlay.");
+			}
+		}
+
+		[Test]
 		public void RemovePermissionTest ([Values] AndroidRuntime runtime)
 		{
 			const bool isRelease = true;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1493,7 +1493,7 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-  <Target Name="_ManifestMerger"
+<Target Name="_ManifestMerger"
     Condition=" '$(AndroidManifestMerger)' == 'manifestmerger.jar' "
     Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);@(AndroidManifestOverlay);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
     Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1494,13 +1494,9 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-  <PropertyGroup>
-    <_ManifestMergerTimingOverlay Condition=" '$(_AndroidFastTiming)' == 'True' ">$(MSBuildThisFileDirectory)\ManifestOverlays\Timing.xml</_ManifestMergerTimingOverlay>
-  </PropertyGroup>
-
   <Target Name="_ManifestMerger"
     Condition=" '$(AndroidManifestMerger)' == 'manifestmerger.jar' "
-    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);@(AndroidManifestOverlay);$(_ManifestMergerTimingOverlay);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
+    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);@(AndroidManifestOverlay);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
     Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml"
   >
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -977,6 +977,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
+		<_PropertyCacheItems Include="_AndroidFastTiming=$(_AndroidFastTiming)" />
 		<_PropertyCacheItems Include="_NuGetAssetsFileHash=%(_NuGetAssetsFileHash.FileHash)" />
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
@@ -1493,9 +1494,13 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
-<Target Name="_ManifestMerger"
+  <PropertyGroup>
+    <_ManifestMergerTimingOverlay Condition=" '$(_AndroidFastTiming)' == 'True' ">$(MSBuildThisFileDirectory)\ManifestOverlays\Timing.xml</_ManifestMergerTimingOverlay>
+  </PropertyGroup>
+
+  <Target Name="_ManifestMerger"
     Condition=" '$(AndroidManifestMerger)' == 'manifestmerger.jar' "
-    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
+    Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);@(AndroidManifestOverlay);$(_ManifestMergerTimingOverlay);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
     Outputs="$(IntermediateOutputPath)android\AndroidManifest.xml"
   >
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -977,7 +977,6 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="OS=$(OS)" />
 		<_PropertyCacheItems Include="AndroidIncludeDebugSymbols=$(AndroidIncludeDebugSymbols)" />
 		<_PropertyCacheItems Include="AndroidPackageNamingPolicy=$(AndroidPackageNamingPolicy)" />
-		<_PropertyCacheItems Include="_AndroidFastTiming=$(_AndroidFastTiming)" />
 		<_PropertyCacheItems Include="_NuGetAssetsFileHash=%(_NuGetAssetsFileHash.FileHash)" />
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />


### PR DESCRIPTION
## Summary
- include `@(AndroidManifestOverlay)` in `_ManifestMerger` incremental inputs
- track the built-in timing overlay in the same incremental path
- add a regression test that updates only an overlay file and verifies `_ManifestMerger` reruns

## Testing
- `dotnet test src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj --filter "OverlayManifestTest|OverlayManifestIncrementalBuildTest" --logger "console;verbosity=minimal"` *(fails locally before build because this checkout was not prepared and the host SDK cannot evaluate the repo's .NET 11 graph)*
- `make prepare` *(built `xaprepare`, but local bootstrap stopped because required host tools were missing: `ccache`, `cmake`, `ninja`, `p7zip`, and the repo's expected `make` detection)*

Fixes #11006