### PR TITLE
[TrimmableTypeMap] Manifest generator fixes

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -47,7 +47,7 @@ steps:
     configuration: ${{ parameters.buildConfiguration }}
     xaSourcePath: ${{ parameters.xaSourcePath }}
     project: ${{ parameters.project }}
-    arguments: -t:Clean -c ${{ parameters.configuration }} --no-restore
+    arguments: -t:Clean -c ${{ parameters.configuration }} --no-restore ${{ parameters.extraBuildArgs }}
     displayName: Clean ${{ parameters.testName }}
     condition: ${{ parameters.condition }}
     continueOnError: false

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ComponentElementBuilder.cs
@@ -165,7 +165,7 @@ static class ComponentElementBuilder
 		PropertyMapper.ApplyMappings (app, component.Properties, PropertyMapper.ApplicationElementMappings);
 	}
 
-	internal static void AddInstrumentation (XElement manifest, JavaPeerInfo peer)
+	internal static void AddInstrumentation (XElement manifest, JavaPeerInfo peer, string packageName)
 	{
 		string jniName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
 		var element = new XElement ("instrumentation",
@@ -176,6 +176,11 @@ static class ComponentElementBuilder
 			return;
 		}
 		PropertyMapper.ApplyMappings (element, component.Properties, PropertyMapper.InstrumentationMappings);
+
+		// Default targetPackage to the app package name, matching legacy ManifestDocument behavior
+		if (element.Attribute (AndroidNs + "targetPackage") is null) {
+			element.SetAttributeValue (AndroidNs + "targetPackage", packageName);
+		}
 
 		manifest.Add (element);
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -142,7 +142,7 @@ class ManifestGenerator
 	/// </summary>
 	void RewriteCompatNames (XElement manifest, IReadOnlyList<JavaPeerInfo> allPeers)
 	{
-		// Build mapping: compat Java name → CRC Java name
+		// Build mapping: fully-qualified compat Java name → CRC Java name
 		var compatToCrc = new Dictionary<string, string> (StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
 			string javaName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
@@ -156,13 +156,20 @@ class ManifestGenerator
 			return;
 		}
 
-		// Rewrite android:name attributes throughout the manifest
+		// Rewrite android:name attributes throughout the manifest. Android allows
+		// android:name to be specified as:
+		//   - fully qualified ("com.example.app.MainActivity")
+		//   - relative to the manifest package, starting with '.' (".MainActivity")
+		//   - bare, with no '.' at all ("MainActivity"), also relative to the package
+		// Resolve to the fully-qualified form before the lookup, then write the CRC
+		// name back so duplicate detection later in the pipeline works correctly.
 		foreach (var element in manifest.DescendantsAndSelf ()) {
 			var nameAttr = element.Attribute (AttName);
 			if (nameAttr is null) {
 				continue;
 			}
-			if (compatToCrc.TryGetValue (nameAttr.Value, out var crcName)) {
+			var resolved = ManifestNameResolver.Resolve (nameAttr.Value, PackageName);
+			if (compatToCrc.TryGetValue (resolved, out var crcName)) {
 				nameAttr.Value = crcName;
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -15,6 +15,14 @@ class ManifestGenerator
 	static readonly XNamespace AndroidNs = ManifestConstants.AndroidNs;
 	static readonly XName AttName = ManifestConstants.AttName;
 	static readonly char [] PlaceholderSeparators = [';'];
+	static readonly HashSet<string> ComponentElementNames = new (StringComparer.Ordinal) {
+		"application",
+		"activity",
+		"instrumentation",
+		"service",
+		"receiver",
+		"provider",
+	};
 
 	int appInitOrder = 2000000000;
 
@@ -62,7 +70,11 @@ class ManifestGenerator
 		}
 
 		var existingTypes = new HashSet<string> (
-			app.Descendants ().Select (a => (string?)a.Attribute (AttName)).OfType<string> ());
+			app.Descendants ()
+				.Where (IsComponentElement)
+				.Select (a => (string?) a.Attribute (AttName))
+				.OfType<string> (),
+			StringComparer.Ordinal);
 
 		// Add components from scanned types
 		foreach (var peer in allPeers) {
@@ -143,7 +155,7 @@ class ManifestGenerator
 	void RewriteCompatNames (XElement manifest, IReadOnlyList<JavaPeerInfo> allPeers)
 	{
 		// Build mapping: fully-qualified compat Java name → CRC Java name
-		var compatToCrc = new Dictionary<string, string> (StringComparer.Ordinal);
+		var compatToCrc = new Dictionary<string, string> (allPeers.Count, StringComparer.Ordinal);
 		foreach (var peer in allPeers) {
 			string javaName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
 			string compatName = JniSignatureHelper.JniNameToJavaName (peer.CompatJniName);
@@ -163,16 +175,27 @@ class ManifestGenerator
 		//   - bare, with no '.' at all ("MainActivity"), also relative to the package
 		// Resolve to the fully-qualified form before the lookup, then write the CRC
 		// name back so duplicate detection later in the pipeline works correctly.
+		var packageName = (string?) manifest.Attribute ("package") ?? "";
+
 		foreach (var element in manifest.DescendantsAndSelf ()) {
+			if (!IsComponentElement (element)) {
+				continue;
+			}
+
 			var nameAttr = element.Attribute (AttName);
 			if (nameAttr is null) {
 				continue;
 			}
-			var resolved = ManifestNameResolver.Resolve (nameAttr.Value, PackageName);
+			var resolved = ManifestNameResolver.Resolve (nameAttr.Value, packageName);
 			if (compatToCrc.TryGetValue (resolved, out var crcName)) {
 				nameAttr.Value = crcName;
 			}
 		}
+	}
+
+	static bool IsComponentElement (XElement element)
+	{
+		return element.Name.NamespaceName.Length == 0 && ComponentElementNames.Contains (element.Name.LocalName);
 	}
 
 	void EnsureManifestAttributes (XElement manifest)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -52,6 +52,10 @@ class ManifestGenerator
 		EnsureManifestAttributes (manifest);
 		var app = EnsureApplicationElement (manifest);
 
+		// Rewrite compat JNI names in the template to CRC names BEFORE collecting
+		// existing types, so the duplicate check works correctly.
+		RewriteCompatNames (manifest, allPeers);
+
 		// Apply assembly-level [Application] properties
 		if (assemblyInfo.ApplicationProperties is not null) {
 			AssemblyLevelElementBuilder.ApplyApplicationProperties (app, assemblyInfo.ApplicationProperties, allPeers, Warn);
@@ -128,6 +132,40 @@ class ManifestGenerator
 			new XElement ("manifest",
 				new XAttribute (XNamespace.Xmlns + "android", AndroidNs.NamespaceName),
 				new XAttribute ("package", PackageName)));
+	}
+
+	/// <summary>
+	/// Manifest templates may use compat JNI names (e.g., "android.apptests.App")
+	/// but the trimmable path generates JCWs with CRC-based names (e.g., "crc64.../App").
+	/// This method rewrites any compat name references to the actual JCW name so the
+	/// Android runtime can find the class.
+	/// </summary>
+	void RewriteCompatNames (XElement manifest, IReadOnlyList<JavaPeerInfo> allPeers)
+	{
+		// Build mapping: compat Java name → CRC Java name
+		var compatToCrc = new Dictionary<string, string> (StringComparer.Ordinal);
+		foreach (var peer in allPeers) {
+			string javaName = JniSignatureHelper.JniNameToJavaName (peer.JavaName);
+			string compatName = JniSignatureHelper.JniNameToJavaName (peer.CompatJniName);
+			if (javaName != compatName) {
+				compatToCrc [compatName] = javaName;
+			}
+		}
+
+		if (compatToCrc.Count == 0) {
+			return;
+		}
+
+		// Rewrite android:name attributes throughout the manifest
+		foreach (var element in manifest.DescendantsAndSelf ()) {
+			var nameAttr = element.Attribute (AttName);
+			if (nameAttr is null) {
+				continue;
+			}
+			if (compatToCrc.TryGetValue (nameAttr.Value, out var crcName)) {
+				nameAttr.Value = crcName;
+			}
+		}
 	}
 
 	void EnsureManifestAttributes (XElement manifest)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -73,7 +73,7 @@ class ManifestGenerator
 			}
 
 			if (peer.ComponentAttribute.Kind == ComponentKind.Instrumentation) {
-				ComponentElementBuilder.AddInstrumentation (manifest, peer);
+				ComponentElementBuilder.AddInstrumentation (manifest, peer, PackageName);
 				continue;
 			}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestNameResolver.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestNameResolver.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace Microsoft.Android.Sdk.TrimmableTypeMap;
+
+static class ManifestNameResolver
+{
+	/// <summary>
+	/// Resolves an <c>android:name</c> value to a fully-qualified class name.
+	/// Names starting with '.' are relative to the package. Names with no '.' at all
+	/// are also treated as relative (Android tooling convention).
+	/// </summary>
+	public static string Resolve (string name, string packageName)
+	{
+		return name switch {
+			_ when name.StartsWith (".", StringComparison.Ordinal) => packageName + name,
+			_ when name.IndexOf ('.') < 0 && !packageName.IsNullOrEmpty () => packageName + "." + name,
+			_ => name,
+		};
+	}
+}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -165,7 +165,7 @@ public class TrimmableTypeMapGenerator
 			case "provider":
 				var name = (string?) element.Attribute (attName);
 				if (name is not null) {
-					var resolvedName = ResolveManifestClassName (name, packageName);
+					var resolvedName = ManifestNameResolver.Resolve (name, packageName);
 					componentNames.Add (resolvedName);
 
 					if (element.Name.LocalName is "application" or "instrumentation") {
@@ -309,17 +309,4 @@ public class TrimmableTypeMapGenerator
 		}
 	}
 
-	/// <summary>
-	/// Resolves an android:name value to a fully-qualified class name.
-	/// Names starting with '.' are relative to the package. Names with no '.' at all
-	/// are also treated as relative (Android tooling convention).
-	/// </summary>
-	static string ResolveManifestClassName (string name, string packageName)
-	{
-		return name switch {
-			_ when name.StartsWith (".", StringComparison.Ordinal) => packageName + name,
-			_ when name.IndexOf ('.') < 0 && !packageName.IsNullOrEmpty () => packageName + "." + name,
-			_ => name,
-		};
-	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -11,7 +11,11 @@
 
   <PropertyGroup>
     <_TypeMapAssemblyName>_Microsoft.Android.TypeMaps</_TypeMapAssemblyName>
-    <_TypeMapBaseOutputDir>$(IntermediateOutputPath)</_TypeMapBaseOutputDir>
+    <!-- Use the outer IntermediateOutputPath when available (inner per-RID builds set
+         _OuterIntermediateOutputPath) so that generated manifests/JCWs are written
+         where the packaging phase expects them. -->
+    <_TypeMapBaseOutputDir Condition=" '$(_OuterIntermediateOutputPath)' != '' ">$(_OuterIntermediateOutputPath)</_TypeMapBaseOutputDir>
+    <_TypeMapBaseOutputDir Condition=" '$(_TypeMapBaseOutputDir)' == '' ">$(IntermediateOutputPath)</_TypeMapBaseOutputDir>
     <_TypeMapBaseOutputDir>$(_TypeMapBaseOutputDir.Replace('\','/'))</_TypeMapBaseOutputDir>
     <_TypeMapOutputDirectory>$(_TypeMapBaseOutputDir)typemap/</_TypeMapOutputDirectory>
     <_TypeMapJavaOutputDirectory>$(_TypeMapBaseOutputDir)typemap/java</_TypeMapJavaOutputDirectory>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -38,20 +38,6 @@
   </Target>
 
   <!--
-    Detect builds that switch from a non-trimmable path to trimmable in the same
-    intermediate directory (e.g. sequential CI test runs).  If the sentinel file
-    doesn't exist, the typemap DLL is stale (left over from a non-trimmable build
-    or a Clean that didn't know about trimmable targets) and must be deleted so
-    _GenerateTrimmableTypeMap re-runs and produces a consistent manifest + JCWs.
-  -->
-  <Target Name="_CleanStaleNonTrimmableState"
-      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and Exists('$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll') and !Exists('$(_TypeMapOutputDirectory).trimmable') "
-      AfterTargets="CoreCompile"
-      BeforeTargets="_GenerateTrimmableTypeMap">
-    <Delete Files="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll" />
-  </Target>
-
-  <!--
     Generate TypeMap assemblies and JCW files.
     AfterTargets="CoreCompile" so it runs after compilation.
     Uses @(ReferencePath) as the primary input (available after compilation).
@@ -59,7 +45,6 @@
   <Target Name="_GenerateTrimmableTypeMap"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
       AfterTargets="CoreCompile"
-      DependsOnTargets="_CleanStaleNonTrimmableState"
       Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs)"
       Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll">
 
@@ -104,11 +89,6 @@
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
       <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
-    </ItemGroup>
-
-    <Touch Files="$(_TypeMapOutputDirectory).trimmable" AlwaysCreate="true" />
-    <ItemGroup>
-      <FileWrites Include="$(_TypeMapOutputDirectory).trimmable" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -34,6 +34,20 @@
   </Target>
 
   <!--
+    Detect builds that switch from a non-trimmable path to trimmable in the same
+    intermediate directory (e.g. sequential CI test runs).  If the sentinel file
+    doesn't exist, the typemap DLL is stale (left over from a non-trimmable build
+    or a Clean that didn't know about trimmable targets) and must be deleted so
+    _GenerateTrimmableTypeMap re-runs and produces a consistent manifest + JCWs.
+  -->
+  <Target Name="_CleanStaleNonTrimmableState"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and Exists('$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll') and !Exists('$(_TypeMapOutputDirectory).trimmable') "
+      AfterTargets="CoreCompile"
+      BeforeTargets="_GenerateTrimmableTypeMap">
+    <Delete Files="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll" />
+  </Target>
+
+  <!--
     Generate TypeMap assemblies and JCW files.
     AfterTargets="CoreCompile" so it runs after compilation.
     Uses @(ReferencePath) as the primary input (available after compilation).
@@ -41,6 +55,7 @@
   <Target Name="_GenerateTrimmableTypeMap"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' "
       AfterTargets="CoreCompile"
+      DependsOnTargets="_CleanStaleNonTrimmableState"
       Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs)"
       Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll">
 
@@ -85,6 +100,11 @@
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
       <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
+    </ItemGroup>
+
+    <Touch Files="$(_TypeMapOutputDirectory).trimmable" AlwaysCreate="true" />
+    <ItemGroup>
+      <FileWrites Include="$(_TypeMapOutputDirectory).trimmable" />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -979,6 +979,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
 		<_PropertyCacheItems Include="AndroidUseDesignerAssembly=$(AndroidUseDesignerAssembly)" />
+		<_PropertyCacheItems Include="_AndroidTypeMapImplementation=$(_AndroidTypeMapImplementation)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -376,6 +376,56 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void CompatNames_RewrittenToCrc_UsesManifestPackageAttribute ()
+	{
+		var gen = CreateDefaultGenerator ();
+		gen.PackageName = "com.other.app";
+
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application android:name=".MyApp">
+					<activity android:name=".MainActivity" />
+				</application>
+			</manifest>
+			""");
+
+		var appPeer = new JavaPeerInfo {
+			JavaName = "crc64abc123/MyApp",
+			CompatJniName = "com/example/app/MyApp",
+			ManagedTypeName = "Com.Example.App.MyApp",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MyApp",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Application,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+		var activityPeer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [appPeer, activityPeer], template: template);
+
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("crc64abc123.MyApp", (string?)app?.Attribute (AttName));
+
+		var activity = app?.Element ("activity");
+		Assert.NotNull (activity);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activity?.Attribute (AttName));
+	}
+
+	[Fact]
 	public void CompatNames_RewrittenToCrc_UnqualifiedForm ()
 	{
 		var gen = CreateDefaultGenerator ();
@@ -464,6 +514,45 @@ public class ManifestGeneratorTests
 		Assert.Equal ("crc64def456.MainActivity", (string?)activities [0].Attribute (AttName));
 		// Existing android:label from the template is preserved (duplicate detection worked).
 		Assert.Equal ("Existing", (string?)activities [0].Attribute (AndroidNs + "label"));
+	}
+
+	[Fact]
+	public void CompatNames_MetadataName_NotRewritten_AndDoesNotSuppressActivity ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application>
+					<meta-data android:name=".MainActivity" android:value="keep-me" />
+				</application>
+			</manifest>
+			""");
+
+		var peer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [peer], template: template);
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+
+		var metadata = app?.Element ("meta-data");
+		Assert.NotNull (metadata);
+		Assert.Equal (".MainActivity", (string?)metadata?.Attribute (AttName));
+
+		var activities = app?.Elements ("activity").ToList ();
+		Assert.NotNull (activities);
+		Assert.Single (activities!);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activities [0].Attribute (AttName));
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -274,6 +274,57 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void CompatNames_RewrittenToCrc ()
+	{
+		var gen = CreateDefaultGenerator ();
+
+		// Template uses compat names
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application android:name="com.example.app.MyApp">
+					<activity android:name="com.example.app.MainActivity" />
+				</application>
+			</manifest>
+			""");
+
+		// Peer has CRC JavaName but compat CompatJniName
+		var appPeer = new JavaPeerInfo {
+			JavaName = "crc64abc123/MyApp",
+			CompatJniName = "com/example/app/MyApp",
+			ManagedTypeName = "Com.Example.App.MyApp",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MyApp",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Application,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+		var activityPeer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [appPeer, activityPeer], template: template);
+
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("crc64abc123.MyApp", (string?)app?.Attribute (AttName));
+
+		var activity = app?.Element ("activity");
+		Assert.NotNull (activity);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activity?.Attribute (AttName));
+	}
+
+	[Fact]
 	public void RuntimeProvider_Added ()
 	{
 		var gen = CreateDefaultGenerator ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -325,6 +325,148 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void CompatNames_RewrittenToCrc_RelativeDotForm ()
+	{
+		var gen = CreateDefaultGenerator ();
+
+		// Template uses the ".Type" relative form that Android resolves against the
+		// manifest package. RewriteCompatNames must resolve it before the compat lookup.
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application android:name=".MyApp">
+					<activity android:name=".MainActivity" />
+				</application>
+			</manifest>
+			""");
+
+		var appPeer = new JavaPeerInfo {
+			JavaName = "crc64abc123/MyApp",
+			CompatJniName = "com/example/app/MyApp",
+			ManagedTypeName = "Com.Example.App.MyApp",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MyApp",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Application,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+		var activityPeer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [appPeer, activityPeer], template: template);
+
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("crc64abc123.MyApp", (string?)app?.Attribute (AttName));
+
+		var activity = app?.Element ("activity");
+		Assert.NotNull (activity);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activity?.Attribute (AttName));
+	}
+
+	[Fact]
+	public void CompatNames_RewrittenToCrc_UnqualifiedForm ()
+	{
+		var gen = CreateDefaultGenerator ();
+
+		// Template uses the bare "Type" form (no dot) that Android also resolves
+		// against the manifest package.
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application android:name="MyApp">
+					<activity android:name="MainActivity" />
+				</application>
+			</manifest>
+			""");
+
+		var appPeer = new JavaPeerInfo {
+			JavaName = "crc64abc123/MyApp",
+			CompatJniName = "com/example/app/MyApp",
+			ManagedTypeName = "Com.Example.App.MyApp",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MyApp",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Application,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+		var activityPeer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> (),
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [appPeer, activityPeer], template: template);
+
+		var app = doc.Root?.Element ("application");
+		Assert.NotNull (app);
+		Assert.Equal ("crc64abc123.MyApp", (string?)app?.Attribute (AttName));
+
+		var activity = app?.Element ("activity");
+		Assert.NotNull (activity);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activity?.Attribute (AttName));
+	}
+
+	[Fact]
+	public void CompatNames_RelativeForm_NotDuplicated ()
+	{
+		// Regression: when a template uses a relative name (".MainActivity"), the
+		// rewrite must resolve it to the fully-qualified compat name before looking
+		// up the CRC mapping. If the relative name slipped through unchanged, the
+		// duplicate-detection in ManifestGenerator would miss it and emit a second
+		// CRC-named <activity> alongside the existing relative-named entry.
+		var gen = CreateDefaultGenerator ();
+		var template = ParseTemplate ("""
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+				<application>
+					<activity android:name=".MainActivity" android:label="Existing" />
+				</application>
+			</manifest>
+			""");
+
+		var peer = new JavaPeerInfo {
+			JavaName = "crc64def456/MainActivity",
+			CompatJniName = "com/example/app/MainActivity",
+			ManagedTypeName = "Com.Example.App.MainActivity",
+			ManagedTypeNamespace = "Com.Example.App",
+			ManagedTypeShortName = "MainActivity",
+			AssemblyName = "TestApp",
+			ComponentAttribute = new ComponentInfo {
+				Kind = ComponentKind.Activity,
+				Properties = new Dictionary<string, object?> { ["Label"] = "New Label" },
+			},
+		};
+
+		var doc = GenerateAndLoad (gen, [peer], template: template);
+		var activities = doc.Root?.Element ("application")?.Elements ("activity").ToList ();
+
+		Assert.NotNull (activities);
+		Assert.Single (activities!);
+		Assert.Equal ("crc64def456.MainActivity", (string?)activities [0].Attribute (AttName));
+		// Existing android:label from the template is preserved (duplicate detection worked).
+		Assert.Equal ("Existing", (string?)activities [0].Attribute (AndroidNs + "label"));
+	}
+
+	[Fact]
 	public void RuntimeProvider_Added ()
 	{
 		var gen = CreateDefaultGenerator ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -254,6 +254,26 @@ public class ManifestGeneratorTests
 	}
 
 	[Fact]
+	public void Instrumentation_DefaultsTargetPackage ()
+	{
+		var gen = CreateDefaultGenerator ();
+		var peer = CreatePeer ("com/example/app/MyInstrumentation", new ComponentInfo {
+			Kind = ComponentKind.Instrumentation,
+			Properties = new Dictionary<string, object?> {
+				["Label"] = "My Test",
+			},
+		});
+
+		var doc = GenerateAndLoad (gen, [peer]);
+
+		var instrumentation = doc.Root?.Element ("instrumentation");
+		Assert.NotNull (instrumentation);
+
+		// targetPackage should default to the app's PackageName
+		Assert.Equal ("com.example.app", (string?)instrumentation?.Attribute (AndroidNs + "targetPackage"));
+	}
+
+	[Fact]
 	public void RuntimeProvider_Added ()
 	{
 		var gen = CreateDefaultGenerator ();


### PR DESCRIPTION
Part 3 of the split of #11091.

### Manifest / targets fixes

1. **Default `instrumentation/@targetPackage` to the app package name**
   (`ComponentElementBuilder`, `ManifestGenerator`) — when an `[Instrumentation]`
   attribute omits `TargetPackage`, fall back to the application package rather
   than emitting an empty attribute.

2. **Use the outer `IntermediateOutputPath` for typemap/manifest generation**
   (`Microsoft.Android.Sdk.TypeMap.Trimmable.targets`) — write generated
   artifacts to the outer `obj/` dir instead of the inner-build per-RID dir so
   they are discoverable from the outer build.

3. **Rewrite compat JNI names in the manifest template to CRC names**
   (`ManifestGenerator`, `ManifestGeneratorTests`) — when the trimmable typemap
   uses CRC64-derived class names, the manifest template must reference the
   same names, not the compat forms, or Android can't resolve the
   `<application>` / `<activity>` / `<instrumentation>` targets.

   Handles all three forms Android accepts for `android:name`:
   - fully qualified (`com.example.app.MainActivity`)
   - relative with leading dot (`.MainActivity`)
   - bare / unqualified (`MainActivity`)

   Relative and unqualified names are resolved against the manifest package
   (via the shared `ManifestNameResolver` helper, factored out of
   `TrimmableTypeMapGenerator.ResolveManifestClassName`) before the
   compat → CRC lookup. This also makes the downstream duplicate-detection
   check work correctly on templates that use relative names.

### Cleaning stale state on typemap-mode switch

Earlier iterations of this PR included a narrow `_CleanStaleNonTrimmableState`
target plus a `.trimmable` sentinel file to handle the sequential-CI case of
`llvm-ir` → `trimmable` reusing the same `obj/`. That approach was dropped in
favor of the more general fix from #11098: adding `_AndroidTypeMapImplementation`
to `_PropertyCacheItems` in `Xamarin.Android.Common.targets`. This hooks
typemap-mode switches into the existing `_CleanIntermediateIfNeeded` →
`_CleanMonoAndroidIntermediateDir` machinery that already covers `AotAssemblies`,
`AndroidLinkMode`, `AndroidPackageFormat`, and ~30 other build-shape knobs, so:

- Both switch directions are cleaned (not only `llvm-ir` → `trimmable`).
- All stale artifacts are wiped (typemap DLL, JCWs in `android/src/`, merged
  manifest, `acw-map.txt`), not just the typemap DLL.
- Customer upgrades inheriting a pre-existing `obj/` from a prior release are
  handled the same way mode changes are handled today.

The single-line `_PropertyCacheItems` addition is included here as an interim
in case #11098 isn't merged first; if #11098 lands first, the line cleanly
deduplicates.

The yaml hunk threading `${{ parameters.extraBuildArgs }}` into `-t:Clean` is
kept — Clean must import the same targets as the build so the cleanup runs
with the correct `_AndroidTypeMapImplementation` value.

### Scope

6 files, +174/-37. All 358 `Microsoft.Android.Sdk.TrimmableTypeMap.Tests` pass
locally.
