### PR TITLE
Add investigation & debugging practices to copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -208,7 +208,7 @@ When diagnosing runtime, build, or test failures, follow these practices. They e
   make prepare && make all CONFIGURATION=Release
   ./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj \
       -t:RunTestApp -c Release \
-      -p:_AndroidTypeMapImplementation=<legacy|trimmable> \
+      -p:_AndroidTypeMapImplementation=<llvm-ir|managed|trimmable> \
       -p:UseMonoRuntime=<true|false>
   ```
   On Windows, use `build.cmd` and `dotnet-local.cmd` instead of `make`/`dotnet-local.sh`.
@@ -216,7 +216,7 @@ When diagnosing runtime, build, or test failures, follow these practices. They e
 
 - **When the build gets into a weird state, nuke `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors. See **Troubleshooting → Build** below.
 
-- **Verify code paths with logging, not reasoning.** Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Logger.Log`/`AndroidLog.Print` in C#, rebuild, re-run, and check `adb logcat -d`. If your log never fires, your call-graph assumption is wrong.
+- **Verify code paths with logging, not reasoning.** Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Android.Util.Log` in C#, rebuild, re-run, and check `adb logcat -d`. If your log never fires, your call-graph assumption is wrong.
 
 - **Decompile the produced `.dll` before blaming runtime.** Use `ilspycmd` or `ildasm` to inspect the actual generated IL/metadata. A missing attribute or misnamed type in generator output cascades into opaque runtime failures.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -199,6 +199,28 @@ This pattern ensures proper encoding, timestamps, and file attributes are handle
 3. For deep .binlog analysis, use the `azdo-build-investigator` skill.
 4. Only after the skill confirms no Azure DevOps failures should you report CI as passing.
 
+## Investigation & Debugging Practices
+
+When diagnosing runtime, build, or test failures, follow these practices. They exist because the .NET ↔ JNI ↔ C++ ↔ generated-native stack is loosely coupled and static reasoning alone is unreliable.
+
+- **Reproduce CI failures locally — do not iterate through CI.** A clean local test cycle is minutes; a CI iteration is hours. Run device tests the same way CI does:
+  ```bash
+  make prepare && make all CONFIGURATION=Release
+  ./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj \
+      -t:RunTestApp -c Release \
+      -p:_AndroidTypeMapImplementation=<legacy|trimmable> \
+      -p:UseMonoRuntime=<true|false>
+  ```
+  Results land in `TestResult-Mono.Android.NET_Tests-*.xml` at the repo root.
+
+- **When the build gets into a weird state, nuke `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors that no amount of code fixing will resolve. A clean `make clean && make prepare && make all CONFIGURATION=Release` is cheap compared to hours chasing ghosts.
+
+- **Verify code paths with logging before reasoning about them.** Loose coupling between .NET, Java, C++, and generated LLVM IR makes "this must be called from X" assumptions unreliable. Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Logger.Log`/`AndroidLog.Print` in C#, rebuild, re-run, and grep `adb logcat -d`. **Absence of log output is itself evidence** — if your log never fires, your mental model of the call graph is wrong.
+
+- **When generated code behaves incorrectly, decompile the produced `.dll` before blaming runtime.** Use `ilspycmd` or `ildasm` to inspect the actual generated IL/metadata (attributes, custom attribute rows, type layout). A single missing attribute or misnamed type in generator output can cascade into opaque runtime failures. Do not trust the generator source to tell you what it emitted.
+
+- **`am instrument` going silent means it crashed, not hung.** If the test runner's output stops mid-run, assume the instrumentation process died. Check `adb logcat -d | grep -E 'FATAL|tombstone|signal'` and look for a native crash dump. Do not wait for a 30-minute CI timeout to "confirm" a hang that was really an instant crash.
+
 ## Troubleshooting
 - **Build:** Clean `bin/`+`obj/`, check Android SDK/NDK, `make clean`
 - **MSBuild:** Test in isolation, validate inputs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -211,18 +211,19 @@ When diagnosing runtime, build, or test failures, follow these practices. They e
       -p:_AndroidTypeMapImplementation=<legacy|trimmable> \
       -p:UseMonoRuntime=<true|false>
   ```
+  On Windows, use `build.cmd` and `dotnet-local.cmd` instead of `make`/`dotnet-local.sh`.
   Results land in `TestResult-Mono.Android.NET_Tests-*.xml` at the repo root.
 
-- **When the build gets into a weird state, nuke `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors that no amount of code fixing will resolve. A clean `make clean && make prepare && make all CONFIGURATION=Release` is cheap compared to hours chasing ghosts.
+- **When the build gets into a weird state, nuke `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors. See **Troubleshooting → Build** below.
 
-- **Verify code paths with logging before reasoning about them.** Loose coupling between .NET, Java, C++, and generated LLVM IR makes "this must be called from X" assumptions unreliable. Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Logger.Log`/`AndroidLog.Print` in C#, rebuild, re-run, and grep `adb logcat -d`. **Absence of log output is itself evidence** — if your log never fires, your mental model of the call graph is wrong.
+- **Verify code paths with logging, not reasoning.** Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Logger.Log`/`AndroidLog.Print` in C#, rebuild, re-run, and check `adb logcat -d`. If your log never fires, your call-graph assumption is wrong.
 
-- **When generated code behaves incorrectly, decompile the produced `.dll` before blaming runtime.** Use `ilspycmd` or `ildasm` to inspect the actual generated IL/metadata (attributes, custom attribute rows, type layout). A single missing attribute or misnamed type in generator output can cascade into opaque runtime failures. Do not trust the generator source to tell you what it emitted.
+- **Decompile the produced `.dll` before blaming runtime.** Use `ilspycmd` or `ildasm` to inspect the actual generated IL/metadata. A missing attribute or misnamed type in generator output cascades into opaque runtime failures.
 
-- **`am instrument` going silent means it crashed, not hung.** If the test runner's output stops mid-run, assume the instrumentation process died. Check `adb logcat -d | grep -E 'FATAL|tombstone|signal'` and look for a native crash dump. Do not wait for a 30-minute CI timeout to "confirm" a hang that was really an instant crash.
+- **`am instrument` going silent means it crashed, not hung.** Check `adb logcat -d | grep -E 'FATAL|tombstone|signal'` for a native crash dump. Do not wait for a CI timeout to "confirm" a hang that was really an instant crash.
 
 ## Troubleshooting
-- **Build:** Clean `bin/`+`obj/`, check Android SDK/NDK, `make clean`
+- **Build:** Clean `bin/`+`obj/`, check Android SDK/NDK, `make clean && make prepare && make all`
 - **MSBuild:** Test in isolation, validate inputs
 - **Device:** Use update directories for rapid Debug iteration
 - **Performance:** See `../Documentation/guides/profiling.md` and `../Documentation/guides/tracing.md`


### PR DESCRIPTION
## Description

Adds an "Investigation & Debugging Practices" section to `.github/copilot-instructions.md` capturing five high-leverage lessons from the CoreCLRTrimmable CI lane investigation (#11091):

1. **Reproduce CI failures locally — do not iterate through CI.** Includes the exact `make` + `dotnet-local.sh` invocation for device tests.
2. **Nuke `bin/` and `obj/` when the build enters a weird state.** Stale incremental output causes phantom errors.
3. **Verify code paths with logging before reasoning about them.** Absence of log output is itself evidence.
4. **Decompile the produced `.dll` when generated code misbehaves.** Don't trust generator source to tell you what it emitted.
5. **`am instrument` going silent means it crashed, not hung.** Check `logcat` for the fatal signal.

These rules target failure modes that cost significant time during PR #11091 — each one would have caught a real dead-end before hours were spent on it.

Split out from #11091 to keep the tests/CI PR focused.

## Follow-up issues filed during the same retrospective

- #11136 — fail CI immediately when `am instrument` crashes
- #11137 — skill: reproduce CI runs locally
- #11138 — skill: trimmable-type-map troubleshooting
- #11139 — skill: diagnosing dotnet/android cross-language
- #11140 — generator output unit tests for trimmable typemap
