### PR TITLE
Use Assert.Inconclusive for emulator acquisition failures

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -176,9 +176,9 @@ namespace Xamarin.Android.Build.Tests
 			dotnet.ProjectDirectory = XABuildPaths.TestAssemblyOutputDirectory;
 			if (!dotnet.Build ("AcquireAndroidTarget", parameters: new string[] { "TestAvdForceCreation=false", $"Configuration={XABuildPaths.Configuration}" })) {
 				var output = string.Join (Environment.NewLine, dotnet.LastBuildOutput);
-				if (output.Contains ("did not finish launching") ||
-					output.Contains ("Emulator failed to start") ||
-					output.Contains ("failed to exit within the timeout")) {
+				if (output.Contains ("did not finish launching", StringComparison.OrdinalIgnoreCase) ||
+					output.Contains ("Emulator failed to start", StringComparison.OrdinalIgnoreCase) ||
+					output.Contains ("failed to exit within the timeout", StringComparison.OrdinalIgnoreCase)) {
 					Assert.Inconclusive ("Failed to acquire emulator due to transient infrastructure issue.");
 				}
 				Assert.Fail ($"Failed to acquire emulator:{Environment.NewLine}{output}");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -175,13 +175,14 @@ namespace Xamarin.Android.Build.Tests
 			var dotnet = new DotNetCLI (Path.Combine (XABuildPaths.TopDirectory, "src", "Xamarin.Android.Build.Tasks", "Tests", "Xamarin.Android.Build.Tests", "Emulator.csproj"));
 			dotnet.ProjectDirectory = XABuildPaths.TestAssemblyOutputDirectory;
 			if (!dotnet.Build ("AcquireAndroidTarget", parameters: new string[] { "TestAvdForceCreation=false", $"Configuration={XABuildPaths.Configuration}" })) {
-				var output = string.Join (Environment.NewLine, dotnet.LastBuildOutput);
-				if (output.Contains ("did not finish launching", StringComparison.OrdinalIgnoreCase) ||
-					output.Contains ("Emulator failed to start", StringComparison.OrdinalIgnoreCase) ||
-					output.Contains ("failed to exit within the timeout", StringComparison.OrdinalIgnoreCase)) {
+				bool isTransient = dotnet.LastBuildOutput.Any (line =>
+					line.Contains ("did not finish launching", StringComparison.OrdinalIgnoreCase) ||
+					line.Contains ("Emulator failed to start", StringComparison.OrdinalIgnoreCase) ||
+					line.Contains ("failed to exit within the timeout", StringComparison.OrdinalIgnoreCase));
+				if (isTransient) {
 					Assert.Inconclusive ("Failed to acquire emulator due to transient infrastructure issue.");
 				}
-				Assert.Fail ($"Failed to acquire emulator:{Environment.NewLine}{output}");
+				Assert.Fail ("Failed to acquire emulator.");
 			}
 			WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -174,7 +174,9 @@ namespace Xamarin.Android.Build.Tests
 			// shell out to msbuild and start the emulator again
 			var dotnet = new DotNetCLI (Path.Combine (XABuildPaths.TopDirectory, "src", "Xamarin.Android.Build.Tasks", "Tests", "Xamarin.Android.Build.Tests", "Emulator.csproj"));
 			dotnet.ProjectDirectory = XABuildPaths.TestAssemblyOutputDirectory;
-			Assert.IsTrue (dotnet.Build ("AcquireAndroidTarget", parameters: new string[] { "TestAvdForceCreation=false", $"Configuration={XABuildPaths.Configuration}" }), "Failed to acquire emulator.");
+			if (!dotnet.Build ("AcquireAndroidTarget", parameters: new string[] { "TestAvdForceCreation=false", $"Configuration={XABuildPaths.Configuration}" })) {
+				Assert.Inconclusive ("Failed to acquire emulator.");
+			}
 			WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -175,7 +175,13 @@ namespace Xamarin.Android.Build.Tests
 			var dotnet = new DotNetCLI (Path.Combine (XABuildPaths.TopDirectory, "src", "Xamarin.Android.Build.Tasks", "Tests", "Xamarin.Android.Build.Tests", "Emulator.csproj"));
 			dotnet.ProjectDirectory = XABuildPaths.TestAssemblyOutputDirectory;
 			if (!dotnet.Build ("AcquireAndroidTarget", parameters: new string[] { "TestAvdForceCreation=false", $"Configuration={XABuildPaths.Configuration}" })) {
-				Assert.Inconclusive ("Failed to acquire emulator.");
+				var output = string.Join (Environment.NewLine, dotnet.LastBuildOutput);
+				if (output.Contains ("did not finish launching") ||
+					output.Contains ("Emulator failed to start") ||
+					output.Contains ("failed to exit within the timeout")) {
+					Assert.Inconclusive ("Failed to acquire emulator due to transient infrastructure issue.");
+				}
+				Assert.Fail ($"Failed to acquire emulator:{Environment.NewLine}{output}");
 			}
 			WaitFor ((int)TimeSpan.FromSeconds (5).TotalMilliseconds);
 		}


### PR DESCRIPTION
## Summary

Emulator acquisition failures in `DeviceTest.RestartDevice()` are infrastructure issues (unresponsive emulator, boot timeout, Vulkan driver errors), not actual test failures. This changes the assertion from `Assert.IsTrue` to `Assert.Inconclusive` so that these tests are marked as **skipped/inconclusive** rather than turning the build red.

## Context

In [build 13830308](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=13830308&view=ms.vss-build-web.run-extensions-tab), `DotNetInstallAndRunPreviousSdk(True, MonoVM)` and `DotNetInstallAndRunPreviousSdk(False, NativeAOT)` both failed with:

`
Failed to acquire emulator.
Expected: True
But was: False
`

The WearOS emulator was present (emulator-5570) but `adb shell echo OK` timed out — a pure infrastructure issue that shouldn't mark tests as failed.
