### PR TITLE
[TrimmableTypeMap] Root AndroidManifest-referenced types

### DIFF
--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -207,6 +207,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA4247](xa4247.md): Could not resolve POM file for artifact '{artifact}'.
 + [XA4248](xa4248.md): Could not find NuGet package '{nugetId}' version '{version}' in lock file. Ensure NuGet Restore has run since this `<PackageReference>` was added.
 + [XA4235](xa4249.md): Maven artifact specification '{artifact}' is invalid. The correct format is 'group_id:artifact_id:version'.
++ [XA4250](xa4250.md): Manifest-referenced type '{type}' was not found in any scanned assembly. It may be a framework type.
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/docs-mobile/messages/xa4250.md
+++ b/Documentation/docs-mobile/messages/xa4250.md
@@ -1,0 +1,33 @@
+---
+title: .NET for Android warning XA4250
+description: XA4250 warning code
+ms.date: 04/07/2026
+f1_keywords:
+  - "XA4250"
+---
+
+# .NET for Android warning XA4250
+
+## Example message
+
+Manifest-referenced type '{0}' was not found in any scanned assembly. It may be a framework type.
+
+```text
+warning XA4250: Manifest-referenced type 'com.example.MainActivity' was not found in any scanned assembly. It may be a framework type.
+```
+
+## Issue
+
+The build found a type name in `AndroidManifest.xml`, but it could not match that name to any Java peer discovered in the app's managed assemblies.
+
+This can be expected for framework-provided types, but it can also indicate that the manifest entry does not match the name generated for a managed Android component.
+
+## Solution
+
+If the manifest entry refers to an Android framework type, this warning can usually be ignored.
+
+Otherwise:
+
+1. Verify the `android:name` value in the manifest.
+2. Ensure the managed type is included in the app build.
+3. Check for namespace, `[Register]`, or nested-type naming mismatches between the manifest and the managed type.

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -116,10 +116,7 @@ class ManifestGenerator
 		}
 
 		// Apply manifest placeholders
-		string? placeholders = ManifestPlaceholders;
-		if (placeholders is not null && placeholders.Length > 0) {
-			ApplyPlaceholders (doc, placeholders);
-		}
+		ApplyPlaceholders (doc, ManifestPlaceholders);
 
 		return (doc, providerNames);
 	}
@@ -250,8 +247,12 @@ class ManifestGenerator
 	/// Replaces ${key} placeholders in all attribute values throughout the document.
 	/// Placeholder format: "key1=value1;key2=value2"
 	/// </summary>
-	static void ApplyPlaceholders (XDocument doc, string placeholders)
+	internal static void ApplyPlaceholders (XDocument doc, string? placeholders)
 	{
+		if (placeholders.IsNullOrEmpty ()) {
+			return;
+		}
+
 		var replacements = new Dictionary<string, string> (StringComparer.Ordinal);
 		foreach (var entry in placeholders.Split (PlaceholderSeparators, StringSplitOptions.RemoveEmptyEntries)) {
 			var eqIndex = entry.IndexOf ('=');

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
@@ -10,4 +10,6 @@ public interface ITrimmableTypeMapLogger
 	void LogGeneratedRootTypeMapInfo (int assemblyReferenceCount);
 	void LogGeneratedTypeMapAssembliesInfo (int assemblyCount);
 	void LogGeneratedJcwFilesInfo (int sourceCount);
+	void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName);
+	void LogManifestReferencedTypeNotFoundWarning (string javaTypeName);
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -69,8 +69,9 @@ public sealed record JavaPeerInfo
 	/// Types with component attributes ([Activity], [Service], etc.),
 	/// custom views from layout XML, or manifest-declared components
 	/// are unconditionally preserved (not trimmable).
-	/// May be set after scanning when the manifest references a type
-	/// that the scanner did not mark as unconditional.
+	/// May be set to <c>true</c> after scanning when the manifest references a type
+	/// that the scanner did not mark as unconditional. Should only ever be set
+	/// to <c>true</c>, never back to <c>false</c>.
 	/// </summary>
 	public bool IsUnconditional { get; set; }
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -80,8 +80,11 @@ public sealed record JavaPeerInfo
 	/// <c>registerNatives</c> in their static initializer because the native library
 	/// (<c>libmonodroid.so</c>) is not loaded until after the Application class is instantiated.
 	/// Registration is deferred to <c>ApplicationRegistration.registerApplications()</c>.
+	/// This may also be set after scanning when a type is only discovered from
+	/// manifest <c>android:name</c> usage on <c>&lt;application&gt;</c> or
+	/// <c>&lt;instrumentation&gt;</c>.
 	/// </summary>
-	public bool CannotRegisterInStaticConstructor { get; init; }
+	public bool CannotRegisterInStaticConstructor { get; set; }
 
 	/// <summary>
 	/// Marshal methods: methods with [Register(name, sig, connector)], [Export], or

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -69,8 +69,10 @@ public sealed record JavaPeerInfo
 	/// Types with component attributes ([Activity], [Service], etc.),
 	/// custom views from layout XML, or manifest-declared components
 	/// are unconditionally preserved (not trimmable).
+	/// May be set after scanning when the manifest references a type
+	/// that the scanner did not mark as unconditional.
 	/// </summary>
-	public bool IsUnconditional { get; init; }
+	public bool IsUnconditional { get; set; }
 
 	/// <summary>
 	/// True for Application and Instrumentation types. These types cannot call

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -155,7 +155,9 @@ public class TrimmableTypeMapGenerator
 		var componentNames = new HashSet<string> (StringComparer.Ordinal);
 		foreach (var element in root.Descendants ()) {
 			switch (element.Name.LocalName) {
+			case "application":
 			case "activity":
+			case "instrumentation":
 			case "service":
 			case "receiver":
 			case "provider":

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -38,6 +38,10 @@ public class TrimmableTypeMapGenerator
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
+		if (manifestTemplate is not null) {
+			RootManifestReferencedTypes (allPeers, manifestTemplate);
+		}
+
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
 			!frameworkAssemblyNames.Contains (p.AssemblyName)
@@ -138,5 +142,58 @@ public class TrimmableTypeMapGenerator
 		var sources = jcwGenerator.GenerateContent (allPeers);
 		logger.LogGeneratedJcwFilesInfo (sources.Count);
 		return sources.ToList ();
+	}
+
+	internal void RootManifestReferencedTypes (List<JavaPeerInfo> allPeers, XDocument doc)
+	{
+		var root = doc.Root;
+		if (root is null) {
+			return;
+		}
+
+		XNamespace androidNs = "http://schemas.android.com/apk/res/android";
+		XName attName = androidNs + "name";
+
+		var componentNames = new HashSet<string> (StringComparer.Ordinal);
+		foreach (var element in root.Descendants ()) {
+			switch (element.Name.LocalName) {
+			case "activity":
+			case "service":
+			case "receiver":
+			case "provider":
+				var name = (string?) element.Attribute (attName);
+				if (name is not null) {
+					componentNames.Add (name);
+				}
+				break;
+			}
+		}
+
+		if (componentNames.Count == 0) {
+			return;
+		}
+
+		var peersByDotName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
+		foreach (var peer in allPeers) {
+			var dotName = peer.JavaName.Replace ('/', '.').Replace ('$', '.');
+			if (!peersByDotName.TryGetValue (dotName, out var list)) {
+				list = [];
+				peersByDotName [dotName] = list;
+			}
+			list.Add (peer);
+		}
+
+		foreach (var name in componentNames) {
+			if (peersByDotName.TryGetValue (name, out var peers)) {
+				foreach (var peer in peers) {
+					if (!peer.IsUnconditional) {
+						peer.IsUnconditional = true;
+						logger.LogRootingManifestReferencedTypeInfo (name, peer.ManagedTypeName);
+					}
+				}
+			} else {
+				logger.LogManifestReferencedTypeNotFoundWarning (name);
+			}
+		}
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -38,9 +38,7 @@ public class TrimmableTypeMapGenerator
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
-		if (manifestTemplate is not null) {
-			RootManifestReferencedTypes (allPeers, manifestTemplate);
-		}
+		RootManifestReferencedTypes (allPeers, manifestTemplate);
 
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
@@ -144,15 +142,15 @@ public class TrimmableTypeMapGenerator
 		return sources.ToList ();
 	}
 
-	internal void RootManifestReferencedTypes (List<JavaPeerInfo> allPeers, XDocument doc)
+	internal void RootManifestReferencedTypes (List<JavaPeerInfo> allPeers, XDocument? doc)
 	{
-		var root = doc.Root;
-		if (root is null) {
+		if (doc?.Root is not { } root) {
 			return;
 		}
 
 		XNamespace androidNs = "http://schemas.android.com/apk/res/android";
 		XName attName = androidNs + "name";
+		var packageName = (string?) root.Attribute ("package") ?? "";
 
 		var componentNames = new HashSet<string> (StringComparer.Ordinal);
 		foreach (var element in root.Descendants ()) {
@@ -163,7 +161,7 @@ public class TrimmableTypeMapGenerator
 			case "provider":
 				var name = (string?) element.Attribute (attName);
 				if (name is not null) {
-					componentNames.Add (name);
+					componentNames.Add (ResolveManifestClassName (name, packageName));
 				}
 				break;
 			}
@@ -173,9 +171,10 @@ public class TrimmableTypeMapGenerator
 			return;
 		}
 
+		// Build lookup by dot-name, keeping '$' for nested types (manifests use '$' too).
 		var peersByDotName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
-			var dotName = peer.JavaName.Replace ('/', '.').Replace ('$', '.');
+			var dotName = peer.JavaName.Replace ('/', '.');
 			if (!peersByDotName.TryGetValue (dotName, out var list)) {
 				list = [];
 				peersByDotName [dotName] = list;
@@ -195,5 +194,23 @@ public class TrimmableTypeMapGenerator
 				logger.LogManifestReferencedTypeNotFoundWarning (name);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Resolves an android:name value to a fully-qualified class name.
+	/// Names starting with '.' are relative to the package. Names with no '.' at all
+	/// are also treated as relative (Android tooling convention).
+	/// </summary>
+	static string ResolveManifestClassName (string name, string packageName)
+	{
+		if (name.StartsWith (".", StringComparison.Ordinal)) {
+			return packageName + name;
+		}
+
+		if (name.IndexOf ('.') < 0 && !packageName.IsNullOrEmpty ()) {
+			return packageName + "." + name;
+		}
+
+		return name;
 	}
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -173,15 +173,19 @@ public class TrimmableTypeMapGenerator
 			return;
 		}
 
-		// Build lookup by dot-name, keeping '$' for nested types (manifests use '$' too).
+		// Build lookup by both Java and compat dot-names. Keep '$' for nested types,
+		// because manifests commonly use '$', but also include the Java source form.
 		var peersByDotName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
-			var dotName = peer.JavaName.Replace ('/', '.');
-			if (!peersByDotName.TryGetValue (dotName, out var list)) {
-				list = [];
-				peersByDotName [dotName] = list;
+			var dotName = GetManifestLookupName (peer.JavaName);
+			AddPeerByDotName (peersByDotName, dotName, peer);
+			AddJavaSourceLookupName (peersByDotName, dotName, peer);
+
+			var compatDotName = GetManifestLookupName (peer.CompatJniName);
+			if (compatDotName != dotName) {
+				AddPeerByDotName (peersByDotName, compatDotName, peer);
+				AddJavaSourceLookupName (peersByDotName, compatDotName, peer);
 			}
-			list.Add (peer);
 		}
 
 		foreach (var name in componentNames) {
@@ -196,6 +200,29 @@ public class TrimmableTypeMapGenerator
 				logger.LogManifestReferencedTypeNotFoundWarning (name);
 			}
 		}
+	}
+
+	static void AddPeerByDotName (Dictionary<string, List<JavaPeerInfo>> peersByDotName, string dotName, JavaPeerInfo peer)
+	{
+		if (!peersByDotName.TryGetValue (dotName, out var list)) {
+			list = [];
+			peersByDotName [dotName] = list;
+		}
+
+		list.Add (peer);
+	}
+
+	static void AddJavaSourceLookupName (Dictionary<string, List<JavaPeerInfo>> peersByDotName, string dotName, JavaPeerInfo peer)
+	{
+		var javaSourceName = dotName.Replace ('$', '.');
+		if (javaSourceName != dotName) {
+			AddPeerByDotName (peersByDotName, javaSourceName, peer);
+		}
+	}
+
+	static string GetManifestLookupName (string jniName)
+	{
+		return jniName.Replace ('/', '.');
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -38,7 +38,7 @@ public class TrimmableTypeMapGenerator
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
-		RootManifestReferencedTypes (allPeers, manifestTemplate);
+		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig));
 
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
@@ -153,6 +153,7 @@ public class TrimmableTypeMapGenerator
 		var packageName = (string?) root.Attribute ("package") ?? "";
 
 		var componentNames = new HashSet<string> (StringComparer.Ordinal);
+		var deferredRegistrationNames = new HashSet<string> (StringComparer.Ordinal);
 		foreach (var element in root.Descendants ()) {
 			switch (element.Name.LocalName) {
 			case "application":
@@ -163,7 +164,12 @@ public class TrimmableTypeMapGenerator
 			case "provider":
 				var name = (string?) element.Attribute (attName);
 				if (name is not null) {
-					componentNames.Add (ResolveManifestClassName (name, packageName));
+					var resolvedName = ResolveManifestClassName (name, packageName);
+					componentNames.Add (resolvedName);
+
+					if (element.Name.LocalName is "application" or "instrumentation") {
+						deferredRegistrationNames.Add (resolvedName);
+					}
 				}
 				break;
 			}
@@ -177,20 +183,19 @@ public class TrimmableTypeMapGenerator
 		// because manifests commonly use '$', but also include the Java source form.
 		var peersByDotName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
-			var dotName = GetManifestLookupName (peer.JavaName);
-			AddPeerByDotName (peersByDotName, dotName, peer);
-			AddJavaSourceLookupName (peersByDotName, dotName, peer);
-
-			var compatDotName = GetManifestLookupName (peer.CompatJniName);
-			if (compatDotName != dotName) {
-				AddPeerByDotName (peersByDotName, compatDotName, peer);
-				AddJavaSourceLookupName (peersByDotName, compatDotName, peer);
+			AddJniLookupNames (peersByDotName, peer.JavaName, peer);
+			if (peer.CompatJniName != peer.JavaName) {
+				AddJniLookupNames (peersByDotName, peer.CompatJniName, peer);
 			}
 		}
 
 		foreach (var name in componentNames) {
 			if (peersByDotName.TryGetValue (name, out var peers)) {
 				foreach (var peer in peers) {
+					if (deferredRegistrationNames.Contains (name)) {
+						peer.CannotRegisterInStaticConstructor = true;
+					}
+
 					if (!peer.IsUnconditional) {
 						peer.IsUnconditional = true;
 						logger.LogRootingManifestReferencedTypeInfo (name, peer.ManagedTypeName);
@@ -212,17 +217,59 @@ public class TrimmableTypeMapGenerator
 		list.Add (peer);
 	}
 
-	static void AddJavaSourceLookupName (Dictionary<string, List<JavaPeerInfo>> peersByDotName, string dotName, JavaPeerInfo peer)
+	static XDocument? PrepareManifestForRooting (XDocument? manifestTemplate, ManifestConfig? manifestConfig)
 	{
-		var javaSourceName = dotName.Replace ('$', '.');
-		if (javaSourceName != dotName) {
-			AddPeerByDotName (peersByDotName, javaSourceName, peer);
+		if (manifestTemplate is null && manifestConfig is null) {
+			return null;
 		}
+
+		var doc = manifestTemplate is not null
+			? new XDocument (manifestTemplate)
+			: new XDocument (
+				new XElement (
+					"manifest",
+					new XAttribute (XNamespace.Xmlns + "android", ManifestConstants.AndroidNs.NamespaceName)));
+
+		if (doc.Root is not { } root) {
+			return doc;
+		}
+
+		if (manifestConfig is null) {
+			return doc;
+		}
+
+		if (((string?) root.Attribute ("package")).IsNullOrEmpty () && !manifestConfig.PackageName.IsNullOrEmpty ()) {
+			root.SetAttributeValue ("package", manifestConfig.PackageName);
+		}
+
+		ManifestGenerator.ApplyPlaceholders (doc, manifestConfig.ManifestPlaceholders);
+
+		if (!manifestConfig.ApplicationJavaClass.IsNullOrEmpty ()) {
+			var app = root.Element ("application");
+			if (app is null) {
+				app = new XElement ("application");
+				root.Add (app);
+			}
+
+			if (app.Attribute (ManifestConstants.AttName) is null) {
+				app.SetAttributeValue (ManifestConstants.AttName, manifestConfig.ApplicationJavaClass);
+			}
+		}
+
+		return doc;
 	}
 
-	static string GetManifestLookupName (string jniName)
+	static void AddJniLookupNames (Dictionary<string, List<JavaPeerInfo>> peersByDotName, string jniName, JavaPeerInfo peer)
 	{
-		return jniName.Replace ('/', '.');
+		var simpleName = JniSignatureHelper.GetJavaSimpleName (jniName);
+		var packageName = JniSignatureHelper.GetJavaPackageName (jniName);
+		var manifestName = packageName.IsNullOrEmpty () ? simpleName : packageName + "." + simpleName;
+		AddPeerByDotName (peersByDotName, manifestName, peer);
+
+		var javaSourceName = JniSignatureHelper.JniNameToJavaName (jniName);
+		if (javaSourceName != manifestName) {
+			AddPeerByDotName (peersByDotName, javaSourceName, peer);
+		}
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -232,14 +232,10 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	static string ResolveManifestClassName (string name, string packageName)
 	{
-		if (name.StartsWith (".", StringComparison.Ordinal)) {
-			return packageName + name;
-		}
-
-		if (name.IndexOf ('.') < 0 && !packageName.IsNullOrEmpty ()) {
-			return packageName + "." + name;
-		}
-
-		return name;
+		return name switch {
+			_ when name.StartsWith (".", StringComparison.Ordinal) => packageName + name,
+			_ when name.IndexOf ('.') < 0 && !packageName.IsNullOrEmpty () => packageName + "." + name,
+			_ => name,
+		};
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -15,6 +15,7 @@
     <_TypeMapBaseOutputDir>$(_TypeMapBaseOutputDir.Replace('\','/'))</_TypeMapBaseOutputDir>
     <_TypeMapOutputDirectory>$(_TypeMapBaseOutputDir)typemap/</_TypeMapOutputDirectory>
     <_TypeMapJavaOutputDirectory>$(_TypeMapBaseOutputDir)typemap/java</_TypeMapJavaOutputDirectory>
+    <_TrimmableTypeMapInputsCacheFile>$(_TypeMapBaseOutputDir)trimmable-typemap.inputs</_TrimmableTypeMapInputsCacheFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,41 @@
     <Error Text="Trimmable typemap is not supported for runtime '$(_AndroidRuntime)'." />
   </Target>
 
+  <Target Name="_CreateTrimmableTypeMapInputsCache"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
+      AfterTargets="CoreCompile">
+    <ItemGroup>
+      <_TrimmableTypeMapInputs Include="$(TargetFrameworkVersion)" />
+      <_TrimmableTypeMapInputs Include="$(_AndroidPackage)" />
+      <_TrimmableTypeMapInputs Include="$(_ApplicationLabel)" />
+      <_TrimmableTypeMapInputs Include="$(_AndroidVersionCode)" />
+      <_TrimmableTypeMapInputs Include="$(_AndroidVersionName)" />
+      <_TrimmableTypeMapInputs Include="$(_AndroidApiLevel)" />
+      <_TrimmableTypeMapInputs Include="$(SupportedOSPlatformVersion)" />
+      <_TrimmableTypeMapInputs Include="$(_TrimmableRuntimeProviderJavaName)" />
+      <_TrimmableTypeMapInputs Include="$(AndroidIncludeDebugSymbols)" />
+      <_TrimmableTypeMapInputs Include="$(AndroidNeedsInternetPermission)" />
+      <_TrimmableTypeMapInputs Include="$(EmbedAssembliesIntoApk)" />
+      <_TrimmableTypeMapInputs Include="$(AndroidManifestPlaceholders)" />
+      <_TrimmableTypeMapInputs Include="$(_AndroidCheckedBuild)" />
+      <_TrimmableTypeMapInputs Include="$(AndroidApplicationJavaClass)" />
+    </ItemGroup>
+
+    <Hash ItemsToHash="@(_TrimmableTypeMapInputs)">
+      <Output TaskParameter="HashResult" PropertyName="_TrimmableTypeMapInputsHash" />
+    </Hash>
+
+    <WriteLinesToFile
+        File="$(_TrimmableTypeMapInputsCacheFile)"
+        Lines="$(_TrimmableTypeMapInputsHash)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="$(_TrimmableTypeMapInputsCacheFile)" />
+    </ItemGroup>
+  </Target>
+
   <!--
     Generate TypeMap assemblies and JCW files.
     AfterTargets="CoreCompile" so it runs after compilation.
@@ -40,8 +76,9 @@
   -->
   <Target Name="_GenerateTrimmableTypeMap"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
+      DependsOnTargets="_CreateTrimmableTypeMapInputsCache"
       AfterTargets="CoreCompile"
-      Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs)"
+      Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_TrimmableTypeMapInputsCacheFile)"
       Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll">
 
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -15,7 +15,6 @@
     <_TypeMapBaseOutputDir>$(_TypeMapBaseOutputDir.Replace('\','/'))</_TypeMapBaseOutputDir>
     <_TypeMapOutputDirectory>$(_TypeMapBaseOutputDir)typemap/</_TypeMapOutputDirectory>
     <_TypeMapJavaOutputDirectory>$(_TypeMapBaseOutputDir)typemap/java</_TypeMapJavaOutputDirectory>
-    <_TrimmableTypeMapInputsCacheFile>$(_TypeMapBaseOutputDir)trimmable-typemap.inputs</_TrimmableTypeMapInputsCacheFile>
   </PropertyGroup>
 
   <ItemGroup>
@@ -34,41 +33,6 @@
     <Error Text="Trimmable typemap is not supported for runtime '$(_AndroidRuntime)'." />
   </Target>
 
-  <Target Name="_CreateTrimmableTypeMapInputsCache"
-      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
-      AfterTargets="CoreCompile">
-    <ItemGroup>
-      <_TrimmableTypeMapInputs Include="$(TargetFrameworkVersion)" />
-      <_TrimmableTypeMapInputs Include="$(_AndroidPackage)" />
-      <_TrimmableTypeMapInputs Include="$(_ApplicationLabel)" />
-      <_TrimmableTypeMapInputs Include="$(_AndroidVersionCode)" />
-      <_TrimmableTypeMapInputs Include="$(_AndroidVersionName)" />
-      <_TrimmableTypeMapInputs Include="$(_AndroidApiLevel)" />
-      <_TrimmableTypeMapInputs Include="$(SupportedOSPlatformVersion)" />
-      <_TrimmableTypeMapInputs Include="$(_TrimmableRuntimeProviderJavaName)" />
-      <_TrimmableTypeMapInputs Include="$(AndroidIncludeDebugSymbols)" />
-      <_TrimmableTypeMapInputs Include="$(AndroidNeedsInternetPermission)" />
-      <_TrimmableTypeMapInputs Include="$(EmbedAssembliesIntoApk)" />
-      <_TrimmableTypeMapInputs Include="$(AndroidManifestPlaceholders)" />
-      <_TrimmableTypeMapInputs Include="$(_AndroidCheckedBuild)" />
-      <_TrimmableTypeMapInputs Include="$(AndroidApplicationJavaClass)" />
-    </ItemGroup>
-
-    <Hash ItemsToHash="@(_TrimmableTypeMapInputs)">
-      <Output TaskParameter="HashResult" PropertyName="_TrimmableTypeMapInputsHash" />
-    </Hash>
-
-    <WriteLinesToFile
-        File="$(_TrimmableTypeMapInputsCacheFile)"
-        Lines="$(_TrimmableTypeMapInputsHash)"
-        Overwrite="true"
-        WriteOnlyWhenDifferent="true" />
-
-    <ItemGroup>
-      <FileWrites Include="$(_TrimmableTypeMapInputsCacheFile)" />
-    </ItemGroup>
-  </Target>
-
   <!--
     Generate TypeMap assemblies and JCW files.
     AfterTargets="CoreCompile" so it runs after compilation.
@@ -76,9 +40,8 @@
   -->
   <Target Name="_GenerateTrimmableTypeMap"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
-      DependsOnTargets="_CreateTrimmableTypeMapInputsCache"
       AfterTargets="CoreCompile"
-      Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_TrimmableTypeMapInputsCacheFile)"
+      Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs)"
       Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll">
 
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1428,6 +1428,15 @@ namespace Xamarin.Android.Tasks.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Manifest-referenced type &apos;{0}&apos; was not found in any scanned assembly. It may be a framework type..
+        /// </summary>
+        public static string XA4250 {
+            get {
+                return ResourceManager.GetString("XA4250", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as &apos;libs/armeabi-v7a/&apos;..
         /// </summary>
         public static string XA4300 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1069,6 +1069,11 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <comment>The following are literal names and should not be translated: Maven, group_id, artifact_id
 {0} - A Maven artifact specification</comment>
   </data>
+  <data name="XA4250" xml:space="preserve">
+    <value>Manifest-referenced type '{0}' was not found in any scanned assembly. It may be a framework type.</value>
+    <comment>The following are literal names and should not be translated: Manifest, framework.
+{0} - Java type name from AndroidManifest.xml</comment>
+  </data>
   <data name="XA0142" xml:space="preserve">
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -36,7 +36,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		public void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName) =>
 			log.LogMessage (MessageImportance.Low, $"Rooting manifest-referenced type '{javaTypeName}' ({managedTypeName}) as unconditional.");
 		public void LogManifestReferencedTypeNotFoundWarning (string javaTypeName) =>
-			log.LogWarning ($"Manifest-referenced type '{javaTypeName}' was not found in any scanned assembly. It may be a framework type.");
+			log.LogCodedWarning ("XA4250", Properties.Resources.XA4250, javaTypeName);
 	}
 
 	public override string TaskPrefix => "GTT";
@@ -118,7 +118,6 @@ public class GenerateTrimmableTypeMap : AndroidTask
 					ApplicationJavaClass: ApplicationJavaClass);
 			}
 
-			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));
 			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));
 
 			XDocument? manifestTemplate = null;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -33,6 +33,10 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			log.LogMessage (MessageImportance.Low, $"Generated {assemblyCount} typemap assemblies.");
 		public void LogGeneratedJcwFilesInfo (int sourceCount) =>
 			log.LogMessage (MessageImportance.Low, $"Generated {sourceCount} JCW Java source files.");
+		public void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName) =>
+			log.LogMessage (MessageImportance.Low, $"Rooting manifest-referenced type '{javaTypeName}' ({managedTypeName}) as unconditional.");
+		public void LogManifestReferencedTypeNotFoundWarning (string javaTypeName) =>
+			log.LogWarning ($"Manifest-referenced type '{javaTypeName}' was not found in any scanned assembly. It may be a framework type.");
 	}
 
 	public override string TaskPrefix => "GTT";
@@ -114,6 +118,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 					ApplicationJavaClass: ApplicationJavaClass);
 			}
 
+			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));
 			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));
 
 			XDocument? manifestTemplate = null;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateTrimmableTypeMapTests.cs
@@ -123,11 +123,60 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (task.Execute (), $"Task should succeed with TargetFrameworkVersion='{tfv}'.");
 		}
 
+		[Test]
+		public void Execute_ManifestPlaceholdersAreResolvedForRooting ()
+		{
+			var path = Path.Combine ("temp", TestName);
+			var outputDir = Path.Combine (Root, path, "typemap");
+			var javaDir = Path.Combine (Root, path, "java");
+			var manifestTemplate = Path.Combine (Root, path, "AndroidManifest.xml");
+			var mergedManifest = Path.Combine (Root, path, "obj", "android", "AndroidManifest.xml");
+			var applicationRegistration = Path.Combine (Root, path, "src", "net", "dot", "android", "ApplicationRegistration.java");
+			var warnings = new List<BuildWarningEventArgs> ();
+
+			var monoAndroidItem = FindMonoAndroidDll ();
+			if (monoAndroidItem is null) {
+				Assert.Ignore ("Mono.Android.dll not found; skipping.");
+				return;
+			}
+
+			var manifestDirectory = Path.GetDirectoryName (manifestTemplate);
+			if (manifestDirectory is null) {
+				Assert.Fail ("Could not determine manifest template directory.");
+			}
+			Directory.CreateDirectory (manifestDirectory);
+			File.WriteAllText (manifestTemplate, """
+				<?xml version="1.0" encoding="utf-8"?>
+				<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${applicationId}">
+				  <application android:name=".Application" />
+				  <instrumentation android:name=".Instrumentation" />
+				</manifest>
+				""");
+
+			var task = CreateTask (new [] { monoAndroidItem }, outputDir, javaDir, warnings: warnings);
+			task.ManifestTemplate = manifestTemplate;
+			task.MergedAndroidManifestOutput = mergedManifest;
+			task.ApplicationRegistrationOutputFile = applicationRegistration;
+			task.PackageName = "android.app";
+			task.AndroidApiLevel = "35";
+			task.SupportedOSPlatformVersion = "21";
+			task.RuntimeProviderJavaName = "mono.MonoRuntimeProvider";
+			task.ManifestPlaceholders = "applicationId=android.app";
+
+			Assert.IsTrue (task.Execute (), "Task should succeed.");
+			FileAssert.Exists (applicationRegistration);
+
+			var registrationText = File.ReadAllText (applicationRegistration);
+			StringAssert.Contains ("mono.android.Runtime.registerNatives (android.app.Application.class);", registrationText);
+			StringAssert.Contains ("mono.android.Runtime.registerNatives (android.app.Instrumentation.class);", registrationText);
+			Assert.IsFalse (warnings.Any (w => w.Code == "XA4250"), "Resolved placeholder-based manifest references should not log XA4250.");
+		}
+
 		GenerateTrimmableTypeMap CreateTask (ITaskItem [] assemblies, string outputDir, string javaDir,
-			IList<BuildMessageEventArgs>? messages = null, string tfv = "v11.0")
+			IList<BuildMessageEventArgs>? messages = null, IList<BuildWarningEventArgs>? warnings = null, string tfv = "v11.0")
 		{
 			return new GenerateTrimmableTypeMap {
-				BuildEngine = new MockBuildEngine (TestContext.Out, messages: messages),
+				BuildEngine = new MockBuildEngine (TestContext.Out, warnings: warnings, messages: messages),
 				ResolvedAssemblies = assemblies,
 				OutputDirectory = outputDir,
 				JavaSourceOutputDirectory = javaDir,

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -12,7 +12,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 {
 	readonly List<string> logMessages = new ();
 
-	sealed class TestTrimmableTypeMapLogger (List<string> logMessages) : ITrimmableTypeMapLogger
+	sealed class TestTrimmableTypeMapLogger (List<string> logMessages, List<string>? warnings = null) : ITrimmableTypeMapLogger
 	{
 		public void LogNoJavaPeerTypesFound () =>
 			logMessages.Add ("No Java peer types found, skipping typemap generation.");
@@ -30,6 +30,10 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 			logMessages.Add ($"Generated {assemblyCount} typemap assemblies.");
 		public void LogGeneratedJcwFilesInfo (int sourceCount) =>
 			logMessages.Add ($"Generated {sourceCount} JCW Java source files.");
+		public void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName) =>
+			logMessages.Add ($"Rooting manifest-referenced type '{javaTypeName}' ({managedTypeName}) as unconditional.");
+		public void LogManifestReferencedTypeNotFoundWarning (string javaTypeName) =>
+			warnings?.Add ($"Manifest-referenced type '{javaTypeName}' was not found in any scanned assembly. It may be a framework type.");
 	}
 
 	[Fact]
@@ -100,6 +104,119 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	TrimmableTypeMapGenerator CreateGenerator () => new (new TestTrimmableTypeMapLogger (logMessages));
+
+	TrimmableTypeMapGenerator CreateGenerator (List<string> warnings) =>
+		new (new TestTrimmableTypeMapLogger (logMessages, warnings));
+
+	[Fact]
+	public void RootManifestReferencedTypes_RootsMatchingPeers ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+			new JavaPeerInfo {
+				JavaName = "com/example/MyService", CompatJniName = "com.example.MyService",
+				ManagedTypeName = "MyApp.MyService", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyService",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application>
+			    <activity android:name="com.example.MyActivity" />
+			  </application>
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional, "MyActivity should be rooted as unconditional.");
+		Assert.False (peers [1].IsUnconditional, "MyService should remain conditional.");
+		Assert.Contains (logMessages, m => m.Contains ("Rooting manifest-referenced type"));
+	}
+
+	[Fact]
+	public void RootManifestReferencedTypes_WarnsForUnresolvedTypes ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp",
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application>
+			    <service android:name="com.example.NonExistentService" />
+			  </application>
+			</manifest>
+			""");
+
+		var warnings = new List<string> ();
+		var generator = CreateGenerator (warnings);
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.Contains (warnings, w => w.Contains ("com.example.NonExistentService"));
+	}
+
+	[Fact]
+	public void RootManifestReferencedTypes_SkipsAlreadyUnconditional ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp", IsUnconditional = true,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application>
+			    <activity android:name="com.example.MyActivity" />
+			  </application>
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional);
+		Assert.DoesNotContain (logMessages, m => m.Contains ("Rooting manifest-referenced type"));
+	}
+
+	[Fact]
+	public void RootManifestReferencedTypes_EmptyManifest_NoChanges ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp",
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.False (peers [0].IsUnconditional);
+	}
 
 	static PEReader CreateTestFixturePEReader ()
 	{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -142,6 +142,37 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void RootManifestReferencedTypes_RootsApplicationAndInstrumentationTypes ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyApplication", CompatJniName = "com.example.MyApplication",
+				ManagedTypeName = "MyApp.MyApplication", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyApplication",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+			new JavaPeerInfo {
+				JavaName = "com/example/MyInstrumentation", CompatJniName = "com.example.MyInstrumentation",
+				ManagedTypeName = "MyApp.MyInstrumentation", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyInstrumentation",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application android:name=".MyApplication" />
+			  <instrumentation android:name="MyInstrumentation" />
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional, "Application type should be rooted from <application android:name>.");
+		Assert.True (peers [1].IsUnconditional, "Instrumentation type should be rooted from <instrumentation android:name>.");
+	}
+
+	[Fact]
 	public void RootManifestReferencedTypes_WarnsForUnresolvedTypes ()
 	{
 		var peers = new List<JavaPeerInfo> {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -218,6 +218,65 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		Assert.False (peers [0].IsUnconditional);
 	}
 
+	[Fact]
+	public void RootManifestReferencedTypes_ResolvesRelativeNames ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+			new JavaPeerInfo {
+				JavaName = "com/example/MyService", CompatJniName = "com.example.MyService",
+				ManagedTypeName = "MyApp.MyService", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyService",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application>
+			    <activity android:name=".MyActivity" />
+			    <service android:name="MyService" />
+			  </application>
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional, "Dot-relative name '.MyActivity' should resolve to com.example.MyActivity.");
+		Assert.True (peers [1].IsUnconditional, "Simple name 'MyService' should resolve to com.example.MyService.");
+	}
+
+	[Fact]
+	public void RootManifestReferencedTypes_MatchesNestedTypes ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/Outer$Inner", CompatJniName = "com.example.Outer$Inner",
+				ManagedTypeName = "MyApp.Outer.Inner", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "Inner",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application>
+			    <activity android:name="com.example.Outer$Inner" />
+			  </application>
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional, "Nested type 'Outer$Inner' should be matched using '$' separator.");
+	}
+
 	static PEReader CreateTestFixturePEReader ()
 	{
 		var dir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -108,27 +108,37 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	TrimmableTypeMapGenerator CreateGenerator (List<string> warnings) =>
 		new (new TestTrimmableTypeMapLogger (logMessages, warnings));
 
-	[Fact]
-	public void RootManifestReferencedTypes_RootsMatchingPeers ()
+	[Theory]
+	[InlineData ("com/example/MyActivity", "com.example.MyActivity", "com.example.MyActivity", "activity", "com.example.MyActivity")]
+	[InlineData ("com/example/MyActivity", "com.example.MyActivity", "com.example", "activity", ".MyActivity")]
+	[InlineData ("com/example/MyService", "com.example.MyService", "com.example", "service", "MyService")]
+	[InlineData ("crc64123456789abc/MyActivity", "my/app/MyActivity", "my.app", "activity", ".MyActivity")]
+	[InlineData ("com/example/Outer$Inner", "com.example.Outer$Inner", "com.example", "activity", "com.example.Outer$Inner")]
+	public void RootManifestReferencedTypes_RootsManifestReferencedTypes (
+		string javaName,
+		string compatJniName,
+		string packageName,
+		string elementName,
+		string manifestName)
 	{
 		var peers = new List<JavaPeerInfo> {
 			new JavaPeerInfo {
-				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
-				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				JavaName = javaName, CompatJniName = compatJniName,
+				ManagedTypeName = "MyApp.MyTarget", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyTarget",
 				AssemblyName = "MyApp", IsUnconditional = false,
 			},
 			new JavaPeerInfo {
-				JavaName = "com/example/MyService", CompatJniName = "com.example.MyService",
-				ManagedTypeName = "MyApp.MyService", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyService",
+				JavaName = "com/example/OtherType", CompatJniName = "com.example.OtherType",
+				ManagedTypeName = "MyApp.OtherType", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "OtherType",
 				AssemblyName = "MyApp", IsUnconditional = false,
 			},
 		};
 
-		var doc = System.Xml.Linq.XDocument.Parse ("""
+		var doc = System.Xml.Linq.XDocument.Parse ($$"""
 			<?xml version="1.0" encoding="utf-8"?>
-			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="{{packageName}}">
 			  <application>
-			    <activity android:name="com.example.MyActivity" />
+			    <{{elementName}} android:name="{{manifestName}}" />
 			  </application>
 			</manifest>
 			""");
@@ -136,8 +146,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		var generator = CreateGenerator ();
 		generator.RootManifestReferencedTypes (peers, doc);
 
-		Assert.True (peers [0].IsUnconditional, "MyActivity should be rooted as unconditional.");
-		Assert.False (peers [1].IsUnconditional, "MyService should remain conditional.");
+		Assert.True (peers [0].IsUnconditional, "The manifest-referenced type should be rooted as unconditional.");
+		Assert.False (peers [1].IsUnconditional, "Non-matching peers should remain conditional.");
 		Assert.Contains (logMessages, m => m.Contains ("Rooting manifest-referenced type"));
 	}
 
@@ -247,91 +257,6 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		generator.RootManifestReferencedTypes (peers, doc);
 
 		Assert.False (peers [0].IsUnconditional);
-	}
-
-	[Fact]
-	public void RootManifestReferencedTypes_ResolvesRelativeNames ()
-	{
-		var peers = new List<JavaPeerInfo> {
-			new JavaPeerInfo {
-				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
-				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
-				AssemblyName = "MyApp", IsUnconditional = false,
-			},
-			new JavaPeerInfo {
-				JavaName = "com/example/MyService", CompatJniName = "com.example.MyService",
-				ManagedTypeName = "MyApp.MyService", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyService",
-				AssemblyName = "MyApp", IsUnconditional = false,
-			},
-		};
-
-		var doc = System.Xml.Linq.XDocument.Parse ("""
-			<?xml version="1.0" encoding="utf-8"?>
-			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
-			  <application>
-			    <activity android:name=".MyActivity" />
-			    <service android:name="MyService" />
-			  </application>
-			</manifest>
-			""");
-
-		var generator = CreateGenerator ();
-		generator.RootManifestReferencedTypes (peers, doc);
-
-		Assert.True (peers [0].IsUnconditional, "Dot-relative name '.MyActivity' should resolve to com.example.MyActivity.");
-		Assert.True (peers [1].IsUnconditional, "Simple name 'MyService' should resolve to com.example.MyService.");
-	}
-
-	[Fact]
-	public void RootManifestReferencedTypes_MatchesCompatNames ()
-	{
-		var peers = new List<JavaPeerInfo> {
-			new JavaPeerInfo {
-				JavaName = "crc64123456789abc/MyActivity", CompatJniName = "my/app/MyActivity",
-				ManagedTypeName = "My.App.MyActivity", ManagedTypeNamespace = "My.App", ManagedTypeShortName = "MyActivity",
-				AssemblyName = "MyApp", IsUnconditional = false,
-			},
-		};
-
-		var doc = System.Xml.Linq.XDocument.Parse ("""
-			<?xml version="1.0" encoding="utf-8"?>
-			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="my.app">
-			  <application>
-			    <activity android:name=".MyActivity" />
-			  </application>
-			</manifest>
-			""");
-
-		var generator = CreateGenerator ();
-		generator.RootManifestReferencedTypes (peers, doc);
-
-		Assert.True (peers [0].IsUnconditional, "Relative manifest name should match CompatJniName when JavaName uses a CRC64 package.");
-	}
-
-	[Fact]
-	public void RootManifestReferencedTypes_MatchesNestedTypes ()
-	{
-		var peers = new List<JavaPeerInfo> {
-			new JavaPeerInfo {
-				JavaName = "com/example/Outer$Inner", CompatJniName = "com.example.Outer$Inner",
-				ManagedTypeName = "MyApp.Outer.Inner", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "Inner",
-				AssemblyName = "MyApp", IsUnconditional = false,
-			},
-		};
-
-		var doc = System.Xml.Linq.XDocument.Parse ("""
-			<?xml version="1.0" encoding="utf-8"?>
-			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
-			  <application>
-			    <activity android:name="com.example.Outer$Inner" />
-			  </application>
-			</manifest>
-			""");
-
-		var generator = CreateGenerator ();
-		generator.RootManifestReferencedTypes (peers, doc);
-
-		Assert.True (peers [0].IsUnconditional, "Nested type 'Outer$Inner' should be matched using '$' separator.");
 	}
 
 	static PEReader CreateTestFixturePEReader ()

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -103,6 +103,35 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 			Assert.Contains ("class ", source.Content);
 	}
 
+	[Fact]
+	public void Execute_ManifestPlaceholdersAreResolvedBeforeRooting ()
+	{
+		using var peReader = CreateTestFixturePEReader ();
+		var manifestTemplate = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="${applicationId}">
+			  <application>
+			    <activity android:name=".SimpleActivity" />
+			  </application>
+			</manifest>
+			""");
+
+		var result = CreateGenerator ().Execute (
+			new List<(string, PEReader)> { ("TestFixtures", peReader) },
+			new Version (11, 0),
+			new HashSet<string> (),
+			new ManifestConfig (
+				PackageName: "my.app",
+				AndroidApiLevel: "35",
+				SupportedOSPlatformVersion: "21",
+				RuntimeProviderJavaName: "mono.MonoRuntimeProvider",
+				ManifestPlaceholders: "applicationId=my.app"),
+			manifestTemplate);
+
+		var peer = result.AllPeers.First (p => p.ManagedTypeName == "MyApp.SimpleActivity");
+		Assert.True (peer.IsUnconditional, "Relative manifest names should root correctly after placeholder substitution.");
+	}
+
 	TrimmableTypeMapGenerator CreateGenerator () => new (new TestTrimmableTypeMapLogger (logMessages));
 
 	TrimmableTypeMapGenerator CreateGenerator (List<string> warnings) =>
@@ -180,6 +209,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 
 		Assert.True (peers [0].IsUnconditional, "Application type should be rooted from <application android:name>.");
 		Assert.True (peers [1].IsUnconditional, "Instrumentation type should be rooted from <instrumentation android:name>.");
+		Assert.True (peers [0].CannotRegisterInStaticConstructor, "Application type should defer Runtime.registerNatives().");
+		Assert.True (peers [1].CannotRegisterInStaticConstructor, "Instrumentation type should defer Runtime.registerNatives().");
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -109,7 +109,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 		new (new TestTrimmableTypeMapLogger (logMessages, warnings));
 
 	[Theory]
-	[InlineData ("com/example/MyActivity", "com.example.MyActivity", "com.example.MyActivity", "activity", "com.example.MyActivity")]
+	[InlineData ("com/example/MyActivity", "com.example.MyActivity", "com.example", "activity", "com.example.MyActivity")]
 	[InlineData ("com/example/MyActivity", "com.example.MyActivity", "com.example", "activity", ".MyActivity")]
 	[InlineData ("com/example/MyService", "com.example.MyService", "com.example", "service", "MyService")]
 	[InlineData ("crc64123456789abc/MyActivity", "my/app/MyActivity", "my.app", "activity", ".MyActivity")]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -283,6 +283,32 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void RootManifestReferencedTypes_MatchesCompatNames ()
+	{
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "crc64123456789abc/MyActivity", CompatJniName = "my/app/MyActivity",
+				ManagedTypeName = "My.App.MyActivity", ManagedTypeNamespace = "My.App", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp", IsUnconditional = false,
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="my.app">
+			  <application>
+			    <activity android:name=".MyActivity" />
+			  </application>
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		Assert.True (peers [0].IsUnconditional, "Relative manifest name should match CompatJniName when JavaName uses a CRC64 package.");
+	}
+
+	[Fact]
 	public void RootManifestReferencedTypes_MatchesNestedTypes ()
 	{
 		var peers = new List<JavaPeerInfo> {


### PR DESCRIPTION
## Summary

Roots Java peer types referenced from `AndroidManifest.xml` before trimmable typemap generation so the ILLink path preserves them even when there is no direct managed reference.

This covers `application`, `instrumentation`, `activity`, `service`, `receiver`, and `provider`, including:

- fully-qualified names
- relative names such as `.MyActivity`
- bare names such as `MyService`
- compat/raw namespace names when `JavaName != CompatJniName`
- nested types such as `Outer$Inner`
- manifest placeholders / resolved package values

This also preserves deferred `registerNatives()` behavior for manifest-rooted `application` / `instrumentation` types and emits coded warning **`XA4250`** when a manifest reference cannot be resolved.

Replaces #11016 (closed — depended on the older PR shape).

### Main changes

- **`JavaPeerInfo.IsUnconditional`**: `init` → `set`, with the mutation contract documented as one-way (`false` → `true`) for post-scan rooting
- **`JavaPeerInfo.CannotRegisterInStaticConstructor`**: set for manifest-rooted `application` / `instrumentation` peers so they still go through deferred `registerNatives()`
- **`TrimmableTypeMapGenerator`**
  - roots manifest references before typemap generation
  - resolves placeholders / package values before matching names
  - matches both `JavaName` and `CompatJniName`
  - handles both `$` and Java-source nested-type naming forms
  - uses the typed `ITrimmableTypeMapLogger` interface for warnings and progress output
- **`GenerateTrimmableTypeMap`** task emits coded warning **`XA4250`** for unresolved manifest-referenced types
- **Docs** add the `XA4250` message documentation entry
- **Tests** cover manifest rooting, unresolved warnings, relative/bare names, `application` / `instrumentation`, compat-name matching, nested types, and placeholder-based package resolution
