### PR TITLE
[Mono.Android] fix global ref leak in TypeManager.Activate

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Views;
@@ -43,6 +44,47 @@ namespace Xamarin.Android.RuntimeTests
 				var inflater = (LayoutInflater)Application.Context.GetSystemService (Context.LayoutInflaterService);
 				inflater.Inflate (Resource.Layout.upper_lower_custom, null);
 			}, "Regression test for widgets with uppercase and lowercase namespace (bug #23880) failed.");
+		}
+
+		// https://github.com/dotnet/android/issues/11101
+		[Test]
+		public void InflateCustomView_ShouldNotLeakGlobalRefs ()
+		{
+			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService);
+			Assert.IsNotNull (inflater);
+
+			// Warm up: inflate once to populate caches and type mappings,
+			// and let any background thread activity from previous tests settle.
+			inflater.Inflate (Resource.Layout.lowercase_custom, null);
+			CollectGarbage (times: 3);
+
+			int grefBefore = Java.Interop.Runtime.GlobalReferenceCount;
+
+			// Use a large number of inflations so that a real leak (3+ global refs
+			// per inflate) produces a delta far above any background noise from
+			// Android system services, GC bridge processing, or finalizer threads.
+			const int inflateCount = 100;
+			for (int i = 0; i < inflateCount; i++) {
+				inflater.Inflate (Resource.Layout.lowercase_custom, null);
+			}
+
+			CollectGarbage (times: 3);
+
+			int grefAfter = Java.Interop.Runtime.GlobalReferenceCount;
+			int delta = grefAfter - grefBefore;
+
+			// A real leak would produce delta >= 300 (3 leaked refs per inflate).
+			// Use a generous threshold to tolerate background noise on real devices.
+			Assert.IsTrue (delta <= 100,
+				$"Global reference leak detected: {delta} extra global refs after inflating/GC'ing {inflateCount} custom views. Before={grefBefore}, After={grefAfter}");
+
+			static void CollectGarbage (int times)
+			{
+				for (int i = 0; i < times; i++) {
+					GC.Collect ();
+					GC.WaitForPendingFinalizers ();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/11101
Fixes: https://github.com/dotnet/android/issues/10989

Context: https://github.com/dotnet/android/commit/5c23bcda8 (PR #9640)

The Java.Interop Unification (5c23bcda8) changed `Object` to extend `JavaObject`, introducing an additional `ConstructPeer` call in the constructor chain. `TypeManager.Activate` was updated to use `SetPeerReference` but never set the `Activatable` state flag. Without it, each `ConstructPeer` call in the constructor chain (`JavaObject()` and `Object.SetHandle()`) creates a new JNI global ref, overwriting the previous one without deleting it — leaking 3 global refs per `LayoutInflater.Inflate` call.

Before the fix, the new test fails with:

    Global reference leak detected: 30 extra global refs after
    inflating/GC'ing 10 custom views. Before=207, After=237

This went unnoticed because the `Activate` path is only triggered when Java creates .NET objects (not the other way around). The two main scenarios are Activity recreation and custom C# views in Android XML layouts. Most developers use .NET MAUI, which has a single Activity and does not use custom C# views in Android layout XML files, so neither scenario was commonly hit.

Changes:

  - Promote `GetUninitializedObject` from a local function in `CreateProxy` to a shared static method. It sets `Activatable | Replaceable`, which tells `ConstructPeer` to return early and not create duplicate global refs.

  - Have `Activate` call `GetUninitializedObject` then `ConstructPeer` to create one global ref while `jobject` is still a valid JNI local ref. The `Activatable` flag then prevents duplicates during the constructor chain.

  - Add regression test that inflates custom views and asserts JNI global reference count does not grow.