### PR TITLE
Port TypeMapObjectsXmlFile.Import to XmlReader streaming

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -179,14 +179,13 @@ class TypeMapObjectsXmlFile
 
 		var type = reader.GetAttribute ("type");
 
-		if (string.IsNullOrWhiteSpace (type))
+		if (type.IsNullOrWhiteSpace ())
 			throw new InvalidOperationException ($"Missing required attribute 'type' in '{filename}'");
 
 		var assemblyName = reader.GetAttribute ("assembly-name");
 		var mvidValue = reader.GetAttribute ("mvid");
-		var mvid = string.IsNullOrWhiteSpace (mvidValue) ? Guid.Empty : Guid.Parse (mvidValue);
-		var foundJniValue = reader.GetAttribute ("found-jni-native-registration");
-		var foundJniNativeRegistration = !string.IsNullOrWhiteSpace (foundJniValue) && Convert.ToBoolean (foundJniValue);
+		var mvid = mvidValue.IsNullOrWhiteSpace () ? Guid.Empty : Guid.Parse (mvidValue);
+		var foundJniNativeRegistration = GetAttributeOrDefault (reader, "found-jni-native-registration", false);
 
 		var file = new TypeMapObjectsXmlFile {
 			WasScanned = true,
@@ -227,7 +226,7 @@ class TypeMapObjectsXmlFile
 		var mvidValue = reader.GetAttribute ("mvid");
 		file.ModuleReleaseData = new ModuleReleaseData {
 			AssemblyName = reader.GetAttribute ("assembly-name") ?? string.Empty,
-			Mvid = string.IsNullOrWhiteSpace (mvidValue) ? Guid.Empty : Guid.Parse (mvidValue),
+			Mvid = mvidValue.IsNullOrWhiteSpace () ? Guid.Empty : Guid.Parse (mvidValue),
 			MvidBytes = Convert.FromBase64String (GetAttributeOrDefault (reader, "mvid-bytes", string.Empty)),
 			TypesScratch = new Dictionary<string, TypeMapReleaseEntry> (StringComparer.Ordinal),
 			DuplicateTypes = new List<TypeMapReleaseEntry> (),
@@ -296,10 +295,10 @@ class TypeMapObjectsXmlFile
 	{
 		var value = reader.GetAttribute (name);
 
-		if (string.IsNullOrWhiteSpace (value))
+		if (value.IsNullOrWhiteSpace ())
 			return defaultValue;
 
-		return (T) Convert.ChangeType (value, typeof (T));
+		return (T) Convert.ChangeType (value, typeof (T), CultureInfo.InvariantCulture);
 	}
 
 	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -213,31 +213,6 @@ class TypeMapObjectsXmlFile
 		}
 	}
 
-	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)
-	{
-		if (reader.IsEmptyElement)
-			return;
-
-		int depth = reader.Depth;
-
-		while (reader.Read ()) {
-			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
-				return;
-
-			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry") {
-				entries.Add (new TypeMapDebugEntry {
-					JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
-					ManagedName = reader.GetAttribute ("managed-name") ?? string.Empty,
-					ManagedTypeTokenId = uint.TryParse (reader.GetAttribute ("managed-type-token-id"), out var tokenId) ? tokenId : 0u,
-					SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
-					IsInvoker = bool.TryParse (reader.GetAttribute ("is-invoker"), out var invoker) && invoker,
-					IsMonoAndroid = isMonoAndroid,
-					AssemblyName = assemblyName,
-				});
-			}
-		}
-	}
-
 	static void ImportReleaseData (XmlReader reader, TypeMapObjectsXmlFile file)
 	{
 		if (!reader.ReadToFollowing ("module"))
@@ -279,6 +254,53 @@ class TypeMapObjectsXmlFile
 		}
 	}
 
+	public static void WriteEmptyFile (string destination, TaskLoggingHelper log)
+	{
+		log.LogDebugMessage ($"Writing empty file '{destination}'");
+
+		// We write a zero byte file to indicate the file couldn't have JLO types and wasn't scanned
+		File.Create (destination).Dispose ();
+	}
+
+	static TypeMapDebugEntry FromDebugEntryXml (XmlReader reader, string assemblyName, bool isMonoAndroid)
+	{
+		return new TypeMapDebugEntry {
+			JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
+			ManagedName = reader.GetAttribute ("managed-name") ?? string.Empty,
+			ManagedTypeTokenId = uint.TryParse (reader.GetAttribute ("managed-type-token-id"), out var tokenId) ? tokenId : 0u,
+			SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
+			IsInvoker = bool.TryParse (reader.GetAttribute ("is-invoker"), out var invoker) && invoker,
+			IsMonoAndroid = isMonoAndroid,
+			AssemblyName = assemblyName,
+		};
+	}
+
+	static TypeMapReleaseEntry FromReleaseEntryXml (XmlReader reader)
+	{
+		return new TypeMapReleaseEntry {
+			JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
+			ManagedTypeName = reader.GetAttribute ("managed-type-name") ?? string.Empty,
+			Token = uint.TryParse (reader.GetAttribute ("token"), out var token) ? token : 0u,
+			SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
+		};
+	}
+
+	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)
+	{
+		if (reader.IsEmptyElement)
+			return;
+
+		int depth = reader.Depth;
+
+		while (reader.Read ()) {
+			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+				return;
+
+			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry")
+				entries.Add (FromDebugEntryXml (reader, assemblyName, isMonoAndroid));
+		}
+	}
+
 	static void ReadReleaseEntries (XmlReader reader, List<TypeMapReleaseEntry> entries)
 	{
 		if (reader.IsEmptyElement)
@@ -291,7 +313,7 @@ class TypeMapObjectsXmlFile
 				return;
 
 			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry")
-				entries.Add (ReadReleaseEntry (reader));
+				entries.Add (FromReleaseEntryXml (reader));
 		}
 	}
 
@@ -308,24 +330,8 @@ class TypeMapObjectsXmlFile
 
 			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry") {
 				var key = reader.GetAttribute ("key") ?? string.Empty;
-				entries[key] = ReadReleaseEntry (reader);
+				entries[key] = FromReleaseEntryXml (reader);
 			}
 		}
 	}
-
-	static TypeMapReleaseEntry ReadReleaseEntry (XmlReader reader) => new TypeMapReleaseEntry {
-		JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
-		ManagedTypeName = reader.GetAttribute ("managed-type-name") ?? string.Empty,
-		Token = uint.TryParse (reader.GetAttribute ("token"), out var token) ? token : 0u,
-		SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
-	};
-
-	public static void WriteEmptyFile (string destination, TaskLoggingHelper log)
-	{
-		log.LogDebugMessage ($"Writing empty file '{destination}'");
-
-		// We write a zero byte file to indicate the file couldn't have JLO types and wasn't scanned
-		File.Create (destination).Dispose ();
-	}
-
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -2,12 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Xml;
-using System.Xml.Linq;
 using Microsoft.Android.Build.Tasks;
 using Microsoft.Build.Utilities;
-using NuGet.Packaging;
 
 using ModuleReleaseData = Xamarin.Android.Tasks.TypeMapGenerator.ModuleReleaseData;
 using TypeMapDebugEntry = Xamarin.Android.Tasks.TypeMapGenerator.TypeMapDebugEntry;
@@ -175,13 +172,15 @@ class TypeMapObjectsXmlFile
 		if (fi.Length == 0)
 			return unscanned;
 
-		var xml = XDocument.Load (filename);
-		var root = xml.Root ?? throw new InvalidOperationException ($"Invalid XML file '{filename}'");
+		using var reader = XmlReader.Create (filename);
 
-		var type = root.GetRequiredAttribute ("type");
-		var assemblyName = root.GetAttributeOrDefault ("assembly-name", (string?)null);
-		var mvid = Guid.Parse (root.GetAttributeOrDefault ("mvid", Guid.Empty.ToString ()));
-		var foundJniNativeRegistration = root.GetAttributeOrDefault ("found-jni-native-registration", false);
+		if (!reader.ReadToFollowing ("api"))
+			throw new InvalidOperationException ($"Invalid XML file '{filename}'");
+
+		var type = reader.GetAttribute ("type") ?? throw new InvalidOperationException ("Missing required attribute 'type'");
+		var assemblyName = reader.GetAttribute ("assembly-name");
+		var mvid = Guid.TryParse (reader.GetAttribute ("mvid"), out var parsedMvid) ? parsedMvid : Guid.Empty;
+		var foundJniNativeRegistration = bool.TryParse (reader.GetAttribute ("found-jni-native-registration"), out var parsedJni) && parsedJni;
 
 		var file = new TypeMapObjectsXmlFile {
 			WasScanned = true,
@@ -191,60 +190,135 @@ class TypeMapObjectsXmlFile
 		};
 
 		if (type == "debug")
-			ImportDebugData (root, file);
+			ImportDebugData (reader, file);
 		else if (type == "release")
-			ImportReleaseData (root, file);
+			ImportReleaseData (reader, file);
 
 		return file;
 	}
 
-	static void ImportDebugData (XElement root, TypeMapObjectsXmlFile file)
+	static void ImportDebugData (XmlReader reader, TypeMapObjectsXmlFile file)
 	{
-		var assemblyName = root.GetAttributeOrDefault ("assembly-name", string.Empty);
+		var assemblyName = file.AssemblyName ?? string.Empty;
 		var isMonoAndroid = assemblyName == "Mono.Android";
-		var javaToManaged = root.Element ("java-to-managed");
 
-		if (javaToManaged is not null) {
-			foreach (var entry in javaToManaged.Elements ("entry"))
-				file.JavaToManagedDebugEntries.Add (FromDebugEntryXml (entry, assemblyName, isMonoAndroid));
-		}
+		while (reader.Read ()) {
+			if (reader.NodeType != XmlNodeType.Element)
+				continue;
 
-		var managedToJava = root.Element ("managed-to-java");
-
-		if (managedToJava is not null) {
-			foreach (var entry in managedToJava.Elements ("entry"))
-				file.ManagedToJavaDebugEntries.Add (FromDebugEntryXml (entry, assemblyName, isMonoAndroid));
+			if (reader.Name == "java-to-managed")
+				ReadDebugEntries (reader, file.JavaToManagedDebugEntries, assemblyName, isMonoAndroid);
+			else if (reader.Name == "managed-to-java")
+				ReadDebugEntries (reader, file.ManagedToJavaDebugEntries, assemblyName, isMonoAndroid);
 		}
 	}
 
-	static void ImportReleaseData (XElement root, TypeMapObjectsXmlFile file)
+	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)
 	{
-		var module = root.Element ("module");
+		if (reader.IsEmptyElement)
+			return;
 
-		if (module is null)
+		int depth = reader.Depth;
+
+		while (reader.Read ()) {
+			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+				return;
+
+			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry") {
+				entries.Add (new TypeMapDebugEntry {
+					JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
+					ManagedName = reader.GetAttribute ("managed-name") ?? string.Empty,
+					ManagedTypeTokenId = uint.TryParse (reader.GetAttribute ("managed-type-token-id"), out var tokenId) ? tokenId : 0u,
+					SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
+					IsInvoker = bool.TryParse (reader.GetAttribute ("is-invoker"), out var invoker) && invoker,
+					IsMonoAndroid = isMonoAndroid,
+					AssemblyName = assemblyName,
+				});
+			}
+		}
+	}
+
+	static void ImportReleaseData (XmlReader reader, TypeMapObjectsXmlFile file)
+	{
+		if (!reader.ReadToFollowing ("module"))
 			return;
 
 		file.ModuleReleaseData = new ModuleReleaseData {
-			AssemblyName = module.GetAttributeOrDefault ("assembly-name", string.Empty),
-			Mvid = Guid.Parse (module.GetAttributeOrDefault ("mvid", Guid.Empty.ToString ())),
-			MvidBytes = Convert.FromBase64String (module.GetAttributeOrDefault ("mvid-bytes", string.Empty)),
+			AssemblyName = reader.GetAttribute ("assembly-name") ?? string.Empty,
+			Mvid = Guid.TryParse (reader.GetAttribute ("mvid"), out var mvid) ? mvid : Guid.Empty,
+			MvidBytes = Convert.FromBase64String (reader.GetAttribute ("mvid-bytes") ?? string.Empty),
 			TypesScratch = new Dictionary<string, TypeMapReleaseEntry> (StringComparer.Ordinal),
 			DuplicateTypes = new List<TypeMapReleaseEntry> (),
 		};
 
-		if (module.Element ("types") is XElement types)
-			file.ModuleReleaseData.Types = types.Elements ("entry")
-				.Select (FromReleaseEntryXml)
-				.ToArray ();
+		if (reader.IsEmptyElement)
+			return;
 
-		if (module.Element ("duplicates") is XElement duplicates)
-			file.ModuleReleaseData.DuplicateTypes.AddRange (duplicates.Elements ("entry")
-				.Select (FromReleaseEntryXml));
+		int depth = reader.Depth;
 
-		if (module.Element ("types-scratch") is XElement typesScratch)
-			file.ModuleReleaseData.TypesScratch.AddRange (typesScratch.Elements ("entry")
-				.Select (elem => new KeyValuePair<string, TypeMapReleaseEntry> (elem.GetAttributeOrDefault ("key", string.Empty), FromReleaseEntryXml (elem))));
+		while (reader.Read ()) {
+			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+				return;
+
+			if (reader.NodeType != XmlNodeType.Element)
+				continue;
+
+			switch (reader.Name) {
+				case "types":
+					var types = new List<TypeMapReleaseEntry> ();
+					ReadReleaseEntries (reader, types);
+					file.ModuleReleaseData.Types = types.ToArray ();
+					break;
+				case "duplicates":
+					ReadReleaseEntries (reader, file.ModuleReleaseData.DuplicateTypes);
+					break;
+				case "types-scratch":
+					ReadReleaseScratchEntries (reader, file.ModuleReleaseData.TypesScratch);
+					break;
+			}
+		}
 	}
+
+	static void ReadReleaseEntries (XmlReader reader, List<TypeMapReleaseEntry> entries)
+	{
+		if (reader.IsEmptyElement)
+			return;
+
+		int depth = reader.Depth;
+
+		while (reader.Read ()) {
+			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+				return;
+
+			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry")
+				entries.Add (ReadReleaseEntry (reader));
+		}
+	}
+
+	static void ReadReleaseScratchEntries (XmlReader reader, Dictionary<string, TypeMapReleaseEntry> entries)
+	{
+		if (reader.IsEmptyElement)
+			return;
+
+		int depth = reader.Depth;
+
+		while (reader.Read ()) {
+			if (reader.NodeType == XmlNodeType.EndElement && reader.Depth == depth)
+				return;
+
+			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry") {
+				var key = reader.GetAttribute ("key") ?? string.Empty;
+				entries[key] = ReadReleaseEntry (reader);
+			}
+		}
+	}
+
+	static TypeMapReleaseEntry ReadReleaseEntry (XmlReader reader) => new TypeMapReleaseEntry {
+		JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
+		ManagedTypeName = reader.GetAttribute ("managed-type-name") ?? string.Empty,
+		Token = uint.TryParse (reader.GetAttribute ("token"), out var token) ? token : 0u,
+		SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
+	};
 
 	public static void WriteEmptyFile (string destination, TaskLoggingHelper log)
 	{
@@ -254,37 +328,4 @@ class TypeMapObjectsXmlFile
 		File.Create (destination).Dispose ();
 	}
 
-	static TypeMapDebugEntry FromDebugEntryXml (XElement entry, string assemblyName, bool isMonoAndroid)
-	{
-		var javaName = entry.GetAttributeOrDefault ("java-name", string.Empty);
-		var managedName = entry.GetAttributeOrDefault ("managed-name", string.Empty);
-		var skipInJavaToManaged = entry.GetAttributeOrDefault ("skip-in-java-to-managed", false);
-		var isInvoker = entry.GetAttributeOrDefault ("is-invoker", false);
-		var managedTokenId = entry.GetAttributeOrDefault ("managed-type-token-id", (uint)0);
-
-		return new TypeMapDebugEntry {
-			JavaName = javaName,
-			ManagedName = managedName,
-			ManagedTypeTokenId = managedTokenId,
-			SkipInJavaToManaged = skipInJavaToManaged,
-			IsInvoker = isInvoker,
-			IsMonoAndroid = isMonoAndroid,
-			AssemblyName = assemblyName,
-		};
-	}
-
-	static TypeMapReleaseEntry FromReleaseEntryXml (XElement entry)
-	{
-		var javaName = entry.GetAttributeOrDefault ("java-name", string.Empty);
-		var managedTypeName = entry.GetAttributeOrDefault ("managed-type-name", string.Empty);
-		var token = entry.GetAttributeOrDefault ("token", 0u);
-		var skipInJavaToManaged = entry.GetAttributeOrDefault ("skip-in-java-to-managed", false);
-
-		return new TypeMapReleaseEntry {
-			JavaName = javaName,
-			ManagedTypeName = managedTypeName,
-			Token = token,
-			SkipInJavaToManaged = skipInJavaToManaged,
-		};
-	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -228,7 +228,7 @@ class TypeMapObjectsXmlFile
 		file.ModuleReleaseData = new ModuleReleaseData {
 			AssemblyName = reader.GetAttribute ("assembly-name") ?? string.Empty,
 			Mvid = string.IsNullOrWhiteSpace (mvidValue) ? Guid.Empty : Guid.Parse (mvidValue),
-			MvidBytes = Convert.FromBase64String (reader.GetAttribute ("mvid-bytes") ?? string.Empty),
+			MvidBytes = Convert.FromBase64String (GetAttributeOrDefault (reader, "mvid-bytes", string.Empty)),
 			TypesScratch = new Dictionary<string, TypeMapReleaseEntry> (StringComparer.Ordinal),
 			DuplicateTypes = new List<TypeMapReleaseEntry> (),
 		};
@@ -347,7 +347,7 @@ class TypeMapObjectsXmlFile
 
 			if (reader.NodeType == XmlNodeType.Element && reader.Name == "entry") {
 				var key = reader.GetAttribute ("key") ?? string.Empty;
-				entries[key] = FromReleaseEntryXml (reader);
+				entries.Add (key, FromReleaseEntryXml (reader));
 			}
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapObjectsXmlFile.cs
@@ -177,10 +177,16 @@ class TypeMapObjectsXmlFile
 		if (!reader.ReadToFollowing ("api"))
 			throw new InvalidOperationException ($"Invalid XML file '{filename}'");
 
-		var type = reader.GetAttribute ("type") ?? throw new InvalidOperationException ("Missing required attribute 'type'");
+		var type = reader.GetAttribute ("type");
+
+		if (string.IsNullOrWhiteSpace (type))
+			throw new InvalidOperationException ($"Missing required attribute 'type' in '{filename}'");
+
 		var assemblyName = reader.GetAttribute ("assembly-name");
-		var mvid = Guid.TryParse (reader.GetAttribute ("mvid"), out var parsedMvid) ? parsedMvid : Guid.Empty;
-		var foundJniNativeRegistration = bool.TryParse (reader.GetAttribute ("found-jni-native-registration"), out var parsedJni) && parsedJni;
+		var mvidValue = reader.GetAttribute ("mvid");
+		var mvid = string.IsNullOrWhiteSpace (mvidValue) ? Guid.Empty : Guid.Parse (mvidValue);
+		var foundJniValue = reader.GetAttribute ("found-jni-native-registration");
+		var foundJniNativeRegistration = !string.IsNullOrWhiteSpace (foundJniValue) && Convert.ToBoolean (foundJniValue);
 
 		var file = new TypeMapObjectsXmlFile {
 			WasScanned = true,
@@ -218,9 +224,10 @@ class TypeMapObjectsXmlFile
 		if (!reader.ReadToFollowing ("module"))
 			return;
 
+		var mvidValue = reader.GetAttribute ("mvid");
 		file.ModuleReleaseData = new ModuleReleaseData {
 			AssemblyName = reader.GetAttribute ("assembly-name") ?? string.Empty,
-			Mvid = Guid.TryParse (reader.GetAttribute ("mvid"), out var mvid) ? mvid : Guid.Empty,
+			Mvid = string.IsNullOrWhiteSpace (mvidValue) ? Guid.Empty : Guid.Parse (mvidValue),
 			MvidBytes = Convert.FromBase64String (reader.GetAttribute ("mvid-bytes") ?? string.Empty),
 			TypesScratch = new Dictionary<string, TypeMapReleaseEntry> (StringComparer.Ordinal),
 			DuplicateTypes = new List<TypeMapReleaseEntry> (),
@@ -267,9 +274,9 @@ class TypeMapObjectsXmlFile
 		return new TypeMapDebugEntry {
 			JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
 			ManagedName = reader.GetAttribute ("managed-name") ?? string.Empty,
-			ManagedTypeTokenId = uint.TryParse (reader.GetAttribute ("managed-type-token-id"), out var tokenId) ? tokenId : 0u,
-			SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
-			IsInvoker = bool.TryParse (reader.GetAttribute ("is-invoker"), out var invoker) && invoker,
+			ManagedTypeTokenId = GetAttributeOrDefault (reader, "managed-type-token-id", 0u),
+			SkipInJavaToManaged = GetAttributeOrDefault (reader, "skip-in-java-to-managed", false),
+			IsInvoker = GetAttributeOrDefault (reader, "is-invoker", false),
 			IsMonoAndroid = isMonoAndroid,
 			AssemblyName = assemblyName,
 		};
@@ -280,9 +287,19 @@ class TypeMapObjectsXmlFile
 		return new TypeMapReleaseEntry {
 			JavaName = reader.GetAttribute ("java-name") ?? string.Empty,
 			ManagedTypeName = reader.GetAttribute ("managed-type-name") ?? string.Empty,
-			Token = uint.TryParse (reader.GetAttribute ("token"), out var token) ? token : 0u,
-			SkipInJavaToManaged = bool.TryParse (reader.GetAttribute ("skip-in-java-to-managed"), out var skip) && skip,
+			Token = GetAttributeOrDefault (reader, "token", 0u),
+			SkipInJavaToManaged = GetAttributeOrDefault (reader, "skip-in-java-to-managed", false),
 		};
+	}
+
+	static T GetAttributeOrDefault<T> (XmlReader reader, string name, T defaultValue)
+	{
+		var value = reader.GetAttribute (name);
+
+		if (string.IsNullOrWhiteSpace (value))
+			return defaultValue;
+
+		return (T) Convert.ChangeType (value, typeof (T));
 	}
 
 	static void ReadDebugEntries (XmlReader reader, List<TypeMapDebugEntry> entries, string assemblyName, bool isMonoAndroid)


### PR DESCRIPTION
## Summary

Replace `XDocument.Load` (full DOM parse per assembly) with forward-only `XmlReader` streaming in the `Import` path of `TypeMapObjectsXmlFile`. This avoids allocating the entire XML DOM tree for each `.typemap.xml` file during the build.

## Changes

- Replace `Import`, `ImportDebugData`, `ImportReleaseData` methods to use `XmlReader`
- Add `ReadDebugEntries`, `ReadReleaseEntries`, `ReadReleaseScratchEntries`, `ReadReleaseEntry` helper methods for streaming reads
- Use depth-tracking to robustly detect container end-elements
- Remove unused `System.Linq`, `System.Xml.Linq`, `NuGet.Packaging` usings
- Export side (`XmlWriter`) is unchanged