### PR TITLE
[TrimmableTypeMap] Use proxy associations for managed -> JNI lookups

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -31,7 +31,7 @@ sealed class TypeMapAssemblyData
 	public List<JavaPeerProxyData> ProxyTypes { get; } = new ();
 
 	/// <summary>
-	/// TypeMapAssociation entries for alias groups (multiple managed types → same JNI name).
+	/// TypeMapAssociation entries for managed types backed by generated proxies.
 	/// </summary>
 	public List<TypeMapAssociationData> Associations { get; } = new ();
 
@@ -86,7 +86,7 @@ sealed class JavaPeerProxyData
 
 	/// <summary>
 	/// JNI type name, e.g., "android/app/Activity" or "crc64abc.../MyButton".
-	/// Passed to the JavaPeerProxy base constructor for managed → Java lookups.
+	/// Used for managed → Java reverse lookups at runtime.
 	/// </summary>
 	public required string JniName { get; init; }
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -85,6 +85,12 @@ sealed class JavaPeerProxyData
 	public required string TypeName { get; init; }
 
 	/// <summary>
+	/// JNI type name, e.g., "android/app/Activity" or "crc64abc.../MyButton".
+	/// Passed to the JavaPeerProxy base constructor for managed → Java lookups.
+	/// </summary>
+	public required string JniName { get; init; }
+
+	/// <summary>
 	/// Namespace for all proxy types.
 	/// </summary>
 	public string Namespace { get; init; } = "_TypeMap.Proxies";

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -117,7 +117,7 @@ static class ModelBuilder
 
 			JavaPeerProxyData? proxy = null;
 			if (hasProxy) {
-				proxy = BuildProxyType (peer, usedProxyNames, isAcw);
+				proxy = BuildProxyType (peer, jniName, usedProxyNames, isAcw);
 				model.ProxyTypes.Add (proxy);
 			}
 
@@ -127,11 +127,13 @@ static class ModelBuilder
 
 			model.Entries.Add (BuildEntry (peer, proxy, assemblyName, entryJniName));
 
-			// Emit TypeMapAssociation linking alias types to the primary proxy
-			if (i > 0 && primaryProxy != null) {
+			// Emit TypeMapAssociation for all types with proxies (enables managed → Java lookups).
+			// For aliases (i > 0), link to the primary proxy.
+			var assocProxy = (i > 0 && primaryProxy != null) ? primaryProxy : proxy;
+			if (assocProxy != null) {
 				model.Associations.Add (new TypeMapAssociationData {
 					SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
-					AliasProxyTypeReference = AssemblyQualify ($"{primaryProxy.Namespace}.{primaryProxy.TypeName}", assemblyName),
+					AliasProxyTypeReference = AssemblyQualify ($"{assocProxy.Namespace}.{assocProxy.TypeName}", assemblyName),
 				});
 			}
 		}
@@ -169,7 +171,7 @@ static class ModelBuilder
 		}
 	}
 
-	static JavaPeerProxyData BuildProxyType (JavaPeerInfo peer, HashSet<string> usedProxyNames, bool isAcw)
+	static JavaPeerProxyData BuildProxyType (JavaPeerInfo peer, string jniName, HashSet<string> usedProxyNames, bool isAcw)
 	{
 		// Use managed type name for proxy naming to guarantee uniqueness across aliases
 		// (two types with the same JNI name will have different managed names).
@@ -188,6 +190,7 @@ static class ModelBuilder
 
 		var proxy = new JavaPeerProxyData {
 			TypeName = proxyTypeName,
+			JniName = jniName,
 			TargetType = new TypeRefData {
 				ManagedTypeName = peer.ManagedTypeName,
 				AssemblyName = peer.AssemblyName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -127,8 +127,8 @@ static class ModelBuilder
 
 			model.Entries.Add (BuildEntry (peer, proxy, assemblyName, entryJniName));
 
-			// Emit TypeMapAssociation for all types with proxies (enables managed → Java lookups).
-			// For aliases (i > 0), link to the primary proxy.
+			// Emit TypeMapAssociation for all proxy-backed types so managed → proxy
+			// lookup works even when the final JNI name differs from the type's attributes.
 			var assocProxy = (i > 0 && primaryProxy != null) ? primaryProxy : proxy;
 			if (assocProxy != null) {
 				model.Associations.Add (new TypeMapAssociationData {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -206,10 +206,12 @@ sealed class TypeMapAssemblyEmitter
 
 	void EmitMemberReferences ()
 	{
+		// JavaPeerProxy..ctor(string jniName, Type targetType, Type? invokerType)
 		_baseCtorRef = _pe.AddMemberRef (_javaPeerProxyRef, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
 				rt => rt.Void (),
 				p => {
+					p.AddParameter ().Type ().String ();
 					p.AddParameter ().Type ().Type (_systemTypeRef, false);
 					p.AddParameter ().Type ().Type (_systemTypeRef, false);
 				}));
@@ -335,13 +337,15 @@ sealed class TypeMapAssemblyEmitter
 	void EmitTypeMapAssociationAttributeCtorRef ()
 	{
 		var metadata = _pe.Metadata;
-		// TypeMapAssociationAttribute is in System.Runtime.InteropServices, takes 2 Type args:
-		// TypeMapAssociation(Type sourceType, Type aliasProxyType)
-		var typeMapAssociationAttrRef = metadata.AddTypeReference (_pe.SystemRuntimeInteropServicesRef,
+		var typeMapAssociationAttrOpenRef = metadata.AddTypeReference (_pe.SystemRuntimeInteropServicesRef,
 			metadata.GetOrAddString ("System.Runtime.InteropServices"),
-			metadata.GetOrAddString ("TypeMapAssociationAttribute"));
+			metadata.GetOrAddString ("TypeMapAssociationAttribute`1"));
+		var javaLangObjectRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Lang"), metadata.GetOrAddString ("Object"));
+		var closedAttrTypeSpec = _pe.MakeGenericTypeSpec (typeMapAssociationAttrOpenRef, javaLangObjectRef);
 
-		_typeMapAssociationAttrCtorRef = _pe.AddMemberRef (typeMapAssociationAttrRef, ".ctor",
+		// TypeMapAssociation<Java.Lang.Object>(Type sourceType, Type aliasProxyType)
+		_typeMapAssociationAttrCtorRef = _pe.AddMemberRef (closedAttrTypeSpec, ".ctor",
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
 				rt => rt.Void (),
 				p => {
@@ -371,6 +375,7 @@ sealed class TypeMapAssemblyEmitter
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				encoder.OpCode (ILOpCode.Ldarg_0);
+				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
 				// arg 1: typeof(TargetType)
 				encoder.OpCode (ILOpCode.Ldtoken);
 				encoder.Token (_pe.ResolveTypeRef (proxy.TargetType));

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// [assembly: TypeMapAssociation&lt;Java.Lang.Object&gt;(typeof(MyTextView), typeof(Android_Widget_TextView_Proxy))]          // managed → proxy
 ///
 /// // One proxy type per Java peer that needs activation or UCO wrappers:
-/// public sealed class Activity_Proxy : JavaPeerProxy, IAndroidCallableWrapper   // IAndroidCallableWrapper for ACWs only
+/// public sealed class Activity_Proxy : JavaPeerProxy&lt;Activity&gt;, IAndroidCallableWrapper   // IAndroidCallableWrapper for ACWs only
 /// {
-///     public Activity_Proxy() : base("android/app/Activity", typeof(Activity), null) { }
+///     public Activity_Proxy() : base("android/app/Activity", null) { }
 ///
 ///     // Creates the managed peer when Java calls into .NET
 ///     public override IJavaPeerable CreateInstance(IntPtr handle, JniHandleOwnership ownership)
@@ -80,7 +80,6 @@ sealed class TypeMapAssemblyEmitter
 	TypeReferenceHandle _notSupportedExceptionRef;
 	TypeReferenceHandle _runtimeHelpersRef;
 
-	MemberReferenceHandle _baseCtorRef;
 	MemberReferenceHandle _getTypeFromHandleRef;
 	MemberReferenceHandle _getUninitializedObjectRef;
 	MemberReferenceHandle _notSupportedExceptionCtorRef;
@@ -164,7 +163,7 @@ sealed class TypeMapAssemblyEmitter
 	{
 		var metadata = _pe.Metadata;
 		_javaPeerProxyRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
-			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerProxy"));
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerProxy`1"));
 		_iJavaPeerableRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerable"));
 		_jniHandleOwnershipRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
@@ -205,15 +204,6 @@ sealed class TypeMapAssemblyEmitter
 
 	void EmitMemberReferences ()
 	{
-		_baseCtorRef = _pe.AddMemberRef (_javaPeerProxyRef, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
-				rt => rt.Void (),
-				p => {
-					p.AddParameter ().Type ().String ();
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-				}));
-
 		_getTypeFromHandleRef = _pe.AddMemberRef (_systemTypeRef, "GetTypeFromHandle",
 			sig => sig.MethodSignature ().Parameters (1,
 				rt => rt.Type ().Type (_systemTypeRef, false),
@@ -354,11 +344,21 @@ sealed class TypeMapAssemblyEmitter
 	void EmitProxyType (JavaPeerProxyData proxy, Dictionary<string, MethodDefinitionHandle> wrapperHandles)
 	{
 		var metadata = _pe.Metadata;
+		var targetTypeRef = _pe.ResolveTypeRef (proxy.TargetType);
+		var proxyBaseType = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, targetTypeRef);
+		var baseCtorRef = _pe.AddMemberRef (proxyBaseType, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().String ();
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
 		var typeDefHandle = metadata.AddTypeDefinition (
 			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
 			metadata.GetOrAddString (proxy.Namespace),
 			metadata.GetOrAddString (proxy.TypeName),
-			_javaPeerProxyRef,
+			proxyBaseType,
 			MetadataTokens.FieldDefinitionHandle (metadata.GetRowCount (TableIndex.Field) + 1),
 			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
 
@@ -366,16 +366,13 @@ sealed class TypeMapAssemblyEmitter
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
 
-		// .ctor — pass the resolved JNI name and peer types to the base proxy
+		// .ctor — pass the resolved JNI name and optional invoker type to the generic base proxy
 		_pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				encoder.OpCode (ILOpCode.Ldarg_0);
 				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
-				encoder.OpCode (ILOpCode.Ldtoken);
-				encoder.Token (_pe.ResolveTypeRef (proxy.TargetType));
-				encoder.Call (_getTypeFromHandleRef);
 				if (proxy.InvokerType != null) {
 					encoder.OpCode (ILOpCode.Ldtoken);
 					encoder.Token (_pe.ResolveTypeRef (proxy.InvokerType));
@@ -383,7 +380,7 @@ sealed class TypeMapAssemblyEmitter
 				} else {
 					encoder.OpCode (ILOpCode.Ldnull);
 				}
-				encoder.Call (_baseCtorRef);
+				encoder.Call (baseCtorRef);
 				encoder.OpCode (ILOpCode.Ret);
 			});
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// // Assembly-level TypeMap attributes — one per Java peer type:
 /// [assembly: TypeMap&lt;Java.Lang.Object&gt;("android/app/Activity", typeof(Activity_Proxy))]                              // unconditional (ACW)
 /// [assembly: TypeMap&lt;Java.Lang.Object&gt;("android/widget/TextView", typeof(TextView_Proxy), typeof(TextView))]          // trimmable (MCW)
-/// [assembly: TypeMapAssociation(typeof(MyTextView), typeof(Android_Widget_TextView_Proxy))]                              // alias
+/// [assembly: TypeMapAssociation&lt;Java.Lang.Object&gt;(typeof(MyTextView), typeof(Android_Widget_TextView_Proxy))]          // managed → proxy
 ///
 /// // One proxy type per Java peer that needs activation or UCO wrappers:
 /// public sealed class Activity_Proxy : JavaPeerProxy, IAndroidCallableWrapper   // IAndroidCallableWrapper for ACWs only
 /// {
-///     public Activity_Proxy() : base() { }
+///     public Activity_Proxy() : base("android/app/Activity", typeof(Activity), null) { }
 ///
 ///     // Creates the managed peer when Java calls into .NET
 ///     public override IJavaPeerable CreateInstance(IntPtr handle, JniHandleOwnership ownership)
@@ -206,7 +206,6 @@ sealed class TypeMapAssemblyEmitter
 
 	void EmitMemberReferences ()
 	{
-		// JavaPeerProxy..ctor(string jniName, Type targetType, Type? invokerType)
 		_baseCtorRef = _pe.AddMemberRef (_javaPeerProxyRef, ".ctor",
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
 				rt => rt.Void (),
@@ -344,7 +343,6 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("Java.Lang"), metadata.GetOrAddString ("Object"));
 		var closedAttrTypeSpec = _pe.MakeGenericTypeSpec (typeMapAssociationAttrOpenRef, javaLangObjectRef);
 
-		// TypeMapAssociation<Java.Lang.Object>(Type sourceType, Type aliasProxyType)
 		_typeMapAssociationAttrCtorRef = _pe.AddMemberRef (closedAttrTypeSpec, ".ctor",
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
 				rt => rt.Void (),
@@ -369,18 +367,16 @@ sealed class TypeMapAssemblyEmitter
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
 
-		// .ctor — pass TargetType and InvokerType to base ctor
+		// .ctor — pass the resolved JNI name and peer types to the base proxy
 		_pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				encoder.OpCode (ILOpCode.Ldarg_0);
 				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
-				// arg 1: typeof(TargetType)
 				encoder.OpCode (ILOpCode.Ldtoken);
 				encoder.Token (_pe.ResolveTypeRef (proxy.TargetType));
 				encoder.Call (_getTypeFromHandleRef);
-				// arg 2: typeof(InvokerType) or null
 				if (proxy.InvokerType != null) {
 					encoder.OpCode (ILOpCode.Ldtoken);
 					encoder.Token (_pe.ResolveTypeRef (proxy.InvokerType));
@@ -656,6 +652,22 @@ sealed class TypeMapAssemblyEmitter
 					p.AddParameter ().Type ().IntPtr ();
 					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
 				}));
+	}
+
+	void EmitTypeGetter (string methodName, TypeRefData typeRef, MethodAttributes attrs)
+	{
+		var handle = _pe.ResolveTypeRef (typeRef);
+
+		_pe.EmitBody (methodName, attrs,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
+				rt => rt.Type ().Type (_systemTypeRef, false),
+				p => { }),
+			encoder => {
+				encoder.OpCode (ILOpCode.Ldtoken);
+				encoder.Token (handle);
+				encoder.Call (_getTypeFromHandleRef);
+				encoder.OpCode (ILOpCode.Ret);
+			});
 	}
 
 	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -33,8 +33,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 ///         // or: null;                                                // no activation
 ///         // or: throw new NotSupportedException(...);                // open generic
 ///
-///     public override Type TargetType =&gt; typeof(Activity);
-///     public Type InvokerType =&gt; typeof(IOnClickListenerInvoker);    // interfaces only
+///     // JniName / TargetType / InvokerType are supplied by the base JavaPeerProxy constructor.
 ///
 ///     // UCO wrappers — [UnmanagedCallersOnly] entry points for JNI native methods (ACWs only):
 ///     [UnmanagedCallersOnly]
@@ -652,22 +651,6 @@ sealed class TypeMapAssemblyEmitter
 					p.AddParameter ().Type ().IntPtr ();
 					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
 				}));
-	}
-
-	void EmitTypeGetter (string methodName, TypeRefData typeRef, MethodAttributes attrs)
-	{
-		var handle = _pe.ResolveTypeRef (typeRef);
-
-		_pe.EmitBody (methodName, attrs,
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
-				rt => rt.Type ().Type (_systemTypeRef, false),
-				p => { }),
-			encoder => {
-				encoder.OpCode (ILOpCode.Ldtoken);
-				encoder.Token (handle);
-				encoder.Call (_getTypeFromHandleRef);
-				encoder.OpCode (ILOpCode.Ret);
-			});
 	}
 
 	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco)

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -19,18 +19,27 @@ namespace Java.Interop
 	public abstract class JavaPeerProxy : Attribute
 	{
 		/// <summary>
-		/// Initializes a new proxy with the specified target and invoker types.
+		/// Initializes a new proxy with the specified JNI, target, and invoker types.
 		/// </summary>
+		/// <param name="jniName">The JNI type name, e.g., "android/app/Activity" or "crc64abc.../MyButton".</param>
 		/// <param name="targetType">The managed peer type this proxy represents.</param>
 		/// <param name="invokerType">The invoker type for interfaces/abstract classes, or <c>null</c> for concrete types.</param>
 		protected JavaPeerProxy (
+			string jniName,
 			Type targetType,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type? invokerType)
 		{
-			TargetType = targetType;
+			JniName = jniName ?? throw new ArgumentNullException (nameof (jniName));
+			TargetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
 			InvokerType = invokerType;
 		}
+
+		/// <summary>
+		/// Gets the JNI type name of the Java class this proxy represents.
+		/// Used for managed → Java type lookups at runtime.
+		/// </summary>
+		public string JniName { get; }
 
 		/// <summary>
 		/// Creates an instance of the target type using the JNI handle and ownership semantics.
@@ -70,8 +79,9 @@ namespace Java.Interop
 	> : JavaPeerProxy where T : class, IJavaPeerable
 	{
 		protected JavaPeerProxy (
+			string jniName,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type? invokerType) : base (typeof (T), invokerType) { }
+			Type? invokerType) : base (jniName, typeof (T), invokerType) { }
 
 		public override JavaPeerContainerFactory GetContainerFactory ()
 			=> JavaPeerContainerFactory<T>.Instance;

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -18,51 +18,79 @@ namespace Java.Interop
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 	public abstract class JavaPeerProxy : Attribute
 	{
-		/// <summary>
-		/// Initializes a new proxy with the specified JNI, target, and invoker types.
-		/// </summary>
-		/// <param name="jniName">The JNI type name, e.g., "android/app/Activity" or "crc64abc.../MyButton".</param>
-		/// <param name="targetType">The managed peer type this proxy represents.</param>
-		/// <param name="invokerType">The invoker type for interfaces/abstract classes, or <c>null</c> for concrete types.</param>
+		string? jniName;
+		Type? targetType;
+		Type? invokerType;
+
+		protected JavaPeerProxy ()
+		{
+		}
+
 		protected JavaPeerProxy (
 			string jniName,
 			Type targetType,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type? invokerType)
 		{
-			JniName = jniName ?? throw new ArgumentNullException (nameof (jniName));
-			TargetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
-			InvokerType = invokerType;
+			this.jniName = jniName ?? throw new ArgumentNullException (nameof (jniName));
+			this.targetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
+			this.invokerType = invokerType;
+		}
+
+		protected JavaPeerProxy (
+			Type targetType,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			Type? invokerType)
+		{
+			this.targetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
+			this.invokerType = invokerType;
 		}
 
 		/// <summary>
-		/// Gets the JNI type name of the Java class this proxy represents.
-		/// Used for managed → Java type lookups at runtime.
+		/// Gets the final JNI type name of the Java class this proxy represents.
 		/// </summary>
-		public string JniName { get; }
+		public virtual string JniName => jniName ?? GetJniName (TargetType);
+
+		static string GetJniName (Type targetType)
+		{
+			if (targetType.GetCustomAttributes (typeof (IJniNameProviderAttribute), inherit: false) is [IJniNameProviderAttribute provider, ..]
+				&& !string.IsNullOrEmpty (provider.Name)) {
+				return provider.Name.Replace ('.', '/');
+			}
+
+			throw new InvalidOperationException (
+				$"No JNI name is available for proxy target type '{targetType.FullName}'. " +
+				$"Use the JavaPeerProxy(string jniName, Type targetType, Type? invokerType) constructor " +
+				$"or apply an {nameof (IJniNameProviderAttribute)}.");
+		}
 
 		/// <summary>
 		/// Creates an instance of the target type using the JNI handle and ownership semantics.
 		/// This replaces the reflection-based constructor invocation used in the legacy path.
 		/// </summary>
+		/// <param name="handle">The JNI object reference handle.</param>
+		/// <param name="transfer">How to handle JNI reference ownership.</param>
+		/// <returns>A new instance of the target type wrapping the JNI handle, or null if activation is not supported.</returns>
 		public abstract IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer);
 
 		/// <summary>
 		/// Gets the target .NET type that this proxy represents.
 		/// </summary>
-		public Type TargetType { get; }
+		public virtual Type TargetType => targetType ?? throw new InvalidOperationException (
+			$"{GetType ().FullName} did not provide a target type.");
 
 		/// <summary>
 		/// Gets the invoker type for interfaces and abstract classes.
 		/// Returns null for concrete types that can be directly instantiated.
 		/// </summary>
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-		public Type? InvokerType { get; }
+		public virtual Type? InvokerType => invokerType;
 
 		/// <summary>
 		/// Gets a factory for creating containers (arrays, collections) of the target type.
 		/// Enables AOT-safe creation of generic collections without <c>MakeGenericType()</c>.
 		/// </summary>
+		/// <returns>A factory for creating containers of the target type, or null if not supported.</returns>
 		public virtual JavaPeerContainerFactory? GetContainerFactory () => null;
 	}
 
@@ -78,10 +106,17 @@ namespace Java.Interop
 		T
 	> : JavaPeerProxy where T : class, IJavaPeerable
 	{
+		protected JavaPeerProxy ()
+			: base (typeof (T), invokerType: null)
+		{
+		}
+
 		protected JavaPeerProxy (
 			string jniName,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type? invokerType) : base (jniName, typeof (T), invokerType) { }
+			Type? invokerType) : base (jniName, typeof (T), invokerType)
+		{
+		}
 
 		public override JavaPeerContainerFactory GetContainerFactory ()
 			=> JavaPeerContainerFactory<T>.Instance;

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -18,51 +18,21 @@ namespace Java.Interop
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 	public abstract class JavaPeerProxy : Attribute
 	{
-		string? jniName;
-		Type? targetType;
-		Type? invokerType;
-
-		protected JavaPeerProxy ()
-		{
-		}
-
 		protected JavaPeerProxy (
 			string jniName,
 			Type targetType,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
 			Type? invokerType)
 		{
-			this.jniName = jniName ?? throw new ArgumentNullException (nameof (jniName));
-			this.targetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
-			this.invokerType = invokerType;
-		}
-
-		protected JavaPeerProxy (
-			Type targetType,
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type? invokerType)
-		{
-			this.targetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
-			this.invokerType = invokerType;
+			JniName = jniName ?? throw new ArgumentNullException (nameof (jniName));
+			TargetType = targetType ?? throw new ArgumentNullException (nameof (targetType));
+			InvokerType = invokerType;
 		}
 
 		/// <summary>
 		/// Gets the final JNI type name of the Java class this proxy represents.
 		/// </summary>
-		public virtual string JniName => jniName ?? GetJniName (TargetType);
-
-		static string GetJniName (Type targetType)
-		{
-			if (targetType.GetCustomAttributes (typeof (IJniNameProviderAttribute), inherit: false) is [IJniNameProviderAttribute provider, ..]
-				&& !string.IsNullOrEmpty (provider.Name)) {
-				return provider.Name.Replace ('.', '/');
-			}
-
-			throw new InvalidOperationException (
-				$"No JNI name is available for proxy target type '{targetType.FullName}'. " +
-				$"Use the JavaPeerProxy(string jniName, Type targetType, Type? invokerType) constructor " +
-				$"or apply an {nameof (IJniNameProviderAttribute)}.");
-		}
+		public string JniName { get; }
 
 		/// <summary>
 		/// Creates an instance of the target type using the JNI handle and ownership semantics.
@@ -76,15 +46,14 @@ namespace Java.Interop
 		/// <summary>
 		/// Gets the target .NET type that this proxy represents.
 		/// </summary>
-		public virtual Type TargetType => targetType ?? throw new InvalidOperationException (
-			$"{GetType ().FullName} did not provide a target type.");
+		public Type TargetType { get; }
 
 		/// <summary>
 		/// Gets the invoker type for interfaces and abstract classes.
 		/// Returns null for concrete types that can be directly instantiated.
 		/// </summary>
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-		public virtual Type? InvokerType => invokerType;
+		public Type? InvokerType { get; }
 
 		/// <summary>
 		/// Gets a factory for creating containers (arrays, collections) of the target type.
@@ -106,11 +75,6 @@ namespace Java.Interop
 		T
 	> : JavaPeerProxy where T : class, IJavaPeerable
 	{
-		protected JavaPeerProxy ()
-			: base (typeof (T), invokerType: null)
-		{
-		}
-
 		protected JavaPeerProxy (
 			string jniName,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -28,7 +28,7 @@ class TrimmableTypeMap
 
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
-	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
+	readonly ConcurrentDictionary<Type, JavaPeerProxy?> _proxyCache = new ();
 
 	TrimmableTypeMap ()
 	{
@@ -72,23 +72,12 @@ class TrimmableTypeMap
 		=> _typeMap.TryGetValue (jniSimpleReference, out type);
 
 	/// <summary>
-	/// Finds the proxy for a managed type via the proxy type map.
-	/// Falls back to the external type map for types that only expose a JNI name attribute.
+	/// Finds the proxy for a managed type using the proxy type map first and
+	/// attribute-based lookup as a fallback.
 	/// Results are cached per type.
 	/// </summary>
 	internal JavaPeerProxy? GetProxyForManagedType (Type managedType)
-	{
-		if (_proxyCache.TryGetValue (managedType, out var cachedProxy)) {
-			return cachedProxy;
-		}
-
-		var proxy = ResolveProxyForManagedType (managedType);
-		if (proxy is not null) {
-			_proxyCache.TryAdd (managedType, proxy);
-		}
-
-		return proxy;
-	}
+		=> _proxyCache.GetOrAdd (managedType, static (type, self) => self.ResolveProxyForManagedType (type), this);
 
 	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
 	{

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -72,8 +72,7 @@ class TrimmableTypeMap
 		=> _typeMap.TryGetValue (jniSimpleReference, out type);
 
 	/// <summary>
-	/// Finds the proxy for a managed type using the proxy type map first and
-	/// attribute-based lookup as a fallback.
+	/// Finds the proxy for a managed type using the generated proxy type map.
 	/// Results are cached per type.
 	/// </summary>
 	internal JavaPeerProxy? GetProxyForManagedType (Type managedType)
@@ -81,20 +80,7 @@ class TrimmableTypeMap
 
 	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
 	{
-		var direct = managedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		if (direct is not null) {
-			return direct;
-		}
-
-		if (_proxyTypeMap.TryGetValue (managedType, out var proxyType)) {
-			return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		}
-
-		if (!TryGetJniNameForType (managedType, out var jniName)) {
-			return null;
-		}
-
-		if (!_typeMap.TryGetValue (jniName, out proxyType)) {
+		if (!_proxyTypeMap.TryGetValue (managedType, out var proxyType)) {
 			return null;
 		}
 
@@ -106,21 +92,6 @@ class TrimmableTypeMap
 		var proxy = GetProxyForManagedType (managedType);
 		if (proxy is not null) {
 			jniName = proxy.JniName;
-			return true;
-		}
-
-		return TryGetJniNameForType (managedType, out jniName);
-	}
-
-	/// <summary>
-	/// Resolves a managed type's JNI name from its <see cref="IJniNameProviderAttribute"/>
-	/// (implemented by both <c>[Register]</c> and <c>[JniTypeSignature]</c>).
-	/// </summary>
-	internal static bool TryGetJniNameForType (Type type, [NotNullWhen (true)] out string? jniName)
-	{
-		if (type.GetCustomAttributes (typeof (IJniNameProviderAttribute), inherit: false) is [IJniNameProviderAttribute provider, ..]
-			&& !string.IsNullOrEmpty (provider.Name)) {
-			jniName = provider.Name.Replace ('.', '/');
 			return true;
 		}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -27,11 +27,13 @@ class TrimmableTypeMap
 			"TrimmableTypeMap has not been initialized. Ensure RuntimeFeature.TrimmableTypeMap is enabled and the JNI runtime is initialized.");
 
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
-	readonly ConcurrentDictionary<Type, JavaPeerProxy?> _proxyCache = new ();
+	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
+	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
 
 	TrimmableTypeMap ()
 	{
 		_typeMap = TypeMapping.GetOrCreateExternalTypeMapping<Java.Lang.Object> ();
+		_proxyTypeMap = TypeMapping.GetOrCreateProxyTypeMapping<Java.Lang.Object> ();
 	}
 
 	/// <summary>
@@ -70,31 +72,55 @@ class TrimmableTypeMap
 		=> _typeMap.TryGetValue (jniSimpleReference, out type);
 
 	/// <summary>
-	/// Finds the proxy for a managed type by resolving its JNI name (from [Register] or
-	/// [JniTypeSignature] attributes) and looking it up in the TypeMap dictionary.
+	/// Finds the proxy for a managed type via the proxy type map.
+	/// Falls back to the external type map for types that only expose a JNI name attribute.
 	/// Results are cached per type.
 	/// </summary>
 	internal JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
-		return _proxyCache.GetOrAdd (managedType, static (type, self) => {
-			// First check if the type itself IS a proxy (has self-applied attribute)
-			var direct = type.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (direct is not null) {
-				return direct;
-			}
+		if (_proxyCache.TryGetValue (managedType, out var cachedProxy)) {
+			return cachedProxy;
+		}
 
-			// Resolve the JNI name from the managed type's attributes
-			if (!TryGetJniNameForType (type, out var jniName)) {
-				return null;
-			}
+		var proxy = ResolveProxyForManagedType (managedType);
+		if (proxy is not null) {
+			_proxyCache.TryAdd (managedType, proxy);
+		}
 
-			// Look up the proxy type in the TypeMap dictionary
-			if (!self._typeMap.TryGetValue (jniName, out var proxyType)) {
-				return null;
-			}
+		return proxy;
+	}
 
+	JavaPeerProxy? ResolveProxyForManagedType (Type managedType)
+	{
+		var direct = managedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+		if (direct is not null) {
+			return direct;
+		}
+
+		if (_proxyTypeMap.TryGetValue (managedType, out var proxyType)) {
 			return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		}, this);
+		}
+
+		if (!TryGetJniNameForType (managedType, out var jniName)) {
+			return null;
+		}
+
+		if (!_typeMap.TryGetValue (jniName, out proxyType)) {
+			return null;
+		}
+
+		return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+	}
+
+	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
+	{
+		var proxy = GetProxyForManagedType (managedType);
+		if (proxy is not null) {
+			jniName = proxy.JniName;
+			return true;
+		}
+
+		return TryGetJniNameForType (managedType, out jniName);
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -28,19 +28,19 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		foreach (var r in base.GetSimpleReferences (type)) {
-			yield return r;
-		}
-
-		if (TrimmableTypeMap.TryGetJniNameForType (type, out var jniName)) {
+		if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName)) {
 			yield return jniName;
 			yield break;
+		}
+
+		foreach (var r in base.GetSimpleReferences (type)) {
+			yield return r;
 		}
 
 		// Walk the base type chain for managed-only subclasses (e.g., JavaProxyThrowable
 		// extends Java.Lang.Error but has no [Register] attribute itself).
 		for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType) {
-			if (TrimmableTypeMap.TryGetJniNameForType (baseType, out var baseJniName)) {
+			if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (baseType, out var baseJniName)) {
 				yield return baseJniName;
 				yield break;
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
 
 public abstract class FixtureTestBase
 {
-	static string TestFixtureAssemblyPath {
+	private protected static string TestFixtureAssemblyPath {
 		get {
 			var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
 				?? throw new InvalidOperationException ("Cannot determine test assembly directory");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -133,7 +133,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.True (assemblyAttrs.Count () >= 3);
 
 		var typeNames = GetTypeRefNames (reader);
-		Assert.Contains ("TypeMapAssociationAttribute", typeNames);
+		Assert.Contains (typeNames, name => name.StartsWith ("TypeMapAssociationAttribute", StringComparison.Ordinal));
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -85,6 +85,18 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Generate_ProxyType_UsesGenericJavaPeerProxyBase ()
+	{
+		var peers = ScanFixtures ();
+		using var stream = GenerateAssembly (peers);
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+		var typeNames = GetTypeRefNames (reader);
+
+		Assert.Contains ("JavaPeerProxy`1", typeNames);
+	}
+
+	[Fact]
 	public void Generate_HasIgnoresAccessChecksToAttribute ()
 	{
 		var peers = ScanFixtures ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -91,9 +91,25 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		using var stream = GenerateAssembly (peers);
 		using var pe = new PEReader (stream);
 		var reader = pe.GetMetadataReader ();
-		var typeNames = GetTypeRefNames (reader);
+		var proxyTypes = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Where (t => reader.GetString (t.Namespace) == "_TypeMap.Proxies")
+			.ToList ();
 
-		Assert.Contains ("JavaPeerProxy`1", typeNames);
+		Assert.NotEmpty (proxyTypes);
+		Assert.All (proxyTypes, proxyType => {
+			Assert.Equal (HandleKind.TypeSpecification, proxyType.BaseType.Kind);
+
+			var baseTypeSpec = reader.GetTypeSpecification ((TypeSpecificationHandle) proxyType.BaseType);
+			var baseTypeName = baseTypeSpec.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null);
+
+			Assert.StartsWith ("Java.Interop.JavaPeerProxy`1<", baseTypeName, StringComparison.Ordinal);
+		});
+
+		var objectProxy = proxyTypes.First (t => reader.GetString (t.Name) == "Java_Lang_Object_Proxy");
+		var objectProxyBaseType = reader.GetTypeSpecification ((TypeSpecificationHandle) objectProxy.BaseType);
+		Assert.Equal ("Java.Interop.JavaPeerProxy`1<Java.Lang.Object>",
+			objectProxyBaseType.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null));
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -174,10 +174,22 @@ public class ModelBuilderTests : FixtureTestBase
 			Assert.Single (model.ProxyTypes);
 			var proxy = model.ProxyTypes [0];
 			Assert.Equal (expectedProxyName, proxy.TypeName);
+			Assert.Equal (jniName, proxy.JniName);
 			Assert.Equal ("_TypeMap.Proxies", proxy.Namespace);
 			Assert.True (proxy.HasActivation);
 			Assert.Equal (managedName, proxy.TargetType.ManagedTypeName);
 			Assert.Equal (asmName, proxy.TargetType.AssemblyName);
+		}
+
+		[Fact]
+		public void Build_PeerWithActivation_CreatesAssociation ()
+		{
+			var peer = MakePeerWithActivation ("my/app/MainActivity", "MyApp.MainActivity", "App");
+			var model = BuildModel (new [] { peer }, "MyTypeMap");
+
+			var assoc = Assert.Single (model.Associations);
+			Assert.Equal ("MyApp.MainActivity, App", assoc.SourceTypeReference);
+			Assert.Equal ("_TypeMap.Proxies.MyApp_MainActivity_Proxy, MyTypeMap", assoc.AliasProxyTypeReference);
 		}
 
 		[Fact]
@@ -713,8 +725,11 @@ public class ModelBuilderTests : FixtureTestBase
 		var asmAttrs = reader.GetCustomAttributes (EntityHandle.AssemblyDefinition);
 		foreach (var attrHandle in asmAttrs) {
 			var attr = reader.GetCustomAttribute (attrHandle);
-			// Skip IgnoresAccessChecksTo attributes (their ctor is a MethodDefinition, not MemberRef)
-			if (attr.Constructor.Kind == HandleKind.MethodDefinition)
+			// Skip non-TypeMap attributes.
+			if (attr.Constructor.Kind != HandleKind.MemberReference)
+				continue;
+			var ctor = reader.GetMemberReference ((MemberReferenceHandle) attr.Constructor);
+			if (ctor.Parent.Kind != HandleKind.TypeSpecification)
 				continue;
 
 			var blobReader = reader.GetBlobReader (attr.Value);
@@ -729,6 +744,10 @@ public class ModelBuilderTests : FixtureTestBase
 			string? targetRef = null;
 			if (blobReader.RemainingBytes > 2) {
 				targetRef = blobReader.ReadSerializedString ();
+			}
+
+			if (string.IsNullOrEmpty (jniName) || !jniName.Contains ('/')) {
+				continue;
 			}
 
 			result.Add ((jniName, proxyRef, targetRef));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -203,6 +203,25 @@ public class ModelBuilderTests : FixtureTestBase
 			Assert.NotNull (proxy.InvokerType);
 			Assert.Equal ("Android.Views.View+IOnClickListenerInvoker", proxy.InvokerType!.ManagedTypeName);
 		}
+
+		[Theory]
+		[InlineData ("MyApp.PlainActivitySubclass")]
+		[InlineData ("MyApp.UnnamedActivity")]
+		[InlineData ("MyApp.UnregisteredClickListener")]
+		[InlineData ("MyApp.UnregisteredExporter")]
+		[InlineData ("MyApp.UnregisteredHelper")]
+		[InlineData ("MyApp.DerivedFromComponentBase")]
+		public void Build_Crc64RenamedPeer_StoresFinalJavaNameOnProxy (string managedName)
+		{
+			var peer = FindFixtureByManagedName (managedName);
+			Assert.StartsWith ("crc64", peer.JavaName);
+			Assert.NotEqual (peer.CompatJniName, peer.JavaName);
+
+			var model = BuildModel (new [] { peer }, "MyTypeMap");
+			var proxy = Assert.Single (model.ProxyTypes);
+
+			Assert.Equal (peer.JavaName, proxy.JniName);
+		}
 	}
 
 	public class FixtureScan
@@ -725,9 +744,9 @@ public class ModelBuilderTests : FixtureTestBase
 		var asmAttrs = reader.GetCustomAttributes (EntityHandle.AssemblyDefinition);
 		foreach (var attrHandle in asmAttrs) {
 			var attr = reader.GetCustomAttribute (attrHandle);
-			// Skip non-TypeMap attributes.
 			if (attr.Constructor.Kind != HandleKind.MemberReference)
 				continue;
+
 			var ctor = reader.GetMemberReference ((MemberReferenceHandle) attr.Constructor);
 			if (ctor.Parent.Kind != HandleKind.TypeSpecification)
 				continue;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -1,9 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
@@ -91,21 +88,11 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 	}
 
 	[Theory]
-	[InlineData ("MyApp.PlainActivitySubclass")]
-	[InlineData ("MyApp.UnregisteredClickListener")]
-	[InlineData ("MyApp.UnregisteredExporter")]
-	public void Scan_UnregisteredType_UsesCrc64PackageName (string managedName)
+	[InlineData ("MyApp.PlainActivitySubclass", "crc64eb3df85c64aa1af6/PlainActivitySubclass")]
+	[InlineData ("MyApp.UnregisteredClickListener", "crc64eb3df85c64aa1af6/UnregisteredClickListener")]
+	[InlineData ("MyApp.UnregisteredExporter", "crc64eb3df85c64aa1af6/UnregisteredExporter")]
+	public void Scan_UnregisteredType_UsesCrc64PackageName (string managedName, string expectedJavaName)
 	{
-		var fixtureAssembly = Assembly.LoadFrom (TestFixtureAssemblyPath);
-		var fixtureType = fixtureAssembly.GetType (managedName)
-			?? throw new InvalidOperationException ($"Could not load fixture type '{managedName}' from '{TestFixtureAssemblyPath}'.");
-
-		var assemblyName = fixtureType.Assembly.GetName ().Name
-			?? throw new InvalidOperationException ($"Could not determine assembly name for '{managedName}'.");
-		var data = Encoding.UTF8.GetBytes ($"{fixtureType.Namespace}:{assemblyName}");
-		var hash = System.IO.Hashing.Crc64.Hash (data);
-		var expectedJavaName = $"crc64{BitConverter.ToString (hash).Replace ("-", "").ToLowerInvariant ()}/{fixtureType.Name}";
-
 		Assert.Equal (expectedJavaName, FindFixtureByManagedName (managedName).JavaName);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -89,20 +89,16 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 		Assert.False (peer.DoNotGenerateAcw);
 		Assert.True (peer.IsUnconditional, "Should be unconditional due to [Activity]");
 	}
+
 	[Theory]
 	[InlineData ("MyApp.PlainActivitySubclass")]
 	[InlineData ("MyApp.UnregisteredClickListener")]
 	[InlineData ("MyApp.UnregisteredExporter")]
 	public void Scan_UnregisteredType_UsesCrc64PackageName (string managedName)
 	{
-		var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
-			?? throw new InvalidOperationException ("Cannot determine test assembly directory");
-		var fixtureAssemblyPath = Path.Combine (testAssemblyDir, "TestFixtures.dll");
-		var fixtureAssembly = Assembly.LoadFrom (fixtureAssemblyPath);
-		var fixtureType = fixtureAssembly.GetType (managedName);
-		if (fixtureType is null) {
-			throw new InvalidOperationException ($"Could not load fixture type '{managedName}' from '{fixtureAssemblyPath}'.");
-		}
+		var fixtureAssembly = Assembly.LoadFrom (TestFixtureAssemblyPath);
+		var fixtureType = fixtureAssembly.GetType (managedName)
+			?? throw new InvalidOperationException ($"Could not load fixture type '{managedName}' from '{TestFixtureAssemblyPath}'.");
 
 		var assemblyName = fixtureType.Assembly.GetName ().Name
 			?? throw new InvalidOperationException ($"Could not determine assembly name for '{managedName}'.");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text;
 using Xunit;
 
 namespace Microsoft.Android.Sdk.TrimmableTypeMap.Tests;
@@ -86,5 +88,28 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 		Assert.Equal ("com/example/dotformat/MainActivity", peer.CompatJniName);
 		Assert.False (peer.DoNotGenerateAcw);
 		Assert.True (peer.IsUnconditional, "Should be unconditional due to [Activity]");
+	}
+	[Theory]
+	[InlineData ("MyApp.PlainActivitySubclass")]
+	[InlineData ("MyApp.UnregisteredClickListener")]
+	[InlineData ("MyApp.UnregisteredExporter")]
+	public void Scan_UnregisteredType_UsesCrc64PackageName (string managedName)
+	{
+		var testAssemblyDir = Path.GetDirectoryName (typeof (FixtureTestBase).Assembly.Location)
+			?? throw new InvalidOperationException ("Cannot determine test assembly directory");
+		var fixtureAssemblyPath = Path.Combine (testAssemblyDir, "TestFixtures.dll");
+		var fixtureAssembly = Assembly.LoadFrom (fixtureAssemblyPath);
+		var fixtureType = fixtureAssembly.GetType (managedName);
+		if (fixtureType is null) {
+			throw new InvalidOperationException ($"Could not load fixture type '{managedName}' from '{fixtureAssemblyPath}'.");
+		}
+
+		var assemblyName = fixtureType.Assembly.GetName ().Name
+			?? throw new InvalidOperationException ($"Could not determine assembly name for '{managedName}'.");
+		var data = Encoding.UTF8.GetBytes ($"{fixtureType.Namespace}:{assemblyName}");
+		var hash = System.IO.Hashing.Crc64.Hash (data);
+		var expectedJavaName = $"crc64{BitConverter.ToString (hash).Replace ("-", "").ToLowerInvariant ()}/{fixtureType.Name}";
+
+		Assert.Equal (expectedJavaName, FindFixtureByManagedName (managedName).JavaName);
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
@@ -12,7 +12,7 @@ namespace Java.InteropTests
 	public class JavaPeerProxyTests
 	{
 		[Test]
-		public void ExplicitJniName_WinsOverTargetAttribute ()
+		public void Constructor_StoresJniNameAndTargetType ()
 		{
 			var proxy = new ExplicitNameProxy ();
 
@@ -22,22 +22,13 @@ namespace Java.InteropTests
 		}
 
 		[Test]
-		public void LegacyConstructor_UsesTargetAttribute ()
+		public void Constructor_StoresInvokerType ()
 		{
-			var proxy = new LegacyProxy ();
+			var proxy = new InvokerProxy ();
 
-			Assert.AreEqual ("test/ProxyTestPeer", proxy.JniName);
+			Assert.AreEqual ("custom/InvokerProxy", proxy.JniName);
 			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
-			Assert.IsNull (proxy.InvokerType);
-		}
-
-		[Test]
-		public void LegacyConstructor_ThrowsForTypeWithoutJniAttribute ()
-		{
-			var proxy = new LegacyUnregisteredProxy ();
-
-			var ex = Assert.Throws<InvalidOperationException> (() => _ = proxy.JniName);
-			Assert.That (ex?.Message, Does.Contain ("No JNI name is available"));
+			Assert.AreEqual (typeof (ProxyTestPeerInvoker), proxy.InvokerType);
 		}
 	}
 
@@ -54,42 +45,32 @@ namespace Java.InteropTests
 		}
 	}
 
-	sealed class UnregisteredProxyPeer : Java.Lang.Object
+	sealed class ProxyTestPeerInvoker : Java.Lang.Object
 	{
-		public UnregisteredProxyPeer ()
+		public ProxyTestPeerInvoker ()
 		{
 		}
 
-		public UnregisteredProxyPeer (IntPtr handle, JniHandleOwnership transfer)
+		public ProxyTestPeerInvoker (IntPtr handle, JniHandleOwnership transfer)
 			: base (handle, transfer)
 		{
 		}
 	}
 
-	sealed class ExplicitNameProxy : JavaPeerProxy<ProxyTestPeer>
+	sealed class ExplicitNameProxy : JavaPeerProxy
 	{
 		public ExplicitNameProxy ()
-			: base ("custom/ExplicitName", invokerType: null)
+			: base ("custom/ExplicitName", typeof (ProxyTestPeer), invokerType: null)
 		{
 		}
 
 		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
 	}
 
-	sealed class LegacyProxy : JavaPeerProxy
+	sealed class InvokerProxy : JavaPeerProxy<ProxyTestPeer>
 	{
-		public LegacyProxy ()
-			: base (typeof (ProxyTestPeer), invokerType: null)
-		{
-		}
-
-		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
-	}
-
-	sealed class LegacyUnregisteredProxy : JavaPeerProxy
-	{
-		public LegacyUnregisteredProxy ()
-			: base (typeof (UnregisteredProxyPeer), invokerType: null)
+		public InvokerProxy ()
+			: base ("custom/InvokerProxy", typeof (ProxyTestPeerInvoker))
 		{
 		}
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
@@ -1,0 +1,98 @@
+using System;
+
+using Android.Runtime;
+
+using Java.Interop;
+
+using NUnit.Framework;
+
+namespace Java.InteropTests
+{
+	[TestFixture]
+	public class JavaPeerProxyTests
+	{
+		[Test]
+		public void ExplicitJniName_WinsOverTargetAttribute ()
+		{
+			var proxy = new ExplicitNameProxy ();
+
+			Assert.AreEqual ("custom/ExplicitName", proxy.JniName);
+			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
+			Assert.IsNull (proxy.InvokerType);
+		}
+
+		[Test]
+		public void LegacyConstructor_UsesTargetAttribute ()
+		{
+			var proxy = new LegacyProxy ();
+
+			Assert.AreEqual ("test/ProxyTestPeer", proxy.JniName);
+			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
+			Assert.IsNull (proxy.InvokerType);
+		}
+
+		[Test]
+		public void LegacyConstructor_ThrowsForTypeWithoutJniAttribute ()
+		{
+			var proxy = new LegacyUnregisteredProxy ();
+
+			var ex = Assert.Throws<InvalidOperationException> (() => _ = proxy.JniName);
+			Assert.That (ex?.Message, Does.Contain ("No JNI name is available"));
+		}
+	}
+
+	[Register ("test/ProxyTestPeer", DoNotGenerateAcw = true)]
+	sealed class ProxyTestPeer : Java.Lang.Object
+	{
+		public ProxyTestPeer ()
+		{
+		}
+
+		public ProxyTestPeer (IntPtr handle, JniHandleOwnership transfer)
+			: base (handle, transfer)
+		{
+		}
+	}
+
+	sealed class UnregisteredProxyPeer : Java.Lang.Object
+	{
+		public UnregisteredProxyPeer ()
+		{
+		}
+
+		public UnregisteredProxyPeer (IntPtr handle, JniHandleOwnership transfer)
+			: base (handle, transfer)
+		{
+		}
+	}
+
+	sealed class ExplicitNameProxy : JavaPeerProxy<ProxyTestPeer>
+	{
+		public ExplicitNameProxy ()
+			: base ("custom/ExplicitName", invokerType: null)
+		{
+		}
+
+		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
+	}
+
+	sealed class LegacyProxy : JavaPeerProxy
+	{
+		public LegacyProxy ()
+			: base (typeof (ProxyTestPeer), invokerType: null)
+		{
+		}
+
+		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
+	}
+
+	sealed class LegacyUnregisteredProxy : JavaPeerProxy
+	{
+		public LegacyUnregisteredProxy ()
+			: base (typeof (UnregisteredProxyPeer), invokerType: null)
+		{
+		}
+
+		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
+	}
+}


### PR DESCRIPTION
- emit `TypeMapAssociation<Java.Lang.Object>` for proxied types so the trimmable runtime has a managed -> proxy mapping
- store the resolved JNI name on `JavaPeerProxy` and use it for reverse managed -> JNI lookups
- update the trimmable runtime to consult the proxy map before attribute-based fallback, while keeping the CRC64 scanner cleanup