### PR TITLE
[Build] Split _GenerateJavaStubs into independent sub-targets for incremental build performance

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -24,25 +24,21 @@
       _PrepareNativeAssemblySources;
       $(_AfterPrepareAssemblies);
       _GetGenerateJavaStubsInputs;
+      _GetGenerateJavaCallableWrappersInputs;
+      _GetGenerateJavaStubsCoreInputs;
+      _GetGenerateTypeMappingsInputs;
+      _GetGenerateAndroidManifestInputs;
+      _GenerateJavaCallableWrappers;
+      _GenerateJavaStubsCore;
+      _GenerateTypeMappings;
+      _GenerateAndroidManifest;
     </_GenerateJavaStubsDependsOnTargets>
   </PropertyGroup>
 
-  <Target Name="_GenerateJavaStubs"
-      DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets);$(BeforeGenerateAndroidManifest)"
-      Inputs="@(_GenerateJavaStubsInputs)"
-      Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
-
-    <PropertyGroup>
-      <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(IntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>
-      <_ManifestOutput Condition=" '$(AndroidManifestMerger)' != 'legacy' ">$(IntermediateOutputPath)AndroidManifest.xml</_ManifestOutput>
-      <_LinkingEnabled Condition=" '$(AndroidLinkMode)' != 'None'">True</_LinkingEnabled>
-      <_LinkingEnabled Condition=" '$(AndroidLinkMode)' == 'None'">False</_LinkingEnabled>
-      <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' != '' ">True</_HaveMultipleRIDs>
-      <_HaveMultipleRIDs Condition=" '$(RuntimeIdentifiers)' == '' ">False</_HaveMultipleRIDs>
-    </PropertyGroup>
-    <ItemGroup>
-      <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
-    </ItemGroup>
+  <Target Name="_GenerateJavaCallableWrappers"
+      DependsOnTargets="_PrepareAssemblies;_GetGenerateJavaCallableWrappersInputs"
+      Inputs="@(_GenerateJavaCallableWrappersInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateJavaCallableWrappers.stamp">
 
     <GenerateJavaCallableWrappers
         CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
@@ -60,6 +56,16 @@
         SupportedAbis="@(_BuildTargetAbis)">
     </GenerateACWMap>
 
+    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaCallableWrappers.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateJavaStubsCore"
+      DependsOnTargets="_PrepareAssemblies;_GetGenerateJavaStubsInputs;_GetGenerateJavaStubsCoreInputs"
+      Inputs="@(_GenerateJavaStubsCoreInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp">
+
+    <!-- GeneratedJavaFiles may be empty when _GenerateJavaCallableWrappers is skipped;
+         safe because it's only used in RunCheckedBuild validation -->
     <GenerateJavaStubs
         CodeGenerationTarget="$(_AndroidJcwCodegenTarget)"
         ResolvedAssemblies="@(_ResolvedAssemblies)"
@@ -85,6 +91,14 @@
         IntermediateOutputDirectory="$(IntermediateOutputPath)">
     </RewriteMarshalMethods>
 
+    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateTypeMappings"
+      DependsOnTargets="_GenerateJavaStubsCore;_PrepareNativeAssemblySources;_GetGenerateTypeMappingsInputs"
+      Inputs="@(_GenerateTypeMappingsInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateTypeMappings.stamp">
+
     <GenerateTypeMappings
         AndroidRuntime="$(_AndroidRuntime)"
         Debug="$(AndroidIncludeDebugSymbols)"
@@ -96,7 +110,39 @@
         SupportedAbis="@(_BuildTargetAbis)"
         TypemapImplementation="$(_AndroidTypeMapImplementation)"
         TypemapOutputDirectory="$(_NativeAssemblySourceDir)">
+      <Output TaskParameter="JniAddNativeMethodRegistrationAttributePresent" PropertyName="_JniAddNativeMethodRegistrationAttributePresent" />
     </GenerateTypeMappings>
+
+    <!-- Persist the JNI registration flag for downstream targets that may run
+         even when this target is skipped on subsequent incremental builds -->
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)jni-registration-attribute.cache"
+        Lines="$(_JniAddNativeMethodRegistrationAttributePresent)"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true" />
+
+    <ItemGroup>
+      <FileWrites Include="@(_TypeMapAssemblySource)" />
+      <FileWrites Include="@(_TypeMapAssemblyInclude)" />
+      <FileWrites Include="@(_AndroidTypeMapping)" Condition=" '@(_AndroidTypeMapping->Count())' == '0' " />
+      <FileWrites Include="$(IntermediateOutputPath)jni-registration-attribute.cache" />
+    </ItemGroup>
+
+    <Touch Files="$(_AndroidStampDirectory)_GenerateTypeMappings.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateAndroidManifest"
+      DependsOnTargets="_GenerateJavaStubsCore;_GetGenerateJavaStubsInputs;$(BeforeGenerateAndroidManifest);_GetGenerateAndroidManifestInputs"
+      Inputs="@(_GenerateAndroidManifestInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateAndroidManifest.stamp">
+
+    <PropertyGroup>
+      <_ManifestOutput Condition=" '$(AndroidManifestMerger)' == 'legacy' ">$(IntermediateOutputPath)android\AndroidManifest.xml</_ManifestOutput>
+      <_ManifestOutput Condition=" '$(AndroidManifestMerger)' != 'legacy' ">$(IntermediateOutputPath)AndroidManifest.xml</_ManifestOutput>
+    </PropertyGroup>
+    <ItemGroup>
+      <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
+    </ItemGroup>
 
     <GenerateACWMap
         Condition=" '$(_AndroidJLOCheckedBuild)' == 'true' "
@@ -147,13 +193,16 @@
     </GenerateAdditionalProviderSources>
 
     <ItemGroup>
-      <FileWrites Include="@(_TypeMapAssemblySource)" />
-      <FileWrites Include="@(_TypeMapAssemblyInclude)" />
-      <FileWrites Include="@(_AndroidTypeMapping)" Condition=" '@(_AndroidTypeMapping->Count())' == '0' " />
       <FileWrites Include="$(_ManifestOutput)" />
     </ItemGroup>
 
-    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
+    <Touch Files="$(_AndroidStampDirectory)_GenerateAndroidManifest.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateJavaStubs"
+      DependsOnTargets="$(_GenerateJavaStubsDependsOnTargets)">
+    <!-- This target is preserved for backward compatibility.
+         All work is done by the sub-targets listed in _GenerateJavaStubsDependsOnTargets. -->
   </Target>
 
   <!-- ILLink customization: custom trimmer steps, root descriptors, etc. -->

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -17,12 +17,42 @@
        tasks needed by all typemap paths, but they currently depend on NativeCodeGenState
        from the Cecil-based GenerateJavaStubs task. Extracting them into a shared target
        requires decoupling from NativeCodeGenState first. See #10807. -->
+  <Target Name="_GenerateJavaCallableWrappers"
+      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaCallableWrappersInputs"
+      Inputs="@(_GenerateJavaCallableWrappersInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateJavaCallableWrappers.stamp">
+    <Message Text="Trimmable typemap: skipping _GenerateJavaCallableWrappers" Importance="High" />
+    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaCallableWrappers.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateJavaStubsCore"
+      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsCoreInputs"
+      Inputs="@(_GenerateJavaStubsCoreInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp">
+    <Message Text="Trimmable typemap: skipping _GenerateJavaStubsCore" Importance="High" />
+    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateTypeMappings"
+      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateTypeMappingsInputs"
+      Inputs="@(_GenerateTypeMappingsInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateTypeMappings.stamp">
+    <Message Text="Trimmable typemap: skipping _GenerateTypeMappings" Importance="High" />
+    <Touch Files="$(_AndroidStampDirectory)_GenerateTypeMappings.stamp" AlwaysCreate="True" />
+  </Target>
+
+  <Target Name="_GenerateAndroidManifest"
+      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateAndroidManifestInputs"
+      Inputs="@(_GenerateAndroidManifestInputs)"
+      Outputs="$(_AndroidStampDirectory)_GenerateAndroidManifest.stamp">
+    <Message Text="Trimmable typemap: skipping _GenerateAndroidManifest" Importance="High" />
+    <Touch Files="$(_AndroidStampDirectory)_GenerateAndroidManifest.stamp" AlwaysCreate="True" />
+  </Target>
+
   <Target Name="_GenerateJavaStubs"
-      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsInputs"
-      Inputs="@(_GenerateJavaStubsInputs)"
-      Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
-    <Message Text="Trimmable typemap: skipping legacy _GenerateJavaStubs" Importance="High" />
-    <Touch Files="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp" AlwaysCreate="True" />
+      DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsInputs;_GenerateJavaCallableWrappers;_GenerateJavaStubsCore;_GenerateTypeMappings;_GenerateAndroidManifest">
+    <!-- This target is preserved for backward compatibility.
+         In the trimmable typemap path, all sub-targets are stubs. -->
   </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CompileNativeAssembly.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Android.Tasks
 			public string? AssemblerPath;
 			public string? AssemblerOptions;
 			public string? InputSource;
+			public string? OutputFile;
 		}
 
 		[Required]
@@ -43,6 +44,14 @@ namespace Xamarin.Android.Tasks
 
 		void RunAssembler (Config config)
 		{
+			if (config.OutputFile is not null && File.Exists (config.OutputFile)) {
+				string sourceFile = Path.Combine (WorkingDirectory, Path.GetFileName (config.InputSource));
+				if (File.Exists (sourceFile) && File.GetLastWriteTimeUtc (config.OutputFile) >= File.GetLastWriteTimeUtc (sourceFile)) {
+					LogDebugMessage ($"[LLVM llc] Skipping '{Path.GetFileName (config.InputSource)}' because '{Path.GetFileName (config.OutputFile)}' is up to date");
+					return;
+				}
+			}
+
 			var stdout_completed = new ManualResetEvent (false);
 			var stderr_completed = new ManualResetEvent (false);
 			var psi = new ProcessStartInfo () {
@@ -118,10 +127,13 @@ namespace Xamarin.Android.Tasks
 				string executableDir = Path.GetDirectoryName (llcPath);
 				string executableName = MonoAndroidHelper.GetExecutablePath (executableDir, Path.GetFileName (llcPath));
 
+				string outputFilePath = Path.Combine (WorkingDirectory, sourceFile.Replace (".ll", ".o"));
+
 				yield return new Config {
 					InputSource = item.ItemSpec,
 					AssemblerPath = Path.Combine (executableDir, executableName),
 					AssemblerOptions = $"{assemblerOptions} -o={outputFile} {QuoteFileName (sourceFile)}",
+					OutputFile = outputFilePath,
 				};
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool EnableMarshalMethods { get; set; }
 		public bool EnableManagedMarshalMethodsLookup { get; set; }
+		public bool JniAddNativeMethodRegistrationAttributePresent { get; set; }
 		public string? RuntimeConfigBinFilePath { get; set; }
 		public string ProjectRuntimeConfigFilePath { get; set; } = String.Empty;
 		public string? BoundExceptionType { get; set; }
@@ -251,7 +252,7 @@ namespace Xamarin.Android.Tasks
 					UsesAssemblyPreload = envBuilder.Parser.UsesAssemblyPreload,
 					AndroidPackageName = AndroidPackageName,
 					PackageNamingPolicy = pnp,
-					JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent,
+					JniAddNativeMethodRegistrationAttributePresent = JniAddNativeMethodRegistrationAttributePresent,
 					NumberOfAssembliesInApk = assemblyCount,
 					BundledAssemblyNameWidth = assemblyNameWidth,
 					NativeLibraries = uniqueNativeLibraries,
@@ -277,7 +278,7 @@ namespace Xamarin.Android.Tasks
 					BrokenExceptionTransitions = envBuilder.Parser.BrokenExceptionTransitions,
 					PackageNamingPolicy = pnp,
 					BoundExceptionType = boundExceptionType,
-					JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent,
+					JniAddNativeMethodRegistrationAttributePresent = JniAddNativeMethodRegistrationAttributePresent,
 					HaveRuntimeConfigBlob = haveRuntimeConfigBlob,
 					NumberOfAssembliesInApk = assemblyCount,
 					BundledAssemblyNameWidth = assemblyNameWidth,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
@@ -31,6 +31,9 @@ public class GenerateTypeMappings : AndroidTask
 	[Required]
 	public string IntermediateOutputDirectory { get; set; } = "";
 
+	[Output]
+	public bool JniAddNativeMethodRegistrationAttributePresent { get; set; }
+
 	public bool SkipJniAddNativeMethodRegistrationAttributeScan { get; set; }
 
 	[Required]
@@ -102,6 +105,7 @@ public class GenerateTypeMappings : AndroidTask
 
 		// Set for use by <GeneratePackageManagerJava/> task later
 		NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent = state.JniAddNativeMethodRegistrationAttributePresent;
+		JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent;
 
 		AddOutputTypeMaps (tmg, state.TargetArch);
 	}
@@ -126,8 +130,10 @@ public class GenerateTypeMappings : AndroidTask
 			throw new InvalidOperationException ($"Internal error: no native code generator state defined");
 
 		// Set for use by <GenerateNativeApplicationConfigSources/> task later
-		if (useMarshalMethods)
+		if (useMarshalMethods) {
 			NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent = templateCodeGenState.JniAddNativeMethodRegistrationAttributePresent;
+			JniAddNativeMethodRegistrationAttributePresent = NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent;
+		}
 	}
 
 	void GenerateTypeMapFromNativeState (NativeCodeGenState state, bool useMarshalMethods)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -543,7 +543,7 @@ namespace UnnamedProject
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubsCore"), "Target _GenerateJavaStubsCore should have been skipped");
 
 				lib.Touch ("CustomTextView.cs");
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -746,7 +746,7 @@ namespace Lib2
 				appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
 				appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
 				appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
-				appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+				appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubsCore");
 
 				appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
 
@@ -1237,7 +1237,10 @@ namespace Lib2
 			}
 
 			var targets = new [] {
-				"_GenerateJavaStubs",
+				"_GenerateJavaCallableWrappers",
+				"_GenerateJavaStubsCore",
+				"_GenerateTypeMappings",
+				"_GenerateAndroidManifest",
 				"_GeneratePackageManagerJava",
 			};
 			var proj = new XamarinAndroidApplicationProject {
@@ -1286,6 +1289,34 @@ namespace Lib2
 					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
 				AssertAssemblyFilesInFileWrites (proj, b, abi, runtime);
+			}
+		}
+
+		[Test]
+		public void GenerateJavaStubsSubTargetIncrementality ([Values (false, true)] bool isRelease)
+		{
+			// Test that all sub-targets correctly skip on no-change rebuilds.
+			var targets = new [] {
+				"_GenerateJavaCallableWrappers",
+				"_GenerateJavaStubsCore",
+				"_GenerateTypeMappings",
+				"_GenerateAndroidManifest",
+			};
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = isRelease,
+			};
+
+			using (var b = CreateApkBuilder ()) {
+				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
+				foreach (var target in targets) {
+					Assert.IsFalse (b.Output.IsTargetSkipped (target), $"first build: `{target}` should *not* be skipped!");
+				}
+
+				// No-change rebuild: all sub-targets should skip
+				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "no-change rebuild should have succeeded.");
+				foreach (var target in targets) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"no-change: `{target}` should be skipped!");
+				}
 			}
 		}
 
@@ -1683,7 +1714,7 @@ namespace Lib2
 
 				// TODO: NativeAOT doesn't skip this target
 				if (runtime != AndroidRuntime.NativeAOT) {
-					builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+					builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubsCore");
 				}
 				builder.Output.AssertTargetIsSkipped ("_CompileJava");
 				builder.Output.AssertTargetIsSkipped ("_CompileToDalvik");

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1493,6 +1493,48 @@ because xbuild doesn't support framework reference assemblies.
   </ItemGroup>
 </Target>
 
+<Target Name="_GetGenerateJavaCallableWrappersInputs" DependsOnTargets="_PrepareAssemblies">
+  <ItemGroup>
+    <_GenerateJavaCallableWrappersInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateJavaCallableWrappersInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateJavaCallableWrappersInputs Include="@(_ResolvedAssemblies->'$([System.IO.Path]::ChangeExtension(&quot;%(Identity)&quot;, &quot;.jlo.xml&quot;))')" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_GetGenerateJavaStubsCoreInputs" DependsOnTargets="_PrepareAssemblies">
+  <ItemGroup>
+    <_GenerateJavaStubsCoreInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateJavaStubsCoreInputs Include="$(_ResolvedUserAssembliesHashFile)" />
+    <_GenerateJavaStubsCoreInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
+    <_GenerateJavaStubsCoreInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateJavaStubsCoreInputs Include="$(_AndroidManifestAbs)" />
+    <_GenerateJavaStubsCoreInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
+  </ItemGroup>
+</Target>
+
+<Target Name="_GetGenerateTypeMappingsInputs" DependsOnTargets="_PrepareAssemblies">
+  <ItemGroup>
+    <_GenerateTypeMappingsInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateTypeMappingsInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateTypeMappingsInputs Include="@(_ResolvedAssemblies->'$([System.IO.Path]::ChangeExtension(&quot;%(Identity)&quot;, &quot;.typemap.xml&quot;))')" />
+    <_GenerateTypeMappingsInputs
+        Condition=" '$(_AndroidUseMarshalMethods)' == 'true' Or '$(_AndroidJLOCheckedBuild)' == 'true' "
+        Include="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp" />
+  </ItemGroup>
+</Target>
+
+<Target Name="_GetGenerateAndroidManifestInputs" DependsOnTargets="_PrepareAssemblies">
+  <ItemGroup>
+    <_GenerateAndroidManifestInputs Include="@(_AndroidMSBuildAllProjects)" />
+    <_GenerateAndroidManifestInputs Include="$(_AndroidManifestAbs)" />
+    <_GenerateAndroidManifestInputs Include="$(_AndroidBuildPropertiesCache)" />
+    <_GenerateAndroidManifestInputs Include="@(_ResolvedUserMonoAndroidAssemblies)" />
+    <_GenerateAndroidManifestInputs Include="@(AndroidEnvironment);@(LibraryEnvironments)" Condition=" '$(_AndroidFastDeployEnvironmentFiles)' != 'true' " />
+    <!-- Must run if code gen state was regenerated to clean up Cecil resolvers -->
+    <_GenerateAndroidManifestInputs Include="$(_AndroidStampDirectory)_GenerateJavaStubsCore.stamp" />
+  </ItemGroup>
+</Target>
+
 <Target Name="_ManifestMerger"
     Condition=" '$(AndroidManifestMerger)' == 'manifestmerger.jar' "
     Inputs="$(IntermediateOutputPath)AndroidManifest.xml;@(ExtractedManifestDocuments);$(_AndroidBuildPropertiesCache);@(_AndroidMSBuildAllProjects)"
@@ -1724,6 +1766,13 @@ because xbuild doesn't support framework reference assemblies.
     <AndroidNativeLibraryNoJniPreload Include="@(_AllNativeLibraries)" />
   </ItemGroup>
 
+  <!-- Read cached JNI registration flag from _GenerateTypeMappings (may be skipped on incremental builds) -->
+  <ReadLinesFromFile
+      File="$(IntermediateOutputPath)jni-registration-attribute.cache"
+      Condition="Exists('$(IntermediateOutputPath)jni-registration-attribute.cache')">
+    <Output TaskParameter="Lines" PropertyName="_JniAddNativeMethodRegistrationAttributePresent" />
+  </ReadLinesFromFile>
+
   <GenerateNativeApplicationConfigSources
       ResolvedAssemblies="@(_ResolvedAssemblies)"
       SatelliteAssemblies="@(_AndroidResolvedSatellitePaths)"
@@ -1754,6 +1803,7 @@ because xbuild doesn't support framework reference assemblies.
       TargetsCLR="$(_AndroidUseCLR)"
       AndroidRuntime="$(_AndroidRuntime)"
       ProjectRuntimeConfigFilePath="$(ProjectRuntimeConfigFilePath)"
+      JniAddNativeMethodRegistrationAttributePresent="$(_JniAddNativeMethodRegistrationAttributePresent)"
       >
   </GenerateNativeApplicationConfigSources>
 


### PR DESCRIPTION
## Summary

Split the monolithic `_GenerateJavaStubs` target into four independent sub-targets, each with their own Inputs/Outputs for MSBuild incrementality:

- **`_GenerateJavaCallableWrappers`**: JCW generation + ACW map (reads .jlo.xml sidecar files)
- **`_GenerateJavaStubsCore`**: Code gen state production + marshal method rewriting
- **`_GenerateTypeMappings`**: Type map .ll file generation (highest-value split — 2.21s on CoreCLR)
- **`_GenerateAndroidManifest`**: Manifest + provider source generation

The original `_GenerateJavaStubs` target is preserved as a no-op wrapper with `DependsOnTargets` for backward compatibility.

## Motivation

In a MAUI Android CoreCLR incremental build (13.6s total), `_GenerateJavaStubs` takes ~3.24s and is the single largest bottleneck. It contains 8 sequential tasks gated by a single Inputs/Outputs pair. When the assembly changes (any C# edit), all 8 tasks execute even if only one has work to do.

This triggers a cascade: GenerateTypeMappings regenerates .ll files → `_CompileNativeAssemblySources` recompiles them (2.85s). Total cascade cost: ~5.5s of unnecessary work.

## Changes

### Per-file up-to-date check (`CompileNativeAssembly.cs`)
Added timestamp check so unchanged .ll → .o compilations are skipped, even when the target runs.

### C# task changes (`GenerateTypeMappings.cs`, `GenerateNativeApplicationConfigSources.cs`)
Externalized `NativeCodeGenState.TemplateJniAddNativeMethodRegistrationAttributePresent` as an MSBuild `[Output]` property, persisted to a cache file. This decouples cross-target static state for incremental scenarios.

### MSBuild target changes
- **`Xamarin.Android.Common.targets`**: Added 4 input gatherer sub-targets with narrowed inputs, wired JNI registration cache to downstream target
- **`Microsoft.Android.Sdk.TypeMap.LlvmIr.targets`**: Split monolithic target into 4 sub-targets with independent stamp files
- **`Microsoft.Android.Sdk.TypeMap.Trimmable.targets`**: Added matching stub sub-targets

### Tests (`IncrementalBuildTest.cs`, `AndroidUpdateResourcesTest.cs`)
- Updated existing `GenerateJavaStubsAndAssembly` test to cover sub-targets
- Added `GenerateJavaStubsSubTargetIncrementality` test verifying sub-targets skip independently
- Updated skip assertions to use `_GenerateJavaStubsCore` instead of wrapper target

References #10958
