### PR TITLE
[TrimmableTypeMap] Extract TrimmableTypeMapGenerator from MSBuild task

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -75,10 +75,23 @@ public sealed class JcwJavaSourceGenerator
 		return generatedFiles;
 	}
 
-	/// <summary>
+	public IReadOnlyList<GeneratedJavaSource> GenerateContent (IReadOnlyList<JavaPeerInfo> types)
+	{
+		if (types is null) throw new ArgumentNullException (nameof (types));
+		var results = new List<GeneratedJavaSource> ();
+		foreach (var type in types) {
+			if (type.DoNotGenerateAcw || type.IsInterface) continue;
+			using var writer = new StringWriter ();
+			Generate (type, writer);
+			results.Add (new GeneratedJavaSource (GetRelativePath (type), writer.ToString ()));
+		}
+		return results;
+	}
+
+		/// <summary>
 	/// Generates a single .java source file for the given type.
 	/// </summary>
-	internal void Generate (JavaPeerInfo type, TextWriter writer)
+	public void Generate (JavaPeerInfo type, TextWriter writer)
 	{
 		writer.NewLine = "\n";
 		WritePackageDeclaration (type, writer);
@@ -91,11 +104,15 @@ public sealed class JcwJavaSourceGenerator
 		WriteClassClose (writer);
 	}
 
-	static string GetOutputFilePath (JavaPeerInfo type, string outputDirectory)
+	static string GetRelativePath (JavaPeerInfo type)
 	{
 		JniSignatureHelper.ValidateJniName (type.JavaName);
-		string relativePath = type.JavaName + ".java";
-		return Path.Combine (outputDirectory, relativePath);
+		return type.JavaName + ".java";
+	}
+
+	static string GetOutputFilePath (JavaPeerInfo type, string outputDirectory)
+	{
+		return Path.Combine (outputDirectory, GetRelativePath (type));
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -41,6 +41,10 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// </remarks>
 public sealed class JcwJavaSourceGenerator
 {
+	/// <summary>
+	/// Generates .java source content for all ACW types and returns them as in-memory
+	/// (relativePath, content) pairs. No filesystem IO is performed.
+	/// </summary>
 	public IReadOnlyList<GeneratedJavaSource> GenerateContent (IReadOnlyList<JavaPeerInfo> types)
 	{
 		if (types is null) throw new ArgumentNullException (nameof (types));
@@ -54,7 +58,7 @@ public sealed class JcwJavaSourceGenerator
 		return results;
 	}
 
-		/// <summary>
+	/// <summary>
 	/// Generates a single .java source file for the given type.
 	/// </summary>
 	public void Generate (JavaPeerInfo type, TextWriter writer)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -41,40 +41,6 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// </remarks>
 public sealed class JcwJavaSourceGenerator
 {
-	/// <summary>
-	/// Generates .java source files for all ACW types and writes them to the output directory.
-	/// Returns the list of generated file paths.
-	/// </summary>
-	public IReadOnlyList<string> Generate (IReadOnlyList<JavaPeerInfo> types, string outputDirectory)
-	{
-		if (types is null) {
-			throw new ArgumentNullException (nameof (types));
-		}
-		if (outputDirectory is null) {
-			throw new ArgumentNullException (nameof (outputDirectory));
-		}
-
-		var generatedFiles = new List<string> ();
-
-		foreach (var type in types) {
-			if (type.DoNotGenerateAcw || type.IsInterface) {
-				continue;
-			}
-
-			string filePath = GetOutputFilePath (type, outputDirectory);
-			string? dir = Path.GetDirectoryName (filePath);
-			if (dir != null) {
-				Directory.CreateDirectory (dir);
-			}
-
-			using var writer = new StreamWriter (filePath);
-			Generate (type, writer);
-			generatedFiles.Add (filePath);
-		}
-
-		return generatedFiles;
-	}
-
 	public IReadOnlyList<GeneratedJavaSource> GenerateContent (IReadOnlyList<JavaPeerInfo> types)
 	{
 		if (types is null) throw new ArgumentNullException (nameof (types));
@@ -110,10 +76,6 @@ public sealed class JcwJavaSourceGenerator
 		return type.JavaName + ".java";
 	}
 
-	static string GetOutputFilePath (JavaPeerInfo type, string outputDirectory)
-	{
-		return Path.Combine (outputDirectory, GetRelativePath (type));
-	}
 
 	/// <summary>
 	/// Validates that the JNI name is well-formed: non-empty, each segment separated by '/'

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -95,20 +95,6 @@ sealed class PEAssemblyBuilder
 	}
 
 	/// <summary>
-	/// Serialises the metadata + IL into a PE DLL at <paramref name="outputPath"/>.
-	/// </summary>
-	public void WritePE (string outputPath)
-	{
-		var dir = Path.GetDirectoryName (outputPath);
-		if (!string.IsNullOrEmpty (dir)) {
-			Directory.CreateDirectory (dir);
-		}
-
-		using var fs = File.Create (outputPath);
-		WritePE (fs);
-	}
-
-	/// <summary>
 	/// Serialises the metadata + IL into a PE DLL and writes it to the given <paramref name="stream"/>.
 	/// </summary>
 	public void WritePE (Stream stream)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
@@ -32,28 +32,6 @@ public sealed class RootTypeMapAssemblyGenerator
 	}
 
 	/// <summary>
-	/// Generates the root typemap assembly and writes it to a file.
-	/// </summary>
-	/// <param name="perAssemblyTypeMapNames">Names of per-assembly typemap assemblies to reference.</param>
-	/// <param name="outputPath">Path to write the output .dll.</param>
-	/// <param name="assemblyName">Optional assembly name (defaults to _Microsoft.Android.TypeMaps).</param>
-	public void Generate (IReadOnlyList<string> perAssemblyTypeMapNames, string outputPath, string? assemblyName = null)
-	{
-		if (outputPath is null) {
-			throw new ArgumentNullException (nameof (outputPath));
-		}
-
-		var dir = Path.GetDirectoryName (outputPath);
-		if (!string.IsNullOrEmpty (dir)) {
-			Directory.CreateDirectory (dir);
-		}
-
-		var moduleName = Path.GetFileName (outputPath);
-		using var fs = File.Create (outputPath);
-		Generate (perAssemblyTypeMapNames, fs, assemblyName, moduleName);
-	}
-
-	/// <summary>
 	/// Generates the root typemap assembly and writes it to the given stream.
 	/// </summary>
 	/// <param name="perAssemblyTypeMapNames">Names of per-assembly typemap assemblies to reference.</param>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -119,22 +119,6 @@ sealed class TypeMapAssemblyEmitter
 	}
 
 	/// <summary>
-	/// Emits a PE assembly from the given model and writes it to <paramref name="outputPath"/>.
-	/// </summary>
-	public void Emit (TypeMapAssemblyData model, string outputPath)
-	{
-		if (model is null) {
-			throw new ArgumentNullException (nameof (model));
-		}
-		if (outputPath is null) {
-			throw new ArgumentNullException (nameof (outputPath));
-		}
-
-		EmitCore (model);
-		_pe.WritePE (outputPath);
-	}
-
-	/// <summary>
 	/// Emits a PE assembly from the given model and writes it to <paramref name="stream"/>.
 	/// </summary>
 	public void Emit (TypeMapAssemblyData model, Stream stream)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyGenerator.cs
@@ -19,19 +19,6 @@ public sealed class TypeMapAssemblyGenerator
 	}
 
 	/// <summary>
-	/// Generates a TypeMap PE assembly from the given Java peer info records.
-	/// </summary>
-	/// <param name="peers">Scanned Java peer types.</param>
-	/// <param name="outputPath">Path where the output .dll will be written.</param>
-	/// <param name="assemblyName">Optional explicit assembly name. Derived from outputPath if null.</param>
-	public void Generate (IReadOnlyList<JavaPeerInfo> peers, string outputPath, string? assemblyName = null)
-	{
-		var model = ModelBuilder.Build (peers, outputPath, assemblyName);
-		var emitter = new TypeMapAssemblyEmitter (_systemRuntimeVersion);
-		emitter.Emit (model, outputPath);
-	}
-
-	/// <summary>
 	/// Generates a TypeMap PE assembly from the given Java peer info records and writes it to <paramref name="stream"/>.
 	/// </summary>
 	/// <param name="peers">Scanned Java peer types.</param>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/NullableExtensions.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/NullableExtensions.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+// The static methods in System.String are not NRT annotated in netstandard2.0,
+// so we need our own extension methods to make them nullable aware.
+static class NullableExtensions
+{
+	public static bool IsNullOrEmpty ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrEmpty (str);
+	}
+
+	public static bool IsNullOrWhiteSpace ([NotNullWhen (false)] this string? str)
+	{
+		return string.IsNullOrWhiteSpace (str);
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -18,7 +18,6 @@ sealed class AssemblyIndex : IDisposable
 
 	public MetadataReader Reader { get; }
 	public string AssemblyName { get; }
-	public string FilePath { get; }
 
 	/// <summary>
 	/// Maps full managed type name (e.g., "Android.App.Activity") to its TypeDefinitionHandle.
@@ -35,13 +34,12 @@ sealed class AssemblyIndex : IDisposable
 	/// </summary>
 	public Dictionary<TypeDefinitionHandle, TypeAttributeInfo> AttributesByType { get; } = new ();
 
-	AssemblyIndex (PEReader peReader, MetadataReader reader, string assemblyName, string filePath)
+	AssemblyIndex (PEReader peReader, MetadataReader reader, string assemblyName)
 	{
 		this.peReader = peReader;
 		this.customAttributeTypeProvider = new CustomAttributeTypeProvider (reader);
 		Reader = reader;
 		AssemblyName = assemblyName;
-		FilePath = filePath;
 	}
 
 	public static AssemblyIndex Create (string filePath)
@@ -49,7 +47,15 @@ sealed class AssemblyIndex : IDisposable
 		var peReader = new PEReader (File.OpenRead (filePath));
 		var reader = peReader.GetMetadataReader ();
 		var assemblyName = reader.GetString (reader.GetAssemblyDefinition ().Name);
-		var index = new AssemblyIndex (peReader, reader, assemblyName, filePath);
+		var index = new AssemblyIndex (peReader, reader, assemblyName);
+		index.Build ();
+		return index;
+	}
+
+	public static AssemblyIndex Create (PEReader peReader, string assemblyName)
+	{
+		var reader = peReader.GetMetadataReader ();
+		var index = new AssemblyIndex (peReader, reader, assemblyName);
 		index.Build ();
 		return index;
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.IO;
 using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 
@@ -40,16 +39,6 @@ sealed class AssemblyIndex : IDisposable
 		this.customAttributeTypeProvider = new CustomAttributeTypeProvider (reader);
 		Reader = reader;
 		AssemblyName = assemblyName;
-	}
-
-	public static AssemblyIndex Create (string filePath)
-	{
-		var peReader = new PEReader (File.OpenRead (filePath));
-		var reader = peReader.GetMetadataReader ();
-		var assemblyName = reader.GetString (reader.GetAssemblyDefinition ().Name);
-		var index = new AssemblyIndex (peReader, reader, assemblyName);
-		index.Build ();
-		return index;
 	}
 
 	public static AssemblyIndex Create (PEReader peReader, string assemblyName)
@@ -483,7 +472,6 @@ sealed class AssemblyIndex : IDisposable
 
 	public void Dispose ()
 	{
-		peReader.Dispose ();
 	}
 }
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -80,26 +80,13 @@ public sealed class JavaPeerScanner : IDisposable
 	/// Phase 1: Build indices for all assemblies.
 	/// Phase 2: Scan all types and produce JavaPeerInfo records.
 	/// </summary>
-	public List<JavaPeerInfo> Scan (IReadOnlyList<string> assemblyPaths)
-	{
-		foreach (var path in assemblyPaths) {
-			var index = AssemblyIndex.Create (path);
-			assemblyCache [index.AssemblyName] = index;
-		}
-		return ScanCore ();
-	}
-
 	public List<JavaPeerInfo> Scan (IReadOnlyList<(string Name, PEReader Reader)> assemblies)
 	{
 		foreach (var (name, reader) in assemblies) {
 			var index = AssemblyIndex.Create (reader, name);
 			assemblyCache [index.AssemblyName] = index;
 		}
-		return ScanCore ();
-	}
 
-	List<JavaPeerInfo> ScanCore ()
-	{
 		var resultsByManagedName = new Dictionary<string, JavaPeerInfo> (StringComparer.Ordinal);
 		foreach (var index in assemblyCache.Values) {
 			ScanAssembly (index, resultsByManagedName);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
@@ -81,22 +82,29 @@ public sealed class JavaPeerScanner : IDisposable
 	/// </summary>
 	public List<JavaPeerInfo> Scan (IReadOnlyList<string> assemblyPaths)
 	{
-		// Phase 1: Build indices for all assemblies
 		foreach (var path in assemblyPaths) {
 			var index = AssemblyIndex.Create (path);
 			assemblyCache [index.AssemblyName] = index;
 		}
+		return ScanCore ();
+	}
 
-		// Phase 2: Analyze types using cached indices
+	public List<JavaPeerInfo> Scan (IReadOnlyList<(string Name, PEReader Reader)> assemblies)
+	{
+		foreach (var (name, reader) in assemblies) {
+			var index = AssemblyIndex.Create (reader, name);
+			assemblyCache [index.AssemblyName] = index;
+		}
+		return ScanCore ();
+	}
+
+	List<JavaPeerInfo> ScanCore ()
+	{
 		var resultsByManagedName = new Dictionary<string, JavaPeerInfo> (StringComparer.Ordinal);
-
 		foreach (var index in assemblyCache.Values) {
 			ScanAssembly (index, resultsByManagedName);
 		}
-
-		// Phase 3: Force unconditional on types referenced by [Application] attributes
 		ForceUnconditionalCrossReferences (resultsByManagedName, assemblyCache);
-
 		return new List<JavaPeerInfo> (resultsByManagedName.Values);
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -2,13 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
-/// <summary>
-/// Core logic for generating trimmable TypeMap assemblies, JCW Java sources, and acw-map files.
-/// Extracted from the MSBuild task so it can be tested directly without MSBuild ceremony.
-/// </summary>
 public class TrimmableTypeMapGenerator
 {
 	readonly Action<string> log;
@@ -21,144 +18,68 @@ public class TrimmableTypeMapGenerator
 		this.log = log;
 	}
 
-	/// <summary>
-	/// Runs the full generation pipeline: scan assemblies, generate typemap
-	/// assemblies, generate JCW Java sources, and write acw-map files.
-	/// </summary>
 	public TrimmableTypeMapResult Execute (
-		IReadOnlyList<string> assemblyPaths,
-		string outputDirectory,
-		string javaSourceOutputDirectory,
+		IReadOnlyList<(string Name, PEReader Reader)> assemblies,
 		Version systemRuntimeVersion,
 		HashSet<string> frameworkAssemblyNames)
 	{
-		if (assemblyPaths is null) {
-			throw new ArgumentNullException (nameof (assemblyPaths));
-		}
-		if (outputDirectory is null) {
-			throw new ArgumentNullException (nameof (outputDirectory));
-		}
-		if (javaSourceOutputDirectory is null) {
-			throw new ArgumentNullException (nameof (javaSourceOutputDirectory));
-		}
-		if (systemRuntimeVersion is null) {
-			throw new ArgumentNullException (nameof (systemRuntimeVersion));
-		}
-		if (frameworkAssemblyNames is null) {
-			throw new ArgumentNullException (nameof (frameworkAssemblyNames));
-		}
+		if (assemblies is null) throw new ArgumentNullException (nameof (assemblies));
+		if (systemRuntimeVersion is null) throw new ArgumentNullException (nameof (systemRuntimeVersion));
+		if (frameworkAssemblyNames is null) throw new ArgumentNullException (nameof (frameworkAssemblyNames));
 
-		Directory.CreateDirectory (outputDirectory);
-		Directory.CreateDirectory (javaSourceOutputDirectory);
-
-		var allPeers = ScanAssemblies (assemblyPaths);
-
+		var allPeers = ScanAssemblies (assemblies);
 		if (allPeers.Count == 0) {
 			log ("No Java peer types found, skipping typemap generation.");
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
-		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, assemblyPaths, outputDirectory);
-
-		// Generate JCW .java files for user assemblies + framework Implementor types.
-		// Framework binding types already have compiled JCWs in the SDK but their constructors
-		// use the legacy TypeManager.Activate() JNI native which isn't available in the
-		// trimmable runtime. Implementor types (View_OnClickListenerImplementor, etc.) are
-		// in the mono.* Java package so we use the mono/ prefix to identify them.
-		// We generate fresh JCWs that use Runtime.registerNatives() for activation.
+		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
-			!frameworkAssemblyNames.Contains (p.AssemblyName)
 			|| p.JavaName.StartsWith ("mono/", StringComparison.Ordinal)).ToList ();
 		log ($"Generating JCW files for {jcwPeers.Count} types (filtered from {allPeers.Count} total).");
-		var generatedJavaFiles = GenerateJcwJavaSources (jcwPeers, javaSourceOutputDirectory);
-
-		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaFiles, allPeers);
+		var generatedJavaSources = GenerateJcwJavaSources (jcwPeers);
+		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaSources, allPeers);
 	}
 
-	// Future optimization: the scanner currently scans all assemblies on every run.
-	// For incremental builds, we could:
-	// 1. Add a Scan(allPaths, changedPaths) overload that only produces JavaPeerInfo
-	//    for changed assemblies while still indexing all assemblies for cross-assembly
-	//    resolution (base types, interfaces, activation ctors).
-	// 2. Cache scan results per assembly to skip PE I/O entirely for unchanged assemblies.
-	// Both require profiling to determine if they meaningfully improve build times.
-	List<JavaPeerInfo> ScanAssemblies (IReadOnlyList<string> assemblyPaths)
+	List<JavaPeerInfo> ScanAssemblies (IReadOnlyList<(string Name, PEReader Reader)> assemblies)
 	{
 		using var scanner = new JavaPeerScanner ();
-		var peers = scanner.Scan (assemblyPaths);
-		log ($"Scanned {assemblyPaths.Count} assemblies, found {peers.Count} Java peer types.");
+		var peers = scanner.Scan (assemblies);
+		log ($"Scanned {assemblies.Count} assemblies, found {peers.Count} Java peer types.");
 		return peers;
 	}
 
-	List<string> GenerateTypeMapAssemblies (List<JavaPeerInfo> allPeers, Version systemRuntimeVersion,
-		IReadOnlyList<string> assemblyPaths, string outputDir)
+	List<GeneratedAssembly> GenerateTypeMapAssemblies (List<JavaPeerInfo> allPeers, Version systemRuntimeVersion)
 	{
-		// Build a map from assembly name → source path for timestamp comparison
-		var sourcePathByName = new Dictionary<string, string> (StringComparer.Ordinal);
-		foreach (var path in assemblyPaths) {
-			var name = Path.GetFileNameWithoutExtension (path);
-			sourcePathByName [name] = path;
-		}
-
-		var peersByAssembly = allPeers
-			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
-			.OrderBy (g => g.Key, StringComparer.Ordinal);
-
-		var generatedAssemblies = new List<string> ();
+		var peersByAssembly = allPeers.GroupBy (p => p.AssemblyName, StringComparer.Ordinal).OrderBy (g => g.Key, StringComparer.Ordinal);
+		var generatedAssemblies = new List<GeneratedAssembly> ();
 		var perAssemblyNames = new List<string> ();
 		var generator = new TypeMapAssemblyGenerator (systemRuntimeVersion);
-		bool anyRegenerated = false;
-
 		foreach (var group in peersByAssembly) {
 			string assemblyName = $"_{group.Key}.TypeMap";
-			string outputPath = Path.Combine (outputDir, assemblyName + ".dll");
 			perAssemblyNames.Add (assemblyName);
-
-			if (IsUpToDate (outputPath, group.Key, sourcePathByName)) {
-				log ($"  {assemblyName}: up to date, skipping");
-				generatedAssemblies.Add (outputPath);
-				continue;
-			}
-
 			var peers = group.ToList ();
-			generator.Generate (peers, outputPath, assemblyName);
-			generatedAssemblies.Add (outputPath);
-			anyRegenerated = true;
-
+			var stream = new MemoryStream ();
+			generator.Generate (peers, stream, assemblyName);
+			stream.Position = 0;
+			generatedAssemblies.Add (new GeneratedAssembly (assemblyName, stream));
 			log ($"  {assemblyName}: {peers.Count} types");
 		}
-
-		// Root assembly references all per-assembly typemaps — regenerate if any changed
-		string rootOutputPath = Path.Combine (outputDir, "_Microsoft.Android.TypeMaps.dll");
-		if (anyRegenerated || !File.Exists (rootOutputPath)) {
-			var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
-			rootGenerator.Generate (perAssemblyNames, rootOutputPath);
-			log ($"  Root: {perAssemblyNames.Count} per-assembly refs");
-		} else {
-			log ("  Root: up to date, skipping");
-		}
-		generatedAssemblies.Add (rootOutputPath);
-
+		var rootStream = new MemoryStream ();
+		var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
+		rootGenerator.Generate (perAssemblyNames, rootStream);
+		rootStream.Position = 0;
+		generatedAssemblies.Add (new GeneratedAssembly ("_Microsoft.Android.TypeMaps", rootStream));
+		log ($"  Root: {perAssemblyNames.Count} per-assembly refs");
 		log ($"Generated {generatedAssemblies.Count} typemap assemblies.");
 		return generatedAssemblies;
 	}
 
-	internal static bool IsUpToDate (string outputPath, string assemblyName, Dictionary<string, string> sourcePathByName)
-	{
-		if (!File.Exists (outputPath)) {
-			return false;
-		}
-		if (!sourcePathByName.TryGetValue (assemblyName, out var sourcePath)) {
-			return false;
-		}
-		return File.GetLastWriteTimeUtc (outputPath) >= File.GetLastWriteTimeUtc (sourcePath);
-	}
-
-	List<string> GenerateJcwJavaSources (List<JavaPeerInfo> allPeers, string javaSourceOutputDirectory)
+	List<GeneratedJavaSource> GenerateJcwJavaSources (List<JavaPeerInfo> allPeers)
 	{
 		var jcwGenerator = new JcwJavaSourceGenerator ();
-		var files = jcwGenerator.Generate (allPeers, javaSourceOutputDirectory);
-		log ($"Generated {files.Count} JCW Java source files.");
-		return files.ToList ();
+		var sources = jcwGenerator.GenerateContent (allPeers);
+		log ($"Generated {sources.Count} JCW Java source files.");
+		return sources.ToList ();
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -30,8 +30,7 @@ public class TrimmableTypeMapGenerator
 		string outputDirectory,
 		string javaSourceOutputDirectory,
 		Version systemRuntimeVersion,
-		HashSet<string> frameworkAssemblyNames,
-		string? acwMapOutputPath = null)
+		HashSet<string> frameworkAssemblyNames)
 	{
 		Directory.CreateDirectory (outputDirectory);
 		Directory.CreateDirectory (javaSourceOutputDirectory);
@@ -40,7 +39,7 @@ public class TrimmableTypeMapGenerator
 
 		if (allPeers.Count == 0) {
 			log ("No Java peer types found, skipping typemap generation.");
-			return new TrimmableTypeMapResult ([], []);
+			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, assemblyPaths, outputDirectory);
@@ -57,14 +56,7 @@ public class TrimmableTypeMapGenerator
 		log ($"Generating JCW files for {jcwPeers.Count} types (filtered from {allPeers.Count} total).");
 		var generatedJavaFiles = GenerateJcwJavaSources (jcwPeers, javaSourceOutputDirectory);
 
-		// Write acw-map.txt so _ConvertCustomView and _UpdateAndroidResgen can resolve custom view names.
-		if (!acwMapOutputPath.IsNullOrEmpty ()) {
-			using var writer = new StreamWriter (acwMapOutputPath, append: false);
-			AcwMapWriter.Write (writer, allPeers);
-			log ($"Written acw-map.txt with {allPeers.Count} entries to {acwMapOutputPath}.");
-		}
-
-		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaFiles);
+		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaFiles, allPeers);
 	}
 
 	// Future optimization: the scanner currently scans all assemblies on every run.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -12,10 +12,7 @@ public class TrimmableTypeMapGenerator
 
 	public TrimmableTypeMapGenerator (Action<string> log)
 	{
-		if (log is null) {
-			throw new ArgumentNullException (nameof (log));
-		}
-		this.log = log;
+		this.log = log ?? throw new ArgumentNullException (nameof (log));
 	}
 
 	public TrimmableTypeMapResult Execute (
@@ -23,9 +20,9 @@ public class TrimmableTypeMapGenerator
 		Version systemRuntimeVersion,
 		HashSet<string> frameworkAssemblyNames)
 	{
-		if (assemblies is null) throw new ArgumentNullException (nameof (assemblies));
-		if (systemRuntimeVersion is null) throw new ArgumentNullException (nameof (systemRuntimeVersion));
-		if (frameworkAssemblyNames is null) throw new ArgumentNullException (nameof (frameworkAssemblyNames));
+		_ = assemblies ?? throw new ArgumentNullException (nameof (assemblies));
+		_ = systemRuntimeVersion ?? throw new ArgumentNullException (nameof (systemRuntimeVersion));
+		_ = frameworkAssemblyNames ?? throw new ArgumentNullException (nameof (frameworkAssemblyNames));
 
 		var allPeers = ScanAssemblies (assemblies);
 		if (allPeers.Count == 0) {
@@ -35,6 +32,7 @@ public class TrimmableTypeMapGenerator
 
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
+			!frameworkAssemblyNames.Contains (p.AssemblyName)
 			|| p.JavaName.StartsWith ("mono/", StringComparison.Ordinal)).ToList ();
 		log ($"Generating JCW files for {jcwPeers.Count} types (filtered from {allPeers.Count} total).");
 		var generatedJavaSources = GenerateJcwJavaSources (jcwPeers);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// Core logic for generating trimmable TypeMap assemblies, JCW Java sources, and acw-map files.
+/// Extracted from the MSBuild task so it can be tested directly without MSBuild ceremony.
+/// </summary>
+public class TrimmableTypeMapGenerator
+{
+	readonly Action<string> log;
+
+	public TrimmableTypeMapGenerator (Action<string> log)
+	{
+		if (log is null) {
+			throw new ArgumentNullException (nameof (log));
+		}
+		this.log = log;
+	}
+
+	/// <summary>
+	/// Runs the full generation pipeline: scan assemblies, generate typemap
+	/// assemblies, generate JCW Java sources, and write acw-map files.
+	/// </summary>
+	public TrimmableTypeMapResult Execute (
+		IReadOnlyList<string> assemblyPaths,
+		string outputDirectory,
+		string javaSourceOutputDirectory,
+		Version systemRuntimeVersion,
+		HashSet<string> frameworkAssemblyNames,
+		string? acwMapOutputPath = null)
+	{
+		Directory.CreateDirectory (outputDirectory);
+		Directory.CreateDirectory (javaSourceOutputDirectory);
+
+		var allPeers = ScanAssemblies (assemblyPaths);
+
+		if (allPeers.Count == 0) {
+			log ("No Java peer types found, skipping typemap generation.");
+			return new TrimmableTypeMapResult ([], []);
+		}
+
+		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, assemblyPaths, outputDirectory);
+
+		// Generate JCW .java files for user assemblies + framework Implementor types.
+		// Framework binding types already have compiled JCWs in the SDK but their constructors
+		// use the legacy TypeManager.Activate() JNI native which isn't available in the
+		// trimmable runtime. Implementor types (View_OnClickListenerImplementor, etc.) are
+		// in the mono.* Java package so we use the mono/ prefix to identify them.
+		// We generate fresh JCWs that use Runtime.registerNatives() for activation.
+		var jcwPeers = allPeers.Where (p =>
+			!frameworkAssemblyNames.Contains (p.AssemblyName)
+			|| p.JavaName.StartsWith ("mono/", StringComparison.Ordinal)).ToList ();
+		log ($"Generating JCW files for {jcwPeers.Count} types (filtered from {allPeers.Count} total).");
+		var generatedJavaFiles = GenerateJcwJavaSources (jcwPeers, javaSourceOutputDirectory);
+
+		// Write acw-map.txt so _ConvertCustomView and _UpdateAndroidResgen can resolve custom view names.
+		if (!acwMapOutputPath.IsNullOrEmpty ()) {
+			using var writer = new StreamWriter (acwMapOutputPath, append: false);
+			AcwMapWriter.Write (writer, allPeers);
+			log ($"Written acw-map.txt with {allPeers.Count} entries to {acwMapOutputPath}.");
+		}
+
+		return new TrimmableTypeMapResult (generatedAssemblies, generatedJavaFiles);
+	}
+
+	// Future optimization: the scanner currently scans all assemblies on every run.
+	// For incremental builds, we could:
+	// 1. Add a Scan(allPaths, changedPaths) overload that only produces JavaPeerInfo
+	//    for changed assemblies while still indexing all assemblies for cross-assembly
+	//    resolution (base types, interfaces, activation ctors).
+	// 2. Cache scan results per assembly to skip PE I/O entirely for unchanged assemblies.
+	// Both require profiling to determine if they meaningfully improve build times.
+	List<JavaPeerInfo> ScanAssemblies (IReadOnlyList<string> assemblyPaths)
+	{
+		using var scanner = new JavaPeerScanner ();
+		var peers = scanner.Scan (assemblyPaths);
+		log ($"Scanned {assemblyPaths.Count} assemblies, found {peers.Count} Java peer types.");
+		return peers;
+	}
+
+	List<string> GenerateTypeMapAssemblies (List<JavaPeerInfo> allPeers, Version systemRuntimeVersion,
+		IReadOnlyList<string> assemblyPaths, string outputDir)
+	{
+		// Build a map from assembly name → source path for timestamp comparison
+		var sourcePathByName = new Dictionary<string, string> (StringComparer.Ordinal);
+		foreach (var path in assemblyPaths) {
+			var name = Path.GetFileNameWithoutExtension (path);
+			sourcePathByName [name] = path;
+		}
+
+		var peersByAssembly = allPeers
+			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
+			.OrderBy (g => g.Key, StringComparer.Ordinal);
+
+		var generatedAssemblies = new List<string> ();
+		var perAssemblyNames = new List<string> ();
+		var generator = new TypeMapAssemblyGenerator (systemRuntimeVersion);
+		bool anyRegenerated = false;
+
+		foreach (var group in peersByAssembly) {
+			string assemblyName = $"_{group.Key}.TypeMap";
+			string outputPath = Path.Combine (outputDir, assemblyName + ".dll");
+			perAssemblyNames.Add (assemblyName);
+
+			if (IsUpToDate (outputPath, group.Key, sourcePathByName)) {
+				log ($"  {assemblyName}: up to date, skipping");
+				generatedAssemblies.Add (outputPath);
+				continue;
+			}
+
+			var peers = group.ToList ();
+			generator.Generate (peers, outputPath, assemblyName);
+			generatedAssemblies.Add (outputPath);
+			anyRegenerated = true;
+
+			log ($"  {assemblyName}: {peers.Count} types");
+		}
+
+		// Root assembly references all per-assembly typemaps — regenerate if any changed
+		string rootOutputPath = Path.Combine (outputDir, "_Microsoft.Android.TypeMaps.dll");
+		if (anyRegenerated || !File.Exists (rootOutputPath)) {
+			var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
+			rootGenerator.Generate (perAssemblyNames, rootOutputPath);
+			log ($"  Root: {perAssemblyNames.Count} per-assembly refs");
+		} else {
+			log ("  Root: up to date, skipping");
+		}
+		generatedAssemblies.Add (rootOutputPath);
+
+		log ($"Generated {generatedAssemblies.Count} typemap assemblies.");
+		return generatedAssemblies;
+	}
+
+	internal static bool IsUpToDate (string outputPath, string assemblyName, Dictionary<string, string> sourcePathByName)
+	{
+		if (!File.Exists (outputPath)) {
+			return false;
+		}
+		if (!sourcePathByName.TryGetValue (assemblyName, out var sourcePath)) {
+			return false;
+		}
+		return File.GetLastWriteTimeUtc (outputPath) >= File.GetLastWriteTimeUtc (sourcePath);
+	}
+
+	List<string> GenerateJcwJavaSources (List<JavaPeerInfo> allPeers, string javaSourceOutputDirectory)
+	{
+		var jcwGenerator = new JcwJavaSourceGenerator ();
+		var files = jcwGenerator.Generate (allPeers, javaSourceOutputDirectory);
+		log ($"Generated {files.Count} JCW Java source files.");
+		return files.ToList ();
+	}
+
+	public static Version ParseTargetFrameworkVersion (string tfv)
+	{
+		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
+			tfv = tfv.Substring (1);
+		}
+		if (Version.TryParse (tfv, out var version)) {
+			return version;
+		}
+		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -32,6 +32,22 @@ public class TrimmableTypeMapGenerator
 		Version systemRuntimeVersion,
 		HashSet<string> frameworkAssemblyNames)
 	{
+		if (assemblyPaths is null) {
+			throw new ArgumentNullException (nameof (assemblyPaths));
+		}
+		if (outputDirectory is null) {
+			throw new ArgumentNullException (nameof (outputDirectory));
+		}
+		if (javaSourceOutputDirectory is null) {
+			throw new ArgumentNullException (nameof (javaSourceOutputDirectory));
+		}
+		if (systemRuntimeVersion is null) {
+			throw new ArgumentNullException (nameof (systemRuntimeVersion));
+		}
+		if (frameworkAssemblyNames is null) {
+			throw new ArgumentNullException (nameof (frameworkAssemblyNames));
+		}
+
 		Directory.CreateDirectory (outputDirectory);
 		Directory.CreateDirectory (javaSourceOutputDirectory);
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -161,15 +161,4 @@ public class TrimmableTypeMapGenerator
 		log ($"Generated {files.Count} JCW Java source files.");
 		return files.ToList ();
 	}
-
-	public static Version ParseTargetFrameworkVersion (string tfv)
-	{
-		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
-			tfv = tfv.Substring (1);
-		}
-		if (Version.TryParse (tfv, out var version)) {
-			return version;
-		}
-		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
-	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+/// <summary>
+/// Result of the trimmable type map generation.
+/// </summary>
+public record TrimmableTypeMapResult (
+	IReadOnlyList<string> GeneratedAssemblies,
+	IReadOnlyList<string> GeneratedJavaFiles);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
@@ -7,4 +7,5 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// </summary>
 public record TrimmableTypeMapResult (
 	IReadOnlyList<string> GeneratedAssemblies,
-	IReadOnlyList<string> GeneratedJavaFiles);
+	IReadOnlyList<string> GeneratedJavaFiles,
+	IReadOnlyList<JavaPeerInfo> AllPeers);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
@@ -1,11 +1,13 @@
 using System.Collections.Generic;
+using System.IO;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
-/// <summary>
-/// Result of the trimmable type map generation.
-/// </summary>
 public record TrimmableTypeMapResult (
-	IReadOnlyList<string> GeneratedAssemblies,
-	IReadOnlyList<string> GeneratedJavaFiles,
+	IReadOnlyList<GeneratedAssembly> GeneratedAssemblies,
+	IReadOnlyList<GeneratedJavaSource> GeneratedJavaSources,
 	IReadOnlyList<JavaPeerInfo> AllPeers);
+
+public record GeneratedAssembly (string Name, MemoryStream Content);
+
+public record GeneratedJavaSource (string RelativePath, string Content);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -38,6 +38,7 @@ public override bool RunTask ()
 {
 var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
 var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
+// TODO(#10792): populate with framework assembly names to skip JCW generation for pre-compiled framework types
 var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 
 Directory.CreateDirectory (OutputDirectory);
@@ -86,7 +87,6 @@ sourcePathByName [name] = path;
 
 var items = new List<ITaskItem> ();
 bool anyRegenerated = false;
-var perAssemblyItems = new List<(string Name, string OutputPath)> ();
 
 foreach (var assembly in assemblies) {
 if (assembly.Name == "_Microsoft.Android.TypeMaps") {
@@ -109,7 +109,6 @@ Log.LogDebugMessage ($"  {assembly.Name}: written");
 }
 
 items.Add (new TaskItem (outputPath));
-perAssemblyItems.Add ((assembly.Name, outputPath));
 }
 
 // Root assembly — regenerate if any per-assembly typemap changed

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -57,7 +57,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 	public override bool RunTask ()
 	{
-		var systemRuntimeVersion = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (TargetFrameworkVersion);
+		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
 		// Don't filter by HasMonoAndroidReference — ReferencePath items from the compiler
 		// don't carry this metadata. The scanner handles non-Java assemblies gracefully.
 		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
@@ -114,5 +114,16 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 		Log.LogDebugMessage ($"Generated {outputFiles.Count} per-assembly ACW map files.");
 		return outputFiles.ToArray ();
+	}
+
+	static Version ParseTargetFrameworkVersion (string tfv)
+	{
+		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
+			tfv = tfv.Substring (1);
+		}
+		if (Version.TryParse (tfv, out var version)) {
+			return version;
+		}
+		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -32,11 +32,6 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public string AcwMapDirectory { get; set; } = "";
 
 	/// <summary>
-	/// Output path for the merged acw-map.txt consumed by _ConvertCustomView and _UpdateAndroidResgen.
-	/// </summary>
-	public string? AcwMapOutputFile { get; set; }
-
-	/// <summary>
 	/// The .NET target framework version (e.g., "v11.0"). Used to set the System.Runtime
 	/// assembly reference version in generated typemap assemblies.
 	/// </summary>
@@ -49,6 +44,11 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	[Output]
 	public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
 
+	/// <summary>
+	/// Per-assembly acw-map files produced during scanning. Each file contains
+	/// three lines per type: PartialAssemblyQualifiedName;JavaKey,
+	/// ManagedKey;JavaKey, and CompatJniName;JavaKey.
+	/// </summary>
 	[Output]
 	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
 
@@ -79,12 +79,44 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			OutputDirectory,
 			JavaSourceOutputDirectory,
 			systemRuntimeVersion,
-			frameworkAssemblyNames,
-			AcwMapOutputFile);
+			frameworkAssemblyNames);
 
 		GeneratedAssemblies = result.GeneratedAssemblies.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
 		GeneratedJavaFiles = result.GeneratedJavaFiles.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
+		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
 
 		return !Log.HasLoggedErrors;
+	}
+
+	ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)
+	{
+		var peersByAssembly = allPeers
+			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
+			.OrderBy (g => g.Key, StringComparer.Ordinal);
+
+		var outputFiles = new List<ITaskItem> ();
+
+		foreach (var group in peersByAssembly) {
+			var peers = group.ToList ();
+			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
+
+			bool written;
+			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
+				AcwMapWriter.Write (sw, peers);
+				sw.Flush ();
+				written = Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
+			}
+
+			Log.LogDebugMessage (written
+				? $"  acw-map.{group.Key}.txt: {peers.Count} types"
+				: $"  acw-map.{group.Key}.txt: unchanged");
+
+			var item = new TaskItem (outputFile);
+			item.SetMetadata ("AssemblyName", group.Key);
+			outputFiles.Add (item);
+		}
+
+		Log.LogDebugMessage ($"Generated {outputFiles.Count} per-assembly ACW map files.");
+		return outputFiles.ToArray ();
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.PortableExecutable;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Android.Sdk.TrimmableTypeMap;
 using Microsoft.Build.Framework;
@@ -11,119 +12,105 @@ using Microsoft.Build.Utilities;
 
 namespace Xamarin.Android.Tasks;
 
-/// <summary>
-/// MSBuild task adapter for <see cref="TrimmableTypeMapGenerator"/>.
-/// Opens files and maps ITaskItem to/from strings, then delegates to the core class.
-/// </summary>
 public class GenerateTrimmableTypeMap : AndroidTask
 {
 	public override string TaskPrefix => "GTT";
 
 	[Required]
 	public ITaskItem [] ResolvedAssemblies { get; set; } = [];
-
 	[Required]
 	public string OutputDirectory { get; set; } = "";
-
 	[Required]
 	public string JavaSourceOutputDirectory { get; set; } = "";
-
-	/// <summary>
-	/// Directory for per-assembly acw-map.{AssemblyName}.txt files.
-	/// </summary>
 	[Required]
 	public string AcwMapDirectory { get; set; } = "";
-
-	/// <summary>
-	/// The .NET target framework version (e.g., "v11.0"). Used to set the System.Runtime
-	/// assembly reference version in generated typemap assemblies.
-	/// </summary>
 	[Required]
 	public string TargetFrameworkVersion { get; set; } = "";
-
 	[Output]
 	public ITaskItem [] GeneratedAssemblies { get; set; } = [];
-
 	[Output]
 	public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
-
-	/// <summary>
-	/// Per-assembly acw-map files produced during scanning. Each file contains
-	/// three lines per type: PartialAssemblyQualifiedName;JavaKey,
-	/// ManagedKey;JavaKey, and CompatJniName;JavaKey.
-	/// </summary>
 	[Output]
 	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
 
 	public override bool RunTask ()
 	{
 		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
-		// Don't filter by HasMonoAndroidReference — ReferencePath items from the compiler
-		// don't carry this metadata. The scanner handles non-Java assemblies gracefully.
 		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
-
-		// Currently we generate JCWs for ALL assemblies including framework bindings.
-		// Pre-generating SDK-compatible JCWs (mono.android-trimmable.jar) is tracked by #10792.
-		// Once that's done, we can skip framework assemblies here.
 		var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
-
+		Directory.CreateDirectory (OutputDirectory);
+		Directory.CreateDirectory (JavaSourceOutputDirectory);
 		Directory.CreateDirectory (AcwMapDirectory);
-
-		var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
-		var result = generator.Execute (
-			assemblyPaths,
-			OutputDirectory,
-			JavaSourceOutputDirectory,
-			systemRuntimeVersion,
-			frameworkAssemblyNames);
-
-		GeneratedAssemblies = result.GeneratedAssemblies.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
-		GeneratedJavaFiles = result.GeneratedJavaFiles.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
-		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
-
+		var peReaders = new List<PEReader> ();
+		var assemblies = new List<(string Name, PEReader Reader)> ();
+		try {
+			foreach (var path in assemblyPaths) {
+				var peReader = new PEReader (File.OpenRead (path));
+				peReaders.Add (peReader);
+				assemblies.Add ((Path.GetFileNameWithoutExtension (path), peReader));
+			}
+			var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
+			var result = generator.Execute (assemblies, systemRuntimeVersion, frameworkAssemblyNames);
+			GeneratedAssemblies = WriteAssembliesToDisk (result.GeneratedAssemblies);
+			GeneratedJavaFiles = WriteJavaSourcesToDisk (result.GeneratedJavaSources);
+			PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
+		} finally {
+			foreach (var peReader in peReaders) peReader.Dispose ();
+		}
 		return !Log.HasLoggedErrors;
+	}
+
+	ITaskItem [] WriteAssembliesToDisk (IReadOnlyList<GeneratedAssembly> assemblies)
+	{
+		var items = new List<ITaskItem> ();
+		foreach (var assembly in assemblies) {
+			string outputPath = Path.Combine (OutputDirectory, assembly.Name + ".dll");
+			Files.CopyIfStreamChanged (assembly.Content, outputPath);
+			items.Add (new TaskItem (outputPath));
+		}
+		return items.ToArray ();
+	}
+
+	ITaskItem [] WriteJavaSourcesToDisk (IReadOnlyList<GeneratedJavaSource> javaSources)
+	{
+		var items = new List<ITaskItem> ();
+		foreach (var source in javaSources) {
+			string outputPath = Path.Combine (JavaSourceOutputDirectory, source.RelativePath);
+			string? dir = Path.GetDirectoryName (outputPath);
+			if (!string.IsNullOrEmpty (dir)) Directory.CreateDirectory (dir);
+			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
+				sw.Write (source.Content);
+				sw.Flush ();
+				Files.CopyIfStreamChanged (sw.BaseStream, outputPath);
+			}
+			items.Add (new TaskItem (outputPath));
+		}
+		return items.ToArray ();
 	}
 
 	ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)
 	{
-		var peersByAssembly = allPeers
-			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
-			.OrderBy (g => g.Key, StringComparer.Ordinal);
-
+		var peersByAssembly = allPeers.GroupBy (p => p.AssemblyName, StringComparer.Ordinal).OrderBy (g => g.Key, StringComparer.Ordinal);
 		var outputFiles = new List<ITaskItem> ();
-
 		foreach (var group in peersByAssembly) {
 			var peers = group.ToList ();
 			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
-
-			bool written;
 			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
 				AcwMapWriter.Write (sw, peers);
 				sw.Flush ();
-				written = Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
+				Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
 			}
-
-			Log.LogDebugMessage (written
-				? $"  acw-map.{group.Key}.txt: {peers.Count} types"
-				: $"  acw-map.{group.Key}.txt: unchanged");
-
 			var item = new TaskItem (outputFile);
 			item.SetMetadata ("AssemblyName", group.Key);
 			outputFiles.Add (item);
 		}
-
-		Log.LogDebugMessage ($"Generated {outputFiles.Count} per-assembly ACW map files.");
 		return outputFiles.ToArray ();
 	}
 
 	static Version ParseTargetFrameworkVersion (string tfv)
 	{
-		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
-			tfv = tfv.Substring (1);
-		}
-		if (Version.TryParse (tfv, out var version)) {
-			return version;
-		}
+		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) tfv = tfv.Substring (1);
+		if (Version.TryParse (tfv, out var version)) return version;
 		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -28,6 +28,9 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	[Required]
 	public string JavaSourceOutputDirectory { get; set; } = "";
 
+	/// <summary>
+	/// Directory for per-assembly acw-map.{AssemblyName}.txt files.
+	/// </summary>
 	[Required]
 	public string AcwMapDirectory { get; set; } = "";
 
@@ -55,19 +58,14 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public override bool RunTask ()
 	{
 		var systemRuntimeVersion = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (TargetFrameworkVersion);
-		var assemblyPaths = GetJavaInteropAssemblyPaths (ResolvedAssemblies);
+		// Don't filter by HasMonoAndroidReference — ReferencePath items from the compiler
+		// don't carry this metadata. The scanner handles non-Java assemblies gracefully.
+		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
 
-		// Framework binding types (Activity, View, etc.) already exist in java_runtime.dex and don't
-		// need JCW .java files. Framework Implementor types (mono/ prefix, e.g. OnClickListenerImplementor)
-		// DO need JCWs — they're included via the mono/ filter below.
-		// User NuGet libraries also need JCWs, so we only filter by FrameworkReferenceName.
-		// Note: Pre-generating SDK-compatible JCWs (mono.android-trimmable.jar) is tracked by #10792.
+		// Currently we generate JCWs for ALL assemblies including framework bindings.
+		// Pre-generating SDK-compatible JCWs (mono.android-trimmable.jar) is tracked by #10792.
+		// Once that's done, we can skip framework assemblies here.
 		var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
-		foreach (var item in ResolvedAssemblies) {
-			if (!item.GetMetadata ("FrameworkReferenceName").IsNullOrEmpty ()) {
-				frameworkAssemblyNames.Add (Path.GetFileNameWithoutExtension (item.ItemSpec));
-			}
-		}
 
 		Directory.CreateDirectory (AcwMapDirectory);
 
@@ -84,17 +82,6 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
 
 		return !Log.HasLoggedErrors;
-	}
-
-	static IReadOnlyList<string> GetJavaInteropAssemblyPaths (ITaskItem [] items)
-	{
-		var paths = new List<string> (items.Length);
-		foreach (var item in items) {
-			if (MonoAndroidHelper.IsMonoAndroidAssembly (item)) {
-				paths.Add (item.ItemSpec);
-			}
-		}
-		return paths;
 	}
 
 	ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Android.Sdk.TrimmableTypeMap;
@@ -47,7 +48,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			foreach (var path in assemblyPaths) {
 				var peReader = new PEReader (File.OpenRead (path));
 				peReaders.Add (peReader);
-				assemblies.Add ((Path.GetFileNameWithoutExtension (path), peReader));
+				var mdReader = peReader.GetMetadataReader ();
+				assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
 			}
 			var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
 			var result = generator.Execute (assemblies, systemRuntimeVersion, frameworkAssemblyNames);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -15,104 +15,178 @@ namespace Xamarin.Android.Tasks;
 
 public class GenerateTrimmableTypeMap : AndroidTask
 {
-	public override string TaskPrefix => "GTT";
+public override string TaskPrefix => "GTT";
 
-	[Required]
-	public ITaskItem [] ResolvedAssemblies { get; set; } = [];
-	[Required]
-	public string OutputDirectory { get; set; } = "";
-	[Required]
-	public string JavaSourceOutputDirectory { get; set; } = "";
-	[Required]
-	public string AcwMapDirectory { get; set; } = "";
-	[Required]
-	public string TargetFrameworkVersion { get; set; } = "";
-	[Output]
-	public ITaskItem [] GeneratedAssemblies { get; set; } = [];
-	[Output]
-	public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
-	[Output]
-	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
+[Required]
+public ITaskItem [] ResolvedAssemblies { get; set; } = [];
+[Required]
+public string OutputDirectory { get; set; } = "";
+[Required]
+public string JavaSourceOutputDirectory { get; set; } = "";
+[Required]
+public string AcwMapDirectory { get; set; } = "";
+[Required]
+public string TargetFrameworkVersion { get; set; } = "";
+[Output]
+public ITaskItem [] GeneratedAssemblies { get; set; } = [];
+[Output]
+public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
+[Output]
+public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
 
-	public override bool RunTask ()
-	{
-		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
-		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
-		var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
-		Directory.CreateDirectory (OutputDirectory);
-		Directory.CreateDirectory (JavaSourceOutputDirectory);
-		Directory.CreateDirectory (AcwMapDirectory);
-		var peReaders = new List<PEReader> ();
-		var assemblies = new List<(string Name, PEReader Reader)> ();
-		try {
-			foreach (var path in assemblyPaths) {
-				var peReader = new PEReader (File.OpenRead (path));
-				peReaders.Add (peReader);
-				var mdReader = peReader.GetMetadataReader ();
-				assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
-			}
-			var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
-			var result = generator.Execute (assemblies, systemRuntimeVersion, frameworkAssemblyNames);
-			GeneratedAssemblies = WriteAssembliesToDisk (result.GeneratedAssemblies);
-			GeneratedJavaFiles = WriteJavaSourcesToDisk (result.GeneratedJavaSources);
-			PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
-		} finally {
-			foreach (var peReader in peReaders) peReader.Dispose ();
-		}
-		return !Log.HasLoggedErrors;
-	}
+public override bool RunTask ()
+{
+var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
+var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
+var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
 
-	ITaskItem [] WriteAssembliesToDisk (IReadOnlyList<GeneratedAssembly> assemblies)
-	{
-		var items = new List<ITaskItem> ();
-		foreach (var assembly in assemblies) {
-			string outputPath = Path.Combine (OutputDirectory, assembly.Name + ".dll");
-			Files.CopyIfStreamChanged (assembly.Content, outputPath);
-			items.Add (new TaskItem (outputPath));
-		}
-		return items.ToArray ();
-	}
+Directory.CreateDirectory (OutputDirectory);
+Directory.CreateDirectory (JavaSourceOutputDirectory);
+Directory.CreateDirectory (AcwMapDirectory);
 
-	ITaskItem [] WriteJavaSourcesToDisk (IReadOnlyList<GeneratedJavaSource> javaSources)
-	{
-		var items = new List<ITaskItem> ();
-		foreach (var source in javaSources) {
-			string outputPath = Path.Combine (JavaSourceOutputDirectory, source.RelativePath);
-			string? dir = Path.GetDirectoryName (outputPath);
-			if (!string.IsNullOrEmpty (dir)) Directory.CreateDirectory (dir);
-			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
-				sw.Write (source.Content);
-				sw.Flush ();
-				Files.CopyIfStreamChanged (sw.BaseStream, outputPath);
-			}
-			items.Add (new TaskItem (outputPath));
-		}
-		return items.ToArray ();
-	}
+var peReaders = new List<PEReader> ();
+var assemblies = new List<(string Name, PEReader Reader)> ();
+TrimmableTypeMapResult? result = null;
+try {
+foreach (var path in assemblyPaths) {
+var peReader = new PEReader (File.OpenRead (path));
+peReaders.Add (peReader);
+var mdReader = peReader.GetMetadataReader ();
+assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
+}
 
-	ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)
-	{
-		var peersByAssembly = allPeers.GroupBy (p => p.AssemblyName, StringComparer.Ordinal).OrderBy (g => g.Key, StringComparer.Ordinal);
-		var outputFiles = new List<ITaskItem> ();
-		foreach (var group in peersByAssembly) {
-			var peers = group.ToList ();
-			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
-			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
-				AcwMapWriter.Write (sw, peers);
-				sw.Flush ();
-				Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
-			}
-			var item = new TaskItem (outputFile);
-			item.SetMetadata ("AssemblyName", group.Key);
-			outputFiles.Add (item);
-		}
-		return outputFiles.ToArray ();
-	}
+var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
+result = generator.Execute (assemblies, systemRuntimeVersion, frameworkAssemblyNames);
 
-	static Version ParseTargetFrameworkVersion (string tfv)
-	{
-		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) tfv = tfv.Substring (1);
-		if (Version.TryParse (tfv, out var version)) return version;
-		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
-	}
+GeneratedAssemblies = WriteAssembliesToDisk (result.GeneratedAssemblies, assemblyPaths);
+GeneratedJavaFiles = WriteJavaSourcesToDisk (result.GeneratedJavaSources);
+PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
+} finally {
+if (result is not null) {
+foreach (var assembly in result.GeneratedAssemblies) {
+assembly.Content.Dispose ();
+}
+}
+foreach (var peReader in peReaders) {
+peReader.Dispose ();
+}
+}
+
+return !Log.HasLoggedErrors;
+}
+
+ITaskItem [] WriteAssembliesToDisk (IReadOnlyList<GeneratedAssembly> assemblies, IReadOnlyList<string> assemblyPaths)
+{
+// Build a map from assembly name -> source path for timestamp comparison
+var sourcePathByName = new Dictionary<string, string> (StringComparer.Ordinal);
+foreach (var path in assemblyPaths) {
+var name = Path.GetFileNameWithoutExtension (path);
+sourcePathByName [name] = path;
+}
+
+var items = new List<ITaskItem> ();
+bool anyRegenerated = false;
+var perAssemblyItems = new List<(string Name, string OutputPath)> ();
+
+foreach (var assembly in assemblies) {
+if (assembly.Name == "_Microsoft.Android.TypeMaps") {
+continue; // Handle root assembly separately below
+}
+
+string outputPath = Path.Combine (OutputDirectory, assembly.Name + ".dll");
+// Extract the original assembly name from the typemap name (e.g., "_Foo.TypeMap" -> "Foo")
+string originalName = assembly.Name;
+if (originalName.StartsWith ("_", StringComparison.Ordinal) && originalName.EndsWith (".TypeMap", StringComparison.Ordinal)) {
+originalName = originalName.Substring (1, originalName.Length - ".TypeMap".Length - 1);
+}
+
+if (IsUpToDate (outputPath, originalName, sourcePathByName)) {
+Log.LogDebugMessage ($"  {assembly.Name}: up to date, skipping");
+} else {
+Files.CopyIfStreamChanged (assembly.Content, outputPath);
+anyRegenerated = true;
+Log.LogDebugMessage ($"  {assembly.Name}: written");
+}
+
+items.Add (new TaskItem (outputPath));
+perAssemblyItems.Add ((assembly.Name, outputPath));
+}
+
+// Root assembly — regenerate if any per-assembly typemap changed
+var rootAssembly = assemblies.FirstOrDefault (a => a.Name == "_Microsoft.Android.TypeMaps");
+if (rootAssembly is not null) {
+string rootOutputPath = Path.Combine (OutputDirectory, rootAssembly.Name + ".dll");
+if (anyRegenerated || !File.Exists (rootOutputPath)) {
+Files.CopyIfStreamChanged (rootAssembly.Content, rootOutputPath);
+Log.LogDebugMessage ($"  Root: written");
+} else {
+Log.LogDebugMessage ($"  Root: up to date, skipping");
+}
+items.Add (new TaskItem (rootOutputPath));
+}
+
+return items.ToArray ();
+}
+
+static bool IsUpToDate (string outputPath, string assemblyName, Dictionary<string, string> sourcePathByName)
+{
+if (!File.Exists (outputPath)) {
+return false;
+}
+if (!sourcePathByName.TryGetValue (assemblyName, out var sourcePath)) {
+return false;
+}
+return File.GetLastWriteTimeUtc (outputPath) >= File.GetLastWriteTimeUtc (sourcePath);
+}
+
+ITaskItem [] WriteJavaSourcesToDisk (IReadOnlyList<GeneratedJavaSource> javaSources)
+{
+var items = new List<ITaskItem> ();
+foreach (var source in javaSources) {
+string outputPath = Path.Combine (JavaSourceOutputDirectory, source.RelativePath);
+string? dir = Path.GetDirectoryName (outputPath);
+if (!string.IsNullOrEmpty (dir)) {
+Directory.CreateDirectory (dir);
+}
+using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
+sw.Write (source.Content);
+sw.Flush ();
+Files.CopyIfStreamChanged (sw.BaseStream, outputPath);
+}
+items.Add (new TaskItem (outputPath));
+}
+return items.ToArray ();
+}
+
+ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)
+{
+var peersByAssembly = allPeers
+.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
+.OrderBy (g => g.Key, StringComparer.Ordinal);
+var outputFiles = new List<ITaskItem> ();
+foreach (var group in peersByAssembly) {
+var peers = group.ToList ();
+string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
+using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
+AcwMapWriter.Write (sw, peers);
+sw.Flush ();
+Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
+}
+var item = new TaskItem (outputFile);
+item.SetMetadata ("AssemblyName", group.Key);
+outputFiles.Add (item);
+}
+return outputFiles.ToArray ();
+}
+
+static Version ParseTargetFrameworkVersion (string tfv)
+{
+if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
+tfv = tfv.Substring (1);
+}
+if (Version.TryParse (tfv, out var version)) {
+return version;
+}
+throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
+}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -12,9 +12,8 @@ using Microsoft.Build.Utilities;
 namespace Xamarin.Android.Tasks;
 
 /// <summary>
-/// Generates trimmable TypeMap assemblies, JCW Java source files, and per-assembly
-/// acw-map files from resolved assemblies. The acw-map files are later merged into
-/// a single acw-map.txt consumed by _ConvertCustomView for layout XML fixups.
+/// MSBuild task adapter for <see cref="TrimmableTypeMapGenerator"/>.
+/// Opens files and maps ITaskItem to/from strings, then delegates to the core class.
 /// </summary>
 public class GenerateTrimmableTypeMap : AndroidTask
 {
@@ -29,11 +28,13 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	[Required]
 	public string JavaSourceOutputDirectory { get; set; } = "";
 
-	/// <summary>
-	/// Directory for per-assembly acw-map.{AssemblyName}.txt files.
-	/// </summary>
 	[Required]
 	public string AcwMapDirectory { get; set; } = "";
+
+	/// <summary>
+	/// Output path for the merged acw-map.txt consumed by _ConvertCustomView and _UpdateAndroidResgen.
+	/// </summary>
+	public string? AcwMapOutputFile { get; set; }
 
 	/// <summary>
 	/// The .NET target framework version (e.g., "v11.0"). Used to set the System.Runtime
@@ -43,187 +44,47 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public string TargetFrameworkVersion { get; set; } = "";
 
 	[Output]
-	public ITaskItem []? GeneratedAssemblies { get; set; }
+	public ITaskItem [] GeneratedAssemblies { get; set; } = [];
 
 	[Output]
-	public ITaskItem []? GeneratedJavaFiles { get; set; }
+	public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
 
-	/// <summary>
-	/// Per-assembly acw-map files produced during scanning. Each file contains
-	/// three lines per type: PartialAssemblyQualifiedName;JavaKey,
-	/// ManagedKey;JavaKey, and CompatJniName;JavaKey.
-	/// </summary>
 	[Output]
 	public ITaskItem []? PerAssemblyAcwMapFiles { get; set; }
 
 	public override bool RunTask ()
 	{
-		var systemRuntimeVersion = ParseTargetFrameworkVersion (TargetFrameworkVersion);
-		var assemblyPaths = GetJavaInteropAssemblyPaths (ResolvedAssemblies);
+		var systemRuntimeVersion = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (TargetFrameworkVersion);
+		// Don't filter by HasMonoAndroidReference — ReferencePath items from the compiler
+		// don't carry this metadata. The scanner handles non-Java assemblies gracefully.
+		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
 
-		Directory.CreateDirectory (OutputDirectory);
-		Directory.CreateDirectory (JavaSourceOutputDirectory);
+		// Framework binding types (Activity, View, etc.) already exist in java_runtime.dex and don't
+		// need JCW .java files. Framework Implementor types (mono/ prefix, e.g. OnClickListenerImplementor)
+		// DO need JCWs — they're included via the mono/ filter below.
+		// User NuGet libraries also need JCWs, so we only filter by FrameworkReferenceName.
+		// Note: Pre-generating SDK-compatible JCWs (mono.android-trimmable.jar) is tracked by #10792.
+		var frameworkAssemblyNames = new HashSet<string> (StringComparer.OrdinalIgnoreCase);
+		foreach (var item in ResolvedAssemblies) {
+			if (!item.GetMetadata ("FrameworkReferenceName").IsNullOrEmpty ()) {
+				frameworkAssemblyNames.Add (Path.GetFileNameWithoutExtension (item.ItemSpec));
+			}
+		}
+
 		Directory.CreateDirectory (AcwMapDirectory);
 
-		var allPeers = ScanAssemblies (assemblyPaths);
-		if (allPeers.Count == 0) {
-			Log.LogDebugMessage ("No Java peer types found, skipping typemap generation.");
-			return !Log.HasLoggedErrors;
-		}
+		var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
+		var result = generator.Execute (
+			assemblyPaths,
+			OutputDirectory,
+			JavaSourceOutputDirectory,
+			systemRuntimeVersion,
+			frameworkAssemblyNames,
+			AcwMapOutputFile);
 
-		GeneratedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion, assemblyPaths);
-		GeneratedJavaFiles = GenerateJcwJavaSources (allPeers);
-		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (allPeers);
+		GeneratedAssemblies = result.GeneratedAssemblies.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
+		GeneratedJavaFiles = result.GeneratedJavaFiles.Select (p => (ITaskItem) new TaskItem (p)).ToArray ();
 
 		return !Log.HasLoggedErrors;
-	}
-
-	// Future optimization: the scanner currently scans all assemblies on every run.
-	// For incremental builds, we could:
-	// 1. Add a Scan(allPaths, changedPaths) overload that only produces JavaPeerInfo
-	//    for changed assemblies while still indexing all assemblies for cross-assembly
-	//    resolution (base types, interfaces, activation ctors).
-	// 2. Cache scan results per assembly to skip PE I/O entirely for unchanged assemblies.
-	// Both require profiling to determine if they meaningfully improve build times.
-	List<JavaPeerInfo> ScanAssemblies (IReadOnlyList<string> assemblyPaths)
-	{
-		using var scanner = new JavaPeerScanner ();
-		var peers = scanner.Scan (assemblyPaths);
-		Log.LogDebugMessage ($"Scanned {assemblyPaths.Count} assemblies, found {peers.Count} Java peer types.");
-		return peers;
-	}
-
-	ITaskItem [] GenerateTypeMapAssemblies (List<JavaPeerInfo> allPeers, Version systemRuntimeVersion,
-		IReadOnlyList<string> assemblyPaths)
-	{
-		// Build a map from assembly name → source path for timestamp comparison
-		var sourcePathByName = new Dictionary<string, string> (StringComparer.Ordinal);
-		foreach (var path in assemblyPaths) {
-			var name = Path.GetFileNameWithoutExtension (path);
-			sourcePathByName [name] = path;
-		}
-
-		var peersByAssembly = allPeers
-			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
-			.OrderBy (g => g.Key, StringComparer.Ordinal);
-
-		var generatedAssemblies = new List<ITaskItem> ();
-		var perAssemblyNames = new List<string> ();
-		var generator = new TypeMapAssemblyGenerator (systemRuntimeVersion);
-		bool anyRegenerated = false;
-
-		foreach (var group in peersByAssembly) {
-			string assemblyName = $"_{group.Key}.TypeMap";
-			string outputPath = Path.Combine (OutputDirectory, assemblyName + ".dll");
-			perAssemblyNames.Add (assemblyName);
-
-			if (IsUpToDate (outputPath, group.Key, sourcePathByName)) {
-				Log.LogDebugMessage ($"  {assemblyName}: up to date, skipping");
-				generatedAssemblies.Add (new TaskItem (outputPath));
-				continue;
-			}
-
-			generator.Generate (group.ToList (), outputPath, assemblyName);
-			generatedAssemblies.Add (new TaskItem (outputPath));
-			anyRegenerated = true;
-
-			Log.LogDebugMessage ($"  {assemblyName}: {group.Count ()} types");
-		}
-
-		// Root assembly references all per-assembly typemaps — regenerate if any changed
-		string rootOutputPath = Path.Combine (OutputDirectory, "_Microsoft.Android.TypeMaps.dll");
-		if (anyRegenerated || !File.Exists (rootOutputPath)) {
-			var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
-			rootGenerator.Generate (perAssemblyNames, rootOutputPath);
-			Log.LogDebugMessage ($"  Root: {perAssemblyNames.Count} per-assembly refs");
-		} else {
-			Log.LogDebugMessage ($"  Root: up to date, skipping");
-		}
-		generatedAssemblies.Add (new TaskItem (rootOutputPath));
-
-		Log.LogDebugMessage ($"Generated {generatedAssemblies.Count} typemap assemblies.");
-		return generatedAssemblies.ToArray ();
-	}
-
-	static bool IsUpToDate (string outputPath, string assemblyName, Dictionary<string, string> sourcePathByName)
-	{
-		if (!File.Exists (outputPath)) {
-			return false;
-		}
-		if (!sourcePathByName.TryGetValue (assemblyName, out var sourcePath)) {
-			return false;
-		}
-		return File.GetLastWriteTimeUtc (outputPath) >= File.GetLastWriteTimeUtc (sourcePath);
-	}
-
-	ITaskItem [] GenerateJcwJavaSources (List<JavaPeerInfo> allPeers)
-	{
-		var jcwGenerator = new JcwJavaSourceGenerator ();
-		var files = jcwGenerator.Generate (allPeers, JavaSourceOutputDirectory);
-		Log.LogDebugMessage ($"Generated {files.Count} JCW Java source files.");
-
-		var items = new ITaskItem [files.Count];
-		for (int i = 0; i < files.Count; i++) {
-			items [i] = new TaskItem (files [i]);
-		}
-		return items;
-	}
-
-	ITaskItem [] GeneratePerAssemblyAcwMaps (List<JavaPeerInfo> allPeers)
-	{
-		var peersByAssembly = allPeers
-			.GroupBy (p => p.AssemblyName, StringComparer.Ordinal)
-			.OrderBy (g => g.Key, StringComparer.Ordinal);
-
-		var outputFiles = new List<ITaskItem> ();
-
-		foreach (var group in peersByAssembly) {
-			var peers = group.ToList ();
-			string outputFile = Path.Combine (AcwMapDirectory, $"acw-map.{group.Key}.txt");
-
-			bool written;
-			using (var sw = MemoryStreamPool.Shared.CreateStreamWriter ()) {
-				AcwMapWriter.Write (sw, peers);
-				sw.Flush ();
-				written = Files.CopyIfStreamChanged (sw.BaseStream, outputFile);
-			}
-
-			Log.LogDebugMessage (written
-				? $"  acw-map.{group.Key}.txt: {peers.Count} types"
-				: $"  acw-map.{group.Key}.txt: unchanged");
-
-			var item = new TaskItem (outputFile);
-			item.SetMetadata ("AssemblyName", group.Key);
-			outputFiles.Add (item);
-		}
-
-		Log.LogDebugMessage ($"Generated {outputFiles.Count} per-assembly ACW map files.");
-		return outputFiles.ToArray ();
-	}
-
-	static Version ParseTargetFrameworkVersion (string tfv)
-	{
-		if (tfv.Length > 0 && (tfv [0] == 'v' || tfv [0] == 'V')) {
-			tfv = tfv.Substring (1);
-		}
-		if (Version.TryParse (tfv, out var version)) {
-			return version;
-		}
-		throw new ArgumentException ($"Cannot parse TargetFrameworkVersion '{tfv}' as a Version.");
-	}
-
-	/// <summary>
-	/// Filters resolved assemblies to only those that reference Mono.Android or Java.Interop
-	/// (i.e., assemblies that could contain [Register] types). Skips BCL assemblies.
-	/// </summary>
-	static IReadOnlyList<string> GetJavaInteropAssemblyPaths (ITaskItem [] items)
-	{
-		var paths = new List<string> (items.Length);
-		foreach (var item in items) {
-			if (MonoAndroidHelper.IsMonoAndroidAssembly (item)) {
-				paths.Add (item.ItemSpec);
-			}
-		}
-		return paths;
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -55,9 +55,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public override bool RunTask ()
 	{
 		var systemRuntimeVersion = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (TargetFrameworkVersion);
-		// Don't filter by HasMonoAndroidReference — ReferencePath items from the compiler
-		// don't carry this metadata. The scanner handles non-Java assemblies gracefully.
-		var assemblyPaths = ResolvedAssemblies.Select (i => i.ItemSpec).Distinct ().ToList ();
+		var assemblyPaths = GetJavaInteropAssemblyPaths (ResolvedAssemblies);
 
 		// Framework binding types (Activity, View, etc.) already exist in java_runtime.dex and don't
 		// need JCW .java files. Framework Implementor types (mono/ prefix, e.g. OnClickListenerImplementor)
@@ -86,6 +84,17 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		PerAssemblyAcwMapFiles = GeneratePerAssemblyAcwMaps (result.AllPeers);
 
 		return !Log.HasLoggedErrors;
+	}
+
+	static IReadOnlyList<string> GetJavaInteropAssemblyPaths (ITaskItem [] items)
+	{
+		var paths = new List<string> (items.Length);
+		foreach (var item in items) {
+			if (MonoAndroidHelper.IsMonoAndroidAssembly (item)) {
+				paths.Add (item.ItemSpec);
+			}
+		}
+		return paths;
 	}
 
 	ITaskItem [] GeneratePerAssemblyAcwMaps (IReadOnlyList<JavaPeerInfo> allPeers)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -24,8 +24,8 @@ namespace Xamarin.Android.Build.Tests {
 			var task = CreateTask ([], outputDir, javaDir);
 
 			Assert.IsTrue (task.Execute (), "Task should succeed with empty assembly list.");
-			Assert.IsNull (task.GeneratedAssemblies);
-			Assert.IsNull (task.GeneratedJavaFiles);
+			Assert.IsEmpty (task.GeneratedAssemblies);
+			Assert.IsEmpty (task.GeneratedJavaFiles);
 		}
 
 		[Test]
@@ -198,8 +198,8 @@ namespace Xamarin.Android.Build.Tests {
 			var task = CreateTask (new [] { new TaskItem (nunitDll) }, outputDir, javaDir, messages);
 
 			Assert.IsTrue (task.Execute (), "Task should succeed with no peer types.");
-			Assert.IsNull (task.GeneratedAssemblies);
-			Assert.IsNull (task.GeneratedJavaFiles);
+			Assert.IsEmpty (task.GeneratedAssemblies);
+			Assert.IsEmpty (task.GeneratedJavaFiles);
 			Assert.IsTrue (messages.Any (m => m.Message.Contains ("No Java peer types found")),
 				"Should log that no peers were found.");
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -26,6 +25,27 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (task.Execute (), "Task should succeed with empty assembly list.");
 			Assert.IsEmpty (task.GeneratedAssemblies);
 			Assert.IsEmpty (task.GeneratedJavaFiles);
+		}
+
+		[Test]
+		public void Execute_InvalidTargetFrameworkVersion_Fails ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var outputDir = Path.Combine (Root, path, "typemap");
+			var javaDir = Path.Combine (Root, path, "java");
+
+			var errors = new List<BuildErrorEventArgs> ();
+			var task = new GenerateTrimmableTypeMap {
+				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
+				ResolvedAssemblies = [],
+				OutputDirectory = outputDir,
+				JavaSourceOutputDirectory = javaDir,
+				AcwMapDirectory = Path.Combine (Root, path, "acw-maps"),
+				TargetFrameworkVersion = "not-a-version",
+			};
+
+			Assert.IsFalse (task.Execute (), "Task should fail with invalid TargetFrameworkVersion.");
+			Assert.IsNotEmpty (errors, "Should have logged an error.");
 		}
 
 		[Test]
@@ -56,152 +76,6 @@ namespace Xamarin.Android.Build.Tests {
 			foreach (var assembly in task.GeneratedAssemblies) {
 				FileAssert.Exists (assembly.ItemSpec);
 			}
-		}
-
-		[Test]
-		public void Execute_SecondRun_SkipsUpToDateAssemblies ()
-		{
-			var path = Path.Combine ("temp", TestName);
-			var outputDir = Path.Combine (Root, path, "typemap");
-			var javaDir = Path.Combine (Root, path, "java");
-
-			var monoAndroidItem = FindMonoAndroidDll ();
-			if (monoAndroidItem is null) {
-				Assert.Ignore ("Mono.Android.dll not found; skipping.");
-				return;
-			}
-
-			var assemblies = new [] { monoAndroidItem };
-
-			// First run: generates everything
-			var task1 = CreateTask (assemblies, outputDir, javaDir);
-			Assert.IsTrue (task1.Execute (), "First run should succeed.");
-
-			var typeMapPath = task1.GeneratedAssemblies
-				.Select (i => i.ItemSpec)
-				.First (p => p.Contains ("_Mono.Android.TypeMap.dll"));
-			var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-
-			// Wait to ensure timestamp difference is detectable
-			Thread.Sleep (100);
-
-			// Second run: same inputs, outputs should be skipped (not rewritten)
-			var messages = new List<BuildMessageEventArgs> ();
-			var task2 = CreateTask (assemblies, outputDir, javaDir, messages);
-			Assert.IsTrue (task2.Execute (), "Second run should succeed.");
-
-			var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-			Assert.AreEqual (firstWriteTime, secondWriteTime,
-				"Typemap assembly should NOT be rewritten when source hasn't changed.");
-
-			Assert.IsTrue (messages.Any (m => m.Message.Contains ("up to date")),
-				"Should log 'up to date' for skipped assemblies.");
-		}
-
-		[Test]
-		public void Execute_SourceTouched_RegeneratesOnlyChangedAssembly ()
-		{
-			var path = Path.Combine ("temp", TestName);
-			var outputDir = Path.Combine (Root, path, "typemap");
-			var javaDir = Path.Combine (Root, path, "java");
-
-			var monoAndroidItem = FindMonoAndroidDll ();
-			if (monoAndroidItem is null) {
-				Assert.Ignore ("Mono.Android.dll not found; skipping.");
-				return;
-			}
-
-			// Copy Mono.Android.dll to a temp location so we can touch it
-			var tempDir = Path.Combine (Root, path, "assemblies");
-			Directory.CreateDirectory (tempDir);
-			var tempAssemblyPath = Path.Combine (tempDir, "Mono.Android.dll");
-			File.Copy (monoAndroidItem.ItemSpec, tempAssemblyPath, true);
-
-			var tempItem = new TaskItem (tempAssemblyPath);
-			tempItem.SetMetadata ("HasMonoAndroidReference", "True");
-			var assemblies = new [] { tempItem };
-
-			// First run
-			var task1 = CreateTask (assemblies, outputDir, javaDir);
-			Assert.IsTrue (task1.Execute (), "First run should succeed.");
-
-			var typeMapPath = task1.GeneratedAssemblies
-				.Select (i => i.ItemSpec)
-				.First (p => p.Contains ("_Mono.Android.TypeMap.dll"));
-			var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-
-			// Touch the source assembly to simulate a change
-			Thread.Sleep (100);
-			File.SetLastWriteTimeUtc (tempAssemblyPath, DateTime.UtcNow);
-
-			// Second run: source is newer → should regenerate
-			var tempItem2 = new TaskItem (tempAssemblyPath);
-			tempItem2.SetMetadata ("HasMonoAndroidReference", "True");
-			var task2 = CreateTask (new [] { tempItem2 }, outputDir, javaDir);
-			Assert.IsTrue (task2.Execute (), "Second run should succeed.");
-
-			var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-			Assert.Greater (secondWriteTime, firstWriteTime,
-				"Typemap assembly should be regenerated when source is touched.");
-		}
-
-		[Test]
-		public void Execute_InvalidTargetFrameworkVersion_Fails ()
-		{
-			var path = Path.Combine ("temp", TestName);
-			var outputDir = Path.Combine (Root, path, "typemap");
-			var javaDir = Path.Combine (Root, path, "java");
-
-			var errors = new List<BuildErrorEventArgs> ();
-			var task = new GenerateTrimmableTypeMap {
-				BuildEngine = new MockBuildEngine (TestContext.Out, errors),
-				ResolvedAssemblies = [],
-				OutputDirectory = outputDir,
-				JavaSourceOutputDirectory = javaDir,
-				AcwMapDirectory = Path.Combine (Root, path, "acw-maps"),
-				TargetFrameworkVersion = "not-a-version",
-			};
-
-			Assert.IsFalse (task.Execute (), "Task should fail with invalid TargetFrameworkVersion.");
-			Assert.IsNotEmpty (errors, "Should have logged an error.");
-		}
-
-		[TestCase ("v11.0")]
-		[TestCase ("v10.0")]
-		[TestCase ("11.0")]
-		public void Execute_ParsesTargetFrameworkVersion (string tfv)
-		{
-			var path = Path.Combine ("temp", TestName);
-			var outputDir = Path.Combine (Root, path, "typemap");
-			var javaDir = Path.Combine (Root, path, "java");
-
-			var task = CreateTask ([], outputDir, javaDir, tfv: tfv);
-			Assert.IsTrue (task.Execute (), $"Task should succeed with TargetFrameworkVersion='{tfv}'.");
-		}
-
-		[Test]
-		public void Execute_NoPeersFound_ReturnsEmpty ()
-		{
-			var path = Path.Combine ("temp", TestName);
-			var outputDir = Path.Combine (Root, path, "typemap");
-			var javaDir = Path.Combine (Root, path, "java");
-
-			// Use a real assembly that has no [Register] types
-			var testAssemblyDir = Path.GetDirectoryName (GetType ().Assembly.Location)!;
-			var nunitDll = Path.Combine (testAssemblyDir, "nunit.framework.dll");
-			if (!File.Exists (nunitDll)) {
-				Assert.Ignore ("nunit.framework.dll not found; skipping.");
-				return;
-			}
-
-			var messages = new List<BuildMessageEventArgs> ();
-			var task = CreateTask (new [] { new TaskItem (nunitDll) }, outputDir, javaDir, messages);
-
-			Assert.IsTrue (task.Execute (), "Task should succeed with no peer types.");
-			Assert.IsEmpty (task.GeneratedAssemblies);
-			Assert.IsEmpty (task.GeneratedJavaFiles);
-			Assert.IsTrue (messages.Any (m => m.Message.Contains ("No Java peer types found")),
-				"Should log that no peers were found.");
 		}
 
 		GenerateTrimmableTypeMap CreateTask (ITaskItem [] assemblies, string outputDir, string javaDir,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -78,6 +78,52 @@ namespace Xamarin.Android.Build.Tests {
 			}
 		}
 
+		[Test]
+		public void Execute_SecondRun_OutputsAreUpToDate ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var outputDir = Path.Combine (Root, path, "typemap");
+			var javaDir = Path.Combine (Root, path, "java");
+
+			var monoAndroidItem = FindMonoAndroidDll ();
+			if (monoAndroidItem is null) {
+				Assert.Ignore ("Mono.Android.dll not found; skipping.");
+				return;
+			}
+
+			var assemblies = new [] { monoAndroidItem };
+
+			// First run: generates everything
+			var task1 = CreateTask (assemblies, outputDir, javaDir);
+			Assert.IsTrue (task1.Execute (), "First run should succeed.");
+
+			var typeMapPath = task1.GeneratedAssemblies
+				.Select (i => i.ItemSpec)
+				.First (p => p.Contains ("_Mono.Android.TypeMap.dll"));
+			var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+
+			// Second run: same inputs — outputs should not be rewritten (CopyIfStreamChanged)
+			var task2 = CreateTask (assemblies, outputDir, javaDir);
+			Assert.IsTrue (task2.Execute (), "Second run should succeed.");
+
+			var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+			Assert.AreEqual (firstWriteTime, secondWriteTime,
+				"Typemap assembly should NOT be rewritten when content hasn't changed.");
+		}
+
+		[TestCase ("v11.0")]
+		[TestCase ("v10.0")]
+		[TestCase ("11.0")]
+		public void Execute_ParsesTargetFrameworkVersion (string tfv)
+		{
+			var path = Path.Combine ("temp", TestName);
+			var outputDir = Path.Combine (Root, path, "typemap");
+			var javaDir = Path.Combine (Root, path, "java");
+
+			var task = CreateTask ([], outputDir, javaDir, tfv: tfv);
+			Assert.IsTrue (task.Execute (), $"Task should succeed with TargetFrameworkVersion='{tfv}'.");
+		}
+
 		GenerateTrimmableTypeMap CreateTask (ITaskItem [] assemblies, string outputDir, string javaDir,
 			IList<BuildMessageEventArgs>? messages = null, string tfv = "v11.0")
 		{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
@@ -1,4 +1,7 @@
+using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Xamarin.Android.Tasks;
 using Xunit;
 
@@ -32,7 +35,12 @@ AssertNoDiffs ("CONNECTOR MISMATCHES", result.ConnectorMismatches);
 public void ScannerDiagnostics_MonoAndroid ()
 {
 using var scanner = new JavaPeerScanner ();
-var peers = scanner.Scan (new [] { MonoAndroidAssemblyPath });
+var peReader = new PEReader (File.OpenRead (MonoAndroidAssemblyPath));
+var mdReader = peReader.GetMetadataReader ();
+var assemblyName = mdReader.GetString (mdReader.GetAssemblyDefinition ().Name);
+var assemblies = new [] { (assemblyName, peReader) };
+var peers = scanner.Scan (assemblies);
+peReader.Dispose ();
 
 var interfaces = peers.Count (p => p.IsInterface);
 var totalMethods = peers.Sum (p => p.MarshalMethods.Count);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Xamarin.Android.Tasks;
 using Xunit;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerComparisonTests.cs
@@ -1,6 +1,5 @@
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Xamarin.Android.Tasks;
 using Xunit;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Microsoft.Build.Utilities;
@@ -77,9 +79,18 @@ static class ScannerRunner
 
 	public static (List<TypeMapEntry> entries, Dictionary<string, List<TypeMethodGroup>> methodsByJavaName) RunNew (string[] assemblyPaths)
 	{
-		var primaryAssemblyName = Path.GetFileNameWithoutExtension (assemblyPaths [0]);
 		using var scanner = new JavaPeerScanner ();
-		var allPeers = scanner.Scan (assemblyPaths);
+		var peReaders = new List<PEReader> ();
+		var assemblies = new List<(string Name, PEReader Reader)> ();
+		foreach (var path in assemblyPaths) {
+			var peReader = new PEReader (File.OpenRead (path));
+			peReaders.Add (peReader);
+			var mdReader = peReader.GetMetadataReader ();
+			assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
+		}
+		var primaryAssemblyName = assemblies [0].Name;
+		var allPeers = scanner.Scan (assemblies);
+		foreach (var peReader in peReaders) peReader.Dispose ();
 		var peers = allPeers.Where (p => p.AssemblyName == primaryAssemblyName).ToList ();
 
 		var entries = peers

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -23,7 +23,7 @@ static class ScannerRunner
 {
 	public static (List<TypeMapEntry> entries, Dictionary<string, List<TypeMethodGroup>> methodsByJavaName) RunLegacy (string assemblyPath)
 	{
-		var cache = new CecilTypeDefinitionCache ();
+		var cache = new TypeDefinitionCache ();
 		var resolver = new DefaultAssemblyResolver ();
 		resolver.AddSearchDirectory (Path.GetDirectoryName (assemblyPath)!);
 
@@ -155,7 +155,7 @@ static class ScannerRunner
 	/// Extracts marshal methods using the real legacy JCW pipeline via
 	/// <see cref="CecilImporter.CreateType"/>.
 	/// </summary>
-	static List<MethodEntry> ExtractMethodRegistrations (CecilTypeDefinition typeDef, CecilTypeDefinitionCache cache)
+	static List<MethodEntry> ExtractMethodRegistrations (CecilTypeDefinition typeDef, TypeDefinitionCache cache)
 	{
 		if (typeDef.IsInterface) {
 			// CecilImporter throws XA4200 for interfaces.

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -84,15 +84,22 @@ static class ScannerRunner
 		using var scanner = new JavaPeerScanner ();
 		var peReaders = new List<PEReader> ();
 		var assemblies = new List<(string Name, PEReader Reader)> ();
-		foreach (var path in assemblyPaths) {
-			var peReader = new PEReader (File.OpenRead (path));
-			peReaders.Add (peReader);
-			var mdReader = peReader.GetMetadataReader ();
-			assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
+		List<JavaPeerInfo> allPeers;
+		string primaryAssemblyName;
+		try {
+			foreach (var path in assemblyPaths) {
+				var peReader = new PEReader (File.OpenRead (path));
+				peReaders.Add (peReader);
+				var mdReader = peReader.GetMetadataReader ();
+				assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
+			}
+			primaryAssemblyName = assemblies [0].Name;
+			allPeers = scanner.Scan (assemblies);
+		} finally {
+			foreach (var peReader in peReaders) {
+				peReader.Dispose ();
+			}
 		}
-		var primaryAssemblyName = assemblies [0].Name;
-		var allPeers = scanner.Scan (assemblies);
-		foreach (var peReader in peReaders) peReader.Dispose ();
 		var peers = allPeers.Where (p => p.AssemblyName == primaryAssemblyName).ToList ();
 
 		var entries = peers

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
+using CecilTypeDefinition = Mono.Cecil.TypeDefinition;
 using Xamarin.Android.Tasks;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
@@ -21,7 +23,7 @@ static class ScannerRunner
 {
 	public static (List<TypeMapEntry> entries, Dictionary<string, List<TypeMethodGroup>> methodsByJavaName) RunLegacy (string assemblyPath)
 	{
-		var cache = new TypeDefinitionCache ();
+		var cache = new CecilTypeDefinitionCache ();
 		var resolver = new DefaultAssemblyResolver ();
 		resolver.AddSearchDirectory (Path.GetDirectoryName (assemblyPath)!);
 
@@ -124,7 +126,7 @@ static class ScannerRunner
 		return (entries, methodsByJavaName);
 	}
 
-	public static string? GetCecilJavaName (TypeDefinition typeDef, IMetadataResolver cache)
+	public static string? GetCecilJavaName (CecilTypeDefinition typeDef, IMetadataResolver cache)
 	{
 		if (typeDef.HasCustomAttributes) {
 			foreach (var attr in typeDef.CustomAttributes) {
@@ -144,7 +146,7 @@ static class ScannerRunner
 		return Java.Interop.Tools.TypeNameMappings.JavaNativeTypeManager.ToJniName (typeDef, cache);
 	}
 
-	public static string GetManagedName (TypeDefinition typeDef)
+	public static string GetManagedName (CecilTypeDefinition typeDef)
 	{
 		return $"{typeDef.FullName.Replace ('/', '+')}, {typeDef.Module.Assembly.Name.Name}";
 	}
@@ -153,7 +155,7 @@ static class ScannerRunner
 	/// Extracts marshal methods using the real legacy JCW pipeline via
 	/// <see cref="CecilImporter.CreateType"/>.
 	/// </summary>
-	static List<MethodEntry> ExtractMethodRegistrations (TypeDefinition typeDef, TypeDefinitionCache cache)
+	static List<MethodEntry> ExtractMethodRegistrations (CecilTypeDefinition typeDef, CecilTypeDefinitionCache cache)
 	{
 		if (typeDef.IsInterface) {
 			// CecilImporter throws XA4200 for interfaces.
@@ -184,7 +186,7 @@ static class ScannerRunner
 		return methods;
 	}
 
-	internal static bool HasDoNotGenerateAcw (TypeDefinition typeDef)
+	internal static bool HasDoNotGenerateAcw (CecilTypeDefinition typeDef)
 	{
 		if (!typeDef.HasCustomAttributes) {
 			return false;
@@ -205,7 +207,7 @@ static class ScannerRunner
 	/// Fallback: extract [Register] from methods/properties directly (for interfaces
 	/// and DoNotGenerateAcw types that are never passed through CecilImporter).
 	/// </summary>
-	static List<MethodEntry> ExtractDirectRegisterAttributes (TypeDefinition typeDef)
+	static List<MethodEntry> ExtractDirectRegisterAttributes (CecilTypeDefinition typeDef)
 	{
 		var methods = new List<MethodEntry> ();
 		foreach (var method in typeDef.Methods) {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -8,6 +8,7 @@ using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
+using CecilAssemblyDefinition = Mono.Cecil.AssemblyDefinition;
 using CecilTypeDefinition = Mono.Cecil.TypeDefinition;
 using Xamarin.Android.Tasks;
 
@@ -33,7 +34,7 @@ static class ScannerRunner
 		}
 
 		var readerParams = new ReaderParameters { AssemblyResolver = resolver };
-		using var assembly = AssemblyDefinition.ReadAssembly (assemblyPath, readerParams);
+		using var assembly = CecilAssemblyDefinition.ReadAssembly (assemblyPath, readerParams);
 
 		var scanner = new XAJavaTypeScanner (
 			Xamarin.Android.Tools.AndroidTargetArch.Arm64,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/ScannerRunner.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -2,12 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
+using CecilTypeDefinition = Mono.Cecil.TypeDefinition;
 using Xamarin.Android.Tasks;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests;
@@ -31,7 +33,7 @@ static class TypeDataBuilder
 {
 	public static (Dictionary<string, TypeComparisonData> perType, List<TypeMapEntry> entries) BuildLegacy (string assemblyPath)
 	{
-		var cache = new TypeDefinitionCache ();
+		var cache = new CecilTypeDefinitionCache ();
 		var resolver = new DefaultAssemblyResolver ();
 		resolver.AddSearchDirectory (Path.GetDirectoryName (assemblyPath)!);
 
@@ -195,14 +197,14 @@ static class TypeDataBuilder
 		return perType;
 	}
 
-	static void FindLegacyActivationCtor (TypeDefinition typeDef, TypeDefinitionCache cache,
+	static void FindLegacyActivationCtor (CecilTypeDefinition typeDef, CecilTypeDefinitionCache cache,
 		out bool found, out string? declaringType, out string? style)
 	{
 		found = false;
 		declaringType = null;
 		style = null;
 
-		TypeDefinition? current = typeDef;
+		CecilTypeDefinition? current = typeDef;
 		while (current != null) {
 			foreach (var method in current.Methods) {
 				if (!method.IsConstructor || method.IsStatic || method.Parameters.Count != 2) {
@@ -232,7 +234,7 @@ static class TypeDataBuilder
 		}
 	}
 
-	static bool GetCecilDoNotGenerateAcw (TypeDefinition typeDef)
+	static bool GetCecilDoNotGenerateAcw (CecilTypeDefinition typeDef)
 	{
 		if (!typeDef.HasCustomAttributes) {
 			return false;
@@ -255,7 +257,7 @@ static class TypeDataBuilder
 		return false;
 	}
 
-	static void ExtractDirectRegisterCtors (TypeDefinition typeDef, List<string> javaCtorSignatures)
+	static void ExtractDirectRegisterCtors (CecilTypeDefinition typeDef, List<string> javaCtorSignatures)
 	{
 		foreach (var method in typeDef.Methods) {
 			if (!method.IsConstructor || method.IsStatic || !method.HasCustomAttributes) {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -9,6 +9,7 @@ using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Java.Interop.Tools.TypeNameMappings;
 using Microsoft.Build.Utilities;
 using Mono.Cecil;
+using CecilAssemblyDefinition = Mono.Cecil.AssemblyDefinition;
 using CecilTypeDefinition = Mono.Cecil.TypeDefinition;
 using Xamarin.Android.Tasks;
 
@@ -43,7 +44,7 @@ static class TypeDataBuilder
 		}
 
 		var readerParams = new ReaderParameters { AssemblyResolver = resolver };
-		using var assembly = AssemblyDefinition.ReadAssembly (assemblyPath, readerParams);
+		using var assembly = CecilAssemblyDefinition.ReadAssembly (assemblyPath, readerParams);
 
 		var scanner = new XAJavaTypeScanner (
 			Xamarin.Android.Tools.AndroidTargetArch.Arm64,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -33,7 +33,7 @@ static class TypeDataBuilder
 {
 	public static (Dictionary<string, TypeComparisonData> perType, List<TypeMapEntry> entries) BuildLegacy (string assemblyPath)
 	{
-		var cache = new CecilTypeDefinitionCache ();
+		var cache = new TypeDefinitionCache ();
 		var resolver = new DefaultAssemblyResolver ();
 		resolver.AddSearchDirectory (Path.GetDirectoryName (assemblyPath)!);
 
@@ -197,7 +197,7 @@ static class TypeDataBuilder
 		return perType;
 	}
 
-	static void FindLegacyActivationCtor (CecilTypeDefinition typeDef, CecilTypeDefinitionCache cache,
+	static void FindLegacyActivationCtor (CecilTypeDefinition typeDef, TypeDefinitionCache cache,
 		out bool found, out string? declaringType, out string? style)
 	{
 		found = false;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;
 using Java.Interop.Tools.TypeNameMappings;
@@ -135,9 +137,18 @@ static class TypeDataBuilder
 
 	public static Dictionary<string, TypeComparisonData> BuildNew (string[] assemblyPaths)
 	{
-		var primaryAssemblyName = Path.GetFileNameWithoutExtension (assemblyPaths [0]);
 		using var scanner = new JavaPeerScanner ();
-		var peers = scanner.Scan (assemblyPaths);
+		var peReaders = new List<PEReader> ();
+		var assemblies = new List<(string Name, PEReader Reader)> ();
+		foreach (var path in assemblyPaths) {
+			var peReader = new PEReader (File.OpenRead (path));
+			peReaders.Add (peReader);
+			var mdReader = peReader.GetMetadataReader ();
+			assemblies.Add ((mdReader.GetString (mdReader.GetAssemblyDefinition ().Name), peReader));
+		}
+		var primaryAssemblyName = assemblies [0].Name;
+		var peers = scanner.Scan (assemblies);
+		foreach (var peReader in peReaders) peReader.Dispose ();
 
 		var perType = new Dictionary<string, TypeComparisonData> (StringComparer.Ordinal);
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/TypeDataBuilder.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Reflection.PortableExecutable;
 using Java.Interop.Tools.Cecil;
 using Java.Interop.Tools.JavaCallableWrappers.Adapters;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection.Metadata;
 using System.Reflection.Metadata.Ecma335;
+using System.Reflection.PortableExecutable;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
@@ -23,8 +24,13 @@ public abstract class FixtureTestBase
 
 	static readonly Lazy<(List<JavaPeerInfo> peers, AssemblyManifestInfo manifestInfo)> _cachedScanResult = new (() => {
 		var scanner = new JavaPeerScanner ();
-		var peers = scanner.Scan (new [] { TestFixtureAssemblyPath });
+		var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
+		var mdReader = peReader.GetMetadataReader ();
+		var assemblyName = mdReader.GetString (mdReader.GetAssemblyDefinition ().Name);
+		var assemblies = new [] { (assemblyName, peReader) };
+		var peers = scanner.Scan (assemblies);
 		var manifestInfo = scanner.ScanAssemblyManifestInfo ();
+		peReader.Dispose ();
 		return (peers, manifestInfo);
 	});
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -135,24 +135,6 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 			"Typemap assembly should be regenerated when source is touched.");
 	}
 
-	[Theory]
-	[InlineData ("v11.0")]
-	[InlineData ("v10.0")]
-	[InlineData ("11.0")]
-	public void ParseTargetFrameworkVersion_ValidInput_Succeeds (string tfv)
-	{
-		var version = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (tfv);
-		Assert.NotNull (version);
-	}
-
-	[Theory]
-	[InlineData ("not-a-version")]
-	[InlineData ("")]
-	public void ParseTargetFrameworkVersion_InvalidInput_Throws (string tfv)
-	{
-		Assert.Throws<ArgumentException> (() => TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (tfv));
-	}
-
 	[Fact]
 	public void Execute_NullAssemblyPaths_Throws ()
 	{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -23,6 +23,21 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Execute_AssemblyWithNoPeers_ReturnsEmpty ()
+	{
+		// Use the test assembly itself — it has no [Register] types
+		var testAssemblyPath = typeof (TrimmableTypeMapGeneratorTests).Assembly.Location;
+		using var peReader = new PEReader (File.OpenRead (testAssemblyPath));
+		var result = CreateGenerator ().Execute (
+			new List<(string, PEReader)> { ("TestAssembly", peReader) },
+			new Version (11, 0),
+			new HashSet<string> ());
+		Assert.Empty (result.GeneratedAssemblies);
+		Assert.Empty (result.GeneratedJavaSources);
+		Assert.Contains (logMessages, m => m.Contains ("No Java peer types found"));
+	}
+
+	[Fact]
 	public void Execute_WithTestFixtures_ProducesOutputs ()
 	{
 		using var peReader = CreateTestFixturePEReader ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
+
+public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
+{
+	readonly string testDir;
+	readonly List<string> logMessages = new ();
+
+	public TrimmableTypeMapGeneratorTests ()
+	{
+		testDir = Path.Combine (Path.GetTempPath (), "TrimmableTypeMapGeneratorTests", Guid.NewGuid ().ToString ("N"));
+		Directory.CreateDirectory (testDir);
+	}
+
+	public void Dispose ()
+	{
+		if (Directory.Exists (testDir)) {
+			Directory.Delete (testDir, recursive: true);
+		}
+	}
+
+	[Fact]
+	public void Execute_EmptyAssemblyList_ReturnsEmptyResults ()
+	{
+		var generator = CreateGenerator ();
+		var result = generator.Execute (
+			Array.Empty<string> (),
+			Path.Combine (testDir, "typemap"),
+			Path.Combine (testDir, "java"),
+			new Version (11, 0),
+			new HashSet<string> ());
+
+		Assert.Empty (result.GeneratedAssemblies);
+		Assert.Empty (result.GeneratedJavaFiles);
+		Assert.Empty (result.AllPeers);
+		Assert.Contains (logMessages, m => m.Contains ("No Java peer types found"));
+	}
+
+	[Fact]
+	public void Execute_WithTestFixtures_ProducesOutputs ()
+	{
+		var assemblyPath = GetTestFixtureAssemblyPath ();
+		var outputDir = Path.Combine (testDir, "typemap");
+		var javaDir = Path.Combine (testDir, "java");
+
+		var generator = CreateGenerator ();
+		var result = generator.Execute (
+			new [] { assemblyPath },
+			outputDir,
+			javaDir,
+			new Version (11, 0),
+			new HashSet<string> ());
+
+		Assert.NotEmpty (result.GeneratedAssemblies);
+		Assert.NotEmpty (result.GeneratedJavaFiles);
+		Assert.NotEmpty (result.AllPeers);
+
+		Assert.Contains (result.GeneratedAssemblies, p => p.Contains ("_Microsoft.Android.TypeMaps.dll"));
+		Assert.Contains (result.GeneratedAssemblies, p => p.Contains ("_TestFixtures.TypeMap.dll"));
+
+		foreach (var assembly in result.GeneratedAssemblies) {
+			Assert.True (File.Exists (assembly), $"Generated assembly should exist: {assembly}");
+		}
+		foreach (var javaFile in result.GeneratedJavaFiles) {
+			Assert.True (File.Exists (javaFile), $"Generated Java file should exist: {javaFile}");
+		}
+	}
+
+	[Fact]
+	public void Execute_SecondRun_SkipsUpToDateAssemblies ()
+	{
+		var assemblyPath = GetTestFixtureAssemblyPath ();
+		var outputDir = Path.Combine (testDir, "typemap");
+		var javaDir = Path.Combine (testDir, "java");
+		var args = new object [] { assemblyPath, outputDir, javaDir };
+
+		// First run
+		var generator1 = CreateGenerator ();
+		var result1 = generator1.Execute (
+			new [] { assemblyPath }, outputDir, javaDir,
+			new Version (11, 0), new HashSet<string> ());
+
+		var typeMapPath = result1.GeneratedAssemblies.First (p => p.Contains ("_TestFixtures.TypeMap.dll"));
+		var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+
+		// Second run with fresh log
+		logMessages.Clear ();
+		var generator2 = CreateGenerator ();
+		generator2.Execute (
+			new [] { assemblyPath }, outputDir, javaDir,
+			new Version (11, 0), new HashSet<string> ());
+
+		var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+		Assert.Equal (firstWriteTime, secondWriteTime);
+		Assert.Contains (logMessages, m => m.Contains ("up to date"));
+	}
+
+	[Fact]
+	public void Execute_SourceTouched_RegeneratesAssembly ()
+	{
+		var originalPath = GetTestFixtureAssemblyPath ();
+		var tempDir = Path.Combine (testDir, "assemblies");
+		Directory.CreateDirectory (tempDir);
+		var assemblyPath = Path.Combine (tempDir, "TestFixtures.dll");
+		File.Copy (originalPath, assemblyPath);
+
+		var outputDir = Path.Combine (testDir, "typemap");
+		var javaDir = Path.Combine (testDir, "java");
+
+		// First run
+		var generator1 = CreateGenerator ();
+		var result1 = generator1.Execute (
+			new [] { assemblyPath }, outputDir, javaDir,
+			new Version (11, 0), new HashSet<string> ());
+
+		var typeMapPath = result1.GeneratedAssemblies.First (p => p.Contains ("_TestFixtures.TypeMap.dll"));
+		var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+
+		// Touch the source assembly
+		File.SetLastWriteTimeUtc (assemblyPath, DateTime.UtcNow.AddSeconds (1));
+
+		// Second run
+		var generator2 = CreateGenerator ();
+		var result2 = generator2.Execute (
+			new [] { assemblyPath }, outputDir, javaDir,
+			new Version (11, 0), new HashSet<string> ());
+
+		var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
+		Assert.True (secondWriteTime > firstWriteTime,
+			"Typemap assembly should be regenerated when source is touched.");
+	}
+
+	[Theory]
+	[InlineData ("v11.0")]
+	[InlineData ("v10.0")]
+	[InlineData ("11.0")]
+	public void ParseTargetFrameworkVersion_ValidInput_Succeeds (string tfv)
+	{
+		var version = TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (tfv);
+		Assert.NotNull (version);
+	}
+
+	[Theory]
+	[InlineData ("not-a-version")]
+	[InlineData ("")]
+	public void ParseTargetFrameworkVersion_InvalidInput_Throws (string tfv)
+	{
+		Assert.Throws<ArgumentException> (() => TrimmableTypeMapGenerator.ParseTargetFrameworkVersion (tfv));
+	}
+
+	[Fact]
+	public void Execute_NullAssemblyPaths_Throws ()
+	{
+		var generator = CreateGenerator ();
+		Assert.Throws<ArgumentNullException> (() => generator.Execute (
+			null!, Path.Combine (testDir, "out"), Path.Combine (testDir, "java"),
+			new Version (11, 0), new HashSet<string> ()));
+	}
+
+	TrimmableTypeMapGenerator CreateGenerator ()
+	{
+		return new TrimmableTypeMapGenerator (msg => logMessages.Add (msg));
+	}
+
+	static string GetTestFixtureAssemblyPath ()
+	{
+		var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
+			?? throw new InvalidOperationException ("Cannot determine test assembly directory");
+		var path = Path.Combine (testAssemblyDir, "TestFixtures.dll");
+		Assert.True (File.Exists (path), $"TestFixtures.dll not found at {path}");
+		return path;
+	}
+}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -29,7 +29,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 	{
 		var generator = CreateGenerator ();
 		var result = generator.Execute (
-			Array.Empty<string> (),
+			[],
 			Path.Combine (testDir, "typemap"),
 			Path.Combine (testDir, "java"),
 			new Version (11, 0),
@@ -77,7 +77,6 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 		var assemblyPath = GetTestFixtureAssemblyPath ();
 		var outputDir = Path.Combine (testDir, "typemap");
 		var javaDir = Path.Combine (testDir, "java");
-		var args = new object [] { assemblyPath, outputDir, javaDir };
 
 		// First run
 		var generator1 = CreateGenerator ();
@@ -126,7 +125,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 
 		// Second run
 		var generator2 = CreateGenerator ();
-		var result2 = generator2.Execute (
+		generator2.Execute (
 			new [] { assemblyPath }, outputDir, javaDir,
 			new Version (11, 0), new HashSet<string> ());
 
@@ -139,9 +138,12 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 	public void Execute_NullAssemblyPaths_Throws ()
 	{
 		var generator = CreateGenerator ();
+		string[]? nullPaths = null;
+#pragma warning disable CS8604 // Possible null reference argument — intentionally testing null guard
 		Assert.Throws<ArgumentNullException> (() => generator.Execute (
-			null!, Path.Combine (testDir, "out"), Path.Combine (testDir, "java"),
+			nullPaths, Path.Combine (testDir, "out"), Path.Combine (testDir, "java"),
 			new Version (11, 0), new HashSet<string> ()));
+#pragma warning restore CS8604
 	}
 
 	TrimmableTypeMapGenerator CreateGenerator ()

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -2,41 +2,22 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
-public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
+public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 {
-	readonly string testDir;
 	readonly List<string> logMessages = new ();
-
-	public TrimmableTypeMapGeneratorTests ()
-	{
-		testDir = Path.Combine (Path.GetTempPath (), "TrimmableTypeMapGeneratorTests", Guid.NewGuid ().ToString ("N"));
-		Directory.CreateDirectory (testDir);
-	}
-
-	public void Dispose ()
-	{
-		if (Directory.Exists (testDir)) {
-			Directory.Delete (testDir, recursive: true);
-		}
-	}
 
 	[Fact]
 	public void Execute_EmptyAssemblyList_ReturnsEmptyResults ()
 	{
-		var generator = CreateGenerator ();
-		var result = generator.Execute (
-			[],
-			Path.Combine (testDir, "typemap"),
-			Path.Combine (testDir, "java"),
-			new Version (11, 0),
-			new HashSet<string> ());
-
+		var result = CreateGenerator ().Execute ([], new Version (11, 0), new HashSet<string> ());
 		Assert.Empty (result.GeneratedAssemblies);
-		Assert.Empty (result.GeneratedJavaFiles);
+		Assert.Empty (result.GeneratedJavaSources);
 		Assert.Empty (result.AllPeers);
 		Assert.Contains (logMessages, m => m.Contains ("No Java peer types found"));
 	}
@@ -44,119 +25,51 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase, IDisposable
 	[Fact]
 	public void Execute_WithTestFixtures_ProducesOutputs ()
 	{
-		var assemblyPath = GetTestFixtureAssemblyPath ();
-		var outputDir = Path.Combine (testDir, "typemap");
-		var javaDir = Path.Combine (testDir, "java");
-
-		var generator = CreateGenerator ();
-		var result = generator.Execute (
-			new [] { assemblyPath },
-			outputDir,
-			javaDir,
-			new Version (11, 0),
-			new HashSet<string> ());
-
+		using var peReader = CreateTestFixturePEReader ();
+		var result = CreateGenerator ().Execute (new List<(string, PEReader)> { ("TestFixtures", peReader) }, new Version (11, 0), new HashSet<string> ());
 		Assert.NotEmpty (result.GeneratedAssemblies);
-		Assert.NotEmpty (result.GeneratedJavaFiles);
-		Assert.NotEmpty (result.AllPeers);
-
-		Assert.Contains (result.GeneratedAssemblies, p => p.Contains ("_Microsoft.Android.TypeMaps.dll"));
-		Assert.Contains (result.GeneratedAssemblies, p => p.Contains ("_TestFixtures.TypeMap.dll"));
-
-		foreach (var assembly in result.GeneratedAssemblies) {
-			Assert.True (File.Exists (assembly), $"Generated assembly should exist: {assembly}");
-		}
-		foreach (var javaFile in result.GeneratedJavaFiles) {
-			Assert.True (File.Exists (javaFile), $"Generated Java file should exist: {javaFile}");
-		}
+		Assert.NotEmpty (result.GeneratedJavaSources);
+		Assert.Contains (result.GeneratedAssemblies, a => a.Name == "_Microsoft.Android.TypeMaps");
+		Assert.Contains (result.GeneratedAssemblies, a => a.Name == "_TestFixtures.TypeMap");
 	}
 
 	[Fact]
-	public void Execute_SecondRun_SkipsUpToDateAssemblies ()
+	public void Execute_NullAssemblyList_Throws ()
 	{
-		var assemblyPath = GetTestFixtureAssemblyPath ();
-		var outputDir = Path.Combine (testDir, "typemap");
-		var javaDir = Path.Combine (testDir, "java");
-
-		// First run
-		var generator1 = CreateGenerator ();
-		var result1 = generator1.Execute (
-			new [] { assemblyPath }, outputDir, javaDir,
-			new Version (11, 0), new HashSet<string> ());
-
-		var typeMapPath = result1.GeneratedAssemblies.First (p => p.Contains ("_TestFixtures.TypeMap.dll"));
-		var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-
-		// Second run with fresh log
-		logMessages.Clear ();
-		var generator2 = CreateGenerator ();
-		generator2.Execute (
-			new [] { assemblyPath }, outputDir, javaDir,
-			new Version (11, 0), new HashSet<string> ());
-
-		var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-		Assert.Equal (firstWriteTime, secondWriteTime);
-		Assert.Contains (logMessages, m => m.Contains ("up to date"));
-	}
-
-	[Fact]
-	public void Execute_SourceTouched_RegeneratesAssembly ()
-	{
-		var originalPath = GetTestFixtureAssemblyPath ();
-		var tempDir = Path.Combine (testDir, "assemblies");
-		Directory.CreateDirectory (tempDir);
-		var assemblyPath = Path.Combine (tempDir, "TestFixtures.dll");
-		File.Copy (originalPath, assemblyPath);
-
-		var outputDir = Path.Combine (testDir, "typemap");
-		var javaDir = Path.Combine (testDir, "java");
-
-		// First run
-		var generator1 = CreateGenerator ();
-		var result1 = generator1.Execute (
-			new [] { assemblyPath }, outputDir, javaDir,
-			new Version (11, 0), new HashSet<string> ());
-
-		var typeMapPath = result1.GeneratedAssemblies.First (p => p.Contains ("_TestFixtures.TypeMap.dll"));
-		var firstWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-
-		// Touch the source assembly
-		File.SetLastWriteTimeUtc (assemblyPath, DateTime.UtcNow.AddSeconds (1));
-
-		// Second run
-		var generator2 = CreateGenerator ();
-		generator2.Execute (
-			new [] { assemblyPath }, outputDir, javaDir,
-			new Version (11, 0), new HashSet<string> ());
-
-		var secondWriteTime = File.GetLastWriteTimeUtc (typeMapPath);
-		Assert.True (secondWriteTime > firstWriteTime,
-			"Typemap assembly should be regenerated when source is touched.");
-	}
-
-	[Fact]
-	public void Execute_NullAssemblyPaths_Throws ()
-	{
-		var generator = CreateGenerator ();
-		string[]? nullPaths = null;
-#pragma warning disable CS8604 // Possible null reference argument — intentionally testing null guard
-		Assert.Throws<ArgumentNullException> (() => generator.Execute (
-			nullPaths, Path.Combine (testDir, "out"), Path.Combine (testDir, "java"),
-			new Version (11, 0), new HashSet<string> ()));
+		IReadOnlyList<(string Name, PEReader Reader)>? n = null;
+#pragma warning disable CS8604
+		Assert.Throws<ArgumentNullException> (() => CreateGenerator ().Execute (n, new Version (11, 0), new HashSet<string> ()));
 #pragma warning restore CS8604
 	}
 
-	TrimmableTypeMapGenerator CreateGenerator ()
+	[Fact]
+	public void Execute_GeneratedAssembliesAreValidPE ()
 	{
-		return new TrimmableTypeMapGenerator (msg => logMessages.Add (msg));
+		using var peReader = CreateTestFixturePEReader ();
+		var result = CreateGenerator ().Execute (new List<(string, PEReader)> { ("TestFixtures", peReader) }, new Version (11, 0), new HashSet<string> ());
+		foreach (var assembly in result.GeneratedAssemblies) {
+			assembly.Content.Position = 0;
+			using var vr = new PEReader (assembly.Content, PEStreamOptions.LeaveOpen);
+			var md = vr.GetMetadataReader ();
+			Assert.Equal (assembly.Name, md.GetString (md.GetAssemblyDefinition ().Name));
+		}
 	}
 
-	static string GetTestFixtureAssemblyPath ()
+	[Fact]
+	public void Execute_JavaSourcesHaveCorrectStructure ()
 	{
-		var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
+		using var peReader = CreateTestFixturePEReader ();
+		var result = CreateGenerator ().Execute (new List<(string, PEReader)> { ("TestFixtures", peReader) }, new Version (11, 0), new HashSet<string> ());
+		foreach (var source in result.GeneratedJavaSources)
+			Assert.Contains ("class ", source.Content);
+	}
+
+	TrimmableTypeMapGenerator CreateGenerator () => new (msg => logMessages.Add (msg));
+
+	static PEReader CreateTestFixturePEReader ()
+	{
+		var dir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
 			?? throw new InvalidOperationException ("Cannot determine test assembly directory");
-		var path = Path.Combine (testAssemblyDir, "TestFixtures.dll");
-		Assert.True (File.Exists (path), $"TestFixtures.dll not found at {path}");
-		return path;
+		return new PEReader (File.OpenRead (Path.Combine (dir, "TestFixtures.dll")));
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -82,7 +82,6 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		Assert.Contains (".ctor", methods);
 		Assert.Contains ("CreateInstance", methods);
-		Assert.Contains ("get_TargetType", methods);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -561,7 +561,6 @@ public class ModelBuilderTests : FixtureTestBase
 
 				Assert.Contains (".ctor", methodNames);
 				Assert.Contains ("CreateInstance", methodNames);
-				Assert.Contains ("get_TargetType", methodNames);
 			});
 		}
 


### PR DESCRIPTION
## Summary

Extract the core generation pipeline (scan → typemaps → JCW → acw-map) from the `GenerateTrimmableTypeMap` MSBuild task into a standalone `TrimmableTypeMapGenerator` class. The generator is **IO-free** — it accepts `PEReader` instances and returns in-memory content. The MSBuild task owns all filesystem IO.

## Motivation

The generator logic was tightly coupled to MSBuild types (`TaskLoggingHelper`, `ITaskItem`) and performed filesystem IO directly (creating directories, checking timestamps, writing files). This made it hard to test without full MSBuild ceremony and temp directories. Extracting it with an IO-free API enables fast, focused unit tests using xUnit + `TestFixtures.dll` that assert on in-memory content.

## Changes

### New files
- `TrimmableTypeMapGenerator.cs` — orchestrates scan → typemaps → JCW pipeline as a pure transformation: `(name, PEReader)[]` in → `(GeneratedAssembly, GeneratedJavaSource)[]` out. No filesystem IO.
- `TrimmableTypeMapTypes.cs` — `TrimmableTypeMapResult`, `GeneratedAssembly(Name, MemoryStream)`, `GeneratedJavaSource(RelativePath, Content)` records
- `NullableExtensions.cs` — NRT-annotated `IsNullOrEmpty`/`IsNullOrWhiteSpace` for netstandard2.0
- `TrimmableTypeMapGeneratorTests.cs` — 6 xUnit tests covering the generator directly (empty input, no-peers output, null validation, PE validity, Java source structure). Tests are IO-free.

### Modified files
- `GenerateTrimmableTypeMap.cs` — rewritten as IO adapter: creates `PEReader` instances from files, calls the generator, writes all outputs to disk using `Files.CopyIfStreamChanged`. Owns directory creation, assembly writing, Java source writing, acw-map generation, and `MemoryStream` disposal in a `finally` block.
- `GenerateTrimmableTypeMapTests.cs` — 5 task-level NUnit tests: empty list, invalid TFV, valid TFV parsing (`v11.0`/`v10.0`/`11.0`), Mono.Android integration, incremental up-to-date check
- `AssemblyIndex.cs` — added `Create(PEReader, string)` overload, removed `FilePath` property, no longer owns `PEReader` disposal
- `JavaPeerScanner.cs` — added `Scan((string, PEReader)[])` overload with shared `ScanCore()`
- `JcwJavaSourceGenerator.cs` — added `GenerateContent()` returning `(relativePath, content)` pairs without filesystem writes, made `Generate(type, TextWriter)` public
- `PEAssemblyBuilder`, `RootTypeMapAssemblyGenerator`, `TypeMapAssemblyEmitter`, `TypeMapAssemblyGenerator` — removed file-path writing overloads, stream-based output only

### Design decisions
- `Action<string>` instead of `TaskLoggingHelper` — keeps TrimmableTypeMap project free of Microsoft.Build packages
- Generator accepts `PEReader` pairs (not file paths or raw streams) — `PEReader` already owns PE parsing; MSBuild task creates them from files, tests from in-memory bytes
- All `MemoryStream` outputs are disposed in a `finally` block in the MSBuild task
- `Files.CopyIfStreamChanged` prevents unnecessary file writes (preserving downstream incrementality)
- Scanner processes all assemblies — framework JCW pre-compilation is future work (#10792)