### PR TITLE
[Mono.Android] follow up remaining value manager activation fixes

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -181,12 +181,12 @@ namespace Java.Interop {
 		internal static void Activate (IntPtr jobject, ConstructorInfo cinfo, object? []? parms)
 		{
 			try {
-				var newobj = RuntimeHelpers.GetUninitializedObject (cinfo.DeclaringType!);
-				if (newobj is IJavaPeerable peer) {
-					peer.SetPeerReference (new JniObjectReference (jobject));
-				} else {
-					throw new InvalidOperationException ($"Unsupported type: '{newobj}'");
-				}
+				var newobj = GetUninitializedObject (cinfo.DeclaringType!);
+				var reference = new JniObjectReference (jobject);
+				JniEnvironment.Runtime.ValueManager.ConstructPeer (
+					newobj,
+					ref reference,
+					JniObjectReferenceOptions.Copy);
 				cinfo.Invoke (newobj, parms);
 			} catch (Exception e) {
 				var m = FormattableString.Invariant (
@@ -425,15 +425,15 @@ namespace Java.Interop {
 			throw new MissingMethodException (
 					"No constructor found for " + type.FullName + "::.ctor(System.IntPtr, Android.Runtime.JniHandleOwnership)",
 					CreateJavaLocationException ());
+		}
 
-			static IJavaPeerable GetUninitializedObject (
-					[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-					Type type)
-			{
-				var v   = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
-				v.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
-				return v;
-			}
+		static IJavaPeerable GetUninitializedObject (
+				[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+				Type type)
+		{
+			var v   = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
+			v.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+			return v;
 		}
 
 		public static void RegisterType (string java_class, Type t)

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -268,13 +268,25 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 	void ActivateViaReflection (JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
 	{
 		var declType  = GetDeclaringType (cinfo);
+		var self      = GetUninitializedObject (declType);
 
-#pragma warning disable IL2072
-		var self      = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (declType);
-#pragma warning restore IL2072
-		self.SetPeerReference (reference);
+		// ConstructPeer BEFORE the constructor to create a proper
+		// global ref and eliminate the race window where bridge
+		// processing could see a raw local ref.
+		// See: https://github.com/dotnet/android/issues/11101
+		JniEnvironment.Runtime.ValueManager.ConstructPeer (
+			self, ref reference, JniObjectReferenceOptions.Copy);
 
 		cinfo.Invoke (self, argumentValues);
+
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Activation constructors are preserved by the runtime typemap.")]
+		static IJavaPeerable GetUninitializedObject (
+				[DynamicallyAccessedMembers (Constructors)] Type type)
+		{
+			var value = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
+			value.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+			return value;
+		}
 
 		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "🤷‍♂️")]
 		[return: DynamicallyAccessedMembers (Constructors)]

--- a/src/Mono.Android/Microsoft.Android.Runtime/SimpleValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/SimpleValueManager.cs
@@ -228,13 +228,25 @@ class SimpleValueManager : JniRuntime.JniValueManager
 	void ActivateViaReflection (JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
 	{
 		var declType  = GetDeclaringType (cinfo);
+		var self      = GetUninitializedObject (declType);
 
-#pragma warning disable IL2072
-		var self      = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (declType);
-#pragma warning restore IL2072
-		self.SetPeerReference (reference);
+		// ConstructPeer BEFORE the constructor to create a proper
+		// global ref and eliminate the race window where bridge
+		// processing could see a raw local ref.
+		// See: https://github.com/dotnet/android/issues/11101
+		JniEnvironment.Runtime.ValueManager.ConstructPeer (
+			self, ref reference, JniObjectReferenceOptions.Copy);
 
 		cinfo.Invoke (self, argumentValues);
+
+		[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Activation constructors are preserved by the runtime typemap.")]
+		static IJavaPeerable GetUninitializedObject (
+				[DynamicallyAccessedMembers (Constructors)] Type type)
+		{
+			var value = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (type);
+			value.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+			return value;
+		}
 
 		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "🤷‍♂️")]
 		[return: DynamicallyAccessedMembers (Constructors)]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -50,7 +50,8 @@ namespace Xamarin.Android.RuntimeTests
 		[Test]
 		public void InflateCustomView_ShouldNotLeakGlobalRefs ()
 		{
-			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService)!;
+			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService);
+			Assert.IsNotNull (inflater);
 
 			// Warm up: inflate once to ensure all caches and type mappings are populated
 			inflater.Inflate (Resource.Layout.lowercase_custom, null);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -1,4 +1,5 @@
-﻿using Android.App;
+﻿using System;
+using Android.App;
 using Android.Content;
 using Android.Util;
 using Android.Views;
@@ -43,6 +44,43 @@ namespace Xamarin.Android.RuntimeTests
 				var inflater = (LayoutInflater)Application.Context.GetSystemService (Context.LayoutInflaterService);
 				inflater.Inflate (Resource.Layout.upper_lower_custom, null);
 			}, "Regression test for widgets with uppercase and lowercase namespace (bug #23880) failed.");
+		}
+
+		// https://github.com/dotnet/android/issues/11101
+		[Test]
+		public void InflateCustomView_ShouldNotLeakGlobalRefs ()
+		{
+			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService)!;
+
+			// Warm up: inflate once to ensure all caches and type mappings are populated
+			inflater.Inflate (Resource.Layout.lowercase_custom, null);
+
+			CollectGarbage (times: 3);
+
+			int grefBefore = Java.Interop.Runtime.GlobalReferenceCount;
+
+			for (int i = 0; i < 10; i++) {
+				inflater.Inflate (Resource.Layout.lowercase_custom, null);
+			}
+
+			CollectGarbage (times: 3);
+
+			int grefAfter = Java.Interop.Runtime.GlobalReferenceCount;
+			int delta = grefAfter - grefBefore;
+
+			// Each inflate creates a LinearLayout + CustomButton via TypeManager.Activate.
+			// If global refs are leaking during activation, delta will be >= 10.
+			// Allow a small delta for noise (cached objects, etc.)
+			Assert.IsTrue (delta <= 5,
+				$"Global reference leak detected: {delta} extra global refs after inflating/GC'ing 10 custom views. Before={grefBefore}, After={grefAfter}");
+
+			static void CollectGarbage (int times)
+			{
+				for (int i = 0; i < times; i++) {
+					GC.Collect ();
+					GC.WaitForPendingFinalizers ();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
Follow-up to #11112.

This PR fixes:

- `JavaMarshalValueManager.ActivateViaReflection()`
- `SimpleValueManager.ActivateViaReflection()`
