### PR TITLE
[TrimmableTypeMap] Propagate deferred registerNatives to base classes

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -39,6 +39,7 @@ public class TrimmableTypeMapGenerator
 		}
 
 		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig));
+		PropagateDeferredRegistrationToBaseClasses (allPeers);
 
 		var generatedAssemblies = GenerateTypeMapAssemblies (allPeers, systemRuntimeVersion);
 		var jcwPeers = allPeers.Where (p =>
@@ -203,6 +204,38 @@ public class TrimmableTypeMapGenerator
 				}
 			} else {
 				logger.LogManifestReferencedTypeNotFoundWarning (name);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Propagates <see cref="JavaPeerInfo.CannotRegisterInStaticConstructor"/> up the base class chain.
+	/// When a type like NUnitInstrumentation has deferred registration, its base class
+	/// TestInstrumentation_1 must also defer — otherwise the base class <c>&lt;clinit&gt;</c> will call
+	/// <c>registerNatives</c> before the managed runtime is ready.
+	/// </summary>
+	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
+	{
+		var peersByJniName = new Dictionary<string, JavaPeerInfo> (StringComparer.Ordinal);
+		foreach (var peer in allPeers) {
+			if (!peersByJniName.ContainsKey (peer.JavaName)) {
+				peersByJniName [peer.JavaName] = peer;
+			}
+		}
+
+		foreach (var peer in allPeers) {
+			if (!peer.CannotRegisterInStaticConstructor) {
+				continue;
+			}
+
+			var current = peer;
+			while (current.BaseJavaName is { } baseJniName && peersByJniName.TryGetValue (baseJniName, out var basePeer)) {
+				if (basePeer.DoNotGenerateAcw) {
+					break;
+				}
+
+				basePeer.CannotRegisterInStaticConstructor = true;
+				current = basePeer;
 			}
 		}
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -216,26 +216,42 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
 	{
-		var peersByJniName = new Dictionary<string, JavaPeerInfo> (StringComparer.Ordinal);
+		var peersByJniName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
-			if (!peersByJniName.ContainsKey (peer.JavaName)) {
-				peersByJniName [peer.JavaName] = peer;
+			if (!peersByJniName.TryGetValue (peer.JavaName, out var peers)) {
+				peers = [];
+				peersByJniName [peer.JavaName] = peers;
 			}
+
+			peers.Add (peer);
 		}
 
 		foreach (var peer in allPeers) {
-			if (!peer.CannotRegisterInStaticConstructor) {
+			if (!peer.CannotRegisterInStaticConstructor || peer.BaseJavaName is not { } baseJniName) {
 				continue;
 			}
 
-			var current = peer;
-			while (current.BaseJavaName is { } baseJniName && peersByJniName.TryGetValue (baseJniName, out var basePeer)) {
-				if (basePeer.DoNotGenerateAcw) {
-					break;
+			var pendingBaseJniNames = new Queue<string> ();
+			var visitedPeers = new HashSet<JavaPeerInfo> ();
+			pendingBaseJniNames.Enqueue (baseJniName);
+
+			while (pendingBaseJniNames.Count > 0) {
+				var currentBaseJniName = pendingBaseJniNames.Dequeue ();
+				if (!peersByJniName.TryGetValue (currentBaseJniName, out var basePeers)) {
+					continue;
 				}
 
-				basePeer.CannotRegisterInStaticConstructor = true;
-				current = basePeer;
+				foreach (var basePeer in basePeers) {
+					if (!visitedPeers.Add (basePeer) || basePeer.DoNotGenerateAcw) {
+						continue;
+					}
+
+					basePeer.CannotRegisterInStaticConstructor = true;
+
+					if (basePeer.BaseJavaName is { } nextBaseJniName) {
+						pendingBaseJniNames.Enqueue (nextBaseJniName);
+					}
+				}
 			}
 		}
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -216,41 +216,51 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
 	{
-		var peersByJniName = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
+		var peersByJniName = BuildJniNameLookup (allPeers);
+
 		foreach (var peer in allPeers) {
-			if (!peersByJniName.TryGetValue (peer.JavaName, out var peers)) {
+			if (peer.CannotRegisterInStaticConstructor && peer.BaseJavaName is { } baseJniName) {
+				PropagateToAncestors (baseJniName, peersByJniName);
+			}
+		}
+	}
+
+	static Dictionary<string, List<JavaPeerInfo>> BuildJniNameLookup (List<JavaPeerInfo> allPeers)
+	{
+		var lookup = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
+		foreach (var peer in allPeers) {
+			if (!lookup.TryGetValue (peer.JavaName, out var peers)) {
 				peers = [];
-				peersByJniName [peer.JavaName] = peers;
+				lookup [peer.JavaName] = peers;
 			}
 
 			peers.Add (peer);
 		}
 
-		foreach (var peer in allPeers) {
-			if (!peer.CannotRegisterInStaticConstructor || peer.BaseJavaName is not { } baseJniName) {
+		return lookup;
+	}
+
+	static void PropagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
+	{
+		var pending = new Queue<string> ();
+		var visited = new HashSet<string> (StringComparer.Ordinal);
+		pending.Enqueue (startJniName);
+
+		while (pending.Count > 0) {
+			var jniName = pending.Dequeue ();
+			if (!visited.Add (jniName) || !peersByJniName.TryGetValue (jniName, out var peers)) {
 				continue;
 			}
 
-			var pendingBaseJniNames = new Queue<string> ();
-			var visitedPeers = new HashSet<JavaPeerInfo> ();
-			pendingBaseJniNames.Enqueue (baseJniName);
-
-			while (pendingBaseJniNames.Count > 0) {
-				var currentBaseJniName = pendingBaseJniNames.Dequeue ();
-				if (!peersByJniName.TryGetValue (currentBaseJniName, out var basePeers)) {
+			foreach (var peer in peers) {
+				if (peer.DoNotGenerateAcw) {
 					continue;
 				}
 
-				foreach (var basePeer in basePeers) {
-					if (!visitedPeers.Add (basePeer) || basePeer.DoNotGenerateAcw) {
-						continue;
-					}
+				peer.CannotRegisterInStaticConstructor = true;
 
-					basePeer.CannotRegisterInStaticConstructor = true;
-
-					if (basePeer.BaseJavaName is { } nextBaseJniName) {
-						pendingBaseJniNames.Enqueue (nextBaseJniName);
-					}
+				if (peer.BaseJavaName is { } nextJniName) {
+					pending.Enqueue (nextJniName);
 				}
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -216,52 +216,30 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
 	{
-		var peersByJniName = BuildJniNameLookup (allPeers);
-
+		// In practice only 1–2 types need propagation (one Application, maybe one
+		// Instrumentation), each with a short base-class chain.  A linear scan per
+		// ancestor is simpler and cheaper than building a Dictionary<JavaName, List<Peer>>
+		// lookup over all peers up front.
 		foreach (var peer in allPeers) {
-			if (peer.CannotRegisterInStaticConstructor && peer.BaseJavaName is { } baseJniName) {
-				PropagateToAncestors (baseJniName, peersByJniName);
+			if (peer.CannotRegisterInStaticConstructor) {
+				PropagateToAncestors (peer.BaseJavaName, allPeers);
 			}
 		}
 
-		static Dictionary<string, List<JavaPeerInfo>> BuildJniNameLookup (List<JavaPeerInfo> allPeers)
+		static void PropagateToAncestors (string? baseJniName, List<JavaPeerInfo> allPeers)
 		{
-			var lookup = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
-			foreach (var peer in allPeers) {
-				if (!lookup.TryGetValue (peer.JavaName, out var peers)) {
-					peers = [];
-					lookup [peer.JavaName] = peers;
-				}
-
-				peers.Add (peer);
-			}
-
-			return lookup;
-		}
-
-		static void PropagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
-		{
-			var pending = new Queue<string> ();
-			var visited = new HashSet<string> (StringComparer.Ordinal);
-			pending.Enqueue (startJniName);
-
-			while (pending.Count > 0) {
-				var jniName = pending.Dequeue ();
-				if (!visited.Add (jniName) || !peersByJniName.TryGetValue (jniName, out var peers)) {
-					continue;
-				}
-
-				foreach (var peer in peers) {
-					if (peer.DoNotGenerateAcw) {
+			while (baseJniName is not null) {
+				string? nextBase = null;
+				foreach (var basePeer in allPeers) {
+					if (basePeer.JavaName != baseJniName || basePeer.DoNotGenerateAcw) {
 						continue;
 					}
 
-					peer.CannotRegisterInStaticConstructor = true;
-
-					if (peer.BaseJavaName is { } nextJniName) {
-						pending.Enqueue (nextJniName);
-					}
+					basePeer.CannotRegisterInStaticConstructor = true;
+					nextBase = basePeer.BaseJavaName;
 				}
+
+				baseJniName = nextBase;
 			}
 		}
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -231,7 +231,7 @@ public class TrimmableTypeMapGenerator
 			while (baseJniName is not null) {
 				string? nextBase = null;
 				foreach (var basePeer in allPeers) {
-					if (basePeer.JavaName != baseJniName || basePeer.DoNotGenerateAcw) {
+					if (!string.Equals (basePeer.JavaName, baseJniName, StringComparison.Ordinal) || basePeer.DoNotGenerateAcw) {
 						continue;
 					}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -216,51 +216,51 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
 	{
-		var peersByJniName = BuildJniNameLookup (allPeers);
+		var peersByJniName = buildJniNameLookup (allPeers);
 
 		foreach (var peer in allPeers) {
 			if (peer.CannotRegisterInStaticConstructor && peer.BaseJavaName is { } baseJniName) {
-				PropagateToAncestors (baseJniName, peersByJniName);
+				propagateToAncestors (baseJniName, peersByJniName);
 			}
 		}
-	}
 
-	static Dictionary<string, List<JavaPeerInfo>> BuildJniNameLookup (List<JavaPeerInfo> allPeers)
-	{
-		var lookup = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
-		foreach (var peer in allPeers) {
-			if (!lookup.TryGetValue (peer.JavaName, out var peers)) {
-				peers = [];
-				lookup [peer.JavaName] = peers;
+		static Dictionary<string, List<JavaPeerInfo>> buildJniNameLookup (List<JavaPeerInfo> allPeers)
+		{
+			var lookup = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
+			foreach (var peer in allPeers) {
+				if (!lookup.TryGetValue (peer.JavaName, out var peers)) {
+					peers = [];
+					lookup [peer.JavaName] = peers;
+				}
+
+				peers.Add (peer);
 			}
 
-			peers.Add (peer);
+			return lookup;
 		}
 
-		return lookup;
-	}
+		static void propagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
+		{
+			var pending = new Queue<string> ();
+			var visited = new HashSet<string> (StringComparer.Ordinal);
+			pending.Enqueue (startJniName);
 
-	static void PropagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
-	{
-		var pending = new Queue<string> ();
-		var visited = new HashSet<string> (StringComparer.Ordinal);
-		pending.Enqueue (startJniName);
-
-		while (pending.Count > 0) {
-			var jniName = pending.Dequeue ();
-			if (!visited.Add (jniName) || !peersByJniName.TryGetValue (jniName, out var peers)) {
-				continue;
-			}
-
-			foreach (var peer in peers) {
-				if (peer.DoNotGenerateAcw) {
+			while (pending.Count > 0) {
+				var jniName = pending.Dequeue ();
+				if (!visited.Add (jniName) || !peersByJniName.TryGetValue (jniName, out var peers)) {
 					continue;
 				}
 
-				peer.CannotRegisterInStaticConstructor = true;
+				foreach (var peer in peers) {
+					if (peer.DoNotGenerateAcw) {
+						continue;
+					}
 
-				if (peer.BaseJavaName is { } nextJniName) {
-					pending.Enqueue (nextJniName);
+					peer.CannotRegisterInStaticConstructor = true;
+
+					if (peer.BaseJavaName is { } nextJniName) {
+						pending.Enqueue (nextJniName);
+					}
 				}
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -216,15 +216,15 @@ public class TrimmableTypeMapGenerator
 	/// </summary>
 	internal static void PropagateDeferredRegistrationToBaseClasses (List<JavaPeerInfo> allPeers)
 	{
-		var peersByJniName = buildJniNameLookup (allPeers);
+		var peersByJniName = BuildJniNameLookup (allPeers);
 
 		foreach (var peer in allPeers) {
 			if (peer.CannotRegisterInStaticConstructor && peer.BaseJavaName is { } baseJniName) {
-				propagateToAncestors (baseJniName, peersByJniName);
+				PropagateToAncestors (baseJniName, peersByJniName);
 			}
 		}
 
-		static Dictionary<string, List<JavaPeerInfo>> buildJniNameLookup (List<JavaPeerInfo> allPeers)
+		static Dictionary<string, List<JavaPeerInfo>> BuildJniNameLookup (List<JavaPeerInfo> allPeers)
 		{
 			var lookup = new Dictionary<string, List<JavaPeerInfo>> (StringComparer.Ordinal);
 			foreach (var peer in allPeers) {
@@ -239,7 +239,7 @@ public class TrimmableTypeMapGenerator
 			return lookup;
 		}
 
-		static void propagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
+		static void PropagateToAncestors (string startJniName, Dictionary<string, List<JavaPeerInfo>> peersByJniName)
 		{
 			var pending = new Queue<string> ();
 			var visited = new HashSet<string> (StringComparer.Ordinal);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -227,6 +227,52 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Execute_PropagatesDeferredRegistrationToBaseClasses ()
+	{
+		var basePeer = new JavaPeerInfo {
+			JavaName = "crc64aaa/TestInstrumentation_1", CompatJniName = "crc64aaa/TestInstrumentation_1",
+			ManagedTypeName = "Tests.TestInstrumentation`1", ManagedTypeNamespace = "Tests", ManagedTypeShortName = "TestInstrumentation`1",
+			AssemblyName = "Tests", IsUnconditional = false,
+			BaseJavaName = "android/app/Instrumentation",
+		};
+		var midPeer = new JavaPeerInfo {
+			JavaName = "crc64bbb/NUnitTestInstrumentation", CompatJniName = "crc64bbb/NUnitTestInstrumentation",
+			ManagedTypeName = "Tests.NUnitTestInstrumentation", ManagedTypeNamespace = "Tests", ManagedTypeShortName = "NUnitTestInstrumentation",
+			AssemblyName = "Tests", IsUnconditional = false,
+			BaseJavaName = "crc64aaa/TestInstrumentation_1",
+		};
+		var leafPeer = new JavaPeerInfo {
+			JavaName = "crc64ccc/NUnitInstrumentation", CompatJniName = "crc64ccc/NUnitInstrumentation",
+			ManagedTypeName = "Tests.NUnitInstrumentation", ManagedTypeNamespace = "Tests", ManagedTypeShortName = "NUnitInstrumentation",
+			AssemblyName = "Tests", IsUnconditional = false,
+			BaseJavaName = "crc64bbb/NUnitTestInstrumentation",
+		};
+		var peers = new List<JavaPeerInfo> { basePeer, midPeer, leafPeer };
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <instrumentation android:name="crc64ccc.NUnitInstrumentation" />
+			</manifest>
+			""");
+
+		var generator = CreateGenerator ();
+		generator.RootManifestReferencedTypes (peers, doc);
+
+		// RootManifestReferencedTypes sets the flag only on the directly matched leaf
+		Assert.True (leafPeer.CannotRegisterInStaticConstructor, "Leaf instrumentation should have deferred registration after manifest rooting.");
+		Assert.False (midPeer.CannotRegisterInStaticConstructor, "Mid peer should NOT have deferred registration before propagation.");
+		Assert.False (basePeer.CannotRegisterInStaticConstructor, "Base peer should NOT have deferred registration before propagation.");
+
+		// PropagateDeferredRegistrationToBaseClasses walks the BaseJavaName chain
+		TrimmableTypeMapGenerator.PropagateDeferredRegistrationToBaseClasses (peers);
+
+		Assert.True (leafPeer.CannotRegisterInStaticConstructor, "Leaf instrumentation should still have deferred registration.");
+		Assert.True (midPeer.CannotRegisterInStaticConstructor, "Mid peer should have deferred registration after propagation.");
+		Assert.True (basePeer.CannotRegisterInStaticConstructor, "Base peer should have deferred registration after propagation.");
+	}
+
+	[Fact]
 	public void RootManifestReferencedTypes_WarnsForUnresolvedTypes ()
 	{
 		var peers = new List<JavaPeerInfo> {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -227,7 +227,7 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void Execute_PropagatesDeferredRegistrationToBaseClasses ()
+	public void PropagateDeferredRegistrationToBaseClasses_PropagatesToBaseClassesOfManifestReferencedTypes ()
 	{
 		var basePeer = new JavaPeerInfo {
 			JavaName = "crc64aaa/TestInstrumentation_1", CompatJniName = "crc64aaa/TestInstrumentation_1",


### PR DESCRIPTION
## Summary

Fixes a startup crash (`UnsatisfiedLinkError: No implementation found for void mono.android.Runtime.registerNatives`) when running device tests with the trimmable typemap enabled.

## Background

Deferred `registerNatives` support was introduced across several PRs:

- **#10957** — Added `CannotRegisterInStaticConstructor` flag and set it in `JavaPeerScanner` for types with `[Application]` or `[Instrumentation]` attributes. The JCW generator skips the `static { registerNatives(...); }` block for these types and emits a lazy `__md_registerNatives()` helper instead.
- **#11037** — Extended deferred registration to manifest-rooted types: `RootManifestReferencedTypes` sets `CannotRegisterInStaticConstructor` on types matched by `<application>` or `<instrumentation>` manifest entries.
- **#11096** / **#11097** — Further scanner and JCW edge-case fixes, including deferred registration propagation for generated managed base types.

**None of these PRs propagated the flag to base classes in the Java type hierarchy.** When `NUnitInstrumentation` (listed in the manifest) correctly uses deferred registration, its base class `TestInstrumentation_1` still emits `static { registerNatives(...); }`. Since Java loads the base class `<clinit>` before the managed runtime registers the JNI native method, this crashes with `UnsatisfiedLinkError`.

## Changes

Add `PropagateDeferredRegistrationToBaseClasses()` in `TrimmableTypeMapGenerator`, called after `RootManifestReferencedTypes`. It walks each flagged peer's `BaseJavaName` chain with a simple linear scan and sets `CannotRegisterInStaticConstructor = true` on all base peers that have JCW stubs (i.e., `!DoNotGenerateAcw`). Framework MCW types are skipped.

In practice only 1–2 types need propagation (one Application, maybe one Instrumentation), each with a short base-class chain. A linear scan per ancestor is simpler and cheaper than building a `Dictionary<JavaName, List<Peer>>` lookup over all peers up front.

### Test

New unit test `PropagateDeferredRegistrationToBaseClasses_PropagatesToBaseClassesOfManifestReferencedTypes` verifies a 3-level instrumentation hierarchy (base → mid → leaf) where only the leaf is in the manifest. After propagation, all three peers have deferred registration.

All 353 existing unit tests continue to pass.