### PR TITLE
Use stackalloc in TypeMapHelper to reduce allocations

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.IO.Hashing;
 using System.Text;
 
@@ -7,7 +6,6 @@ namespace Xamarin.Android.Tasks;
 
 static class TypeMapHelper
 {
-	const int MaxStackallocBytes = 512;
 	/// <summary>
 	/// Hash the given Java type name for use in java-to-managed typemap array (MonoVM version)
 	/// </summary>
@@ -41,21 +39,14 @@ static class TypeMapHelper
 	static unsafe ulong HashString (string name, Encoding encoding, bool is64Bit)
 	{
 		int byteCount = encoding.GetByteCount (name);
-		byte[]? rented = null;
-		Span<byte> buffer = byteCount <= MaxStackallocBytes
+		Span<byte> buffer = byteCount <= 256
 			? stackalloc byte [byteCount]
-			: (rented = ArrayPool<byte>.Shared.Rent (byteCount)).AsSpan (0, byteCount);
-		try {
-			fixed (char* pChars = name)
-			fixed (byte* pBuffer = buffer) {
-				encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
-			}
-			return HashBytes (buffer, is64Bit);
-		} finally {
-			if (rented != null) {
-				ArrayPool<byte>.Shared.Return (rented);
-			}
+			: new byte [byteCount];
+		fixed (char* pChars = name)
+		fixed (byte* pBuffer = buffer) {
+			encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
 		}
+		return HashBytes (buffer, is64Bit);
 	}
 
 	static ulong HashBytes (ReadOnlySpan<byte> bytes, bool is64Bit)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO.Hashing;
 using System.Text;
 
@@ -17,7 +18,7 @@ static class TypeMapHelper
 
 		// Native code (EmbeddedAssemblies::typemap_java_to_managed in embedded-assemblies.cc) will operate on wchar_t cast to a byte array, we need to do
 		// the same
-		return HashBytes (Encoding.Unicode.GetBytes (name), is64Bit);
+		return HashString (name, Encoding.Unicode, is64Bit);
 	}
 
 	/// <summary>
@@ -29,10 +30,23 @@ static class TypeMapHelper
 			return UInt64.MaxValue;
 		}
 
-		return HashBytes (Encoding.UTF8.GetBytes (name), is64Bit);
+		return HashString (name, Encoding.UTF8, is64Bit);
 	}
 
-	static ulong HashBytes (byte[] bytes, bool is64Bit)
+	static ulong HashString (string name, Encoding encoding, bool is64Bit)
+	{
+		int byteCount = encoding.GetByteCount (name);
+		byte[] buffer = ArrayPool<byte>.Shared.Rent (byteCount);
+		try {
+			encoding.GetBytes (name, 0, name.Length, buffer, 0);
+			// Rent may return a larger array, so only hash the actual bytes
+			return HashBytes (new ReadOnlySpan<byte> (buffer, 0, byteCount), is64Bit);
+		} finally {
+			ArrayPool<byte>.Shared.Return (buffer);
+		}
+	}
+
+	static ulong HashBytes (ReadOnlySpan<byte> bytes, bool is64Bit)
 	{
 		if (is64Bit) {
 			return XxHash3.HashToUInt64 (bytes);

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Buffers;
 using System.IO.Hashing;
 using System.Text;
 
@@ -33,17 +32,19 @@ static class TypeMapHelper
 		return HashString (name, Encoding.UTF8, is64Bit);
 	}
 
-	static ulong HashString (string name, Encoding encoding, bool is64Bit)
+	// Java type names are always ASCII and typically 20-100 characters,
+	// so the encoded byte count is well within stackalloc limits.
+	// The unsafe Encoding.GetBytes(char*, int, byte*, int) overload is
+	// used because the Span-based overload requires netstandard2.1+.
+	static unsafe ulong HashString (string name, Encoding encoding, bool is64Bit)
 	{
 		int byteCount = encoding.GetByteCount (name);
-		byte[] buffer = ArrayPool<byte>.Shared.Rent (byteCount);
-		try {
-			encoding.GetBytes (name, 0, name.Length, buffer, 0);
-			// Rent may return a larger array, so only hash the actual bytes
-			return HashBytes (new ReadOnlySpan<byte> (buffer, 0, byteCount), is64Bit);
-		} finally {
-			ArrayPool<byte>.Shared.Return (buffer);
+		Span<byte> buffer = stackalloc byte [byteCount];
+		fixed (char* pChars = name)
+		fixed (byte* pBuffer = buffer) {
+			encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
 		}
+		return HashBytes (buffer, is64Bit);
 	}
 
 	static ulong HashBytes (ReadOnlySpan<byte> bytes, bool is64Bit)

--- a/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/TypeMapHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.IO.Hashing;
 using System.Text;
 
@@ -6,6 +7,7 @@ namespace Xamarin.Android.Tasks;
 
 static class TypeMapHelper
 {
+	const int MaxStackallocBytes = 512;
 	/// <summary>
 	/// Hash the given Java type name for use in java-to-managed typemap array (MonoVM version)
 	/// </summary>
@@ -39,12 +41,21 @@ static class TypeMapHelper
 	static unsafe ulong HashString (string name, Encoding encoding, bool is64Bit)
 	{
 		int byteCount = encoding.GetByteCount (name);
-		Span<byte> buffer = stackalloc byte [byteCount];
-		fixed (char* pChars = name)
-		fixed (byte* pBuffer = buffer) {
-			encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
+		byte[]? rented = null;
+		Span<byte> buffer = byteCount <= MaxStackallocBytes
+			? stackalloc byte [byteCount]
+			: (rented = ArrayPool<byte>.Shared.Rent (byteCount)).AsSpan (0, byteCount);
+		try {
+			fixed (char* pChars = name)
+			fixed (byte* pBuffer = buffer) {
+				encoding.GetBytes (pChars, name.Length, pBuffer, byteCount);
+			}
+			return HashBytes (buffer, is64Bit);
+		} finally {
+			if (rented != null) {
+				ArrayPool<byte>.Shared.Return (rented);
+			}
 		}
-		return HashBytes (buffer, is64Bit);
 	}
 
 	static ulong HashBytes (ReadOnlySpan<byte> bytes, bool is64Bit)

--- a/tools/tmt/tmt.csproj
+++ b/tools/tmt/tmt.csproj
@@ -9,6 +9,7 @@
     <OutputPath>../../bin/$(Configuration)/bin/typemap-tool</OutputPath>
     <OutputType>Exe</OutputType>
     <LibZipSharpBundleAllNativeLibraries>true</LibZipSharpBundleAllNativeLibraries>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <RollForward>Major</RollForward>
   </PropertyGroup>


### PR DESCRIPTION
Each call to `Encoding.GetBytes(string)` allocates a new `byte[]` that is immediately discarded after hashing. Since `TypeMapHelper` is called for every Java type name during the build, these short-lived allocations add up.

This PR replaces those allocations with `stackalloc` + the unsafe `Encoding.GetBytes(char*, int, byte*, int)` overload (since the Span-based overload requires netstandard2.1+). For the rare case where encoded bytes exceed 256, it falls back to a plain `new byte[]` allocation.

Key details:

- Extracted a shared `HashString()` helper that both `HashJavaName` (Unicode) and `HashJavaNameForCLR` (UTF8) delegate to
- `HashBytes` now takes `ReadOnlySpan<byte>` so it works with both stackalloc and heap-allocated buffers
- Java type names are ASCII identifiers (e.g. `android/widget/TextView`), typically 20-100 chars, so the stackalloc path handles virtually all real-world usage