### PR TITLE
[TrimmableTypeMap] Use proxy-provided JNI names

### DIFF
--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Java.Interop;
 
 namespace Microsoft.Android.Runtime;
@@ -28,20 +27,11 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 
 	protected override IEnumerable<string> GetSimpleReferences (Type type)
 	{
-		if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName)) {
-			yield return jniName;
-			yield break;
-		}
-
-		foreach (var r in base.GetSimpleReferences (type)) {
-			yield return r;
-		}
-
-		// Walk the base type chain for managed-only subclasses (e.g., JavaProxyThrowable
-		// extends Java.Lang.Error but has no [Register] attribute itself).
-		for (var baseType = type.BaseType; baseType is not null; baseType = baseType.BaseType) {
-			if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (baseType, out var baseJniName)) {
-				yield return baseJniName;
+		// In the trimmable typemap path, JNI names come from generated proxy metadata only.
+		// Managed-only subclasses can still inherit the JNI name of a mapped base type.
+		for (var currentType = type; currentType is not null; currentType = currentType.BaseType) {
+			if (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (currentType, out var jniName)) {
+				yield return jniName;
 				yield break;
 			}
 		}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -85,6 +85,39 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Generate_ProxyCtor_PassesJniNameWithoutMetadataOverrides ()
+	{
+		var peer = MakePeerWithActivation ("test/TypeA", "Test.TypeA", "TestAsm");
+
+		using var stream = GenerateAssembly (new [] { peer }, "CtorJniNameTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+		var proxyType = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Single (t => reader.GetString (t.Name) == "Test_TypeA_Proxy");
+
+		var methods = proxyType.GetMethods ()
+			.Select (h => reader.GetMethodDefinition (h))
+			.Select (m => reader.GetString (m.Name))
+			.ToList ();
+
+		Assert.DoesNotContain ("get_JniName", methods);
+		Assert.DoesNotContain ("get_TargetType", methods);
+		Assert.DoesNotContain ("get_InvokerType", methods);
+
+		var ctorHandle = proxyType.GetMethods ()
+			.First (h => reader.GetString (reader.GetMethodDefinition (h).Name) == ".ctor");
+		var ctor = reader.GetMethodDefinition (ctorHandle);
+		var body = pe.GetMethodBody (ctor.RelativeVirtualAddress);
+		var ilBytes = body.GetILBytes ();
+		if (ilBytes == null) {
+			throw new InvalidOperationException ("Expected proxy constructor IL.");
+		}
+
+		Assert.Equal ("test/TypeA", TryGetLdstrOperand (ilBytes, reader));
+	}
+
+	[Fact]
 	public void Generate_ProxyType_UsesGenericJavaPeerProxyBase ()
 	{
 		var peers = ScanFixtures ();
@@ -647,5 +680,22 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			Assert.True (rvaFields.Count < allStrings.Count,
 				$"Expected fewer RVA fields ({rvaFields.Count}) than total strings ({allStrings.Count}) due to deduplication");
 		}
+	}
+
+	static string? TryGetLdstrOperand (IReadOnlyList<byte> il, MetadataReader reader)
+	{
+		for (int i = 0; i <= il.Count - 5; i++) {
+			if (il [i] != (byte) ILOpCode.Ldstr) {
+				continue;
+			}
+
+			int token = il [i + 1]
+				| (il [i + 2] << 8)
+				| (il [i + 3] << 16)
+				| (il [i + 4] << 24);
+			return reader.GetUserString (MetadataTokens.UserStringHandle (token));
+		}
+
+		return null;
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
@@ -30,6 +30,17 @@ namespace Java.InteropTests
 			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
 			Assert.AreEqual (typeof (ProxyTestPeerInvoker), proxy.InvokerType);
 		}
+
+		[Test]
+		public void JniName_Getter_IsNotVirtual ()
+		{
+			var property = typeof (JavaPeerProxy).GetProperty (nameof (JavaPeerProxy.JniName));
+			Assert.IsNotNull (property);
+
+			var getter = property.GetMethod;
+			Assert.IsNotNull (getter);
+			Assert.False (getter.IsVirtual);
+		}
 	}
 
 	[Register ("test/ProxyTestPeer", DoNotGenerateAcw = true)]


### PR DESCRIPTION
## Summary
- make `JavaPeerProxy` own `JniName`, `TargetType`, and `InvokerType` as ctor-backed metadata
- pass the canonical JNI name and type metadata from generated proxy subclasses into the base ctor
- remove the trimmable typemap runtime path that reads JNI names from attributes
- add focused tests covering the deterministic proxy contract and the absence of generated property overrides

## Testing
- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj --no-restore`