### PR TITLE
Avoid O(n²) array growth in GenerateTypeMappings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
@@ -155,7 +155,6 @@ public class GenerateTypeMappings : AndroidTask
 	void AddOutputTypeMaps (TypeMapGenerator tmg, AndroidTargetArch arch)
 	{
 		string abi = MonoAndroidHelper.ArchToAbi (arch);
-		var items = new List<ITaskItem> ();
 
 		foreach (string file in tmg.GeneratedBinaryTypeMaps) {
 			var item = new TaskItem (file);
@@ -163,9 +162,7 @@ public class GenerateTypeMappings : AndroidTask
 			item.SetMetadata ("DestinationSubPath", $"{abi}/{fileName}");
 			item.SetMetadata ("DestinationSubDirectory", $"{abi}/");
 			item.SetMetadata ("Abi", abi);
-			items.Add (item);
+			generatedBinaryTypeMaps.Add (item);
 		}
-
-		generatedBinaryTypeMaps.AddRange (items);
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTypeMappings.cs
@@ -50,6 +50,7 @@ public class GenerateTypeMappings : AndroidTask
 	public string TypemapOutputDirectory { get; set; } = "";
 
 	AndroidRuntime androidRuntime;
+	readonly List<ITaskItem> generatedBinaryTypeMaps = new List<ITaskItem> ();
 
 	public override bool RunTask ()
 	{
@@ -71,6 +72,7 @@ public class GenerateTypeMappings : AndroidTask
 		if (RunCheckedBuild || useMarshalMethods)
 			GenerateAllTypeMappingsFromNativeState (useMarshalMethods);
 
+		GeneratedBinaryTypeMaps = generatedBinaryTypeMaps.ToArray ();
 		return !Log.HasLoggedErrors;
 	}
 
@@ -164,6 +166,6 @@ public class GenerateTypeMappings : AndroidTask
 			items.Add (item);
 		}
 
-		GeneratedBinaryTypeMaps = GeneratedBinaryTypeMaps.Concat (items).ToArray ();
+		generatedBinaryTypeMaps.AddRange (items);
 	}
 }


### PR DESCRIPTION
## Description

`GenerateTypeMappings.AddOutputTypeMaps()` called `Concat().ToArray()` on `GeneratedBinaryTypeMaps` for each architecture iteration, copying the entire array each time -- O(n²) growth.

This replaces that pattern with a backing `List<ITaskItem>` field that items are added to directly, with a single `.ToArray()` call at the end of `RunTask()` to satisfy the MSBuild `[Output]` property type requirement.