### PR TITLE
[TrimmableTypeMap] Fix manifest builder gaps: SupportsGLTexture, UsesPermissionFlags, RoundIcon, dedup

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -28,7 +28,7 @@ static class AssemblyLevelElementBuilder
 
 		// <permission> elements
 		foreach (var perm in info.Permissions) {
-			if (string.IsNullOrEmpty (perm.Name) || existingPermissions.Contains (perm.Name)) {
+			if (string.IsNullOrEmpty (perm.Name) || !existingPermissions.Add (perm.Name)) {
 				continue;
 			}
 			var element = new XElement ("permission", new XAttribute (AttName, perm.Name));
@@ -43,7 +43,7 @@ static class AssemblyLevelElementBuilder
 
 		// <permission-group> elements
 		foreach (var pg in info.PermissionGroups) {
-			if (string.IsNullOrEmpty (pg.Name) || existingPermissionGroups.Contains (pg.Name)) {
+			if (string.IsNullOrEmpty (pg.Name) || !existingPermissionGroups.Add (pg.Name)) {
 				continue;
 			}
 			var element = new XElement ("permission-group", new XAttribute (AttName, pg.Name));
@@ -51,11 +51,12 @@ static class AssemblyLevelElementBuilder
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "Description", "description");
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "Icon", "icon");
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "RoundIcon", "roundIcon");
-			manifest.Add (element);		}
+			manifest.Add (element);
+		}
 
 		// <permission-tree> elements
 		foreach (var pt in info.PermissionTrees) {
-			if (string.IsNullOrEmpty (pt.Name) || existingPermissionTrees.Contains (pt.Name)) {
+			if (string.IsNullOrEmpty (pt.Name) || !existingPermissionTrees.Add (pt.Name)) {
 				continue;
 			}
 			var element = new XElement ("permission-tree", new XAttribute (AttName, pt.Name));
@@ -67,7 +68,7 @@ static class AssemblyLevelElementBuilder
 
 		// <uses-permission> elements
 		foreach (var up in info.UsesPermissions) {
-			if (string.IsNullOrEmpty (up.Name) || existingUsesPermissions.Contains (up.Name)) {
+			if (string.IsNullOrEmpty (up.Name) || !existingUsesPermissions.Add (up.Name)) {
 				continue;
 			}
 			var element = new XElement ("uses-permission", new XAttribute (AttName, up.Name));
@@ -84,7 +85,7 @@ static class AssemblyLevelElementBuilder
 		var existingFeatures = new HashSet<string> (
 			manifest.Elements ("uses-feature").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
 		foreach (var uf in info.UsesFeatures) {
-			if (uf.Name is not null && !existingFeatures.Contains (uf.Name)) {
+			if (uf.Name is not null && existingFeatures.Add (uf.Name)) {
 				var element = new XElement ("uses-feature",
 					new XAttribute (AttName, uf.Name),
 					new XAttribute (AndroidNs + "required", uf.Required ? "true" : "false"));
@@ -165,7 +166,7 @@ static class AssemblyLevelElementBuilder
 		var existingGLTextures = new HashSet<string> (
 			manifest.Elements ("supports-gl-texture").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
 		foreach (var gl in info.SupportsGLTextures) {
-			if (!existingGLTextures.Contains (gl.Name)) {
+			if (existingGLTextures.Add (gl.Name)) {
 				manifest.Add (new XElement ("supports-gl-texture", new XAttribute (AttName, gl.Name)));
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -171,11 +171,44 @@ static class AssemblyLevelElementBuilder
 		}
 	}
 
-	internal static void ApplyApplicationProperties (XElement app, Dictionary<string, object?> properties)
+	internal static void ApplyApplicationProperties (
+		XElement app,
+		Dictionary<string, object?> properties,
+		IReadOnlyList<JavaPeerInfo> allPeers)
 	{
-		// TODO: Application BackupAgent and ManageSpaceActivity properties require type→JNI-name
-		// resolution before they can be emitted to the manifest. Add support in a follow-up PR.
 		PropertyMapper.ApplyMappings (app, properties, PropertyMapper.ApplicationPropertyMappings, skipExisting: true);
+
+		// BackupAgent and ManageSpaceActivity are Type properties — resolve managed type names to JNI names
+		ApplyTypeProperty (app, properties, allPeers, "BackupAgent", "backupAgent");
+		ApplyTypeProperty (app, properties, allPeers, "ManageSpaceActivity", "manageSpaceActivity");
+	}
+
+	static void ApplyTypeProperty (
+		XElement app,
+		Dictionary<string, object?> properties,
+		IReadOnlyList<JavaPeerInfo> allPeers,
+		string propertyName,
+		string xmlAttrName)
+	{
+		if (app.Attribute (AndroidNs + xmlAttrName) is not null) {
+			return;
+		}
+		if (!properties.TryGetValue (propertyName, out var value) || value is not string managedName || managedName.Length == 0) {
+			return;
+		}
+
+		// Strip assembly qualification if present (e.g., "MyApp.MyAgent, MyAssembly")
+		var commaIndex = managedName.IndexOf (',');
+		if (commaIndex > 0) {
+			managedName = managedName.Substring (0, commaIndex).Trim ();
+		}
+
+		foreach (var peer in allPeers) {
+			if (peer.ManagedTypeName == managedName) {
+				app.SetAttributeValue (AndroidNs + xmlAttrName, peer.JavaName.Replace ('/', '.'));
+				return;
+			}
+		}
 	}
 
 	internal static void AddInternetPermission (XElement manifest)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -175,13 +175,14 @@ static class AssemblyLevelElementBuilder
 	internal static void ApplyApplicationProperties (
 		XElement app,
 		Dictionary<string, object?> properties,
-		IReadOnlyList<JavaPeerInfo> allPeers)
+		IReadOnlyList<JavaPeerInfo> allPeers,
+		Action<string>? warn = null)
 	{
 		PropertyMapper.ApplyMappings (app, properties, PropertyMapper.ApplicationPropertyMappings, skipExisting: true);
 
 		// BackupAgent and ManageSpaceActivity are Type properties — resolve managed type names to JNI names
-		ApplyTypeProperty (app, properties, allPeers, "BackupAgent", "backupAgent");
-		ApplyTypeProperty (app, properties, allPeers, "ManageSpaceActivity", "manageSpaceActivity");
+		ApplyTypeProperty (app, properties, allPeers, "BackupAgent", "backupAgent", warn);
+		ApplyTypeProperty (app, properties, allPeers, "ManageSpaceActivity", "manageSpaceActivity", warn);
 	}
 
 	static void ApplyTypeProperty (
@@ -189,7 +190,8 @@ static class AssemblyLevelElementBuilder
 		Dictionary<string, object?> properties,
 		IReadOnlyList<JavaPeerInfo> allPeers,
 		string propertyName,
-		string xmlAttrName)
+		string xmlAttrName,
+		Action<string>? warn)
 	{
 		if (app.Attribute (AndroidNs + xmlAttrName) is not null) {
 			return;
@@ -210,6 +212,8 @@ static class AssemblyLevelElementBuilder
 				return;
 			}
 		}
+
+		warn?.Invoke ($"Could not resolve {propertyName} type '{managedName}' to a Java peer for android:{xmlAttrName}.");
 	}
 
 	internal static void AddInternetPermission (XElement manifest)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -21,6 +19,10 @@ static class AssemblyLevelElementBuilder
 	{
 		var existingPermissions = new HashSet<string> (
 			manifest.Elements ("permission").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
+		var existingPermissionGroups = new HashSet<string> (
+			manifest.Elements ("permission-group").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
+		var existingPermissionTrees = new HashSet<string> (
+			manifest.Elements ("permission-tree").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
 		var existingUsesPermissions = new HashSet<string> (
 			manifest.Elements ("uses-permission").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
 
@@ -41,7 +43,7 @@ static class AssemblyLevelElementBuilder
 
 		// <permission-group> elements
 		foreach (var pg in info.PermissionGroups) {
-			if (string.IsNullOrEmpty (pg.Name)) {
+			if (string.IsNullOrEmpty (pg.Name) || existingPermissionGroups.Contains (pg.Name)) {
 				continue;
 			}
 			var element = new XElement ("permission-group", new XAttribute (AttName, pg.Name));
@@ -53,7 +55,7 @@ static class AssemblyLevelElementBuilder
 
 		// <permission-tree> elements
 		foreach (var pt in info.PermissionTrees) {
-			if (string.IsNullOrEmpty (pt.Name)) {
+			if (string.IsNullOrEmpty (pt.Name) || existingPermissionTrees.Contains (pt.Name)) {
 				continue;
 			}
 			var element = new XElement ("permission-tree", new XAttribute (AttName, pt.Name));

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -33,6 +33,7 @@ static class AssemblyLevelElementBuilder
 			PropertyMapper.MapDictionaryProperties (element, perm.Properties, "Label", "label");
 			PropertyMapper.MapDictionaryProperties (element, perm.Properties, "Description", "description");
 			PropertyMapper.MapDictionaryProperties (element, perm.Properties, "Icon", "icon");
+			PropertyMapper.MapDictionaryProperties (element, perm.Properties, "RoundIcon", "roundIcon");
 			PropertyMapper.MapDictionaryProperties (element, perm.Properties, "PermissionGroup", "permissionGroup");
 			PropertyMapper.MapDictionaryEnumProperty (element, perm.Properties, "ProtectionLevel", "protectionLevel", AndroidEnumConverter.ProtectionToString);
 			manifest.Add (element);
@@ -47,8 +48,8 @@ static class AssemblyLevelElementBuilder
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "Label", "label");
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "Description", "description");
 			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "Icon", "icon");
-			manifest.Add (element);
-		}
+			PropertyMapper.MapDictionaryProperties (element, pg.Properties, "RoundIcon", "roundIcon");
+			manifest.Add (element);		}
 
 		// <permission-tree> elements
 		foreach (var pt in info.PermissionTrees) {
@@ -58,6 +59,7 @@ static class AssemblyLevelElementBuilder
 			var element = new XElement ("permission-tree", new XAttribute (AttName, pt.Name));
 			PropertyMapper.MapDictionaryProperties (element, pt.Properties, "Label", "label");
 			PropertyMapper.MapDictionaryProperties (element, pt.Properties, "Icon", "icon");
+			PropertyMapper.MapDictionaryProperties (element, pt.Properties, "RoundIcon", "roundIcon");
 			manifest.Add (element);
 		}
 
@@ -69,6 +71,9 @@ static class AssemblyLevelElementBuilder
 			var element = new XElement ("uses-permission", new XAttribute (AttName, up.Name));
 			if (up.MaxSdkVersion.HasValue) {
 				element.SetAttributeValue (AndroidNs + "maxSdkVersion", up.MaxSdkVersion.Value.ToString (CultureInfo.InvariantCulture));
+			}
+			if (!string.IsNullOrEmpty (up.UsesPermissionFlags)) {
+				element.SetAttributeValue (AndroidNs + "usesPermissionFlags", up.UsesPermissionFlags);
 			}
 			manifest.Add (element);
 		}
@@ -153,10 +158,21 @@ static class AssemblyLevelElementBuilder
 			}
 			manifest.Add (element);
 		}
+
+		// <supports-gl-texture> elements
+		var existingGLTextures = new HashSet<string> (
+			manifest.Elements ("supports-gl-texture").Select (e => (string?)e.Attribute (AttName)).OfType<string> ());
+		foreach (var gl in info.SupportsGLTextures) {
+			if (!existingGLTextures.Contains (gl.Name)) {
+				manifest.Add (new XElement ("supports-gl-texture", new XAttribute (AttName, gl.Name)));
+			}
+		}
 	}
 
 	internal static void ApplyApplicationProperties (XElement app, Dictionary<string, object?> properties)
 	{
+		// TODO: Application BackupAgent and ManageSpaceActivity properties require type→JNI-name
+		// resolution before they can be emitted to the manifest. Add support in a follow-up PR.
 		PropertyMapper.ApplyMappings (app, properties, PropertyMapper.ApplicationPropertyMappings, skipExisting: true);
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -33,6 +33,7 @@ class ManifestGenerator
 	public bool ForceExtractNativeLibs { get; set; }
 	public string? ManifestPlaceholders { get; set; }
 	public string? ApplicationJavaClass { get; set; }
+	public Action<string>? Warn { get; set; }
 
 	/// <summary>
 	/// Generates the merged manifest from an optional pre-loaded template and writes it to <paramref name="outputPath"/>.
@@ -55,7 +56,7 @@ class ManifestGenerator
 
 		// Apply assembly-level [Application] properties
 		if (assemblyInfo.ApplicationProperties is not null) {
-			AssemblyLevelElementBuilder.ApplyApplicationProperties (app, assemblyInfo.ApplicationProperties, allPeers);
+			AssemblyLevelElementBuilder.ApplyApplicationProperties (app, assemblyInfo.ApplicationProperties, allPeers, Warn);
 		}
 
 		var existingTypes = new HashSet<string> (

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -55,7 +55,7 @@ class ManifestGenerator
 
 		// Apply assembly-level [Application] properties
 		if (assemblyInfo.ApplicationProperties is not null) {
-			AssemblyLevelElementBuilder.ApplyApplicationProperties (app, assemblyInfo.ApplicationProperties);
+			AssemblyLevelElementBuilder.ApplyApplicationProperties (app, assemblyInfo.ApplicationProperties, allPeers);
 		}
 
 		var existingTypes = new HashSet<string> (

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -343,13 +343,27 @@ sealed class AssemblyIndex : IDisposable
 	/// <summary>
 	/// Scans assembly-level custom attributes for manifest-related data.
 	/// </summary>
+	static readonly HashSet<string> KnownAssemblyAttributes = new (StringComparer.Ordinal) {
+		"PermissionAttribute",
+		"PermissionGroupAttribute",
+		"PermissionTreeAttribute",
+		"UsesPermissionAttribute",
+		"UsesFeatureAttribute",
+		"UsesLibraryAttribute",
+		"UsesConfigurationAttribute",
+		"MetaDataAttribute",
+		"PropertyAttribute",
+		"SupportsGLTextureAttribute",
+		"ApplicationAttribute",
+	};
+
 	internal void ScanAssemblyAttributes (AssemblyManifestInfo info)
 	{
 		var asmDef = Reader.GetAssemblyDefinition ();
 		foreach (var caHandle in asmDef.GetCustomAttributes ()) {
 			var ca = Reader.GetCustomAttribute (caHandle);
 			var attrName = GetCustomAttributeName (ca, Reader);
-			if (attrName is null) {
+			if (attrName is null || !KnownAssemblyAttributes.Contains (attrName)) {
 				continue;
 			}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -383,6 +383,11 @@ sealed class AssemblyIndex : IDisposable
 			case "PropertyAttribute":
 				info.Properties.Add (CreatePropertyInfo (name, props));
 				break;
+			case "SupportsGLTextureAttribute":
+				if (name.Length > 0) {
+					info.SupportsGLTextures.Add (new SupportsGLTextureInfo { Name = name });
+				}
+				break;
 			case "ApplicationAttribute":
 				info.ApplicationProperties ??= new Dictionary<string, object?> (StringComparer.Ordinal);
 				foreach (var kvp in props) {
@@ -421,7 +426,8 @@ sealed class AssemblyIndex : IDisposable
 	static UsesPermissionInfo CreateUsesPermissionInfo (string name, Dictionary<string, object?> props)
 	{
 		int? maxSdk = props.TryGetValue ("MaxSdkVersion", out var v) && v is int max ? max : null;
-		return new UsesPermissionInfo { Name = name, MaxSdkVersion = maxSdk };
+		string? flags = props.TryGetValue ("UsesPermissionFlags", out var f) && f is string s ? s : null;
+		return new UsesPermissionInfo { Name = name, MaxSdkVersion = maxSdk, UsesPermissionFlags = flags };
 	}
 
 	static UsesFeatureInfo CreateUsesFeatureInfo (string name, Dictionary<string, object?> props)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyManifestInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyManifestInfo.cs
@@ -13,6 +13,7 @@ internal sealed class AssemblyManifestInfo
 	public List<UsesConfigurationInfo> UsesConfigurations { get; } = [];
 	public List<MetaDataInfo> MetaData { get; } = [];
 	public List<PropertyInfo> Properties { get; } = [];
+	public List<SupportsGLTextureInfo> SupportsGLTextures { get; } = [];
 
 	public Dictionary<string, object?>? ApplicationProperties { get; set; }
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -246,7 +246,7 @@ public sealed class JavaPeerScanner : IDisposable
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
 				IsGenericDefinition = isGenericDefinition,
-				ComponentAttribute = ToComponentInfo (attrInfo, typeDef, index),
+				ComponentAttribute = ToComponentInfo (attrInfo),
 			};
 
 			results [fullName] = peer;
@@ -1553,7 +1553,7 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 	}
 
-	static ComponentInfo? ToComponentInfo (TypeAttributeInfo? attrInfo, TypeDefinition typeDef, AssemblyIndex index)
+	static ComponentInfo? ToComponentInfo (TypeAttributeInfo? attrInfo)
 	{
 		if (attrInfo is null) {
 			return null;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/SupportsGLTextureInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/SupportsGLTextureInfo.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+internal sealed record SupportsGLTextureInfo
+{
+	public required string Name { get; init; }
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/UsesPermissionInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/UsesPermissionInfo.cs
@@ -4,4 +4,5 @@ internal sealed record UsesPermissionInfo
 {
 	public required string Name { get; init; }
 	public int? MaxSdkVersion { get; init; }
+	public string? UsesPermissionFlags { get; init; }
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -23,7 +23,7 @@ public abstract class FixtureTestBase
 	}
 
 	static readonly Lazy<(List<JavaPeerInfo> peers, AssemblyManifestInfo manifestInfo)> _cachedScanResult = new (() => {
-		var scanner = new JavaPeerScanner ();
+		using var scanner = new JavaPeerScanner ();
 		var peReader = new PEReader (File.OpenRead (TestFixtureAssemblyPath));
 		var mdReader = peReader.GetMetadataReader ();
 		var assemblyName = mdReader.GetString (mdReader.GetAssemblyDefinition ().Name);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -616,4 +616,53 @@ public class ManifestGeneratorTests : IDisposable
 		Assert.True (parts.Contains ("screenSize"), "configChanges should contain 'screenSize'");
 		Assert.Equal (3, parts.Length);
 	}
+
+	[Fact]
+	public void AssemblyLevel_SupportsGLTexture ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var info = new AssemblyManifestInfo ();
+		info.SupportsGLTextures.Add (new SupportsGLTextureInfo { Name = "GL_OES_compressed_ETC1_RGB8_texture" });
+
+		var doc = GenerateAndLoad (gen, assemblyInfo: info);
+		var element = doc.Root?.Elements ("supports-gl-texture")
+			.FirstOrDefault (e => (string?)e.Attribute (AttName) == "GL_OES_compressed_ETC1_RGB8_texture");
+		Assert.NotNull (element);
+	}
+
+	[Fact]
+	public void AssemblyLevel_UsesPermissionFlags ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var info = new AssemblyManifestInfo ();
+		info.UsesPermissions.Add (new UsesPermissionInfo {
+			Name = "android.permission.POST_NOTIFICATIONS",
+			UsesPermissionFlags = "neverForLocation",
+		});
+
+		var doc = GenerateAndLoad (gen, assemblyInfo: info);
+		var perm = doc.Root?.Elements ("uses-permission")
+			.FirstOrDefault (e => (string?)e.Attribute (AttName) == "android.permission.POST_NOTIFICATIONS");
+		Assert.NotNull (perm);
+		Assert.Equal ("neverForLocation", (string?)perm?.Attribute (AndroidNs + "usesPermissionFlags"));
+	}
+
+	[Fact]
+	public void AssemblyLevel_PermissionRoundIcon ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var info = new AssemblyManifestInfo ();
+		info.Permissions.Add (new PermissionInfo {
+			Name = "com.example.MY_PERMISSION",
+			Properties = new Dictionary<string, object?> {
+				["RoundIcon"] = "@mipmap/ic_launcher_round",
+			},
+		});
+
+		var doc = GenerateAndLoad (gen, assemblyInfo: info);
+		var perm = doc.Root?.Elements ("permission")
+			.FirstOrDefault (e => (string?)e.Attribute (AttName) == "com.example.MY_PERMISSION");
+		Assert.NotNull (perm);
+		Assert.Equal ("@mipmap/ic_launcher_round", (string?)perm?.Attribute (AndroidNs + "roundIcon"));
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -665,4 +665,54 @@ public class ManifestGeneratorTests : IDisposable
 		Assert.NotNull (perm);
 		Assert.Equal ("@mipmap/ic_launcher_round", (string?)perm?.Attribute (AndroidNs + "roundIcon"));
 	}
+
+	[Fact]
+	public void AssemblyLevel_ApplicationBackupAgent ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var info = new AssemblyManifestInfo ();
+		info.ApplicationProperties = new Dictionary<string, object?> {
+			["BackupAgent"] = "MyApp.MyBackupAgent",
+		};
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/app/MyBackupAgent",
+				CompatJniName = "com/example/app/MyBackupAgent",
+				ManagedTypeName = "MyApp.MyBackupAgent",
+				ManagedTypeNamespace = "MyApp",
+				ManagedTypeShortName = "MyBackupAgent",
+				AssemblyName = "TestApp",
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, peers: peers, assemblyInfo: info);
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("com.example.app.MyBackupAgent", (string?)app?.Attribute (AndroidNs + "backupAgent"));
+	}
+
+	[Fact]
+	public void AssemblyLevel_ApplicationManageSpaceActivity ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var info = new AssemblyManifestInfo ();
+		info.ApplicationProperties = new Dictionary<string, object?> {
+			["ManageSpaceActivity"] = "MyApp.ManageActivity",
+		};
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/app/ManageActivity",
+				CompatJniName = "com/example/app/ManageActivity",
+				ManagedTypeName = "MyApp.ManageActivity",
+				ManagedTypeNamespace = "MyApp",
+				ManagedTypeShortName = "ManageActivity",
+				AssemblyName = "TestApp",
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, peers: peers, assemblyInfo: info);
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("com.example.app.ManageActivity", (string?)app?.Attribute (AndroidNs + "manageSpaceActivity"));
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/AssemblyAttributeScanningTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/AssemblyAttributeScanningTests.cs
@@ -66,4 +66,21 @@ public class AssemblyAttributeScanningTests : FixtureTestBase
 		Assert.NotNull (meta);
 		Assert.Equal ("test-value", meta.Value);
 	}
+
+	[Fact]
+	public void UsesPermission_Flags ()
+	{
+		var info = ScanAssemblyManifestInfo ();
+		var perm = info.UsesPermissions.FirstOrDefault (p => p.Name == "android.permission.POST_NOTIFICATIONS");
+		Assert.NotNull (perm);
+		Assert.Equal ("neverForLocation", perm.UsesPermissionFlags);
+	}
+
+	[Fact]
+	public void SupportsGLTexture_ConstructorArg ()
+	{
+		var info = ScanAssemblyManifestInfo ();
+		var gl = info.SupportsGLTextures.FirstOrDefault (g => g.Name == "GL_OES_compressed_ETC1_RGB8_texture");
+		Assert.NotNull (gl);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/AssemblyAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/AssemblyAttributes.cs
@@ -4,6 +4,8 @@ using Android.App;
 [assembly: UsesFeature ("android.hardware.camera.autofocus", Required = false)]
 [assembly: UsesFeature (GLESVersion = 0x00020000)]
 [assembly: UsesPermission ("android.permission.INTERNET")]
+[assembly: UsesPermission ("android.permission.POST_NOTIFICATIONS", UsesPermissionFlags = "neverForLocation")]
 [assembly: UsesLibrary ("org.apache.http.legacy")]
 [assembly: UsesLibrary ("com.example.optional", false)]
 [assembly: MetaData ("com.example.key", Value = "test-value")]
+[assembly: SupportsGLTexture ("GL_OES_compressed_ETC1_RGB8_texture")]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/StubAttributes.cs
@@ -110,6 +110,7 @@ namespace Android.App
 
 		public string? Name { get; set; }
 		public int MaxSdkVersion { get; set; }
+		public string? UsesPermissionFlags { get; set; }
 	}
 
 	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
@@ -144,6 +145,14 @@ namespace Android.App
 
 		public string [] Actions { get; }
 		public string []? Categories { get; set; }
+	}
+
+	[AttributeUsage (AttributeTargets.Assembly, AllowMultiple = true)]
+	public sealed class SupportsGLTextureAttribute : Attribute
+	{
+		public SupportsGLTextureAttribute (string name) => Name = name;
+
+		public string Name { get; private set; }
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix gaps in the assembly-level manifest builder compared to the old `ManifestDocument` path.

## Changes

### Scanner
- **SupportsGLTexture**: Add `SupportsGLTextureInfo` record and `SupportsGLTextureAttribute` handling in `ScanAssemblyAttributes`
- **UsesPermissionFlags**: Add `UsesPermissionFlags` property to `UsesPermissionInfo`, extract in scanner
- **Perf**: Guard `ParseNameAndProperties` with `KnownAssemblyAttributes` HashSet to skip non-manifest attributes early

### Generator
- **SupportsGLTexture**: Emit `<supports-gl-texture>` element in `AssemblyLevelElementBuilder`
- **UsesPermissionFlags**: Emit `android:usesPermissionFlags` attribute on `<uses-permission>`
- **RoundIcon**: Add `android:roundIcon` mapping for `<permission>`, `<permission-group>`, and `<permission-tree>` elements
- **BackupAgent/ManageSpaceActivity**: Resolve managed type name strings to JNI names via scanned peers and emit `android:backupAgent` / `android:manageSpaceActivity` on `<application>`
- **Dedup**: Deduplicate `<permission-group>` and `<permission-tree>` against manifest template (matching existing `<permission>` and `<uses-permission>` dedup)

### Cleanup
- Remove redundant `#nullable enable` from `AssemblyLevelElementBuilder.cs`
- Dispose `JavaPeerScanner` in `FixtureTestBase` after scan completes
- Remove unused parameters from `ToComponentInfo`
- Use `HashSet.Add()` pattern for all dedup sets to prevent cross-assembly duplicates

## Tests

- Scanner tests: `SupportsGLTexture_ConstructorArg`, `UsesPermission_Flags`
- Generator tests: `AssemblyLevel_SupportsGLTexture`, `AssemblyLevel_UsesPermissionFlags`, `AssemblyLevel_PermissionRoundIcon`
