### PR TITLE
[TrimmableTypeMap] Runtime-only trimmable typemap support

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -445,7 +445,7 @@ namespace Android.Runtime {
 			if (RuntimeFeature.TrimmableTypeMap) {
 				// The trimmable typemap doesn't use the native typemap tables.
 				// Delegate to the managed TrimmableTypeMap instead.
-				return TrimmableTypeMap.Instance.TryGetJniName (type, out var jniName) ? jniName : null;
+				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
 			}
 
 			if (mvid_bytes == null)

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -442,6 +442,12 @@ namespace Android.Runtime {
 
 		internal static unsafe string? TypemapManagedToJava (Type type)
 		{
+			if (RuntimeFeature.TrimmableTypeMap) {
+				// The trimmable typemap doesn't use the native typemap tables.
+				// Delegate to the managed TrimmableTypeMap instead.
+				return TrimmableTypeMap.Instance.TryGetJniName (type, out var jniName) ? jniName : null;
+			}
+
 			if (mvid_bytes == null)
 				mvid_bytes = new byte[16];
 

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -110,6 +110,7 @@ namespace Android.Runtime
 		internal static void InitializeJniRuntime (JniRuntime runtime, JnienvInitializeArgs args)
 		{
 			androidRuntime = runtime;
+			JniRuntime.SetCurrent (runtime);
 			SetSynchronizationContext ();
 		}
 
@@ -159,6 +160,7 @@ namespace Android.Runtime
 					valueManager,
 					args->jniAddNativeMethodRegistrationAttributePresent != 0
 			);
+			JniRuntime.SetCurrent (androidRuntime);
 
 			if (RuntimeFeature.TrimmableTypeMap) {
 				TrimmableTypeMap.Initialize ();

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -269,11 +269,10 @@ namespace Java.Interop {
 			}
 
 			if (RuntimeFeature.TrimmableTypeMap) {
-				// The trimmable typemap doesn't use the native typemap tables.
-				// Delegate to the managed TrimmableTypeMap instead.
-				if (!TrimmableTypeMap.Instance.TryGetType (class_name, out type)) {
-					return null;
-				}
+				throw new System.Diagnostics.UnreachableException (
+					$"{nameof (TypeManager)}.{nameof (GetJavaToManagedTypeCore)} should not be used when " +
+					$"{nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
+					$"types through {nameof (TrimmableTypeMapTypeManager)}.");
 			} else if (RuntimeFeature.IsMonoRuntime) {
 				type = monovm_typemap_java_to_managed (class_name);
 			} else if (RuntimeFeature.IsCoreClrRuntime) {

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -268,7 +268,13 @@ namespace Java.Interop {
 				return type;
 			}
 
-			if (RuntimeFeature.IsMonoRuntime) {
+			if (RuntimeFeature.TrimmableTypeMap) {
+				// The trimmable typemap doesn't use the native typemap tables.
+				// Delegate to the managed TrimmableTypeMap instead.
+				if (!TrimmableTypeMap.Instance.TryGetType (class_name, out type)) {
+					return null;
+				}
+			} else if (RuntimeFeature.IsMonoRuntime) {
 				type = monovm_typemap_java_to_managed (class_name);
 			} else if (RuntimeFeature.IsCoreClrRuntime) {
 				type = clr_typemap_java_to_managed (class_name);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -508,10 +508,16 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			Type? targetType)
 	{
 		if (RuntimeFeature.TrimmableTypeMap) {
+			// Prefer proxy-backed activation first, but keep the generic JniValueManager
+			// fallback for parity when there is no proxy match for the requested target type.
 			var typeMap = TrimmableTypeMap.Instance;
 			var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
 			if (peer is not null) {
-				peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+				var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
+				if (Android.Runtime.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
+					peerState |= JniManagedPeerStates.Activatable;
+				}
+				peer.SetJniManagedPeerState (peerState);
 				JniObjectReference.Dispose (ref reference, transfer);
 				return peer;
 			}

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -514,30 +514,28 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		}
 
 		if (RuntimeFeature.TrimmableTypeMap) {
-			var typeMap = TrimmableTypeMap.Instance;
-			var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
-			if (peer is not null) {
-				var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
-				if (Android.Runtime.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
-					peerState |= JniManagedPeerStates.Activatable;
-				}
-				peer.SetJniManagedPeerState (peerState);
-				JniObjectReference.Dispose (ref reference, transfer);
-				return peer;
-			}
-
-			var targetName = targetType?.AssemblyQualifiedName ?? "<null>";
-			string? javaType = null;
 			try {
-				javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
+				var typeMap = TrimmableTypeMap.Instance;
+				var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
+				if (peer is not null) {
+					var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
+					if (Android.Runtime.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
+						peerState |= JniManagedPeerStates.Activatable;
+					}
+					peer.SetJniManagedPeerState (peerState);
+					return peer;
+				}
+
+				var targetName = targetType?.AssemblyQualifiedName ?? "<null>";
+				var javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
+
+				throw new NotSupportedException (
+					$"No generated {nameof (JavaPeerProxy)} was found for Java type '{javaType}' " +
+					$"with targetType '{targetName}' while {nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. " +
+					$"This indicates a missing trimmable typemap proxy or association and should be fixed in the generator.");
 			} finally {
 				JniObjectReference.Dispose (ref reference, transfer);
 			}
-
-			throw new NotSupportedException (
-				$"No generated {nameof (JavaPeerProxy)} was found for Java type '{javaType}' " +
-				$"with targetType '{targetName}' while {nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. " +
-				$"This indicates a missing trimmable typemap proxy or association and should be fixed in the generator.");
 		}
 
 		return base.CreatePeer (ref reference, transfer, targetType);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -507,6 +507,12 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			[DynamicallyAccessedMembers (Constructors)]
 			Type? targetType)
 	{
+		ThrowIfDisposed ();
+
+		if (!reference.IsValid) {
+			return null;
+		}
+
 		if (RuntimeFeature.TrimmableTypeMap) {
 			var typeMap = TrimmableTypeMap.Instance;
 			var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -509,16 +509,11 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 	{
 		if (RuntimeFeature.TrimmableTypeMap) {
 			var typeMap = TrimmableTypeMap.Instance;
-			if (typeMap is not null && targetType is not null) {
-				var proxy = typeMap.GetProxyForManagedType (targetType);
-				if (proxy is not null) {
-					var peer = proxy.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
-					if (peer is not null) {
-						peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
-						JniObjectReference.Dispose (ref reference, transfer);
-						return peer;
-					}
-				}
+			var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
+			if (peer is not null) {
+				peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+				JniObjectReference.Dispose (ref reference, transfer);
+				return peer;
 			}
 		}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -520,7 +520,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 				var peer = proxy?.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
 				if (peer is not null) {
 					var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
-					if (Android.Runtime.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
+					if (global::Java.Interop.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
 						peerState |= JniManagedPeerStates.Activatable;
 					}
 					peer.SetJniManagedPeerState (peerState);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -516,7 +516,8 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		if (RuntimeFeature.TrimmableTypeMap) {
 			try {
 				var typeMap = TrimmableTypeMap.Instance;
-				var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
+				var proxy = typeMap.GetProxyForJavaObject (reference.Handle, targetType);
+				var peer = proxy?.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
 				if (peer is not null) {
 					var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
 					if (Android.Runtime.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -527,7 +527,13 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			}
 
 			var targetName = targetType?.AssemblyQualifiedName ?? "<null>";
-			var javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
+			string? javaType = null;
+			try {
+				javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
+			} finally {
+				JniObjectReference.Dispose (ref reference, transfer);
+			}
+
 			throw new NotSupportedException (
 				$"No generated {nameof (JavaPeerProxy)} was found for Java type '{javaType}' " +
 				$"with targetType '{targetName}' while {nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. " +

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -508,8 +508,6 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			Type? targetType)
 	{
 		if (RuntimeFeature.TrimmableTypeMap) {
-			// Prefer proxy-backed activation first, but keep the generic JniValueManager
-			// fallback for parity when there is no proxy match for the requested target type.
 			var typeMap = TrimmableTypeMap.Instance;
 			var peer = typeMap.CreatePeer (reference.Handle, JniHandleOwnership.DoNotTransfer, targetType);
 			if (peer is not null) {
@@ -521,6 +519,13 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 				JniObjectReference.Dispose (ref reference, transfer);
 				return peer;
 			}
+
+			var targetName = targetType?.AssemblyQualifiedName ?? "<null>";
+			var javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
+			throw new NotSupportedException (
+				$"No generated {nameof (JavaPeerProxy)} was found for Java type '{javaType}' " +
+				$"with targetType '{targetName}' while {nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. " +
+				$"This indicates a missing trimmable typemap proxy or association and should be fixed in the generator.");
 		}
 
 		return base.CreatePeer (ref reference, transfer, targetType);

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -102,14 +102,11 @@ class TrimmableTypeMap
 		return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 	}
 
-	internal bool TryGetJniName (Type type, [NotNullWhen (true)] out string? jniName)
+	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
 	{
-		jniName = _jniNameCache.GetOrAdd (type, static (type, self) => self.GetProxyForManagedType (type)?.JniName, this);
+		jniName = _jniNameCache.GetOrAdd (managedType, static (type, self) => self.GetProxyForManagedType (type)?.JniName, this);
 		return jniName is not null;
 	}
-
-	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
-		=> TryGetJniName (managedType, out jniName);
 
 	internal JavaPeerProxy? GetProxyForPeer (IntPtr handle, Type? targetType = null)
 	{
@@ -156,7 +153,7 @@ class TrimmableTypeMap
 			// Verify the Java object is actually assignable to the target Java type
 			// before creating the peer. Without this, we'd create invalid peers
 			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
-			if (proxy is not null && TryGetJniName (targetType, out var targetJniName)) {
+			if (proxy is not null && TryGetJniNameForManagedType (targetType, out var targetJniName)) {
 				var selfRef = new JniObjectReference (handle);
 				var objClass = JniEnvironment.Types.GetObjectClass (selfRef);
 				var targetClass = JniEnvironment.Types.FindClass (targetJniName);

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -58,9 +58,6 @@ class TrimmableTypeMap
 		}
 	}
 
-	/// <summary>
-	/// Registers the <c>mono.android.Runtime.registerNatives</c> JNI native method.
-	/// </summary>
 	unsafe void RegisterNatives ()
 	{
 		using var runtimeClass = new JniType ("mono/android/Runtime"u8);
@@ -87,13 +84,15 @@ class TrimmableTypeMap
 		return true;
 	}
 
-	/// <summary>
-	/// Finds the proxy for a managed type using the generated proxy type map.
-	/// Results are cached per type.
-	/// </summary>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
 		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type) ?? s_noPeerSentinel, this);
+		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
+	}
+
+	JavaPeerProxy? GetProxyForJavaType (string className)
+	{
+		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
@@ -108,14 +107,8 @@ class TrimmableTypeMap
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
 	{
-		var proxy = GetProxyForManagedType (managedType);
-		if (proxy is null) {
-			jniName = null;
-			return false;
-		}
-
-		jniName = proxy.JniName;
-		return true;
+		jniName = GetProxyForManagedType (managedType)?.JniName;
+		return jniName is not null;
 	}
 
 	internal JavaPeerProxy? GetProxyForJavaObject (IntPtr handle, Type? targetType = null)
@@ -124,56 +117,60 @@ class TrimmableTypeMap
 			return null;
 		}
 
-		var selfRef = new JniObjectReference (handle);
-		var jniClass = JniEnvironment.Types.GetObjectClass (selfRef);
+		return TryGetProxyFromHierarchy () ?? TryGetProxyFromTargetType ();
 
-		try {
-			while (jniClass.IsValid) {
-				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
-				if (className != null) {
-					var proxy = GetProxyForJavaType (className);
-					if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
-						return proxy;
+		JavaPeerProxy? TryGetProxyFromHierarchy ()
+		{
+			var selfRef = new JniObjectReference (handle);
+			var jniClass = JniEnvironment.Types.GetObjectClass (selfRef);
+
+			try {
+				while (jniClass.IsValid) {
+					var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
+					if (className != null) {
+						var proxy = GetProxyForJavaType (className);
+						if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
+							return proxy;
+						}
 					}
+
+					var super = JniEnvironment.Types.GetSuperclass (jniClass);
+					JniObjectReference.Dispose (ref jniClass);
+					jniClass = super;
 				}
-
-				var super = JniEnvironment.Types.GetSuperclass (jniClass);
+			} finally {
 				JniObjectReference.Dispose (ref jniClass);
-				jniClass = super;
 			}
-		} finally {
-			JniObjectReference.Dispose (ref jniClass);
-		}
 
-		if (targetType is null) {
 			return null;
 		}
 
-		var proxy = GetProxyForManagedType (targetType);
-		// Verify the Java object is actually assignable to the target Java type
-		// before creating the peer. Without this, we'd create invalid peers
-		// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
-		if (proxy is null || !TryGetJniNameForManagedType (targetType, out var targetJniName)) {
-			return null;
-		}
+		JavaPeerProxy? TryGetProxyFromTargetType ()
+		{
+			if (targetType is null) {
+				return null;
+			}
 
-		var selfRef = new JniObjectReference (handle);
-		var objClass = default (JniObjectReference);
-		var targetClass = default (JniObjectReference);
-		try {
-			objClass = JniEnvironment.Types.GetObjectClass (selfRef);
-			targetClass = JniEnvironment.Types.FindClass (targetJniName);
-			return JniEnvironment.Types.IsAssignableFrom (objClass, targetClass) ? proxy : null;
-		} finally {
-			JniObjectReference.Dispose (ref objClass);
-			JniObjectReference.Dispose (ref targetClass);
-		}
-	}
+			var proxy = GetProxyForManagedType (targetType);
+			// Verify the Java object is actually assignable to the target Java type
+			// before returning the fallback proxy. Without this, we'd create invalid peers
+			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
+			if (proxy is null || !TryGetJniNameForManagedType (targetType, out var targetJniName)) {
+				return null;
+			}
 
-	JavaPeerProxy? GetProxyForJavaType (string className)
-	{
-		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
-		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
+			var selfRef = new JniObjectReference (handle);
+			var objClass = default (JniObjectReference);
+			var targetClass = default (JniObjectReference);
+			try {
+				objClass = JniEnvironment.Types.GetObjectClass (selfRef);
+				targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				return JniEnvironment.Types.IsAssignableFrom (objClass, targetClass) ? proxy : null;
+			} finally {
+				JniObjectReference.Dispose (ref objClass);
+				JniObjectReference.Dispose (ref targetClass);
+			}
+		}
 	}
 
 	JavaPeerProxy? ResolveProxyForJavaType (string className)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -118,7 +118,7 @@ class TrimmableTypeMap
 		return true;
 	}
 
-	JavaPeerProxy? GetProxyForJavaObject (IntPtr handle, Type? targetType = null)
+	internal JavaPeerProxy? GetProxyForJavaObject (IntPtr handle, Type? targetType = null)
 	{
 		if (handle == IntPtr.Zero) {
 			return null;
@@ -145,7 +145,29 @@ class TrimmableTypeMap
 			JniObjectReference.Dispose (ref jniClass);
 		}
 
-		return null;
+		if (targetType is null) {
+			return null;
+		}
+
+		var proxy = GetProxyForManagedType (targetType);
+		// Verify the Java object is actually assignable to the target Java type
+		// before creating the peer. Without this, we'd create invalid peers
+		// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
+		if (proxy is null || !TryGetJniNameForManagedType (targetType, out var targetJniName)) {
+			return null;
+		}
+
+		var selfRef = new JniObjectReference (handle);
+		var objClass = default (JniObjectReference);
+		var targetClass = default (JniObjectReference);
+		try {
+			objClass = JniEnvironment.Types.GetObjectClass (selfRef);
+			targetClass = JniEnvironment.Types.FindClass (targetJniName);
+			return JniEnvironment.Types.IsAssignableFrom (objClass, targetClass) ? proxy : null;
+		} finally {
+			JniObjectReference.Dispose (ref objClass);
+			JniObjectReference.Dispose (ref targetClass);
+		}
 	}
 
 	JavaPeerProxy? GetProxyForJavaType (string className)
@@ -161,34 +183,6 @@ class TrimmableTypeMap
 		}
 
 		return GetProxyForManagedType (managedType);
-	}
-
-	internal IJavaPeerable? CreatePeer (IntPtr handle, JniHandleOwnership transfer, Type? targetType = null)
-	{
-		var proxy = GetProxyForJavaObject (handle, targetType);
-		if (proxy is null && targetType is not null) {
-			proxy = GetProxyForManagedType (targetType);
-			// Verify the Java object is actually assignable to the target Java type
-			// before creating the peer. Without this, we'd create invalid peers
-			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
-			if (proxy is not null && TryGetJniNameForManagedType (targetType, out var targetJniName)) {
-				var selfRef = new JniObjectReference (handle);
-				var objClass = default (JniObjectReference);
-				var targetClass = default (JniObjectReference);
-				try {
-					objClass = JniEnvironment.Types.GetObjectClass (selfRef);
-					targetClass = JniEnvironment.Types.FindClass (targetJniName);
-					if (!JniEnvironment.Types.IsAssignableFrom (objClass, targetClass)) {
-						proxy = null;
-					}
-				} finally {
-					JniObjectReference.Dispose (ref objClass);
-					JniObjectReference.Dispose (ref targetClass);
-				}
-			}
-		}
-
-		return proxy?.CreateInstance (handle, transfer);
 	}
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -28,9 +28,10 @@ class TrimmableTypeMap
 
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
-	readonly ConcurrentDictionary<Type, JavaPeerProxy?> _proxyCache = new ();
-	readonly ConcurrentDictionary<Type, string?> _jniNameCache = new ();
-	readonly ConcurrentDictionary<string, JavaPeerProxy?> _peerProxyCache = new (StringComparer.Ordinal);
+	// ConcurrentDictionary doesn't accept null values, so these caches only store hits.
+	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
+	readonly ConcurrentDictionary<Type, string> _jniNameCache = new ();
+	readonly ConcurrentDictionary<string, JavaPeerProxy> _peerProxyCache = new (StringComparer.Ordinal);
 
 	TrimmableTypeMap ()
 	{
@@ -91,7 +92,18 @@ class TrimmableTypeMap
 	/// Results are cached per type.
 	/// </summary>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
-		=> _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type), this);
+	{
+		if (_proxyCache.TryGetValue (managedType, out var cached)) {
+			return cached;
+		}
+
+		var resolved = ResolveProxyForManagedType (managedType);
+		if (resolved is null) {
+			return null;
+		}
+
+		return _proxyCache.GetOrAdd (managedType, resolved);
+	}
 
 	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
 	{
@@ -104,8 +116,19 @@ class TrimmableTypeMap
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
 	{
-		jniName = _jniNameCache.GetOrAdd (managedType, static (type, self) => self.GetProxyForManagedType (type)?.JniName, this);
-		return jniName is not null;
+		if (_jniNameCache.TryGetValue (managedType, out var cached)) {
+			jniName = cached;
+			return true;
+		}
+
+		var proxy = GetProxyForManagedType (managedType);
+		if (proxy is null) {
+			jniName = null;
+			return false;
+		}
+
+		jniName = _jniNameCache.GetOrAdd (managedType, proxy.JniName);
+		return true;
 	}
 
 	JavaPeerProxy? GetProxyForJavaObject (IntPtr handle, Type? targetType = null)
@@ -121,13 +144,13 @@ class TrimmableTypeMap
 			while (jniClass.IsValid) {
 				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 				if (className != null) {
-					var cached = _peerProxyCache.GetOrAdd (className, static (name, self) => {
-						if (!self._typeMap.TryGetValue (name, out var mappedType)) {
-							return null;
+					JavaPeerProxy? cached = null;
+					if (!_peerProxyCache.TryGetValue (className, out cached) && _typeMap.TryGetValue (className, out var mappedType)) {
+						var resolved = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+						if (resolved is not null) {
+							cached = _peerProxyCache.GetOrAdd (className, resolved);
 						}
-
-						return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-					}, this);
+					}
 
 					if (cached != null && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
 						return cached;
@@ -155,9 +178,11 @@ class TrimmableTypeMap
 			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
 			if (proxy is not null && TryGetJniNameForManagedType (targetType, out var targetJniName)) {
 				var selfRef = new JniObjectReference (handle);
-				var objClass = JniEnvironment.Types.GetObjectClass (selfRef);
-				var targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				var objClass = default (JniObjectReference);
+				var targetClass = default (JniObjectReference);
 				try {
+					objClass = JniEnvironment.Types.GetObjectClass (selfRef);
+					targetClass = JniEnvironment.Types.FindClass (targetJniName);
 					if (!JniEnvironment.Types.IsAssignableFrom (objClass, targetClass)) {
 						proxy = null;
 					}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -71,7 +71,7 @@ class TrimmableTypeMap
 		}
 	}
 
-	internal bool TryGetType (string jniSimpleReference, [NotNullWhen (true)] out Type? type)
+	internal bool TryGetTargetType (string jniSimpleReference, [NotNullWhen (true)] out Type? type)
 	{
 		if (!_typeMap.TryGetValue (jniSimpleReference, out var mappedType)) {
 			type = null;
@@ -151,7 +151,7 @@ class TrimmableTypeMap
 
 	JavaPeerProxy? ResolveProxyForJavaType (string className)
 	{
-		if (!TryGetType (className, out var managedType)) {
+		if (!TryGetTargetType (className, out var managedType)) {
 			return null;
 		}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -29,7 +29,6 @@ class TrimmableTypeMap
 
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
-	// ConcurrentDictionary doesn't accept null values, so misses are cached with s_noPeerSentinel.
 	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
 	readonly ConcurrentDictionary<string, JavaPeerProxy> _peerProxyCache = new (StringComparer.Ordinal);
 
@@ -121,7 +120,7 @@ class TrimmableTypeMap
 		}
 
 		return TryGetProxyFromHierarchy (this, handle, targetType) ??
-			(targetType is null ? null : TryGetProxyFromTargetType (this, handle, targetType));
+			TryGetProxyFromTargetType (this, handle, targetType);
 
 		static JavaPeerProxy? TryGetProxyFromHierarchy (TrimmableTypeMap self, IntPtr handle, Type? targetType)
 		{
@@ -149,8 +148,12 @@ class TrimmableTypeMap
 			return null;
 		}
 
-		static JavaPeerProxy? TryGetProxyFromTargetType (TrimmableTypeMap self, IntPtr handle, Type targetType)
+		static JavaPeerProxy? TryGetProxyFromTargetType (TrimmableTypeMap self, IntPtr handle, Type? targetType)
 		{
+			if (targetType is null) {
+				return null;
+			}
+
 			var proxy = self.GetProxyForManagedType (targetType);
 			// Verify the Java object is actually assignable to the target Java type
 			// before returning the fallback proxy. Without this, we'd create invalid peers

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -131,10 +131,9 @@ class TrimmableTypeMap
 			while (jniClass.IsValid) {
 				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 				if (className != null) {
-					var cached = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
-
-					if (!ReferenceEquals (cached, s_noPeerSentinel) && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
-						return cached;
+					var proxy = GetProxyForJavaType (className);
+					if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
+						return proxy;
 					}
 				}
 
@@ -147,6 +146,12 @@ class TrimmableTypeMap
 		}
 
 		return null;
+	}
+
+	JavaPeerProxy? GetProxyForJavaType (string className)
+	{
+		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
+		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
 	JavaPeerProxy? ResolveProxyForJavaType (string className)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -74,12 +74,15 @@ class TrimmableTypeMap
 			return false;
 		}
 
-		// External typemap entries for ACW-backed types resolve to the generated proxy-bearing
-		// helper (including alias slots such as "jni/name[1]"). Surface the actual managed peer
-		// when a JavaPeerProxy attribute is present so activation and virtual dispatch land on
-		// the user's type instead of the generated helper.
 		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		type = proxy?.TargetType ?? mappedType;
+		if (proxy is null) {
+			// Alias typemap entries (for example "jni/name[1]") are not implemented yet.
+			// Support for them will be added in a follow-up for https://github.com/dotnet/android/issues/10788.
+			throw new NotImplementedException (
+				$"Trimmable typemap alias handling is not implemented yet for '{jniSimpleReference}'.");
+		}
+
+		type = proxy.TargetType;
 		return true;
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -77,9 +77,10 @@ class TrimmableTypeMap
 			return false;
 		}
 
-		// External typemap entries usually point at the generated proxy for ACW-backed types.
-		// Surface the real managed peer when possible so activation and virtual dispatch land
-		// on the user's override instead of the generated proxy type.
+		// External typemap entries for ACW-backed types resolve to the generated proxy-bearing
+		// helper (including alias slots such as "jni/name[1]"). Surface the actual managed peer
+		// when a JavaPeerProxy attribute is present so activation and virtual dispatch land on
+		// the user's type instead of the generated helper.
 		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 		type = proxy?.TargetType ?? mappedType;
 		return true;
@@ -103,20 +104,8 @@ class TrimmableTypeMap
 
 	internal bool TryGetJniName (Type type, [NotNullWhen (true)] out string? jniName)
 	{
-		if (_jniNameCache.TryGetValue (type, out jniName)) {
-			return jniName != null;
-		}
-
-		var proxy = GetProxyForManagedType (type);
-		if (proxy is not null) {
-			jniName = proxy.JniName;
-			_jniNameCache [type] = jniName;
-			return true;
-		}
-
-		jniName = null;
-		_jniNameCache [type] = null;
-		return false;
+		jniName = _jniNameCache.GetOrAdd (type, static (type, self) => self.GetProxyForManagedType (type)?.JniName, this);
+		return jniName is not null;
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
@@ -135,16 +124,16 @@ class TrimmableTypeMap
 			while (jniClass.IsValid) {
 				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 				if (className != null) {
-					if (_peerProxyCache.TryGetValue (className, out var cached)) {
-						if (cached != null && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
-							return cached;
+					var cached = _peerProxyCache.GetOrAdd (className, static (name, self) => {
+						if (!self._typeMap.TryGetValue (name, out var mappedType)) {
+							return null;
 						}
-					} else if (_typeMap.TryGetValue (className, out var mappedType)) {
-						var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-						_peerProxyCache [className] = proxy;
-						if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
-							return proxy;
-						}
+
+						return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+					}, this);
+
+					if (cached != null && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
+						return cached;
 					}
 				}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -86,23 +86,26 @@ class TrimmableTypeMap
 
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
-		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type) ?? s_noPeerSentinel, this);
+		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
+			if (!self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
+				return s_noPeerSentinel;
+			}
+
+			return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
 	JavaPeerProxy? GetProxyForJavaType (string className)
 	{
-		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
+		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => {
+			if (!self.TryGetTargetType (name, out var managedType)) {
+				return s_noPeerSentinel;
+			}
+
+			return self.GetProxyForManagedType (managedType) ?? s_noPeerSentinel;
+		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
-	}
-
-	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
-	{
-		if (!_proxyTypeMap.TryGetValue (managedType, out var proxyType)) {
-			return null;
-		}
-
-		return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
@@ -117,9 +120,10 @@ class TrimmableTypeMap
 			return null;
 		}
 
-		return TryGetProxyFromHierarchy () ?? TryGetProxyFromTargetType ();
+		return TryGetProxyFromHierarchy (this, handle, targetType) ??
+			(targetType is null ? null : TryGetProxyFromTargetType (this, handle, targetType));
 
-		JavaPeerProxy? TryGetProxyFromHierarchy ()
+		static JavaPeerProxy? TryGetProxyFromHierarchy (TrimmableTypeMap self, IntPtr handle, Type? targetType)
 		{
 			var selfRef = new JniObjectReference (handle);
 			var jniClass = JniEnvironment.Types.GetObjectClass (selfRef);
@@ -128,7 +132,7 @@ class TrimmableTypeMap
 				while (jniClass.IsValid) {
 					var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 					if (className != null) {
-						var proxy = GetProxyForJavaType (className);
+						var proxy = self.GetProxyForJavaType (className);
 						if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
 							return proxy;
 						}
@@ -145,17 +149,13 @@ class TrimmableTypeMap
 			return null;
 		}
 
-		JavaPeerProxy? TryGetProxyFromTargetType ()
+		static JavaPeerProxy? TryGetProxyFromTargetType (TrimmableTypeMap self, IntPtr handle, Type targetType)
 		{
-			if (targetType is null) {
-				return null;
-			}
-
-			var proxy = GetProxyForManagedType (targetType);
+			var proxy = self.GetProxyForManagedType (targetType);
 			// Verify the Java object is actually assignable to the target Java type
 			// before returning the fallback proxy. Without this, we'd create invalid peers
 			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
-			if (proxy is null || !TryGetJniNameForManagedType (targetType, out var targetJniName)) {
+			if (proxy is null || !self.TryGetJniNameForManagedType (targetType, out var targetJniName)) {
 				return null;
 			}
 
@@ -171,15 +171,6 @@ class TrimmableTypeMap
 				JniObjectReference.Dispose (ref targetClass);
 			}
 		}
-	}
-
-	JavaPeerProxy? ResolveProxyForJavaType (string className)
-	{
-		if (!TryGetTargetType (className, out var managedType)) {
-			return null;
-		}
-
-		return GetProxyForManagedType (managedType);
 	}
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -90,7 +90,7 @@ class TrimmableTypeMap
 	/// Finds the proxy for a managed type using the generated proxy type map.
 	/// Results are cached per type.
 	/// </summary>
-	internal JavaPeerProxy? GetProxyForManagedType (Type managedType)
+	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 		=> _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type), this);
 
 	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
@@ -108,7 +108,7 @@ class TrimmableTypeMap
 		return jniName is not null;
 	}
 
-	internal JavaPeerProxy? GetProxyForPeer (IntPtr handle, Type? targetType = null)
+	JavaPeerProxy? GetProxyForPeer (IntPtr handle, Type? targetType = null)
 	{
 		if (handle == IntPtr.Zero) {
 			return null;
@@ -169,15 +169,6 @@ class TrimmableTypeMap
 		}
 
 		return proxy?.CreateInstance (handle, transfer);
-	}
-
-	/// <summary>
-	/// Creates a peer instance using the proxy's CreateInstance method.
-	/// Given a managed type, resolves the JNI name, finds the proxy, and calls CreateInstance.
-	/// </summary>
-	internal bool TryCreatePeer (Type type, IntPtr handle, JniHandleOwnership transfer)
-	{
-		return CreatePeer (handle, transfer, type) != null;
 	}
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -151,11 +151,11 @@ class TrimmableTypeMap
 
 	JavaPeerProxy? ResolveProxyForJavaType (string className)
 	{
-		if (!_typeMap.TryGetValue (className, out var mappedType)) {
+		if (!TryGetType (className, out var managedType)) {
 			return null;
 		}
 
-		return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+		return GetProxyForManagedType (managedType);
 	}
 
 	internal IJavaPeerable? CreatePeer (IntPtr handle, JniHandleOwnership transfer, Type? targetType = null)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -30,7 +30,6 @@ class TrimmableTypeMap
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
 	// ConcurrentDictionary doesn't accept null values, so these caches only store hits.
 	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
-	readonly ConcurrentDictionary<Type, string> _jniNameCache = new ();
 	readonly ConcurrentDictionary<string, JavaPeerProxy> _peerProxyCache = new (StringComparer.Ordinal);
 
 	TrimmableTypeMap ()
@@ -116,18 +115,13 @@ class TrimmableTypeMap
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
 	{
-		if (_jniNameCache.TryGetValue (managedType, out var cached)) {
-			jniName = cached;
-			return true;
-		}
-
 		var proxy = GetProxyForManagedType (managedType);
 		if (proxy is null) {
 			jniName = null;
 			return false;
 		}
 
-		jniName = _jniNameCache.GetOrAdd (managedType, proxy.JniName);
+		jniName = proxy.JniName;
 		return true;
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -108,7 +108,7 @@ class TrimmableTypeMap
 		return jniName is not null;
 	}
 
-	JavaPeerProxy? GetProxyForPeer (IntPtr handle, Type? targetType = null)
+	JavaPeerProxy? GetProxyForJavaObject (IntPtr handle, Type? targetType = null)
 	{
 		if (handle == IntPtr.Zero) {
 			return null;
@@ -147,7 +147,7 @@ class TrimmableTypeMap
 
 	internal IJavaPeerable? CreatePeer (IntPtr handle, JniHandleOwnership transfer, Type? targetType = null)
 	{
-		var proxy = GetProxyForPeer (handle, targetType);
+		var proxy = GetProxyForJavaObject (handle, targetType);
 		if (proxy is null && targetType is not null) {
 			proxy = GetProxyForManagedType (targetType);
 			// Verify the Java object is actually assignable to the target Java type

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -69,21 +69,8 @@ class TrimmableTypeMap
 
 	internal bool TryGetTargetType (string jniSimpleReference, [NotNullWhen (true)] out Type? type)
 	{
-		if (!_typeMap.TryGetValue (jniSimpleReference, out var mappedType)) {
-			type = null;
-			return false;
-		}
-
-		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		if (proxy is null) {
-			// Alias typemap entries (for example "jni/name[1]") are not implemented yet.
-			// Support for them will be added in a follow-up for https://github.com/dotnet/android/issues/10788.
-			throw new NotImplementedException (
-				$"Trimmable typemap alias handling is not implemented yet for '{jniSimpleReference}'.");
-		}
-
-		type = proxy.TargetType;
-		return true;
+		type = GetProxyForJavaType (jniSimpleReference)?.TargetType;
+		return type is not null;
 	}
 
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
@@ -101,11 +88,19 @@ class TrimmableTypeMap
 	JavaPeerProxy? GetProxyForJavaType (string className)
 	{
 		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => {
-			if (!self.TryGetTargetType (name, out var managedType)) {
+			if (!self._typeMap.TryGetValue (name, out var mappedType)) {
 				return s_noPeerSentinel;
 			}
 
-			return self.GetProxyForManagedType (managedType) ?? s_noPeerSentinel;
+			var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+			if (proxy is null) {
+				// Alias typemap entries (for example "jni/name[1]") are not implemented yet.
+				// Support for them will be added in a follow-up for https://github.com/dotnet/android/issues/10788.
+				throw new NotImplementedException (
+					$"Trimmable typemap alias handling is not implemented yet for '{name}'.");
+			}
+
+			return proxy;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -9,7 +9,6 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Android.Runtime;
 using Java.Interop;
-using Java.Interop.Tools.TypeNameMappings;
 
 namespace Microsoft.Android.Runtime;
 
@@ -115,26 +114,6 @@ class TrimmableTypeMap
 			return true;
 		}
 
-		if (TryGetJniNameForType (type, out jniName)) {
-			_jniNameCache [type] = jniName;
-			return true;
-		}
-
-		if (TryGetCompatJniNameForAndroidComponent (type, out jniName)) {
-			_jniNameCache [type] = jniName;
-			return true;
-		}
-
-		// Prefer the JavaNativeTypeManager calculation for user/application types,
-		// as it matches the ACW generation rules used during the build.
-		if (typeof (IJavaPeerable).IsAssignableFrom (type)) {
-			jniName = JavaNativeTypeManager.ToJniName (type);
-			if (!string.IsNullOrEmpty (jniName) && jniName != "java/lang/Object") {
-				_jniNameCache [type] = jniName;
-				return true;
-			}
-		}
-
 		jniName = null;
 		_jniNameCache [type] = null;
 		return false;
@@ -204,59 +183,6 @@ class TrimmableTypeMap
 		}
 
 		return proxy?.CreateInstance (handle, transfer);
-	}
-
-	static bool TryGetCompatJniNameForAndroidComponent (Type type, [NotNullWhen (true)] out string? jniName)
-	{
-		if (!IsAndroidComponentType (type)) {
-			jniName = null;
-			return false;
-		}
-
-		var (typeName, parentJniName, ns) = GetCompatTypeNameParts (type);
-		jniName = parentJniName is not null
-			? $"{parentJniName}_{typeName}"
-			: ns.Length == 0
-				? typeName
-				: $"{ns.ToLowerInvariant ().Replace ('.', '/')}/{typeName}";
-		return true;
-	}
-
-	static bool IsAndroidComponentType (Type type)
-	{
-		return type.IsDefined (typeof (global::Android.App.ActivityAttribute), inherit: false) ||
-			type.IsDefined (typeof (global::Android.App.ApplicationAttribute), inherit: false) ||
-			type.IsDefined (typeof (global::Android.App.InstrumentationAttribute), inherit: false) ||
-			type.IsDefined (typeof (global::Android.App.ServiceAttribute), inherit: false) ||
-			type.IsDefined (typeof (global::Android.Content.BroadcastReceiverAttribute), inherit: false) ||
-			type.IsDefined (typeof (global::Android.Content.ContentProviderAttribute), inherit: false);
-	}
-
-	static (string TypeName, string? ParentJniName, string Namespace) GetCompatTypeNameParts (Type type)
-	{
-		var nameParts = new List<string> { SanitizeTypeName (type.Name) };
-		var current = type;
-		string? parentJniName = null;
-
-		while (current.DeclaringType is Type parentType) {
-			if (TryGetJniNameForType (parentType, out var explicitJniName) ||
-					TryGetCompatJniNameForAndroidComponent (parentType, out explicitJniName)) {
-				parentJniName = explicitJniName;
-				break;
-			}
-
-			nameParts.Add (SanitizeTypeName (parentType.Name));
-			current = parentType;
-		}
-
-		nameParts.Reverse ();
-		return (string.Join ("_", nameParts), parentJniName, current.Namespace ?? "");
-	}
-
-	static string SanitizeTypeName (string name)
-	{
-		var tick = name.IndexOf ('`');
-		return (tick >= 0 ? name.Substring (0, tick) : name).Replace ('+', '_');
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Android.Runtime;
 class TrimmableTypeMap
 {
 	static readonly Lock s_initLock = new ();
+	static readonly JavaPeerProxy s_noPeerSentinel = new MissingJavaPeerProxy ();
 	static TrimmableTypeMap? s_instance;
 
 	internal static TrimmableTypeMap Instance =>
@@ -28,7 +29,7 @@ class TrimmableTypeMap
 
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
-	// ConcurrentDictionary doesn't accept null values, so these caches only store hits.
+	// ConcurrentDictionary doesn't accept null values, so misses are cached with s_noPeerSentinel.
 	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
 	readonly ConcurrentDictionary<string, JavaPeerProxy> _peerProxyCache = new (StringComparer.Ordinal);
 
@@ -92,16 +93,8 @@ class TrimmableTypeMap
 	/// </summary>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
-		if (_proxyCache.TryGetValue (managedType, out var cached)) {
-			return cached;
-		}
-
-		var resolved = ResolveProxyForManagedType (managedType);
-		if (resolved is null) {
-			return null;
-		}
-
-		return _proxyCache.GetOrAdd (managedType, resolved);
+		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type) ?? s_noPeerSentinel, this);
+		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
 	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
@@ -138,15 +131,9 @@ class TrimmableTypeMap
 			while (jniClass.IsValid) {
 				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 				if (className != null) {
-					JavaPeerProxy? cached = null;
-					if (!_peerProxyCache.TryGetValue (className, out cached) && _typeMap.TryGetValue (className, out var mappedType)) {
-						var resolved = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-						if (resolved is not null) {
-							cached = _peerProxyCache.GetOrAdd (className, resolved);
-						}
-					}
+					var cached = _peerProxyCache.GetOrAdd (className, static (name, self) => self.ResolveProxyForJavaType (name) ?? s_noPeerSentinel, this);
 
-					if (cached != null && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
+					if (!ReferenceEquals (cached, s_noPeerSentinel) && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
 						return cached;
 					}
 				}
@@ -160,6 +147,15 @@ class TrimmableTypeMap
 		}
 
 		return null;
+	}
+
+	JavaPeerProxy? ResolveProxyForJavaType (string className)
+	{
+		if (!_typeMap.TryGetValue (className, out var mappedType)) {
+			return null;
+		}
+
+		return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 	}
 
 	internal IJavaPeerable? CreatePeer (IntPtr handle, JniHandleOwnership transfer, Type? targetType = null)
@@ -237,6 +233,15 @@ class TrimmableTypeMap
 		} catch (Exception ex) {
 			Environment.FailFast ($"TrimmableTypeMap: Failed to register natives for class '{className}'.", ex);
 		}
+	}
+
+	sealed class MissingJavaPeerProxy : JavaPeerProxy
+	{
+		public MissingJavaPeerProxy () : base ("<missing>", typeof (Java.Lang.Object), null)
+		{
+		}
+
+		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
 	}
 
 }

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using Android.Runtime;
 using Java.Interop;
+using Java.Interop.Tools.TypeNameMappings;
 
 namespace Microsoft.Android.Runtime;
 
@@ -29,6 +30,8 @@ class TrimmableTypeMap
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
 	readonly ConcurrentDictionary<Type, JavaPeerProxy?> _proxyCache = new ();
+	readonly ConcurrentDictionary<Type, string?> _jniNameCache = new ();
+	readonly ConcurrentDictionary<string, JavaPeerProxy?> _peerProxyCache = new (StringComparer.Ordinal);
 
 	TrimmableTypeMap ()
 	{
@@ -69,7 +72,19 @@ class TrimmableTypeMap
 	}
 
 	internal bool TryGetType (string jniSimpleReference, [NotNullWhen (true)] out Type? type)
-		=> _typeMap.TryGetValue (jniSimpleReference, out type);
+	{
+		if (!_typeMap.TryGetValue (jniSimpleReference, out var mappedType)) {
+			type = null;
+			return false;
+		}
+
+		// External typemap entries usually point at the generated proxy for ACW-backed types.
+		// Surface the real managed peer when possible so activation and virtual dispatch land
+		// on the user's override instead of the generated proxy type.
+		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+		type = proxy?.TargetType ?? mappedType;
+		return true;
+	}
 
 	/// <summary>
 	/// Finds the proxy for a managed type using the generated proxy type map.
@@ -87,16 +102,161 @@ class TrimmableTypeMap
 		return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 	}
 
-	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
+	internal bool TryGetJniName (Type type, [NotNullWhen (true)] out string? jniName)
 	{
-		var proxy = GetProxyForManagedType (managedType);
+		if (_jniNameCache.TryGetValue (type, out jniName)) {
+			return jniName != null;
+		}
+
+		var proxy = GetProxyForManagedType (type);
 		if (proxy is not null) {
 			jniName = proxy.JniName;
+			_jniNameCache [type] = jniName;
 			return true;
 		}
 
+		if (TryGetJniNameForType (type, out jniName)) {
+			_jniNameCache [type] = jniName;
+			return true;
+		}
+
+		if (TryGetCompatJniNameForAndroidComponent (type, out jniName)) {
+			_jniNameCache [type] = jniName;
+			return true;
+		}
+
+		// Prefer the JavaNativeTypeManager calculation for user/application types,
+		// as it matches the ACW generation rules used during the build.
+		if (typeof (IJavaPeerable).IsAssignableFrom (type)) {
+			jniName = JavaNativeTypeManager.ToJniName (type);
+			if (!string.IsNullOrEmpty (jniName) && jniName != "java/lang/Object") {
+				_jniNameCache [type] = jniName;
+				return true;
+			}
+		}
+
 		jniName = null;
+		_jniNameCache [type] = null;
 		return false;
+	}
+
+	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
+		=> TryGetJniName (managedType, out jniName);
+
+	internal JavaPeerProxy? GetProxyForPeer (IntPtr handle, Type? targetType = null)
+	{
+		if (handle == IntPtr.Zero) {
+			return null;
+		}
+
+		var selfRef = new JniObjectReference (handle);
+		var jniClass = JniEnvironment.Types.GetObjectClass (selfRef);
+
+		try {
+			while (jniClass.IsValid) {
+				var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
+				if (className != null) {
+					if (_peerProxyCache.TryGetValue (className, out var cached)) {
+						if (cached != null && (targetType is null || targetType.IsAssignableFrom (cached.TargetType))) {
+							return cached;
+						}
+					} else if (_typeMap.TryGetValue (className, out var mappedType)) {
+						var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+						_peerProxyCache [className] = proxy;
+						if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
+							return proxy;
+						}
+					}
+				}
+
+				var super = JniEnvironment.Types.GetSuperclass (jniClass);
+				JniObjectReference.Dispose (ref jniClass);
+				jniClass = super;
+			}
+		} finally {
+			JniObjectReference.Dispose (ref jniClass);
+		}
+
+		return null;
+	}
+
+	internal IJavaPeerable? CreatePeer (IntPtr handle, JniHandleOwnership transfer, Type? targetType = null)
+	{
+		var proxy = GetProxyForPeer (handle, targetType);
+		if (proxy is null && targetType is not null) {
+			proxy = GetProxyForManagedType (targetType);
+			// Verify the Java object is actually assignable to the target Java type
+			// before creating the peer. Without this, we'd create invalid peers
+			// (e.g., IAppendableInvoker wrapping a java.lang.Integer).
+			if (proxy is not null && TryGetJniName (targetType, out var targetJniName)) {
+				var selfRef = new JniObjectReference (handle);
+				var objClass = JniEnvironment.Types.GetObjectClass (selfRef);
+				var targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				try {
+					if (!JniEnvironment.Types.IsAssignableFrom (objClass, targetClass)) {
+						proxy = null;
+					}
+				} finally {
+					JniObjectReference.Dispose (ref objClass);
+					JniObjectReference.Dispose (ref targetClass);
+				}
+			}
+		}
+
+		return proxy?.CreateInstance (handle, transfer);
+	}
+
+	static bool TryGetCompatJniNameForAndroidComponent (Type type, [NotNullWhen (true)] out string? jniName)
+	{
+		if (!IsAndroidComponentType (type)) {
+			jniName = null;
+			return false;
+		}
+
+		var (typeName, parentJniName, ns) = GetCompatTypeNameParts (type);
+		jniName = parentJniName is not null
+			? $"{parentJniName}_{typeName}"
+			: ns.Length == 0
+				? typeName
+				: $"{ns.ToLowerInvariant ().Replace ('.', '/')}/{typeName}";
+		return true;
+	}
+
+	static bool IsAndroidComponentType (Type type)
+	{
+		return type.IsDefined (typeof (global::Android.App.ActivityAttribute), inherit: false) ||
+			type.IsDefined (typeof (global::Android.App.ApplicationAttribute), inherit: false) ||
+			type.IsDefined (typeof (global::Android.App.InstrumentationAttribute), inherit: false) ||
+			type.IsDefined (typeof (global::Android.App.ServiceAttribute), inherit: false) ||
+			type.IsDefined (typeof (global::Android.Content.BroadcastReceiverAttribute), inherit: false) ||
+			type.IsDefined (typeof (global::Android.Content.ContentProviderAttribute), inherit: false);
+	}
+
+	static (string TypeName, string? ParentJniName, string Namespace) GetCompatTypeNameParts (Type type)
+	{
+		var nameParts = new List<string> { SanitizeTypeName (type.Name) };
+		var current = type;
+		string? parentJniName = null;
+
+		while (current.DeclaringType is Type parentType) {
+			if (TryGetJniNameForType (parentType, out var explicitJniName) ||
+					TryGetCompatJniNameForAndroidComponent (parentType, out explicitJniName)) {
+				parentJniName = explicitJniName;
+				break;
+			}
+
+			nameParts.Add (SanitizeTypeName (parentType.Name));
+			current = parentType;
+		}
+
+		nameParts.Reverse ();
+		return (string.Join ("_", nameParts), parentJniName, current.Namespace ?? "");
+	}
+
+	static string SanitizeTypeName (string name)
+	{
+		var tick = name.IndexOf ('`');
+		return (tick >= 0 ? name.Substring (0, tick) : name).Replace ('+', '_');
 	}
 
 	/// <summary>
@@ -105,12 +265,7 @@ class TrimmableTypeMap
 	/// </summary>
 	internal bool TryCreatePeer (Type type, IntPtr handle, JniHandleOwnership transfer)
 	{
-		var proxy = GetProxyForManagedType (type);
-		if (proxy is null) {
-			return false;
-		}
-
-		return proxy.CreateInstance (handle, transfer) != null;
+		return CreatePeer (handle, transfer, type) != null;
 	}
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -28,7 +28,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName)) {
+		if (TrimmableTypeMap.Instance.TryGetJniName (type, out var jniName)) {
 			yield return jniName;
 			yield break;
 		}
@@ -40,7 +40,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 		// Walk the base type chain for managed-only subclasses (e.g., JavaProxyThrowable
 		// extends Java.Lang.Error but has no [Register] attribute itself).
 		for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType) {
-			if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (baseType, out var baseJniName)) {
+			if (TrimmableTypeMap.Instance.TryGetJniName (baseType, out var baseJniName)) {
 				yield return baseJniName;
 				yield break;
 			}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -21,7 +21,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 			yield return t;
 		}
 
-		if (TrimmableTypeMap.Instance.TryGetType (jniSimpleReference, out var type)) {
+		if (TrimmableTypeMap.Instance.TryGetTargetType (jniSimpleReference, out var type)) {
 			yield return type;
 		}
 	}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -28,7 +28,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		if (TrimmableTypeMap.Instance.TryGetJniName (type, out var jniName)) {
+		if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName)) {
 			yield return jniName;
 			yield break;
 		}
@@ -40,7 +40,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 		// Walk the base type chain for managed-only subclasses (e.g., JavaProxyThrowable
 		// extends Java.Lang.Error but has no [Register] attribute itself).
 		for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType) {
-			if (TrimmableTypeMap.Instance.TryGetJniName (baseType, out var baseJniName)) {
+			if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (baseType, out var baseJniName)) {
 				yield return baseJniName;
 				yield break;
 			}


### PR DESCRIPTION
- `JNIEnv.TypemapManagedToJava` uses managed JNI-name resolution from `TrimmableTypeMap` for the trimmable path
- `JNIEnvInit` publishes the current `JniRuntime` before trimmable typemap initialization so managed JNI services and native registration work correctly
- legacy `TypeManager.GetJavaToManagedType` is now explicitly unreachable in trimmable mode; lookups should flow through `TrimmableTypeMapTypeManager`
- `JavaMarshalValueManager` + `TrimmableTypeMap` handle the remaining runtime peer creation/JNI-name resolution after the split and now fail fast if required proxy coverage is missing
