### PR TITLE
[Mono.Android] Throw NotSupportedException for open generic type activation

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -170,6 +170,10 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (Type type, string jniCtorSignature, JValue* constructorParameters)
 		{
+			if (type.IsGenericTypeDefinition) {
+				throw new NotSupportedException (
+					"Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined.");
+			}
 			return AllocObject (type);
 		}
 


### PR DESCRIPTION
Adds an `IsGenericTypeDefinition` guard to `JNIEnv.StartCreateInstance(Type, ...)` that throws `NotSupportedException` before attempting to allocate a Java object for an open generic type (e.g., `GenericHolder<>`).

## Background

In the legacy typemap path, open generic types are rejected by `ManagedPeer.Construct` during `FinishCreateInstance`:
```csharp
if (type.IsGenericTypeDefinition)
    throw new NotSupportedException("...");
```

In the trimmable typemap path, `ManagedPeer.Construct` is not used — the UCO constructor handles activation. The UCO for open generic types is a no-op (`ret`), so the activation silently succeeds, which violates the expected behavior.

## Fix

Move the check earlier to `StartCreateInstance(Type, ...)`, before `AllocObject` is called. This ensures consistent behavior regardless of which typemap path is active.