### PR TITLE
[TrimmableTypeMap] Fix JniNameToJavaName

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -163,11 +163,14 @@ static class JniSignatureHelper
 
 	/// <summary>
 	/// Converts a JNI type name to a Java source type name.
-	/// e.g., "android/app/Activity" \u2192 "android.app.Activity"
+	/// JNI uses '/' for packages and '$' for inner classes.
+	/// Java source uses '.' for both.
+	/// e.g., "android/app/Activity" → "android.app.Activity"
+	/// e.g., "android/drm/DrmManagerClient$OnEventListener" → "android.drm.DrmManagerClient.OnEventListener"
 	/// </summary>
 	internal static string JniNameToJavaName (string jniName)
 	{
-		return jniName.Replace ('/', '.');
+		return jniName.Replace ('/', '.').Replace ('$', '.');
 	}
 
 	/// <summary>

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -113,6 +113,14 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			Assert.Contains ("public abstract class AbstractBase\n", java);
 		}
 
+		[Fact]
+		public void Generate_ClickableView_UsesDotsForNestedInterfaceName ()
+		{
+			var java = GenerateFixture ("my/app/ClickableView");
+			Assert.Contains ("\t\tandroid.view.View.OnClickListener", java);
+			Assert.DoesNotContain ("View$OnClickListener", java);
+		}
+
 	}
 
 	public class StaticInitializer

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -37,7 +37,7 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 		[Theory]
 		[InlineData ("android/app/Activity", "android.app.Activity")]
 		[InlineData ("java/lang/Object", "java.lang.Object")]
-		[InlineData ("android/view/View$OnClickListener", "android.view.View$OnClickListener")]
+		[InlineData ("android/view/View$OnClickListener", "android.view.View.OnClickListener")]
 		public void JniNameToJavaName_ConvertsCorrectly (string jniName, string expected)
 		{
 			Assert.Equal (expected, JniSignatureHelper.JniNameToJavaName (jniName));


### PR DESCRIPTION
**Problem:** `JniNameToJavaName` was only replacing `/` with `.`, but JNI uses `$` for inner/nested classes. Java source uses `.` for both package and inner class separators.

**Before:** `android/view/View$OnClickListener` → `android.view.View$OnClickListener` ❌
**After:**  `android/view/View$OnClickListener` → `android.view.View.OnClickListener` ✅

This caused generated JCW Java source files to use `$` in type references instead of `.`, which is incorrect for Java source code.