### PR TITLE
[TrimmableTypeMap] Add typed logger interface

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
@@ -1,0 +1,13 @@
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+public interface ITrimmableTypeMapLogger
+{
+	void LogNoJavaPeerTypesFound ();
+	void LogJavaPeerScanInfo (int assemblyCount, int peerCount);
+	void LogGeneratingJcwFilesInfo (int jcwPeerCount, int totalPeerCount);
+	void LogDeferredRegistrationTypesInfo (int typeCount);
+	void LogGeneratedTypeMapAssemblyInfo (string assemblyName, int typeCount);
+	void LogGeneratedRootTypeMapInfo (int assemblyReferenceCount);
+	void LogGeneratedTypeMapAssembliesInfo (int assemblyCount);
+	void LogGeneratedJcwFilesInfo (int sourceCount);
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 
 public class TrimmableTypeMapGenerator
 {
-	readonly Action<string> log;
+	readonly ITrimmableTypeMapLogger logger;
 
-	public TrimmableTypeMapGenerator (Action<string> log)
+	public TrimmableTypeMapGenerator (ITrimmableTypeMapLogger logger)
 	{
-		this.log = log ?? throw new ArgumentNullException (nameof (log));
+		this.logger = logger ?? throw new ArgumentNullException (nameof (logger));
 	}
 
 	/// <summary>
@@ -34,7 +34,7 @@ public class TrimmableTypeMapGenerator
 
 		var (allPeers, assemblyManifestInfo) = ScanAssemblies (assemblies);
 		if (allPeers.Count == 0) {
-			log ("No Java peer types found, skipping typemap generation.");
+			logger.LogNoJavaPeerTypesFound ();
 			return new TrimmableTypeMapResult ([], [], allPeers);
 		}
 
@@ -42,7 +42,7 @@ public class TrimmableTypeMapGenerator
 		var jcwPeers = allPeers.Where (p =>
 			!frameworkAssemblyNames.Contains (p.AssemblyName)
 			|| p.JavaName.StartsWith ("mono/", StringComparison.Ordinal)).ToList ();
-		log ($"Generating JCW files for {jcwPeers.Count} types (filtered from {allPeers.Count} total).");
+		logger.LogGeneratingJcwFilesInfo (jcwPeers.Count, allPeers.Count);
 		var generatedJavaSources = GenerateJcwJavaSources (jcwPeers);
 
 		// Collect Application/Instrumentation types that need deferred registerNatives
@@ -51,7 +51,7 @@ public class TrimmableTypeMapGenerator
 			.Select (p => JniSignatureHelper.JniNameToJavaName (p.JavaName))
 			.ToList ();
 		if (appRegTypes.Count > 0) {
-			log ($"Found {appRegTypes.Count} Application/Instrumentation types for deferred registration.");
+			logger.LogDeferredRegistrationTypesInfo (appRegTypes.Count);
 		}
 
 		var manifest = manifestConfig is not null
@@ -102,7 +102,7 @@ public class TrimmableTypeMapGenerator
 		using var scanner = new JavaPeerScanner ();
 		var peers = scanner.Scan (assemblies);
 		var manifestInfo = scanner.ScanAssemblyManifestInfo ();
-		log ($"Scanned {assemblies.Count} assemblies, found {peers.Count} Java peer types.");
+		logger.LogJavaPeerScanInfo (assemblies.Count, peers.Count);
 		return (peers, manifestInfo);
 	}
 
@@ -120,15 +120,15 @@ public class TrimmableTypeMapGenerator
 			generator.Generate (peers, stream, assemblyName);
 			stream.Position = 0;
 			generatedAssemblies.Add (new GeneratedAssembly (assemblyName, stream));
-			log ($"  {assemblyName}: {peers.Count} types");
+			logger.LogGeneratedTypeMapAssemblyInfo (assemblyName, peers.Count);
 		}
 		var rootStream = new MemoryStream ();
 		var rootGenerator = new RootTypeMapAssemblyGenerator (systemRuntimeVersion);
 		rootGenerator.Generate (perAssemblyNames, rootStream);
 		rootStream.Position = 0;
 		generatedAssemblies.Add (new GeneratedAssembly ("_Microsoft.Android.TypeMaps", rootStream));
-		log ($"  Root: {perAssemblyNames.Count} per-assembly refs");
-		log ($"Generated {generatedAssemblies.Count} typemap assemblies.");
+		logger.LogGeneratedRootTypeMapInfo (perAssemblyNames.Count);
+		logger.LogGeneratedTypeMapAssembliesInfo (generatedAssemblies.Count);
 		return generatedAssemblies;
 	}
 
@@ -136,7 +136,7 @@ public class TrimmableTypeMapGenerator
 	{
 		var jcwGenerator = new JcwJavaSourceGenerator ();
 		var sources = jcwGenerator.GenerateContent (allPeers);
-		log ($"Generated {sources.Count} JCW Java source files.");
+		logger.LogGeneratedJcwFilesInfo (sources.Count);
 		return sources.ToList ();
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -15,6 +15,26 @@ namespace Xamarin.Android.Tasks;
 
 public class GenerateTrimmableTypeMap : AndroidTask
 {
+	sealed class MSBuildTrimmableTypeMapLogger (TaskLoggingHelper log) : ITrimmableTypeMapLogger
+	{
+		public void LogNoJavaPeerTypesFound () =>
+			log.LogMessage (MessageImportance.Low, "No Java peer types found, skipping typemap generation.");
+		public void LogJavaPeerScanInfo (int assemblyCount, int peerCount) =>
+			log.LogMessage (MessageImportance.Low, $"Scanned {assemblyCount} assemblies, found {peerCount} Java peer types.");
+		public void LogGeneratingJcwFilesInfo (int jcwPeerCount, int totalPeerCount) =>
+			log.LogMessage (MessageImportance.Low, $"Generating JCW files for {jcwPeerCount} types (filtered from {totalPeerCount} total).");
+		public void LogDeferredRegistrationTypesInfo (int typeCount) =>
+			log.LogMessage (MessageImportance.Low, $"Found {typeCount} Application/Instrumentation types for deferred registration.");
+		public void LogGeneratedTypeMapAssemblyInfo (string assemblyName, int typeCount) =>
+			log.LogMessage (MessageImportance.Low, $"  {assemblyName}: {typeCount} types");
+		public void LogGeneratedRootTypeMapInfo (int assemblyReferenceCount) =>
+			log.LogMessage (MessageImportance.Low, $"  Root: {assemblyReferenceCount} per-assembly refs");
+		public void LogGeneratedTypeMapAssembliesInfo (int assemblyCount) =>
+			log.LogMessage (MessageImportance.Low, $"Generated {assemblyCount} typemap assemblies.");
+		public void LogGeneratedJcwFilesInfo (int sourceCount) =>
+			log.LogMessage (MessageImportance.Low, $"Generated {sourceCount} JCW Java source files.");
+	}
+
 	public override string TaskPrefix => "GTT";
 
 	[Required]
@@ -94,7 +114,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 					ApplicationJavaClass: ApplicationJavaClass);
 			}
 
-			var generator = new TrimmableTypeMapGenerator (msg => Log.LogMessage (MessageImportance.Low, msg));
+			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));
 
 			XDocument? manifestTemplate = null;
 			if (!ManifestTemplate.IsNullOrEmpty () && File.Exists (ManifestTemplate)) {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -12,6 +12,26 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 {
 	readonly List<string> logMessages = new ();
 
+	sealed class TestTrimmableTypeMapLogger (List<string> logMessages) : ITrimmableTypeMapLogger
+	{
+		public void LogNoJavaPeerTypesFound () =>
+			logMessages.Add ("No Java peer types found, skipping typemap generation.");
+		public void LogJavaPeerScanInfo (int assemblyCount, int peerCount) =>
+			logMessages.Add ($"Scanned {assemblyCount} assemblies, found {peerCount} Java peer types.");
+		public void LogGeneratingJcwFilesInfo (int jcwPeerCount, int totalPeerCount) =>
+			logMessages.Add ($"Generating JCW files for {jcwPeerCount} types (filtered from {totalPeerCount} total).");
+		public void LogDeferredRegistrationTypesInfo (int typeCount) =>
+			logMessages.Add ($"Found {typeCount} Application/Instrumentation types for deferred registration.");
+		public void LogGeneratedTypeMapAssemblyInfo (string assemblyName, int typeCount) =>
+			logMessages.Add ($"  {assemblyName}: {typeCount} types");
+		public void LogGeneratedRootTypeMapInfo (int assemblyReferenceCount) =>
+			logMessages.Add ($"  Root: {assemblyReferenceCount} per-assembly refs");
+		public void LogGeneratedTypeMapAssembliesInfo (int assemblyCount) =>
+			logMessages.Add ($"Generated {assemblyCount} typemap assemblies.");
+		public void LogGeneratedJcwFilesInfo (int sourceCount) =>
+			logMessages.Add ($"Generated {sourceCount} JCW Java source files.");
+	}
+
 	[Fact]
 	public void Execute_EmptyAssemblyList_ReturnsEmptyResults ()
 	{
@@ -79,7 +99,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 			Assert.Contains ("class ", source.Content);
 	}
 
-	TrimmableTypeMapGenerator CreateGenerator () => new (msg => logMessages.Add (msg));
+	TrimmableTypeMapGenerator CreateGenerator () => new (new TestTrimmableTypeMapLogger (logMessages));
 
 	static PEReader CreateTestFixturePEReader ()
 	{


### PR DESCRIPTION
## Summary

Replace `Action<string> log` callback with `ITrimmableTypeMapLogger` interface in `TrimmableTypeMapGenerator`. This enables structured logging with typed methods instead of free-form string messages, making it easier to extend with new log categories (e.g., warnings) in follow-up PRs.

No behavioral changes — pure refactoring.

### Changes
- **`ITrimmableTypeMapLogger`** — new interface with 8 typed log methods
- **`TrimmableTypeMapGenerator`** — accept `ITrimmableTypeMapLogger?` instead of `Action<string>`
- **`GenerateTrimmableTypeMap`** — add `MSBuildTrimmableTypeMapLogger` adapter class
- **Tests** — add `TestTrimmableTypeMapLogger` test double