### PR TITLE
[TrimmableTypeMap] Implement alias support in codegen and runtime

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -36,6 +36,11 @@ sealed class TypeMapAssemblyData
 	public List<TypeMapAssociationData> Associations { get; } = new ();
 
 	/// <summary>
+	/// Alias holder types to emit — one per alias group (≥2 types sharing a JNI name).
+	/// </summary>
+	public List<AliasHolderData> AliasHolders { get; } = new ();
+
+	/// <summary>
 	/// Assembly names that need [IgnoresAccessChecksTo] for cross-assembly n_* calls.
 	/// </summary>
 	public List<string> IgnoresAccessChecksTo { get; } = new ();
@@ -252,7 +257,7 @@ sealed record ActivationCtorData
 
 /// <summary>
 /// One [assembly: TypeMapAssociation(typeof(Source), typeof(AliasProxy))] entry.
-/// Links a managed type to the proxy that holds its alias TypeMap entry.
+/// Links a managed type to the alias holder that owns the alias group.
 /// </summary>
 sealed record TypeMapAssociationData
 {
@@ -262,7 +267,30 @@ sealed record TypeMapAssociationData
 	public required string SourceTypeReference { get; init; }
 
 	/// <summary>
-	/// Assembly-qualified proxy type reference (the alias holder proxy).
+	/// Assembly-qualified proxy type reference (the alias holder).
 	/// </summary>
 	public required string AliasProxyTypeReference { get; init; }
+}
+
+/// <summary>
+/// An alias holder class to generate in the TypeMap assembly.
+/// Extends JavaPeerProxy and implements IJavaPeerAliases.
+/// Emitted when multiple .NET types map to the same JNI name.
+/// </summary>
+sealed class AliasHolderData
+{
+	/// <summary>
+	/// Simple type name, e.g., "Test_AliasTarget_Aliases".
+	/// </summary>
+	public required string TypeName { get; init; }
+
+	/// <summary>
+	/// Namespace for alias holder types.
+	/// </summary>
+	public string Namespace { get; init; } = "_TypeMap.Aliases";
+
+	/// <summary>
+	/// Indexed TypeMap keys, e.g., ["test/AliasTarget[0]", "test/AliasTarget[1]"].
+	/// </summary>
+	public required List<string> AliasKeys { get; init; }
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -108,12 +108,35 @@ static class ModelBuilder
 	static void EmitPeers (TypeMapAssemblyData model, string jniName,
 		List<JavaPeerInfo> peersForName, string assemblyName, HashSet<string> usedProxyNames)
 	{
-		// First peer is the "primary" — it gets the base JNI name entry.
-		// Remaining peers get indexed alias entries: "jni/name[1]", "jni/name[2]", ...
-		JavaPeerProxyData? primaryProxy = null;
+		bool isAliasGroup = peersForName.Count > 1;
+
+		if (!isAliasGroup) {
+			// Single peer — no aliases needed, emit directly with the base JNI name
+			var peer = peersForName [0];
+			bool hasProxy = peer.ActivationCtor != null || peer.InvokerTypeName != null;
+			bool isAcw = !peer.DoNotGenerateAcw && !peer.IsInterface && peer.MarshalMethods.Count > 0;
+
+			JavaPeerProxyData? proxy = null;
+			if (hasProxy) {
+				proxy = BuildProxyType (peer, jniName, usedProxyNames, isAcw);
+				model.ProxyTypes.Add (proxy);
+			}
+
+			model.Entries.Add (BuildEntry (peer, proxy, assemblyName, jniName));
+			return;
+		}
+
+		// Alias group: generate an alias holder and indexed entries for each peer.
+		// The base JNI name maps to the alias holder; each peer gets "[0]", "[1]", etc.
+		var aliasKeys = new List<string> ();
+		string holderTypeName = jniName.Replace ('/', '_').Replace ('$', '_') + "_Aliases";
+		var holderNamespace = "_TypeMap.Aliases";
+		string holderRef = AssemblyQualify ($"{holderNamespace}.{holderTypeName}", assemblyName);
+
 		for (int i = 0; i < peersForName.Count; i++) {
 			var peer = peersForName [i];
-			string entryJniName = i == 0 ? jniName : $"{jniName}[{i}]";
+			string entryJniName = $"{jniName}[{i}]";
+			aliasKeys.Add (entryJniName);
 
 			bool hasProxy = peer.ActivationCtor != null || peer.InvokerTypeName != null;
 			bool isAcw = !peer.DoNotGenerateAcw && !peer.IsInterface && peer.MarshalMethods.Count > 0;
@@ -124,25 +147,27 @@ static class ModelBuilder
 				model.ProxyTypes.Add (proxy);
 			}
 
-			if (i == 0) {
-				primaryProxy = proxy;
-			}
-
 			model.Entries.Add (BuildEntry (peer, proxy, assemblyName, entryJniName));
 
-			// Emit TypeMapAssociation for all proxy-backed types so managed → proxy
-			// lookup works even when the final JNI name differs from the type's attributes.
-			// Generic definitions are included — their proxy types derive from the
-			// non-generic `JavaPeerProxy` base so the CLR can load them without
-			// resolving an open generic argument.
-			var assocProxy = (i > 0 && primaryProxy != null) ? primaryProxy : proxy;
-			if (assocProxy != null) {
-				model.Associations.Add (new TypeMapAssociationData {
-					SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
-					AliasProxyTypeReference = AssemblyQualify ($"{assocProxy.Namespace}.{assocProxy.TypeName}", assemblyName),
-				});
-			}
+			// Link each alias type to the alias holder for trimming
+			model.Associations.Add (new TypeMapAssociationData {
+				SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
+				AliasProxyTypeReference = holderRef,
+			});
 		}
+
+		// Base JNI name entry → alias holder (self-referencing trim target, kept alive by associations)
+		model.Entries.Add (new TypeMapAttributeData {
+			JniName = jniName,
+			ProxyTypeReference = holderRef,
+			TargetTypeReference = holderRef,
+		});
+
+		model.AliasHolders.Add (new AliasHolderData {
+			TypeName = holderTypeName,
+			Namespace = holderNamespace,
+			AliasKeys = aliasKeys,
+		});
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -123,6 +123,12 @@ static class ModelBuilder
 			}
 
 			model.Entries.Add (BuildEntry (peer, proxy, assemblyName, jniName));
+			if (proxy != null && peer.IsGenericDefinition) {
+				model.Associations.Add (new TypeMapAssociationData {
+					SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
+					AliasProxyTypeReference = AssemblyQualify ($"{proxy.Namespace}.{proxy.TypeName}", assemblyName),
+				});
+			}
 			return;
 		}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -81,7 +81,8 @@ sealed class TypeMapAssemblyEmitter
 	TypeReferenceHandle _jniTypeRef;
 	TypeReferenceHandle _notSupportedExceptionRef;
 	TypeReferenceHandle _runtimeHelpersRef;
-	TypeReferenceHandle _iJavaPeerAliasesRef;
+	TypeReferenceHandle _javaPeerAliasesAttrRef;
+	MemberReferenceHandle _javaPeerAliasesAttrCtorRef;
 
 	MemberReferenceHandle _getTypeFromHandleRef;
 	MemberReferenceHandle _getUninitializedObjectRef;
@@ -195,8 +196,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("NotSupportedException"));
 		_runtimeHelpersRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System.Runtime.CompilerServices"), metadata.GetOrAddString ("RuntimeHelpers"));
-		_iJavaPeerAliasesRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
-			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerAliases"));
+		_javaPeerAliasesAttrRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerAliasesAttribute"));
 
 		_jniNativeMethodRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JniNativeMethod"));
@@ -296,6 +297,7 @@ sealed class TypeMapAssemblyEmitter
 
 		EmitTypeMapAttributeCtorRef ();
 		EmitTypeMapAssociationAttributeCtorRef ();
+		EmitJavaPeerAliasesAttributeCtorRef ();
 	}
 
 	void EmitTypeMapAttributeCtorRef ()
@@ -463,83 +465,54 @@ sealed class TypeMapAssemblyEmitter
 	{
 		var metadata = _pe.Metadata;
 
-		// Alias holder base ctor: JavaPeerProxy(string jniName, Type targetType, Type? invokerType)
-		var baseCtorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
-				rt => rt.Void (),
-				p => {
-					p.AddParameter ().Type ().String ();
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-				}));
+		// Alias holders are plain classes (NOT JavaPeerProxy subclasses).
+		// GetCustomAttribute<JavaPeerProxy>() returns null for these — the fast path
+		// stays clean. Aliases are discovered via [JavaPeerAliases] attribute only when needed.
+		var objectRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
+			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Object"));
 
-		var typeDefHandle = metadata.AddTypeDefinition (
+		metadata.AddTypeDefinition (
 			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
 			metadata.GetOrAddString (holder.Namespace),
 			metadata.GetOrAddString (holder.TypeName),
-			_javaPeerProxyNonGenericRef,
+			objectRef,
 			MetadataTokens.FieldDefinitionHandle (metadata.GetRowCount (TableIndex.Field) + 1),
 			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
 
-		// Implement IJavaPeerAliases
-		metadata.AddInterfaceImplementation (typeDefHandle, _iJavaPeerAliasesRef);
-
-		// .ctor — call base(jniName: "<aliases>", targetType: typeof(void), invokerType: null)
-		var ctorHandle = _pe.EmitBody (".ctor",
-			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
-			encoder => {
-				encoder.OpCode (ILOpCode.Ldarg_0);
-				encoder.LoadString (metadata.GetOrAddUserString ("<aliases>"));
-				encoder.OpCode (ILOpCode.Ldtoken);
-				var voidTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
-					metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Void"));
-				encoder.Token (voidTypeRef);
-				encoder.Call (_getTypeFromHandleRef);
-				encoder.OpCode (ILOpCode.Ldnull);
-				encoder.Call (baseCtorRef);
-				encoder.OpCode (ILOpCode.Ret);
-			});
-
-		// Self-apply the attribute: [AliasHolder] on the alias holder class itself.
-		var emptyBlob = _pe.BuildAttributeBlob (b => { });
-		metadata.AddCustomAttribute (typeDefHandle, ctorHandle, emptyBlob);
-
-		// CreateInstance → throw new NotSupportedException("...")
-		EmitCreateInstanceBody (encoder => {
-			encoder.LoadString (metadata.GetOrAddUserString ("Alias holders do not support direct activation."));
-			encoder.OpCode (ILOpCode.Newobj);
-			encoder.Token (_notSupportedExceptionCtorRef);
-			encoder.OpCode (ILOpCode.Throw);
-		});
-
-		// get_Aliases → return new string[] { "key[0]", "key[1]", ... }
-		EmitAliasesGetter (holder.AliasKeys);
+		// Apply [JavaPeerAliases("key[0]", "key[1]", ...)] to the type
+		EmitJavaPeerAliasesAttribute (holder.AliasKeys);
 	}
 
-	void EmitAliasesGetter (List<string> aliasKeys)
+	void EmitJavaPeerAliasesAttributeCtorRef ()
 	{
-		var metadata = _pe.Metadata;
-		var stringTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
-			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("String"));
+		// JavaPeerAliasesAttribute(params string[] aliases) — in Mono.Android, Java.Interop namespace
+		_javaPeerAliasesAttrCtorRef = _pe.AddMemberRef (_javaPeerAliasesAttrRef, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
+				rt => rt.Void (),
+				p => p.AddParameter ().Type ().SZArray ().String ()));
+	}
 
-		_pe.EmitBody ("get_Aliases",
-			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Final,
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
-				rt => rt.Type ().SZArray ().String (),
-				p => { }),
-			encoder => {
-				encoder.LoadConstantI4 (aliasKeys.Count);
-				encoder.OpCode (ILOpCode.Newarr);
-				encoder.Token (stringTypeRef);
-				for (int i = 0; i < aliasKeys.Count; i++) {
-					encoder.OpCode (ILOpCode.Dup);
-					encoder.LoadConstantI4 (i);
-					encoder.LoadString (metadata.GetOrAddUserString (aliasKeys [i]));
-					encoder.OpCode (ILOpCode.Stelem_ref);
-				}
-				encoder.OpCode (ILOpCode.Ret);
-			});
+	void EmitJavaPeerAliasesAttribute (List<string> aliasKeys)
+	{
+		// Encode the attribute blob: prolog (0x0001), then packed string array, then NumNamed (0x0000).
+		// The params string[] is encoded as: element count (uint32), then each string as SerializedString.
+		var blobBuilder = new BlobBuilder ();
+		blobBuilder.WriteUInt16 (1); // prolog
+		blobBuilder.WriteInt32 (aliasKeys.Count); // array length
+		foreach (var key in aliasKeys) {
+			WriteSerializedString (blobBuilder, key);
+		}
+		blobBuilder.WriteUInt16 (0); // NumNamed
+
+		var lastTypeDef = MetadataTokens.TypeDefinitionHandle (_pe.Metadata.GetRowCount (TableIndex.TypeDef));
+		_pe.Metadata.AddCustomAttribute (lastTypeDef, _javaPeerAliasesAttrCtorRef, _pe.Metadata.GetOrAddBlob (blobBuilder));
+	}
+
+	static void WriteSerializedString (BlobBuilder builder, string value)
+	{
+		var bytes = System.Text.Encoding.UTF8.GetBytes (value);
+		builder.WriteCompressedInteger (bytes.Length);
+		builder.WriteBytes (bytes);
 	}
 
 	void EmitCreateInstance (JavaPeerProxyData proxy)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -505,8 +505,9 @@ sealed class TypeMapAssemblyEmitter
 		var emptyBlob = _pe.BuildAttributeBlob (b => { });
 		metadata.AddCustomAttribute (typeDefHandle, ctorHandle, emptyBlob);
 
-		// CreateInstance → throw new NotSupportedException()
+		// CreateInstance → throw new NotSupportedException("...")
 		EmitCreateInstanceBody (encoder => {
+			encoder.LoadString (metadata.GetOrAddUserString ("Alias holders do not support direct activation."));
 			encoder.OpCode (ILOpCode.Newobj);
 			encoder.Token (_notSupportedExceptionCtorRef);
 			encoder.OpCode (ILOpCode.Throw);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -81,6 +81,7 @@ sealed class TypeMapAssemblyEmitter
 	TypeReferenceHandle _jniTypeRef;
 	TypeReferenceHandle _notSupportedExceptionRef;
 	TypeReferenceHandle _runtimeHelpersRef;
+	TypeReferenceHandle _iJavaPeerAliasesRef;
 
 	MemberReferenceHandle _getTypeFromHandleRef;
 	MemberReferenceHandle _getUninitializedObjectRef;
@@ -150,6 +151,10 @@ sealed class TypeMapAssemblyEmitter
 			EmitProxyType (proxy, wrapperHandles);
 		}
 
+		foreach (var holder in model.AliasHolders) {
+			EmitAliasHolderType (holder);
+		}
+
 		foreach (var entry in model.Entries) {
 			EmitTypeMapAttribute (entry);
 		}
@@ -190,6 +195,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("NotSupportedException"));
 		_runtimeHelpersRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System.Runtime.CompilerServices"), metadata.GetOrAddString ("RuntimeHelpers"));
+		_iJavaPeerAliasesRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerAliases"));
 
 		_jniNativeMethodRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JniNativeMethod"));
@@ -450,6 +457,88 @@ sealed class TypeMapAssemblyEmitter
 		if (proxy.IsAcw) {
 			EmitRegisterNatives (proxy.NativeRegistrations, wrapperHandles);
 		}
+	}
+
+	void EmitAliasHolderType (AliasHolderData holder)
+	{
+		var metadata = _pe.Metadata;
+
+		// Alias holder base ctor: JavaPeerProxy(string jniName, Type targetType, Type? invokerType)
+		var baseCtorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().String ();
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
+		var typeDefHandle = metadata.AddTypeDefinition (
+			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
+			metadata.GetOrAddString (holder.Namespace),
+			metadata.GetOrAddString (holder.TypeName),
+			_javaPeerProxyNonGenericRef,
+			MetadataTokens.FieldDefinitionHandle (metadata.GetRowCount (TableIndex.Field) + 1),
+			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
+
+		// Implement IJavaPeerAliases
+		metadata.AddInterfaceImplementation (typeDefHandle, _iJavaPeerAliasesRef);
+
+		// .ctor — call base(jniName: "<aliases>", targetType: typeof(void), invokerType: null)
+		var ctorHandle = _pe.EmitBody (".ctor",
+			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
+			encoder => {
+				encoder.OpCode (ILOpCode.Ldarg_0);
+				encoder.LoadString (metadata.GetOrAddUserString ("<aliases>"));
+				encoder.OpCode (ILOpCode.Ldtoken);
+				var voidTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
+					metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Void"));
+				encoder.Token (voidTypeRef);
+				encoder.Call (_getTypeFromHandleRef);
+				encoder.OpCode (ILOpCode.Ldnull);
+				encoder.Call (baseCtorRef);
+				encoder.OpCode (ILOpCode.Ret);
+			});
+
+		// Self-apply the attribute: [AliasHolder] on the alias holder class itself.
+		var emptyBlob = _pe.BuildAttributeBlob (b => { });
+		metadata.AddCustomAttribute (typeDefHandle, ctorHandle, emptyBlob);
+
+		// CreateInstance → throw new NotSupportedException()
+		EmitCreateInstanceBody (encoder => {
+			encoder.OpCode (ILOpCode.Newobj);
+			encoder.Token (_notSupportedExceptionCtorRef);
+			encoder.OpCode (ILOpCode.Throw);
+		});
+
+		// get_Aliases → return new string[] { "key[0]", "key[1]", ... }
+		EmitAliasesGetter (holder.AliasKeys);
+	}
+
+	void EmitAliasesGetter (List<string> aliasKeys)
+	{
+		var metadata = _pe.Metadata;
+		var stringTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
+			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("String"));
+
+		_pe.EmitBody ("get_Aliases",
+			MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName | MethodAttributes.HideBySig | MethodAttributes.NewSlot | MethodAttributes.Final,
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
+				rt => rt.Type ().SZArray ().String (),
+				p => { }),
+			encoder => {
+				encoder.LoadConstantI4 (aliasKeys.Count);
+				encoder.OpCode (ILOpCode.Newarr);
+				encoder.Token (stringTypeRef);
+				for (int i = 0; i < aliasKeys.Count; i++) {
+					encoder.OpCode (ILOpCode.Dup);
+					encoder.LoadConstantI4 (i);
+					encoder.LoadString (metadata.GetOrAddUserString (aliasKeys [i]));
+					encoder.OpCode (ILOpCode.Stelem_ref);
+				}
+				encoder.OpCode (ILOpCode.Ret);
+			});
 	}
 
 	void EmitCreateInstance (JavaPeerProxyData proxy)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -407,17 +407,9 @@ sealed class TypeMapAssemblyEmitter
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
 
-		// Self-apply: the proxy type is its own [JavaPeerProxy] attribute.
-		// This enables type.GetCustomAttribute<JavaPeerProxy>() to instantiate the proxy
-		// at runtime for AOT-safe type resolution.
-		var selfAttrCtorRef = _pe.AddMemberRef (typeDefHandle, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }));
-		var selfAttrBlob = _pe.BuildAttributeBlob (b => { });
-		metadata.AddCustomAttribute (typeDefHandle, selfAttrCtorRef, selfAttrBlob);
-
 		// .ctor — pass the resolved JNI name, (for generic-definition base) target type, and
 		// optional invoker type to the base proxy constructor.
-		_pe.EmitBody (".ctor",
+		var selfAttrCtorDef = _pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
@@ -440,6 +432,12 @@ sealed class TypeMapAssemblyEmitter
 				encoder.Call (baseCtorRef);
 				encoder.OpCode (ILOpCode.Ret);
 			});
+
+		// Self-apply: the proxy type is its own [JavaPeerProxy] attribute.
+		// This enables type.GetCustomAttribute<JavaPeerProxy>() to instantiate the proxy
+		// at runtime for AOT-safe type resolution.
+		var selfAttrBlob = _pe.BuildAttributeBlob (b => { });
+		metadata.AddCustomAttribute (typeDefHandle, selfAttrCtorDef, selfAttrBlob);
 
 		// CreateInstance
 		EmitCreateInstance (proxy);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -469,7 +469,7 @@ sealed class TypeMapAssemblyEmitter
 		var objectRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Object"));
 
-		metadata.AddTypeDefinition (
+		var typeDefHandle = metadata.AddTypeDefinition (
 			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
 			metadata.GetOrAddString (holder.Namespace),
 			metadata.GetOrAddString (holder.TypeName),
@@ -478,7 +478,7 @@ sealed class TypeMapAssemblyEmitter
 			MetadataTokens.MethodDefinitionHandle (metadata.GetRowCount (TableIndex.MethodDef) + 1));
 
 		// Apply [JavaPeerAliases("key[0]", "key[1]", ...)] to the type
-		EmitJavaPeerAliasesAttribute (holder.AliasKeys);
+		EmitJavaPeerAliasesAttribute (typeDefHandle, holder.AliasKeys);
 	}
 
 	void EmitJavaPeerAliasesAttributeCtorRef ()
@@ -490,7 +490,7 @@ sealed class TypeMapAssemblyEmitter
 				p => p.AddParameter ().Type ().SZArray ().String ()));
 	}
 
-	void EmitJavaPeerAliasesAttribute (List<string> aliasKeys)
+	void EmitJavaPeerAliasesAttribute (TypeDefinitionHandle typeDefHandle, List<string> aliasKeys)
 	{
 		// Encode the attribute blob: prolog (0x0001), then packed string array, then NumNamed (0x0000).
 		// The params string[] is encoded as: element count (uint32), then each string as SerializedString.
@@ -502,8 +502,7 @@ sealed class TypeMapAssemblyEmitter
 		}
 		blobBuilder.WriteUInt16 (0); // NumNamed
 
-		var lastTypeDef = MetadataTokens.TypeDefinitionHandle (_pe.Metadata.GetRowCount (TableIndex.TypeDef));
-		_pe.Metadata.AddCustomAttribute (lastTypeDef, _javaPeerAliasesAttrCtorRef, _pe.Metadata.GetOrAddBlob (blobBuilder));
+		_pe.Metadata.AddCustomAttribute (typeDefHandle, _javaPeerAliasesAttrCtorRef, _pe.Metadata.GetOrAddBlob (blobBuilder));
 	}
 
 	static void WriteSerializedString (BlobBuilder builder, string value)

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -7,6 +7,21 @@ using Android.Runtime;
 namespace Java.Interop
 {
 	/// <summary>
+	/// Implemented by generated alias holder proxy types. When multiple .NET types
+	/// map to the same JNI name (e.g., <c>JavaCollection</c> and <c>JavaCollection&lt;T&gt;</c>
+	/// both map to <c>"java/util/Collection"</c>), the base JNI name entry points to
+	/// an alias holder that lists the indexed TypeMap keys for each alias type.
+	/// </summary>
+	public interface IJavaPeerAliases
+	{
+		/// <summary>
+		/// Gets the indexed TypeMap keys for this alias group (e.g., <c>"java/util/Collection[0]"</c>,
+		/// <c>"java/util/Collection[1]"</c>).
+		/// </summary>
+		string[] Aliases { get; }
+	}
+
+	/// <summary>
 	/// Base attribute class for generated proxy types that enable AOT-safe type mapping
 	/// between Java and .NET types.
 	/// </summary>

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -7,18 +7,27 @@ using Android.Runtime;
 namespace Java.Interop
 {
 	/// <summary>
-	/// Implemented by generated alias holder proxy types. When multiple .NET types
+	/// Attribute applied to generated alias holder types. When multiple .NET types
 	/// map to the same JNI name (e.g., <c>JavaCollection</c> and <c>JavaCollection&lt;T&gt;</c>
 	/// both map to <c>"java/util/Collection"</c>), the base JNI name entry points to
-	/// an alias holder that lists the indexed TypeMap keys for each alias type.
+	/// a plain holder class annotated with this attribute, which lists the indexed
+	/// TypeMap keys for each alias type.
 	/// </summary>
-	public interface IJavaPeerAliases
+	/// <remarks>
+	/// The alias holder is NOT a <see cref="JavaPeerProxy"/> subclass — this ensures
+	/// <c>GetCustomAttribute&lt;JavaPeerProxy&gt;()</c> returns null for alias entries,
+	/// keeping the fast path (non-alias types) free of alias checks.
+	/// </remarks>
+	[AttributeUsage (AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
+	public sealed class JavaPeerAliasesAttribute : Attribute
 	{
 		/// <summary>
 		/// Gets the indexed TypeMap keys for this alias group (e.g., <c>"java/util/Collection[0]"</c>,
 		/// <c>"java/util/Collection[1]"</c>).
 		/// </summary>
-		string[] Aliases { get; }
+		public string[] Aliases { get; }
+
+		public JavaPeerAliasesAttribute (params string[] aliases) => Aliases = aliases;
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -76,60 +76,47 @@ class TrimmableTypeMap
 		}
 	}
 
-	internal bool TryGetTargetType (string jniSimpleReference, [NotNullWhen (true)] out Type? type)
-	{
-		type = GetProxyForJavaType (jniSimpleReference)?.TargetType;
-		return type is not null;
-	}
-
 	/// <summary>
-	/// Resolves the <see cref="JavaPeerProxy"/> for a managed type via the CLR
-	/// <c>TypeMapping</c> proxy dictionary.
+	/// Returns all target types mapped to a JNI name. For non-alias entries, returns a
+	/// single-element array. For alias groups, returns the surviving target types from
+	/// each alias key. Returns false when no mapping exists or all aliases were trimmed.
 	/// </summary>
-	/// <remarks>
-	/// The generator emits exactly one <c>TypeMapAssociation</c> per generic peer,
-	/// keyed by the open generic definition (Java erases generics, so one proxy
-	/// fits every closed instantiation). Closed instantiations are normalised to
-	/// their generic type definition before the lookup because the CLR lazy
-	/// dictionary does identity-based key matching
-	/// (see <c>dotnet/runtime</c> <c>TypeMapLazyDictionary.cs</c>).
-	/// <see cref="Type.GetGenericTypeDefinition"/> is safe under full AOT + trim
-	/// (it is not <c>RequiresDynamicCode</c>). Java→managed construction of a
-	/// closed generic peer still requires a closed <see cref="Type"/> at the call
-	/// site and is tracked separately.
-	/// </remarks>
-	/// <summary>
-	/// Enumerates all proxy types for a JNI name, including alias entries.
-	/// If the base JNI name maps to an alias holder (annotated with <see cref="JavaPeerAliasesAttribute"/>),
-	/// enumerates the explicit alias keys. Otherwise yields only the primary type.
-	/// </summary>
-	internal IEnumerable<Type> GetAllTypesForJniName (string jniName)
+	internal bool TryGetTargetTypes (string jniName, [NotNullWhen (true)] out Type[]? types)
 	{
-		if (!_typeMap.TryGetValue (jniName, out var primaryType)) {
-			return [];
+		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
+			types = null;
+			return false;
 		}
 
-		// Fast path: non-alias entry — most JNI names map directly to a proxy
-		if (primaryType.GetCustomAttribute<JavaPeerProxy> (inherit: false) is not null) {
-			return [primaryType];
+		// Fast path: non-alias entry (the vast majority of JNI names)
+		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+		if (proxy is not null) {
+			types = [proxy.TargetType];
+			return true;
 		}
 
-		// Slow path: alias holder — enumerate the explicit alias keys
-		var aliases = primaryType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
+		// Slow path: alias holder — collect surviving target types
+		var aliases = mappedType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
 		if (aliases is null) {
-			return [];
+			types = null;
+			return false;
 		}
 
-		return GetAliasedProxyTypes (aliases);
-	}
-
-	IEnumerable<Type> GetAliasedProxyTypes (JavaPeerAliasesAttribute aliases)
-	{
+		var result = new List<Type> ();
 		foreach (var key in aliases.Aliases) {
-			if (_typeMap.TryGetValue (key, out var aliasType)) {
-				yield return aliasType;
+			var aliasProxy = GetProxyForJavaType (key);
+			if (aliasProxy is not null) {
+				result.Add (aliasProxy.TargetType);
 			}
 		}
+
+		if (result.Count == 0) {
+			types = null;
+			return false;
+		}
+
+		types = result.ToArray ();
+		return true;
 	}
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
@@ -167,15 +154,14 @@ class TrimmableTypeMap
 			}
 
 			// Alias holders don't have JavaPeerProxy — GetCustomAttribute returns null naturally.
-			// No alias check needed here; callers use GetAliasesForJniName when proxy is null.
 			return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
 	/// <summary>
-	/// Reads the alias holder's explicit key list and returns the proxy whose
-	/// <c>TargetType</c> is assignable from <paramref name="targetType"/>.
+	/// Returns the proxy whose TargetType exactly matches <paramref name="targetType"/>
+	/// from an alias group's explicit key list.
 	/// </summary>
 	static JavaPeerProxy? GetProxyFromAliases (TrimmableTypeMap self, JavaPeerAliasesAttribute aliases, Type targetType)
 	{
@@ -184,7 +170,7 @@ class TrimmableTypeMap
 				continue;
 			}
 			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (aliasProxy is not null && targetType.IsAssignableFrom (aliasProxy.TargetType)) {
+			if (aliasProxy is not null && aliasProxy.TargetType == targetType) {
 				return aliasProxy;
 			}
 		}
@@ -192,9 +178,23 @@ class TrimmableTypeMap
 	}
 
 	/// <summary>
-	/// Reads the <see cref="JavaPeerAliasesAttribute"/> from the TypeMap entry for the given JNI name.
-	/// Returns null when the entry is not an alias holder.
+	/// Returns the first surviving proxy from an alias group's key list.
+	/// Used when no specific targetType is available.
 	/// </summary>
+	static JavaPeerProxy? GetFirstProxyFromAliases (TrimmableTypeMap self, JavaPeerAliasesAttribute aliases)
+	{
+		foreach (var key in aliases.Aliases) {
+			if (!self._typeMap.TryGetValue (key, out var aliasProxyType)) {
+				continue;
+			}
+			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+			if (aliasProxy is not null) {
+				return aliasProxy;
+			}
+		}
+		return null;
+	}
+
 	JavaPeerAliasesAttribute? GetAliasesForJniName (string jniName)
 	{
 		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
@@ -233,11 +233,13 @@ class TrimmableTypeMap
 						}
 
 						// GetProxyForJavaType returns null for alias holders —
-						// resolve from the alias group when a targetType is available.
-						if (proxy is null && targetType is not null) {
+						// resolve from the alias group.
+						if (proxy is null) {
 							var aliases = self.GetAliasesForJniName (className);
 							if (aliases is not null) {
-								var aliasProxy = GetProxyFromAliases (self, aliases, targetType);
+								var aliasProxy = targetType is not null
+									? GetProxyFromAliases (self, aliases, targetType)
+									: GetFirstProxyFromAliases (self, aliases);
 								if (aliasProxy is not null) {
 									return aliasProxy;
 								}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -98,6 +98,28 @@ class TrimmableTypeMap
 	/// closed generic peer still requires a closed <see cref="Type"/> at the call
 	/// site and is tracked separately.
 	/// </remarks>
+	/// <summary>
+	/// Enumerates all proxy types for a JNI name, including alias entries.
+	/// If the base JNI name maps to an alias holder (implementing <see cref="IJavaPeerAliases"/>),
+	/// enumerates the explicit alias keys. Otherwise yields only the primary type.
+	/// </summary>
+	internal IEnumerable<Type> GetAllTypesForJniName (string jniName)
+	{
+		if (!_typeMap.TryGetValue (jniName, out var primaryType)) {
+			yield break;
+		}
+
+		var proxy = primaryType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+		if (proxy is IJavaPeerAliases aliases) {
+			foreach (var key in aliases.Aliases) {
+				if (_typeMap.TryGetValue (key, out var aliasType)) {
+					yield return aliasType;
+				}
+			}
+		} else {
+			yield return primaryType;
+		}
+	}
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
 		if (managedType.IsGenericType && !managedType.IsGenericTypeDefinition) {
@@ -105,11 +127,21 @@ class TrimmableTypeMap
 		}
 
 		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
-			if (self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
-				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+			if (!self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
+				return s_noPeerSentinel;
 			}
 
-			return s_noPeerSentinel;
+			var proxy = proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+			if (proxy is null) {
+				return s_noPeerSentinel;
+			}
+
+			// If _proxyTypeMap mapped this type to an alias holder, resolve the actual proxy
+			if (proxy is IJavaPeerAliases aliases) {
+				return ResolveAlias (self, aliases, type) ?? s_noPeerSentinel;
+			}
+
+			return proxy;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
@@ -121,17 +153,27 @@ class TrimmableTypeMap
 				return s_noPeerSentinel;
 			}
 
-			var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (proxy is null) {
-				// Alias typemap entries (for example "jni/name[1]") are not implemented yet.
-				// Support for them will be added in a follow-up for https://github.com/dotnet/android/issues/10788.
-				throw new NotImplementedException (
-					$"Trimmable typemap alias handling is not implemented yet for '{name}'.");
-			}
-
-			return proxy;
+			return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
+	}
+
+	/// <summary>
+	/// Resolves a specific managed type from an alias group by iterating
+	/// the explicit alias keys and checking TargetType on each proxy.
+	/// </summary>
+	static JavaPeerProxy? ResolveAlias (TrimmableTypeMap self, IJavaPeerAliases aliases, Type targetType)
+	{
+		foreach (var key in aliases.Aliases) {
+			if (!self._typeMap.TryGetValue (key, out var aliasProxyType)) {
+				continue;
+			}
+			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+			if (aliasProxy is not null && aliasProxy.TargetType == targetType) {
+				return aliasProxy;
+			}
+		}
+		return null;
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -341,16 +341,19 @@ class TrimmableTypeMap
 				return;
 			}
 
-			if (!s_instance._typeMap.TryGetValue (className, out var type)) {
+			var proxies = s_instance.GetProxiesForJniName (className);
+			if (proxies.Length == 0) {
 				return;
 			}
 
-			var proxy = type.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (proxy is IAndroidCallableWrapper acw) {
-				// Use the class reference passed from Java (via C++) — not JniType(className)
-				// which resolves via FindClass and may get a different class from a different ClassLoader.
-				using var jniType = new JniType (ref classRef, JniObjectReferenceOptions.Copy);
-				acw.RegisterNatives (jniType);
+			// Use the class reference passed from Java (via C++) — not JniType(className)
+			// which resolves via FindClass and may get a different class from a different ClassLoader.
+			// Registering natives on that other instance is silently wrong.
+			using var jniType = new JniType (ref classRef, JniObjectReferenceOptions.Copy);
+			foreach (var proxy in proxies) {
+				if (proxy is IAndroidCallableWrapper acw) {
+					acw.RegisterNatives (jniType);
+				}
 			}
 		} catch (Exception ex) {
 			Environment.FailFast ($"TrimmableTypeMap: Failed to register natives for class '{className}'.", ex);

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -138,7 +138,7 @@ class TrimmableTypeMap
 
 			// If _proxyTypeMap mapped this type to an alias holder, resolve the actual proxy
 			if (proxy is IJavaPeerAliases aliases) {
-				return ResolveAlias (self, aliases, type) ?? s_noPeerSentinel;
+				return GetProxyFromAliases (self, aliases, type) ?? s_noPeerSentinel;
 			}
 
 			return proxy;
@@ -153,27 +153,47 @@ class TrimmableTypeMap
 				return s_noPeerSentinel;
 			}
 
-			return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+			var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+
+			// Alias holders are not real proxies — skip them here.
+			// Callers that need alias resolution use GetProxyFromAliases directly.
+			if (proxy is IJavaPeerAliases) {
+				return s_noPeerSentinel;
+			}
+
+			return proxy ?? s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
 	/// <summary>
-	/// Resolves a specific managed type from an alias group by iterating
-	/// the explicit alias keys and checking TargetType on each proxy.
+	/// Reads the alias holder's explicit key list and returns the proxy whose
+	/// <c>TargetType</c> is assignable from <paramref name="targetType"/>.
 	/// </summary>
-	static JavaPeerProxy? ResolveAlias (TrimmableTypeMap self, IJavaPeerAliases aliases, Type targetType)
+	static JavaPeerProxy? GetProxyFromAliases (TrimmableTypeMap self, IJavaPeerAliases aliases, Type targetType)
 	{
 		foreach (var key in aliases.Aliases) {
 			if (!self._typeMap.TryGetValue (key, out var aliasProxyType)) {
 				continue;
 			}
 			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (aliasProxy is not null && aliasProxy.TargetType == targetType) {
+			if (aliasProxy is not null && targetType.IsAssignableFrom (aliasProxy.TargetType)) {
 				return aliasProxy;
 			}
 		}
 		return null;
+	}
+
+	/// <summary>
+	/// Reads the <see cref="IJavaPeerAliases"/> attribute from the TypeMap entry for the given JNI name.
+	/// Returns null when the entry is not an alias holder.
+	/// </summary>
+	IJavaPeerAliases? GetAliasesForJniName (string jniName)
+	{
+		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
+			return null;
+		}
+		return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) as IJavaPeerAliases;
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
@@ -203,6 +223,18 @@ class TrimmableTypeMap
 						var proxy = self.GetProxyForJavaType (className);
 						if (proxy != null && (targetType is null || TargetTypeMatches (targetType, proxy.TargetType))) {
 							return proxy;
+						}
+
+						// GetProxyForJavaType returns null for alias holders —
+						// resolve from the alias group when a targetType is available.
+						if (proxy is null && targetType is not null) {
+							var aliases = self.GetAliasesForJniName (className);
+							if (aliases is not null) {
+								var aliasProxy = GetProxyFromAliases (self, aliases, targetType);
+								if (aliasProxy is not null) {
+									return aliasProxy;
+								}
+							}
 						}
 					}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -30,7 +30,7 @@ class TrimmableTypeMap
 	readonly IReadOnlyDictionary<string, Type> _typeMap;
 	readonly IReadOnlyDictionary<Type, Type> _proxyTypeMap;
 	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
-	readonly ConcurrentDictionary<string, JavaPeerProxy> _peerProxyCache = new (StringComparer.Ordinal);
+	readonly ConcurrentDictionary<string, JavaPeerProxy[]> _jniProxyCache = new (StringComparer.Ordinal);
 
 	TrimmableTypeMap ()
 	{
@@ -83,40 +83,76 @@ class TrimmableTypeMap
 	/// </summary>
 	internal bool TryGetTargetTypes (string jniName, [NotNullWhen (true)] out Type[]? types)
 	{
-		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
+		var proxies = GetProxiesForJniName (jniName);
+		if (proxies.Length == 0) {
 			types = null;
 			return false;
 		}
 
-		// Fast path: non-alias entry (the vast majority of JNI names)
-		var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		if (proxy is not null) {
-			types = [proxy.TargetType];
-			return true;
+		types = new Type [proxies.Length];
+		for (int i = 0; i < proxies.Length; i++) {
+			types [i] = proxies [i].TargetType;
 		}
+		return true;
+	}
 
-		// Slow path: alias holder — collect surviving target types
-		var aliases = mappedType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
-		if (aliases is null) {
-			types = null;
-			return false;
+	/// <summary>
+	/// Resolves and caches all proxies for a JNI name. For non-alias entries, returns a
+	/// single-element array. For alias groups, resolves each alias key and returns the
+	/// surviving proxies. Returns an empty array when no mapping exists or all aliases were trimmed.
+	/// </summary>
+	JavaPeerProxy[] GetProxiesForJniName (string jniName)
+	{
+		return _jniProxyCache.GetOrAdd (jniName, static (name, self) => {
+			if (!self._typeMap.TryGetValue (name, out var mappedType)) {
+				return [];
+			}
+
+			// Fast path: non-alias entry
+			var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+			if (proxy is not null) {
+				return [proxy];
+			}
+
+			// Slow path: alias holder — resolve each alias key
+			var aliases = mappedType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
+			if (aliases is null) {
+				return [];
+			}
+
+			var result = new List<JavaPeerProxy> ();
+			foreach (var key in aliases.Aliases) {
+				if (self._typeMap.TryGetValue (key, out var aliasEntryType)) {
+					var aliasProxy = aliasEntryType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
+					if (aliasProxy is not null) {
+						result.Add (aliasProxy);
+					}
+				}
+			}
+			return result.Count > 0 ? result.ToArray () : [];
+		}, this);
+	}
+
+	/// <summary>
+	/// Resolves the best proxy for a JNI class name, handling both direct entries and alias groups.
+	/// When targetType is available, finds the proxy whose TargetType matches.
+	/// When targetType is null, returns the first available proxy.
+	/// </summary>
+	JavaPeerProxy? GetProxyForJniClass (string className, Type? targetType)
+	{
+		var proxies = GetProxiesForJniName (className);
+		if (proxies.Length == 0) {
+			return null;
 		}
-
-		var result = new List<Type> ();
-		foreach (var key in aliases.Aliases) {
-			var aliasProxy = GetProxyForJavaType (key);
-			if (aliasProxy is not null) {
-				result.Add (aliasProxy.TargetType);
+		if (proxies.Length == 1 || targetType is null) {
+			return proxies [0];
+		}
+		foreach (var proxy in proxies) {
+			if (proxy.TargetType == targetType) {
+				return proxy;
 			}
 		}
-
-		if (result.Count == 0) {
-			types = null;
-			return false;
-		}
-
-		types = result.ToArray ();
-		return true;
+		return null;
 	}
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
@@ -146,23 +182,6 @@ class TrimmableTypeMap
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
 
-	JavaPeerProxy? GetProxyForJavaType (string className)
-	{
-		var proxy = _peerProxyCache.GetOrAdd (className, static (name, self) => {
-			if (!self._typeMap.TryGetValue (name, out var mappedType)) {
-				return s_noPeerSentinel;
-			}
-
-			// Alias holders don't have JavaPeerProxy — GetCustomAttribute returns null naturally.
-			return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
-		}, this);
-		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
-	}
-
-	/// <summary>
-	/// Returns the proxy whose TargetType exactly matches <paramref name="targetType"/>
-	/// from an alias group's explicit key list.
-	/// </summary>
 	static JavaPeerProxy? GetProxyFromAliases (TrimmableTypeMap self, JavaPeerAliasesAttribute aliases, Type targetType)
 	{
 		foreach (var key in aliases.Aliases) {
@@ -175,32 +194,6 @@ class TrimmableTypeMap
 			}
 		}
 		return null;
-	}
-
-	/// <summary>
-	/// Returns the first surviving proxy from an alias group's key list.
-	/// Used when no specific targetType is available.
-	/// </summary>
-	static JavaPeerProxy? GetFirstProxyFromAliases (TrimmableTypeMap self, JavaPeerAliasesAttribute aliases)
-	{
-		foreach (var key in aliases.Aliases) {
-			if (!self._typeMap.TryGetValue (key, out var aliasProxyType)) {
-				continue;
-			}
-			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (aliasProxy is not null) {
-				return aliasProxy;
-			}
-		}
-		return null;
-	}
-
-	JavaPeerAliasesAttribute? GetAliasesForJniName (string jniName)
-	{
-		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
-			return null;
-		}
-		return mappedType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)
@@ -227,23 +220,9 @@ class TrimmableTypeMap
 				while (jniClass.IsValid) {
 					var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 					if (className != null) {
-						var proxy = self.GetProxyForJavaType (className);
+						var proxy = self.GetProxyForJniClass (className, targetType);
 						if (proxy != null && (targetType is null || TargetTypeMatches (targetType, proxy.TargetType))) {
 							return proxy;
-						}
-
-						// GetProxyForJavaType returns null for alias holders —
-						// resolve from the alias group.
-						if (proxy is null) {
-							var aliases = self.GetAliasesForJniName (className);
-							if (aliases is not null) {
-								var aliasProxy = targetType is not null
-									? GetProxyFromAliases (self, aliases, targetType)
-									: GetFirstProxyFromAliases (self, aliases);
-								if (aliasProxy is not null) {
-									return aliasProxy;
-								}
-							}
 						}
 					}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -100,24 +100,35 @@ class TrimmableTypeMap
 	/// </remarks>
 	/// <summary>
 	/// Enumerates all proxy types for a JNI name, including alias entries.
-	/// If the base JNI name maps to an alias holder (implementing <see cref="IJavaPeerAliases"/>),
+	/// If the base JNI name maps to an alias holder (annotated with <see cref="JavaPeerAliasesAttribute"/>),
 	/// enumerates the explicit alias keys. Otherwise yields only the primary type.
 	/// </summary>
 	internal IEnumerable<Type> GetAllTypesForJniName (string jniName)
 	{
 		if (!_typeMap.TryGetValue (jniName, out var primaryType)) {
-			yield break;
+			return [];
 		}
 
-		var proxy = primaryType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-		if (proxy is IJavaPeerAliases aliases) {
-			foreach (var key in aliases.Aliases) {
-				if (_typeMap.TryGetValue (key, out var aliasType)) {
-					yield return aliasType;
-				}
+		// Fast path: non-alias entry — most JNI names map directly to a proxy
+		if (primaryType.GetCustomAttribute<JavaPeerProxy> (inherit: false) is not null) {
+			return [primaryType];
+		}
+
+		// Slow path: alias holder — enumerate the explicit alias keys
+		var aliases = primaryType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
+		if (aliases is null) {
+			return [];
+		}
+
+		return GetAliasedProxyTypes (aliases);
+	}
+
+	IEnumerable<Type> GetAliasedProxyTypes (JavaPeerAliasesAttribute aliases)
+	{
+		foreach (var key in aliases.Aliases) {
+			if (_typeMap.TryGetValue (key, out var aliasType)) {
+				yield return aliasType;
 			}
-		} else {
-			yield return primaryType;
 		}
 	}
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
@@ -131,17 +142,19 @@ class TrimmableTypeMap
 				return s_noPeerSentinel;
 			}
 
+			// Fast path: direct proxy lookup (non-alias types)
 			var proxy = proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (proxy is null) {
-				return s_noPeerSentinel;
+			if (proxy is not null) {
+				return proxy;
 			}
 
-			// If _proxyTypeMap mapped this type to an alias holder, resolve the actual proxy
-			if (proxy is IJavaPeerAliases aliases) {
+			// Slow path: _proxyTypeMap mapped this type to an alias holder — resolve from aliases
+			var aliases = proxyType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
+			if (aliases is not null) {
 				return GetProxyFromAliases (self, aliases, type) ?? s_noPeerSentinel;
 			}
 
-			return proxy;
+			return s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
@@ -153,15 +166,9 @@ class TrimmableTypeMap
 				return s_noPeerSentinel;
 			}
 
-			var proxy = mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-
-			// Alias holders are not real proxies — skip them here.
-			// Callers that need alias resolution use GetProxyFromAliases directly.
-			if (proxy is IJavaPeerAliases) {
-				return s_noPeerSentinel;
-			}
-
-			return proxy ?? s_noPeerSentinel;
+			// Alias holders don't have JavaPeerProxy — GetCustomAttribute returns null naturally.
+			// No alias check needed here; callers use GetAliasesForJniName when proxy is null.
+			return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
@@ -170,7 +177,7 @@ class TrimmableTypeMap
 	/// Reads the alias holder's explicit key list and returns the proxy whose
 	/// <c>TargetType</c> is assignable from <paramref name="targetType"/>.
 	/// </summary>
-	static JavaPeerProxy? GetProxyFromAliases (TrimmableTypeMap self, IJavaPeerAliases aliases, Type targetType)
+	static JavaPeerProxy? GetProxyFromAliases (TrimmableTypeMap self, JavaPeerAliasesAttribute aliases, Type targetType)
 	{
 		foreach (var key in aliases.Aliases) {
 			if (!self._typeMap.TryGetValue (key, out var aliasProxyType)) {
@@ -185,15 +192,15 @@ class TrimmableTypeMap
 	}
 
 	/// <summary>
-	/// Reads the <see cref="IJavaPeerAliases"/> attribute from the TypeMap entry for the given JNI name.
+	/// Reads the <see cref="JavaPeerAliasesAttribute"/> from the TypeMap entry for the given JNI name.
 	/// Returns null when the entry is not an alias holder.
 	/// </summary>
-	IJavaPeerAliases? GetAliasesForJniName (string jniName)
+	JavaPeerAliasesAttribute? GetAliasesForJniName (string jniName)
 	{
 		if (!_typeMap.TryGetValue (jniName, out var mappedType)) {
 			return null;
 		}
-		return mappedType.GetCustomAttribute<JavaPeerProxy> (inherit: false) as IJavaPeerAliases;
+		return mappedType.GetCustomAttribute<JavaPeerAliasesAttribute> (inherit: false);
 	}
 
 	internal bool TryGetJniNameForManagedType (Type managedType, [NotNullWhen (true)] out string? jniName)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -148,7 +148,7 @@ class TrimmableTypeMap
 			return proxies [0];
 		}
 		foreach (var proxy in proxies) {
-			if (proxy.TargetType == targetType) {
+			if (TargetTypeMatches (targetType, proxy.TargetType)) {
 				return proxy;
 			}
 		}
@@ -189,7 +189,7 @@ class TrimmableTypeMap
 				continue;
 			}
 			var aliasProxy = aliasProxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false);
-			if (aliasProxy is not null && aliasProxy.TargetType == targetType) {
+			if (aliasProxy is not null && TargetTypeMatches (targetType, aliasProxy.TargetType)) {
 				return aliasProxy;
 			}
 		}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -21,8 +21,10 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 			yield return t;
 		}
 
-		foreach (var type in TrimmableTypeMap.Instance.GetAllTypesForJniName (jniSimpleReference)) {
-			yield return type;
+		if (TrimmableTypeMap.Instance.TryGetTargetTypes (jniSimpleReference, out var types)) {
+			foreach (var type in types) {
+				yield return type;
+			}
 		}
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMapTypeManager.cs
@@ -21,7 +21,7 @@ class TrimmableTypeMapTypeManager : JniRuntime.JniTypeManager
 			yield return t;
 		}
 
-		if (TrimmableTypeMap.Instance.TryGetTargetType (jniSimpleReference, out var type)) {
+		foreach (var type in TrimmableTypeMap.Instance.GetAllTypesForJniName (jniSimpleReference)) {
 			yield return type;
 		}
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -778,4 +778,98 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		// Verify the alias holder has JavaPeerAliasesAttribute
 		Assert.Contains ("JavaPeerAliasesAttribute", typeNames);
 	}
+
+	[Fact]
+	public void Generate_AliasHolder_ExtendsObjectNotJavaPeerProxy ()
+	{
+		var peers = ScanFixtures ();
+		var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+		using var stream = GenerateAssembly (aliasPeers, "AliasBaseType");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var aliasHolder = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.First (t => reader.GetString (t.Namespace) == "_TypeMap.Aliases");
+
+		var baseTypeHandle = aliasHolder.BaseType;
+		Assert.Equal (HandleKind.TypeReference, baseTypeHandle.Kind);
+		var baseType = reader.GetTypeReference ((TypeReferenceHandle) baseTypeHandle);
+		Assert.Equal ("Object", reader.GetString (baseType.Name));
+		Assert.Equal ("System", reader.GetString (baseType.Namespace));
+	}
+
+	[Fact]
+	public void Generate_AliasHolder_HasDeserializableAliasKeys ()
+	{
+		var peers = ScanFixtures ();
+		var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+		using var stream = GenerateAssembly (aliasPeers, "AliasAttrBlob");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var aliasHolder = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.First (t => reader.GetString (t.Namespace) == "_TypeMap.Aliases");
+
+		var aliasHolderHandle = reader.TypeDefinitions
+			.First (h => reader.GetString (reader.GetTypeDefinition (h).Namespace) == "_TypeMap.Aliases");
+
+		// Read the JavaPeerAliasesAttribute blob from the alias holder's custom attributes
+		var attrs = reader.GetCustomAttributes (aliasHolderHandle);
+		Assert.NotEmpty (attrs);
+
+		// Find the attribute blob and parse it
+		foreach (var attrHandle in attrs) {
+			var attr = reader.GetCustomAttribute (attrHandle);
+			var blobReader = reader.GetBlobReader (attr.Value);
+			ushort prolog = blobReader.ReadUInt16 ();
+			Assert.Equal (1, prolog);
+
+			// Read the params string[] — encoded as int32 count + serialized strings
+			int count = blobReader.ReadInt32 ();
+			Assert.Equal (3, count);
+
+			var keys = new List<string> ();
+			for (int i = 0; i < count; i++) {
+				keys.Add (blobReader.ReadSerializedString ()!);
+			}
+
+			Assert.Contains ("test/AliasTarget[0]", keys);
+			Assert.Contains ("test/AliasTarget[1]", keys);
+			Assert.Contains ("test/AliasTarget[2]", keys);
+		}
+	}
+
+	[Fact]
+	public void Generate_ProxyTypes_HaveSelfAppliedAttribute ()
+	{
+		var peers = ScanFixtures ();
+		var activityPeer = peers.First (p => p.JavaName == "android/app/Activity");
+
+		using var stream = GenerateAssembly (new [] { activityPeer }, "SelfApply");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var proxyTypeDef = reader.TypeDefinitions
+			.First (h => reader.GetString (reader.GetTypeDefinition (h).Namespace) == "_TypeMap.Proxies");
+
+		// The proxy type should have a custom attribute applied to itself (self-application)
+		var attrs = reader.GetCustomAttributes (proxyTypeDef);
+		Assert.NotEmpty (attrs);
+
+		// Verify the attribute's constructor is a MethodDef (i.e., defined in this assembly,
+		// meaning it's the proxy's own .ctor — self-application)
+		bool hasSelfApplied = false;
+		foreach (var attrHandle in attrs) {
+			var attr = reader.GetCustomAttribute (attrHandle);
+			if (attr.Constructor.Kind == HandleKind.MethodDefinition) {
+				hasSelfApplied = true;
+				break;
+			}
+		}
+		Assert.True (hasSelfApplied, "Proxy type should have a self-applied attribute (ctor is MethodDefinition)");
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -715,4 +715,67 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 				$"Expected fewer RVA fields ({rvaFields.Count}) than total strings ({allStrings.Count}) due to deduplication");
 		}
 	}
+
+	[Fact]
+	public void Generate_AliasGroup_ProducesCorrectIndexedEntries ()
+	{
+		var peers = ScanFixtures ();
+		var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+		Assert.Equal (3, aliasPeers.Count);
+
+		using var stream = GenerateAssembly (aliasPeers, "AliasRoundTrip");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		// Read all TypeMap attribute blobs
+		var typeMapBlobs = new List<(string? jniName, string? proxyRef, string? targetRef)> ();
+		var asmAttrs = reader.GetCustomAttributes (EntityHandle.AssemblyDefinition);
+		foreach (var attrHandle in asmAttrs) {
+			var attr = reader.GetCustomAttribute (attrHandle);
+			if (attr.Constructor.Kind == HandleKind.MethodDefinition)
+				continue;
+
+			var blobReader = reader.GetBlobReader (attr.Value);
+			ushort prolog = blobReader.ReadUInt16 ();
+			if (prolog != 1)
+				continue;
+
+			string? val1 = blobReader.ReadSerializedString ();
+			string? val2 = blobReader.ReadSerializedString ();
+
+			// TypeMap has a jniName string arg; TypeMapAssociation has two Type args.
+			// We distinguish by checking if val1 looks like a JNI name (contains '/').
+			if (val1 is not null && val1.Contains ('/')) {
+				string? val3 = blobReader.RemainingBytes > 2 ? blobReader.ReadSerializedString () : null;
+				typeMapBlobs.Add ((val1, val2, val3));
+			}
+		}
+
+		// Verify indexed entries: "test/AliasTarget[0]", "test/AliasTarget[1]", "test/AliasTarget[2]", and base "test/AliasTarget"
+		var jniNames = typeMapBlobs.Select (b => b.jniName).ToList ();
+		Assert.Contains ("test/AliasTarget", jniNames);
+		Assert.Contains ("test/AliasTarget[0]", jniNames);
+		Assert.Contains ("test/AliasTarget[1]", jniNames);
+		Assert.Contains ("test/AliasTarget[2]", jniNames);
+
+		// Verify TypeMapAssociationAttribute is referenced (generic version)
+		var typeNames = GetTypeRefNames (reader);
+		Assert.Contains ("TypeMapAssociationAttribute`1", typeNames);
+
+		// Verify 3 proxy types + 1 alias holder were emitted
+		var proxyTypes = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Where (t => reader.GetString (t.Namespace) == "_TypeMap.Proxies")
+			.ToList ();
+		Assert.Equal (3, proxyTypes.Count);
+
+		var aliasHolders = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Where (t => reader.GetString (t.Namespace) == "_TypeMap.Aliases")
+			.ToList ();
+		Assert.Single (aliasHolders);
+
+		// Verify the alias holder implements IJavaPeerAliases
+		Assert.Contains ("IJavaPeerAliases", typeNames);
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -775,7 +775,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			.ToList ();
 		Assert.Single (aliasHolders);
 
-		// Verify the alias holder implements IJavaPeerAliases
-		Assert.Contains ("IJavaPeerAliases", typeNames);
+		// Verify the alias holder has JavaPeerAliasesAttribute
+		Assert.Contains ("JavaPeerAliasesAttribute", typeNames);
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -63,15 +63,71 @@ public class ModelBuilderTests : FixtureTestBase
 			};
 
 			var model = BuildModel (peers);
-			// Two entries: primary "test/Dup" and alias "test/Dup[1]"
-			Assert.Equal (2, model.Entries.Count);
-			Assert.Equal ("test/Dup", model.Entries [0].JniName);
+			// Three entries: "test/Dup[0]", "test/Dup[1]", and the base "test/Dup" → alias holder
+			Assert.Equal (3, model.Entries.Count);
+			Assert.Equal ("test/Dup[0]", model.Entries [0].JniName);
 			Assert.Contains ("Test.First", model.Entries [0].ProxyTypeReference);
 			Assert.Equal ("test/Dup[1]", model.Entries [1].JniName);
 			Assert.Contains ("Test.Second", model.Entries [1].ProxyTypeReference);
+			Assert.Equal ("test/Dup", model.Entries [2].JniName);
 
-			// No associations when neither peer has a proxy (no activation ctor or invoker)
-			Assert.Empty (model.Associations);
+			// Both peers get associations to the alias holder
+			Assert.Equal (2, model.Associations.Count);
+
+			// One alias holder
+			Assert.Single (model.AliasHolders);
+			Assert.Equal (2, model.AliasHolders [0].AliasKeys.Count);
+		}
+
+		[Fact]
+		public void Build_ThreeWayAlias_CreatesCorrectIndexedEntries ()
+		{
+			var peers = new List<JavaPeerInfo> {
+				MakePeerWithActivation ("test/Triple", "Test.Alpha", "A"),
+				MakePeerWithActivation ("test/Triple", "Test.Beta", "A"),
+				MakePeerWithActivation ("test/Triple", "Test.Gamma", "A"),
+			};
+
+			var model = BuildModel (peers, "TripleAlias");
+			// 3 indexed entries + 1 base entry → alias holder = 4
+			Assert.Equal (4, model.Entries.Count);
+			Assert.Equal ("test/Triple[0]", model.Entries [0].JniName);
+			Assert.Equal ("test/Triple[1]", model.Entries [1].JniName);
+			Assert.Equal ("test/Triple[2]", model.Entries [2].JniName);
+			Assert.Equal ("test/Triple", model.Entries [3].JniName);
+
+			// All three peers get associations to the alias holder
+			Assert.Equal (3, model.Associations.Count);
+
+			// Three distinct proxy types
+			Assert.Equal (3, model.ProxyTypes.Count);
+
+			// One alias holder with 3 keys
+			Assert.Single (model.AliasHolders);
+			Assert.Equal (3, model.AliasHolders [0].AliasKeys.Count);
+		}
+
+		[Fact]
+		public void Build_AliasWithMixedActivation_PrimaryNoActivation_AliasHasActivation ()
+		{
+			var peers = new List<JavaPeerInfo> {
+				MakeMcwPeer ("test/Mixed", "Test.NoAct", "A"),
+				MakePeerWithActivation ("test/Mixed", "Test.WithAct", "A"),
+			};
+
+			var model = BuildModel (peers, "MixedAlias");
+			// 2 indexed entries + 1 base entry → alias holder = 3
+			Assert.Equal (3, model.Entries.Count);
+			Assert.Equal ("test/Mixed[0]", model.Entries [0].JniName);
+			Assert.Equal ("test/Mixed[1]", model.Entries [1].JniName);
+			Assert.Equal ("test/Mixed", model.Entries [2].JniName);
+
+			// Only the alias peer with activation gets a proxy
+			Assert.Single (model.ProxyTypes);
+			Assert.Equal ("Test_WithAct_Proxy", model.ProxyTypes [0].TypeName);
+
+			// Both peers get associations to alias holder
+			Assert.Equal (2, model.Associations.Count);
 		}
 	}
 
@@ -183,14 +239,13 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
-		public void Build_PeerWithActivation_CreatesAssociation ()
+		public void Build_SinglePeer_NoAssociation ()
 		{
+			// Single peers don't need associations — only alias groups do
 			var peer = MakePeerWithActivation ("my/app/MainActivity", "MyApp.MainActivity", "App");
 			var model = BuildModel (new [] { peer }, "MyTypeMap");
 
-			var assoc = Assert.Single (model.Associations);
-			Assert.Equal ("MyApp.MainActivity, App", assoc.SourceTypeReference);
-			Assert.Equal ("_TypeMap.Proxies.MyApp_MainActivity_Proxy, MyTypeMap", assoc.AliasProxyTypeReference);
+			Assert.Empty (model.Associations);
 		}
 
 		[Fact]
@@ -435,6 +490,79 @@ public class ModelBuilderTests : FixtureTestBase
 
 			// Interface proxy has activation because it will create the invoker
 			Assert.True (proxy.HasActivation);
+		}
+	}
+
+	public class FixtureAliases
+	{
+		[Fact]
+		public void Fixture_AliasTarget_ThreeTypesShareJniName ()
+		{
+			var peers = ScanFixtures ();
+			var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+			Assert.Equal (3, aliasPeers.Count);
+		}
+
+		[Fact]
+		public void Fixture_AliasTarget_ProducesIndexedEntries ()
+		{
+			var peers = ScanFixtures ();
+			var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+			var model = BuildModel (aliasPeers, "AliasFixture");
+
+			// 3 indexed entries + 1 base entry → alias holder = 4
+			Assert.Equal (4, model.Entries.Count);
+			Assert.Equal ("test/AliasTarget[0]", model.Entries [0].JniName);
+			Assert.Equal ("test/AliasTarget[1]", model.Entries [1].JniName);
+			Assert.Equal ("test/AliasTarget[2]", model.Entries [2].JniName);
+			Assert.Equal ("test/AliasTarget", model.Entries [3].JniName);
+		}
+
+		[Fact]
+		public void Fixture_AliasTarget_EachPeerGetsDistinctProxy ()
+		{
+			var peers = ScanFixtures ();
+			var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+			var model = BuildModel (aliasPeers, "AliasFixture");
+			Assert.Equal (3, model.ProxyTypes.Count);
+
+			var proxyNames = model.ProxyTypes.Select (p => p.TypeName).ToList ();
+			Assert.Equal (proxyNames.Distinct ().Count (), proxyNames.Count);
+		}
+
+		[Fact]
+		public void Fixture_AliasTarget_AssociationsLinkToAliasHolder ()
+		{
+			var peers = ScanFixtures ();
+			var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+			var model = BuildModel (aliasPeers, "AliasFixture");
+			// All 3 peers get associations to the alias holder
+			Assert.Equal (3, model.Associations.Count);
+
+			// All associations point to the same alias holder
+			var holderRef = model.Associations [0].AliasProxyTypeReference;
+			Assert.All (model.Associations, a => Assert.Equal (holderRef, a.AliasProxyTypeReference));
+			Assert.Contains ("_Aliases", holderRef);
+		}
+
+		[Fact]
+		public void Fixture_AliasTarget_GeneratesAliasHolder ()
+		{
+			var peers = ScanFixtures ();
+			var aliasPeers = peers.Where (p => p.JavaName == "test/AliasTarget").ToList ();
+
+			var model = BuildModel (aliasPeers, "AliasFixture");
+			Assert.Single (model.AliasHolders);
+
+			var holder = model.AliasHolders [0];
+			Assert.Equal ("_TypeMap.Aliases", holder.Namespace);
+			Assert.Equal (3, holder.AliasKeys.Count);
+			Assert.Equal ("test/AliasTarget[0]", holder.AliasKeys [0]);
+			Assert.Equal ("test/AliasTarget[1]", holder.AliasKeys [1]);
+			Assert.Equal ("test/AliasTarget[2]", holder.AliasKeys [2]);
 		}
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -914,3 +914,37 @@ public class DotFormatActivity : Android.App.Activity
 {
 	protected DotFormatActivity (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
 }
+
+// --- Alias test types ---
+// Multiple .NET types mapping to the same JNI name (e.g., generic + non-generic collection wrappers).
+
+namespace MyApp.Aliases
+{
+	/// <summary>
+	/// Non-generic type registered as "test/AliasTarget" — forms the primary entry.
+	/// </summary>
+	[Register ("test/AliasTarget", DoNotGenerateAcw = true)]
+	public class AliasTarget : Java.Lang.Object
+	{
+		protected AliasTarget (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
+	}
+
+	/// <summary>
+	/// Generic type also registered as "test/AliasTarget" — forms an alias entry.
+	/// Mirrors the real-world pattern of JavaCollection/JavaCollection&lt;T&gt;.
+	/// </summary>
+	[Register ("test/AliasTarget", DoNotGenerateAcw = true)]
+	public class AliasTargetGeneric<T> : Java.Lang.Object
+	{
+		protected AliasTargetGeneric (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
+	}
+
+	/// <summary>
+	/// Third type also registered as "test/AliasTarget" — tests 3-way alias groups.
+	/// </summary>
+	[Register ("test/AliasTarget", DoNotGenerateAcw = true)]
+	public class AliasTargetExtended : Java.Lang.Object
+	{
+		protected AliasTargetExtended (IntPtr handle, Android.Runtime.JniHandleOwnership transfer) : base (handle, transfer) { }
+	}
+}


### PR DESCRIPTION
## Summary

Implements trimmable typemap alias support end-to-end, covering both generated metadata/code and runtime lookup/activation.

Fixes #11103
Part of #10788

## Changes

### New: `IJavaPeerAliases` interface (`JavaPeerProxy.cs`)
- `string[] Aliases { get; }` — lists the exact TypeMap keys for an alias group

### Build-time (ModelBuilder + Emitter)
For alias groups (≥2 .NET types sharing a JNI name, e.g., `JavaCollection` / `JavaCollection<T>`):
- Generates an **alias holder class** extending `JavaPeerProxy` + `IJavaPeerAliases`
- Base JNI name entry → alias holder (self-referencing trim target)
- Each type gets `[0]`-based indexed entry: `"jni/Name[0]"`, `"jni/Name[1]"`, ...
- `TypeMapAssociation` links each type to the alias holder (keeps holder alive when any alias survives trimming)
- `TargetType` / `CreateInstance` throw `NotSupportedException` (alias holder is never used for peer creation)
- Also adds **self-application** (`AddCustomAttribute` on `typeDefHandle`) for all proxy types — required for `GetCustomAttribute<JavaPeerProxy>()` to work at runtime

### Runtime (`TrimmableTypeMap.cs`)
- `GetProxyForManagedType()`: `if (proxy is IJavaPeerAliases aliases)` → iterate exact keys from `Aliases` property
- `GetAllTypesForJniName()`: detect alias holder, enumerate listed keys
- `ActivateInstance()`: same alias holder detection
- **Zero cost for non-alias types** — single `is` check that's false, no dictionary probing

### Generated output for an alias group
```csharp
// TypeMap entries:
[assembly: TypeMap<Object>("some/JavaType", typeof(JavaType_Aliases), typeof(JavaType_Aliases))]
[assembly: TypeMap<Object>("some/JavaType[0]", typeof(A_Proxy), typeof(A))]
[assembly: TypeMap<Object>("some/JavaType[1]", typeof(B_Proxy), typeof(B))]

// Keep alias holder alive when any alias type survives trimming:
[assembly: TypeMapAssociation<Object>(typeof(A), typeof(JavaType_Aliases))]
[assembly: TypeMapAssociation<Object>(typeof(B), typeof(JavaType_Aliases))]

// Alias holder — IS a JavaPeerProxy, implements IJavaPeerAliases:
[JavaType_Aliases]
class JavaType_Aliases : JavaPeerProxy, IJavaPeerAliases
{
    public override Type TargetType => throw new NotSupportedException();
    public override IJavaPeerable? CreateInstance(...) => throw new NotSupportedException();
    public string[] Aliases => new[] { "some/JavaType[0]", "some/JavaType[1]" };
}
```

## Tests

331 passing (+9 new):
- 3 alias fixture types (3-way alias group mirroring `JavaCollection`/`JavaCollection<T>` pattern)
- Model builder tests for alias holders, 3-way aliases, mixed activation
- Fixture scanner tests verifying alias detection from real assemblies
- Integration test verifying alias holder class + `IJavaPeerAliases` in emitted PE