### PR TITLE
[TrimmableTypeMap] Fix NativeCallbackName and DeclaringType derivation from Connector

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -773,7 +773,7 @@ public sealed class JavaPeerScanner : IDisposable
 			JniSignature = registerInfo.Signature,
 			Connector = registerInfo.Connector,
 			ManagedMethodName = methodName,
-			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{methodName}",
+			NativeCallbackName = GetNativeCallbackName (registerInfo.Connector, methodName, isConstructor),
 			IsConstructor = isConstructor,
 			DeclaringTypeName = result.Value.DeclaringTypeName,
 			DeclaringAssemblyName = result.Value.DeclaringAssemblyName,
@@ -818,7 +818,7 @@ public sealed class JavaPeerScanner : IDisposable
 					JniSignature = propRegister.Signature,
 					Connector = propRegister.Connector,
 					ManagedMethodName = getterName,
-					NativeCallbackName = $"n_{getterName}",
+					NativeCallbackName = GetNativeCallbackName (propRegister.Connector, getterName, false),
 					IsConstructor = false,
 					DeclaringTypeName = baseTypeName,
 					DeclaringAssemblyName = baseAssemblyName,
@@ -866,12 +866,18 @@ public sealed class JavaPeerScanner : IDisposable
 		string managedName = index.Reader.GetString (methodDef.Name);
 		string jniSignature = registerInfo.Signature ?? "()V";
 
+		string declaringTypeName = "";
+		string declaringAssemblyName = "";
+		ParseConnectorDeclaringType (registerInfo.Connector, out declaringTypeName, out declaringAssemblyName);
+
 		methods.Add (new MarshalMethodInfo {
 			JniName = registerInfo.JniName,
 			JniSignature = jniSignature,
 			Connector = registerInfo.Connector,
 			ManagedMethodName = managedName,
-			NativeCallbackName = isConstructor ? "n_ctor" : $"n_{managedName}",
+			DeclaringTypeName = declaringTypeName,
+			DeclaringAssemblyName = declaringAssemblyName,
+			NativeCallbackName = GetNativeCallbackName (registerInfo.Connector, managedName, isConstructor),
 			IsConstructor = isConstructor,
 			IsExport = isExport,
 			IsInterfaceImplementation = isInterfaceImplementation,
@@ -1381,6 +1387,65 @@ public sealed class JavaPeerScanner : IDisposable
 		var ns = index.Reader.GetString (current.Namespace);
 
 		return (typeName, parentJniName, ns);
+	}
+
+	/// <summary>
+	/// Derives the native callback method name from a <c>[Register]</c> attribute's Connector field.
+	/// The Connector may be a simple name like <c>"GetOnCreate_Landroid_os_Bundle_Handler"</c>
+	/// or a qualified name like <c>"GetOnClick_Landroid_view_View_Handler:Android.Views.View/IOnClickListenerInvoker, Mono.Android, …"</c>.
+	/// In both cases the result is e.g. <c>"n_OnCreate_Landroid_os_Bundle_"</c>.
+	/// Falls back to <c>"n_{managedName}"</c> when the Connector doesn't follow the expected pattern.
+	/// </summary>
+	static string GetNativeCallbackName (string? connector, string managedName, bool isConstructor)
+	{
+		if (isConstructor) {
+			return "n_ctor";
+		}
+
+		if (connector is not null) {
+			// Strip the optional type qualifier after ':'
+			int colonIndex = connector.IndexOf (':');
+			string handlerName = colonIndex >= 0 ? connector.Substring (0, colonIndex) : connector;
+
+			if (handlerName.StartsWith ("Get", StringComparison.Ordinal)
+				&& handlerName.EndsWith ("Handler", StringComparison.Ordinal)) {
+				return "n_" + handlerName.Substring (3, handlerName.Length - 3 - "Handler".Length);
+			}
+		}
+
+		return $"n_{managedName}";
+	}
+
+	/// <summary>
+	/// Parses the type qualifier from a Connector string.
+	/// Connector format: <c>"GetOnClickHandler:Android.Views.View/IOnClickListenerInvoker, Mono.Android, Version=…"</c>.
+	/// Extracts the managed type name (converting <c>/</c> → <c>+</c> for nested types) and assembly name.
+	/// </summary>
+	static void ParseConnectorDeclaringType (string? connector, out string declaringTypeName, out string declaringAssemblyName)
+	{
+		declaringTypeName = "";
+		declaringAssemblyName = "";
+
+		if (connector is null) {
+			return;
+		}
+
+		int colonIndex = connector.IndexOf (':');
+		if (colonIndex < 0) {
+			return;
+		}
+
+		// After ':' is "TypeName, AssemblyName, Version=…" (assembly-qualified name)
+		string typeQualified = connector.Substring (colonIndex + 1);
+		int commaIndex = typeQualified.IndexOf (',');
+		if (commaIndex < 0) {
+			return;
+		}
+
+		declaringTypeName = typeQualified.Substring (0, commaIndex).Trim ().Replace ('/', '+');
+		string rest = typeQualified.Substring (commaIndex + 1).Trim ();
+		int nextComma = rest.IndexOf (',');
+		declaringAssemblyName = nextComma >= 0 ? rest.Substring (0, nextComma).Trim () : rest.Trim ();
 	}
 
 	static string GetCrc64PackageName (string ns, string assemblyName)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1418,8 +1418,10 @@ public sealed class JavaPeerScanner : IDisposable
 
 	/// <summary>
 	/// Parses the type qualifier from a Connector string.
-	/// Connector format: <c>"GetOnClickHandler:Android.Views.View/IOnClickListenerInvoker, Mono.Android, Version=…"</c>.
-	/// Extracts the managed type name (converting <c>/</c> → <c>+</c> for nested types) and assembly name.
+	/// Connector format is either assembly-qualified:
+	/// <c>"GetOnClickHandler:Android.Views.View/IOnClickListenerInvoker, Mono.Android, Version=…"</c>
+	/// or type-only: <c>"GetOnClickHandler:Android.Views.IOnClickListenerInvoker"</c>.
+	/// Extracts the managed type name (converting <c>/</c> → <c>+</c> for nested types) and assembly name (if present).
 	/// </summary>
 	static void ParseConnectorDeclaringType (string? connector, out string declaringTypeName, out string declaringAssemblyName)
 	{
@@ -1435,10 +1437,14 @@ public sealed class JavaPeerScanner : IDisposable
 			return;
 		}
 
-		// After ':' is "TypeName, AssemblyName, Version=…" (assembly-qualified name)
+		// After ':' is typically "TypeName, AssemblyName, Version=…" (assembly-qualified name),
+		// but some connectors only provide "TypeName" without an assembly.
 		string typeQualified = connector.Substring (colonIndex + 1);
 		int commaIndex = typeQualified.IndexOf (',');
+
 		if (commaIndex < 0) {
+			// No assembly information; treat the whole segment as the type name
+			declaringTypeName = typeQualified.Trim ().Replace ('/', '+');
 			return;
 		}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -245,8 +245,8 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			var java = GenerateFixture ("my/app/MainActivity");
 			AssertContainsLine ("@Override\n", java);
 			AssertContainsLine ("public void onCreate (android.os.Bundle p0)\n", java);
-			AssertContainsLine ("n_OnCreate (p0);\n", java);
-			AssertContainsLine ("public native void n_OnCreate (android.os.Bundle p0);\n", java);
+			AssertContainsLine ("n_OnCreate_Landroid_os_Bundle_ (p0);\n", java);
+			AssertContainsLine ("public native void n_OnCreate_Landroid_os_Bundle_ (android.os.Bundle p0);\n", java);
 		}
 
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
@@ -54,8 +54,9 @@ public class InterfaceMethodDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/ImplicitPropertyImpl");
 		var getName = peer.MarshalMethods.First (m => m.JniName == "getName");
 		Assert.Equal ("()Ljava/lang/String;", getName.JniSignature);
-		Assert.Equal ("GetGetNameHandler:Android.Views.IHasNameInvoker", getName.Connector);
+		Assert.Equal ("GetGetNameHandler:Android.Views.IHasNameInvoker, TestFixtures, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null", getName.Connector);
 		Assert.Equal ("Android.Views.IHasNameInvoker", getName.DeclaringTypeName);
+		Assert.Equal ("TestFixtures", getName.DeclaringAssemblyName);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/InterfaceMethodDetectionTests.cs
@@ -18,6 +18,7 @@ public class InterfaceMethodDetectionTests : FixtureTestBase
 		var onClick = peer.MarshalMethods.First (m => m.JniName == "onClick");
 		Assert.Equal ("(Landroid/view/View;)V", onClick.JniSignature);
 		Assert.Equal ("GetOnClick_Landroid_view_View_Handler:Android.Views.IOnClickListenerInvoker", onClick.Connector);
+		Assert.Equal ("Android.Views.IOnClickListenerInvoker", onClick.DeclaringTypeName);
 	}
 
 	[Fact]
@@ -54,6 +55,7 @@ public class InterfaceMethodDetectionTests : FixtureTestBase
 		var getName = peer.MarshalMethods.First (m => m.JniName == "getName");
 		Assert.Equal ("()Ljava/lang/String;", getName.JniSignature);
 		Assert.Equal ("GetGetNameHandler:Android.Views.IHasNameInvoker", getName.Connector);
+		Assert.Equal ("Android.Views.IHasNameInvoker", getName.DeclaringTypeName);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -15,7 +15,7 @@ public class OverrideDetectionTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("my/app/UserActivity");
 		var onCreate = peer.MarshalMethods.First (m => m.JniName == "onCreate");
 		Assert.Equal ("(Landroid/os/Bundle;)V", onCreate.JniSignature);
-		Assert.Equal ("n_OnCreate", onCreate.NativeCallbackName);
+		Assert.Equal ("n_OnCreate_Landroid_os_Bundle_", onCreate.NativeCallbackName);
 		Assert.False (onCreate.IsConstructor);
 		Assert.Equal ("GetOnCreate_Landroid_os_Bundle_Handler", onCreate.Connector);
 		Assert.NotNull (peer.ActivationCtor);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -104,7 +104,7 @@ namespace Android.Views
 	[Register ("android/view/View$IHasName", "", "Android.Views.IHasNameInvoker")]
 	public interface IHasName
 	{
-		[Register ("getName", "()Ljava/lang/String;", "GetGetNameHandler:Android.Views.IHasNameInvoker")]
+		[Register ("getName", "()Ljava/lang/String;", "GetGetNameHandler:Android.Views.IHasNameInvoker, TestFixtures, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		string? Name { get; }
 	}
 


### PR DESCRIPTION
**Problem 1:** `NativeCallbackName` was set to `n_{managedName}` (e.g. `n_OnCreate`) but the JNI native method expects names derived from the Connector field (e.g. `n_OnCreate_Landroid_os_Bundle_`).

**Problem 2:** `AddMarshalMethod` was not populating `DeclaringTypeName`/`DeclaringAssemblyName` for interface implementation methods, leaving them empty.

**Fix:** Added `GetNativeCallbackName()` that parses the Connector `GetXxxHandler` pattern to derive the correct native callback name. Added `ParseConnectorDeclaringType()` that extracts the declaring type and assembly from the Connector's type qualifier after the colon.