### PR TITLE
[TrimmableTypeMap] Fix IL1034 by excluding app assembly from trimmer roots

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -6,9 +6,12 @@
   </PropertyGroup>
 
   <!--
-    Android apps have no managed Main() entry point, so upstream Microsoft.NET.ILLink.targets'
-    default of adding @(IntermediateAssembly) to @(TrimmerRootAssembly) with RootMode="EntryPoint"
-    causes ILLink to fail with IL1034 ("Entry point was not found in assembly ...").
+    WORKAROUND (temporary): Upstream Microsoft.NET.ILLink.targets' _PrepareTrimConfiguration
+    target historically added @(IntermediateAssembly) to @(TrimmerRootAssembly) with
+    RootMode="EntryPoint" unconditionally. Android apps have no managed Main() (we force
+    OutputType=Library in Microsoft.Android.Sdk.DefaultProperties.targets), so ILLink fails
+    with IL1034 ("Entry point was not found in assembly ...") whenever the trimmable typemap
+    path is exercised.
 
     The trimmable typemap path intentionally does not root the app assembly at all: reachability
     is driven by (1) TypeMapAttribute<T> entries on the generated _*.TypeMap.dll assemblies
@@ -16,11 +19,22 @@
     the manifest-rooting machinery), and (3) explicit [DynamicDependency] / preserve-list
     descriptors. That lets us trim as much of the app assembly as possible.
 
-    Remove the app assembly from @(TrimmerRootAssembly) after PrepareForILLink has populated it.
+    Fixed upstream in https://github.com/dotnet/runtime/pull/125673 (merged 2026-04-15), which
+    gates the Include on '$(OutputType)' != 'Library'. Once that flows into the .NET SDK we
+    consume, the app assembly is no longer added to @(TrimmerRootAssembly) for Android projects
+    and this target becomes a no-op.
+
+    We only remove items whose RootMode is "EntryPoint" - the exact shape of the entry the
+    upstream target creates - to avoid clobbering a root the user or another target deliberately
+    added with a different RootMode.
+
+    TODO: Delete this target once the consumed .NET SDK contains dotnet/runtime#125673.
+    Tracked by https://github.com/dotnet/android/issues/11146.
   -->
   <Target Name="_RemoveAppAssemblyFromTrimmerRoots" AfterTargets="PrepareForILLink">
     <ItemGroup>
-      <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')" />
+      <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')"
+                           Condition=" '%(TrimmerRootAssembly.RootMode)' == 'EntryPoint' " />
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -5,6 +5,25 @@
     <_TrimmableRuntimeProviderJavaName Condition=" '$(_TrimmableRuntimeProviderJavaName)' == '' ">mono.MonoRuntimeProvider</_TrimmableRuntimeProviderJavaName>
   </PropertyGroup>
 
+  <!--
+    Android apps have no managed Main() entry point, so upstream Microsoft.NET.ILLink.targets'
+    default of adding @(IntermediateAssembly) to @(TrimmerRootAssembly) with RootMode="EntryPoint"
+    causes ILLink to fail with IL1034 ("Entry point was not found in assembly ...").
+
+    The trimmable typemap path intentionally does not root the app assembly at all: reachability
+    is driven by (1) TypeMapAttribute<T> entries on the generated _*.TypeMap.dll assemblies
+    (understood natively by ILLink), (2) types referenced by the AndroidManifest.xml (rooted by
+    the manifest-rooting machinery), and (3) explicit [DynamicDependency] / preserve-list
+    descriptors. That lets us trim as much of the app assembly as possible.
+
+    Remove the app assembly from @(TrimmerRootAssembly) after PrepareForILLink has populated it.
+  -->
+  <Target Name="_RemoveAppAssemblyFromTrimmerRoots" AfterTargets="PrepareForILLink">
+    <ItemGroup>
+      <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')" />
+    </ItemGroup>
+  </Target>
+
   <!-- Add TypeMap DLLs to ILLink input. ILLink natively understands TypeMapAttribute<T>. -->
   <Target Name="_AddTrimmableTypeMapToLinker"
       BeforeTargets="PrepareForILLink;_RunILLink"


### PR DESCRIPTION
Part 2 of the split of the trimmable-test-plumbing branch. (PR-1: #11142, PR-3: #11143)

### Problem

Upstream `Microsoft.NET.ILLink.targets` adds the current `@(IntermediateAssembly)`
to `@(TrimmerRootAssembly)` with `RootMode="EntryPoint"`. Android apps have no
managed `Main()`, so ILLink fails with `IL1034` ("Entry point was not found in
assembly ...") as soon as the trimmable typemap path is exercised under ILLink.

### Why not just `RootMode="All"`

A natural workaround would be to update the root mode to `All`, but that would
root every type in the app assembly and defeat the entire purpose of the
trimmable typemap: the whole point is to let ILLink trim as much of the app
as possible and rely on (a) `TypeMapAttribute<T>` on the generated
`_*.TypeMap.dll` assemblies, (b) types referenced by `AndroidManifest.xml`
(rooted by the manifest-rooting machinery introduced in #11037), and (c) explicit
`[DynamicDependency]` annotations / preserve-list descriptors.

### Fix

Remove the app assembly from `@(TrimmerRootAssembly)` after `PrepareForILLink`:

```xml
<Target Name="_RemoveAppAssemblyFromTrimmerRoots" AfterTargets="PrepareForILLink">
  <ItemGroup>
    <TrimmerRootAssembly Remove="@(IntermediateAssembly->'%(Filename)')" />
  </ItemGroup>
</Target>
```

1 file, +19/−0 (target + explanatory comment).