### PR TITLE
[Build] Add incrementality to _CheckForObsoletePreserveAttribute target

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -237,8 +237,12 @@ _ResolveAssemblies MSBuild target.
     </ItemGroup>
   </Target>
 
-  <Target Name="_CheckForObsoletePreserveAttribute" AfterTargets="_PrepareAssemblies">
+  <Target Name="_CheckForObsoletePreserveAttribute"
+      AfterTargets="_PrepareAssemblies"
+      Inputs="@(_ResolvedUserAssemblies)"
+      Outputs="$(_AndroidStampDirectory)_CheckForObsoletePreserveAttribute.stamp">
     <CheckForObsoletePreserveAttribute Assemblies="@(_ResolvedUserAssemblies)" />
+    <Touch Files="$(_AndroidStampDirectory)_CheckForObsoletePreserveAttribute.stamp" AlwaysCreate="true" />
   </Target>
 
   <Target Name="_IncludeNativeSystemLibraries">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -531,6 +531,7 @@ namespace Lib2
 			}
 
 			var targets = new List<(string target, bool ignoreOnNAOT)> {
+				("_CheckForObsoletePreserveAttribute", false),
 				("_GeneratePackageManagerJava", true), // TODO: NativeAOT doesn't skip this target on 3rd attempt, check if that's ok?
 				("_ResolveLibraryProjectImports", false),
 				("_CleanIntermediateIfNeeded", false),


### PR DESCRIPTION
Add Inputs/Outputs and a stamp file to the _CheckForObsoletePreserveAttribute MSBuild target so it is properly skipped on incremental builds when assemblies have not changed.

Changes:
- Added `Inputs="@(_ResolvedUserAssemblies)"` and `Outputs="$(_AndroidStampDirectory)_CheckForObsoletePreserveAttribute.stamp"` to the target
- Added Touch task to update the stamp file after the target runs
- Added target to `AppProjectTargetsDoNotBreak` incrementality test