### PR TITLE
[TrimmableTypeMap] Package CoreCLR preserve list in SDK pack

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -77,6 +77,7 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <FilesToPackage Include="@(VersionFiles)" TargetPath="tools" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" TargetPath="Sdk" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" TargetPath="PreserveLists" />
+      <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\PreserveLists\**" TargetPath="PreserveLists" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\targets\**" TargetPath="targets" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\profiled-aot\dotnet.aotprofile" TargetPath="targets" />
       <FilesToPackage Include="$(IntermediateOutputPath)UnixFilePermissions.xml" TargetPath="data" Condition=" '$(HostOS)' != 'Windows' " />

--- a/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
+++ b/src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj
@@ -38,6 +38,10 @@
       <Link>..\PreserveLists\%(Filename)%(Extension)</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="$(MSBuildThisFileDirectory)..\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\PreserveLists\*.xml">
+      <Link>..\PreserveLists\%(Filename)%(Extension)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.ProjectTools;
@@ -47,6 +48,14 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (
 				builder.Output.IsTargetSkipped ("_GenerateJavaStubs"),
 				"_GenerateJavaStubs should be skipped on incremental build.");
+		}
+
+		[Test]
+		public void TrimmableTypeMap_PreserveList_IsPackagedInSdk ()
+		{
+			var path = Path.Combine (TestEnvironment.DotNetPreviewAndroidSdkDirectory, "PreserveLists", "Trimmable.CoreCLR.xml");
+
+			FileAssert.Exists (path, $"{path} should exist in the SDK pack.");
 		}
 	}
 }


### PR DESCRIPTION
Part 1 of the split of #11091

### Problem

The trimmable typemap's CoreCLR preserve list (`Trimmable.CoreCLR.xml`) was not reliably packaged in the `Microsoft.Android.Sdk` pack. The file lives in `src/Microsoft.Android.Sdk.ILLink/PreserveLists/` but the SDK-pack glob only reached `src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/PreserveLists/`. Local inner builds also saw a different file set than CI.

### Fix

- `build-tools/create-packs/Microsoft.Android.Sdk.proj`: include `src/Microsoft.Android.Sdk.ILLink/PreserveLists/**` in the pack.
- `src/Microsoft.Android.Sdk.ILLink/Microsoft.Android.Sdk.ILLink.csproj`: link the SDK-local PreserveLists into the project output so local inner builds see the same files as the CI SDK pack.
- Add `TrimmableTypeMap_PreserveList_IsPackagedInSdk` regression test that asserts `Trimmable.CoreCLR.xml` is present in the preview SDK pack.

### Scope

Pure packaging fix — 3 files, 14 insertions.