### PR TITLE
[TrimmableTypeMap] Wire AcwMapWriter to populate acw-map.txt

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -73,7 +73,8 @@
         EmbedAssemblies="$(EmbedAssembliesIntoApk)"
         ManifestPlaceholders="$(AndroidManifestPlaceholders)"
         CheckedBuild="$(_AndroidCheckedBuild)"
-        ApplicationJavaClass="$(AndroidApplicationJavaClass)">
+        ApplicationJavaClass="$(AndroidApplicationJavaClass)"
+        AcwMapOutputFile="$(IntermediateOutputPath)acw-map.txt">
       <Output TaskParameter="GeneratedAssemblies" ItemName="_GeneratedTypeMapAssemblies" />
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_GeneratedJavaFiles" />
       <Output TaskParameter="AdditionalProviderSources" ItemName="_AdditionalProviderSources" />
@@ -83,6 +84,7 @@
       <FileWrites Include="@(_GeneratedTypeMapAssemblies)" />
       <FileWrites Include="@(_GeneratedJavaFiles)" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
+      <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
     </ItemGroup>
   </Target>
 
@@ -134,10 +136,11 @@
         SkipUnchangedFiles="true"
         Condition="Exists('$(_TypeMapBaseOutputDir)AndroidManifest.xml')" />
 
-    <!-- acw-map.txt is consumed as an Input by _ConvertCustomView and _UpdateAndroidResgen.
-         Create an empty file if it doesn't exist yet. The trimmable path doesn't populate it
-         (no Cecil-based ACW mapping), but it must exist for downstream targets to evaluate. -->
-    <Touch Files="$(IntermediateOutputPath)acw-map.txt" AlwaysCreate="true" />
+    <!-- acw-map.txt is populated by _GenerateTrimmableTypeMap with real managed→Java mappings.
+         If that target was skipped (e.g., no input assemblies), create an empty placeholder so
+         downstream targets (_ConvertCustomView, _UpdateAndroidResgen) can evaluate their Inputs. -->
+    <Touch Files="$(IntermediateOutputPath)acw-map.txt" AlwaysCreate="true"
+        Condition="!Exists('$(IntermediateOutputPath)acw-map.txt')" />
 
     <!-- Generate ApplicationRegistration.java.
          In the trimmable path, Application/Instrumentation types are activated via


### PR DESCRIPTION
Part of #10807
Depends on #10980

## Summary

Wires the existing `AcwMapWriter` class into `GenerateTrimmableTypeMap` so that `acw-map.txt` is populated with real managed→Java name mappings instead of being an empty placeholder.

This enables `_ConvertCustomView` to correctly rewrite custom view names in layout XMLs for the trimmable typemap path.

### Changes

- **`GenerateTrimmableTypeMap.cs`**: Added `AcwMapOutputFile` property and `WriteAcwMap()` method that calls `AcwMapWriter.Write()`
- **`Microsoft.Android.Sdk.TypeMap.Trimmable.targets`**: Passes `AcwMapOutputFile` to the task, adds to `FileWrites`, demotes `<Touch>` to a fallback
- **Tests**: Verifies acw-map content for Mono.Android types and empty assembly list