### PR TITLE
[TrimmableTypeMap] Runtime and typemap generator fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -214,7 +214,7 @@ When diagnosing runtime, build, or test failures, follow these practices. They e
   On Windows, use `build.cmd` and `dotnet-local.cmd` instead of `make`/`dotnet-local.sh`.
   Results land in `TestResult-Mono.Android.NET_Tests-*.xml` at the repo root.
 
-- **When the build gets into a weird state, nuke `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors. See **Troubleshooting → Build** below.
+- **When the build gets into a weird state, delete `bin/` and `obj/` and rebuild from scratch.** Stale incremental output causes phantom errors. See **Troubleshooting → Build** below.
 
 - **Verify code paths with logging, not reasoning.** Add `log_warn (LOG_DEFAULT, "..."sv, ...)` in C++ or `Android.Util.Log` in C#, rebuild, re-run, and check `adb logcat -d`. If your log never fires, your call-graph assumption is wrong.
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -125,9 +125,15 @@ public sealed class JcwJavaSourceGenerator
 		string className = JniSignatureHelper.GetJavaSimpleName (type.JavaName);
 
 		// Application and Instrumentation types cannot call registerNatives in their
-		// static initializer — the runtime isn't ready yet at that point. Emit a
-		// lazy one-time helper instead so the first managed callback can register
-		// the class just before invoking its native method.
+		// static initializer — the runtime isn't ready yet at that point. Instead we
+		// rely on ApplicationRegistration.registerApplications() (invoked from
+		// MonoPackageManager.LoadApplication, which runs from MonoRuntimeProvider.attachInfo)
+		// to register natives for these classes. However, Application.attachBaseContext
+		// fires *before* ContentProvider.attachInfo, so an override of attachBaseContext
+		// on a user Application subclass can invoke a native callback before
+		// registerApplications() has run. To cover that early-callback window we also
+		// emit a lazy one-time __md_registerNatives() helper and call it at the top of
+		// each generated native-method wrapper.
 		if (type.CannotRegisterInStaticConstructor) {
 			writer.Write ($$"""
 	private static boolean __md_natives_registered;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -132,8 +132,9 @@ static class ModelBuilder
 
 			// Emit TypeMapAssociation for all proxy-backed types so managed → proxy
 			// lookup works even when the final JNI name differs from the type's attributes.
+			// Skip generic definitions — their open generic type can't be loaded by the runtime.
 			var assocProxy = (i > 0 && primaryProxy != null) ? primaryProxy : proxy;
-			if (assocProxy != null) {
+			if (assocProxy != null && !peer.IsGenericDefinition) {
 				model.Associations.Add (new TypeMapAssociationData {
 					SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
 					AliasProxyTypeReference = AssemblyQualify ($"{assocProxy.Namespace}.{assocProxy.TypeName}", assemblyName),

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -132,9 +132,11 @@ static class ModelBuilder
 
 			// Emit TypeMapAssociation for all proxy-backed types so managed → proxy
 			// lookup works even when the final JNI name differs from the type's attributes.
-			// Skip generic definitions — their open generic type can't be loaded by the runtime.
+			// Generic definitions are included — their proxy types derive from the
+			// non-generic `JavaPeerProxy` base so the CLR can load them without
+			// resolving an open generic argument.
 			var assocProxy = (i > 0 && primaryProxy != null) ? primaryProxy : proxy;
-			if (assocProxy != null && !peer.IsGenericDefinition) {
+			if (assocProxy != null) {
 				model.Associations.Add (new TypeMapAssociationData {
 					SourceTypeReference = AssemblyQualify (peer.ManagedTypeName, peer.AssemblyName),
 					AliasProxyTypeReference = AssemblyQualify ($"{assocProxy.Namespace}.{assocProxy.TypeName}", assemblyName),

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -69,6 +69,7 @@ sealed class TypeMapAssemblyEmitter
 	AssemblyReferenceHandle _javaInteropRef;
 
 	TypeReferenceHandle _javaPeerProxyRef;
+	TypeReferenceHandle _javaLangObjectRef;
 	TypeReferenceHandle _iJavaPeerableRef;
 	TypeReferenceHandle _jniHandleOwnershipRef;
 	TypeReferenceHandle _jniObjectReferenceRef;
@@ -165,6 +166,8 @@ sealed class TypeMapAssemblyEmitter
 		var metadata = _pe.Metadata;
 		_javaPeerProxyRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerProxy`1"));
+		_javaLangObjectRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Lang"), metadata.GetOrAddString ("Object"));
 		_iJavaPeerableRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerable"));
 		_jniHandleOwnershipRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
@@ -352,7 +355,13 @@ sealed class TypeMapAssemblyEmitter
 
 		var metadata = _pe.Metadata;
 		var targetTypeRef = _pe.ResolveTypeRef (proxy.TargetType);
-		var proxyBaseType = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, targetTypeRef);
+
+		// For open generic definitions, use Java.Lang.Object as the JavaPeerProxy<T> type parameter.
+		// Loading the proxy type forces the CLR to resolve the base class generic argument, and open
+		// generics from external assemblies can't be resolved by the TypeMapLazyDictionary loader.
+		// The T parameter only affects CreateInstance, which already throws for generic definitions.
+		var proxyTypeArg = proxy.IsGenericDefinition ? _javaLangObjectRef : targetTypeRef;
+		var proxyBaseType = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, proxyTypeArg);
 		var baseCtorRef = _pe.AddMemberRef (proxyBaseType, ".ctor",
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
 				rt => rt.Void (),
@@ -372,6 +381,14 @@ sealed class TypeMapAssemblyEmitter
 		if (proxy.IsAcw) {
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
+
+		// Self-apply: the proxy type is its own [JavaPeerProxy] attribute.
+		// This enables type.GetCustomAttribute<JavaPeerProxy>() to instantiate the proxy
+		// at runtime for AOT-safe type resolution.
+		var selfAttrCtorRef = _pe.AddMemberRef (typeDefHandle, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }));
+		var selfAttrBlob = _pe.BuildAttributeBlob (b => { });
+		metadata.AddCustomAttribute (typeDefHandle, selfAttrCtorRef, selfAttrBlob);
 
 		// .ctor — pass the resolved JNI name and optional invoker type to the generic base proxy
 		_pe.EmitBody (".ctor",

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -69,7 +69,7 @@ sealed class TypeMapAssemblyEmitter
 	AssemblyReferenceHandle _javaInteropRef;
 
 	TypeReferenceHandle _javaPeerProxyRef;
-	TypeReferenceHandle _javaLangObjectRef;
+	TypeReferenceHandle _javaPeerProxyNonGenericRef;
 	TypeReferenceHandle _iJavaPeerableRef;
 	TypeReferenceHandle _jniHandleOwnershipRef;
 	TypeReferenceHandle _jniObjectReferenceRef;
@@ -166,8 +166,8 @@ sealed class TypeMapAssemblyEmitter
 		var metadata = _pe.Metadata;
 		_javaPeerProxyRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerProxy`1"));
-		_javaLangObjectRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
-			metadata.GetOrAddString ("Java.Lang"), metadata.GetOrAddString ("Object"));
+		_javaPeerProxyNonGenericRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JavaPeerProxy"));
 		_iJavaPeerableRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IJavaPeerable"));
 		_jniHandleOwnershipRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
@@ -356,19 +356,35 @@ sealed class TypeMapAssemblyEmitter
 		var metadata = _pe.Metadata;
 		var targetTypeRef = _pe.ResolveTypeRef (proxy.TargetType);
 
-		// For open generic definitions, use Java.Lang.Object as the JavaPeerProxy<T> type parameter.
-		// Loading the proxy type forces the CLR to resolve the base class generic argument, and open
-		// generics from external assemblies can't be resolved by the TypeMapLazyDictionary loader.
-		// The T parameter only affects CreateInstance, which already throws for generic definitions.
-		var proxyTypeArg = proxy.IsGenericDefinition ? _javaLangObjectRef : targetTypeRef;
-		var proxyBaseType = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, proxyTypeArg);
-		var baseCtorRef = _pe.AddMemberRef (proxyBaseType, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
-				rt => rt.Void (),
-				p => {
-					p.AddParameter ().Type ().String ();
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-				}));
+		// Open generic definitions derive from the non-generic `JavaPeerProxy` abstract base.
+		// Using `JavaPeerProxy<T>` with an open T would force the CLR to resolve a generic
+		// argument that isn't available via the TypeMapLazyDictionary loader, and using a
+		// placeholder like `Java.Lang.Object` leaks an incorrect TargetType into the typemap.
+		// The non-generic base takes `targetType` as a ctor parameter, so we can pass the real
+		// open-generic type token (a TypeRef, not a closed TypeSpec) and keep TargetType correct.
+		EntityHandle proxyBaseType;
+		MemberReferenceHandle baseCtorRef;
+		if (proxy.IsGenericDefinition) {
+			proxyBaseType = _javaPeerProxyNonGenericRef;
+			baseCtorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, ".ctor",
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
+					rt => rt.Void (),
+					p => {
+						p.AddParameter ().Type ().String ();
+						p.AddParameter ().Type ().Type (_systemTypeRef, false);
+						p.AddParameter ().Type ().Type (_systemTypeRef, false);
+					}));
+		} else {
+			var genericProxyBase = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, targetTypeRef);
+			proxyBaseType = genericProxyBase;
+			baseCtorRef = _pe.AddMemberRef (genericProxyBase, ".ctor",
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+					rt => rt.Void (),
+					p => {
+						p.AddParameter ().Type ().String ();
+						p.AddParameter ().Type ().Type (_systemTypeRef, false);
+					}));
+		}
 
 		var typeDefHandle = metadata.AddTypeDefinition (
 			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Class,
@@ -390,13 +406,21 @@ sealed class TypeMapAssemblyEmitter
 		var selfAttrBlob = _pe.BuildAttributeBlob (b => { });
 		metadata.AddCustomAttribute (typeDefHandle, selfAttrCtorRef, selfAttrBlob);
 
-		// .ctor — pass the resolved JNI name and optional invoker type to the generic base proxy
+		// .ctor — pass the resolved JNI name, (for generic-definition base) target type, and
+		// optional invoker type to the base proxy constructor.
 		_pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
 			encoder => {
 				encoder.OpCode (ILOpCode.Ldarg_0);
 				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
+				if (proxy.IsGenericDefinition) {
+					// Non-generic base ctor signature: (string, Type, Type?). Push the open-generic
+					// target type as the second argument.
+					encoder.OpCode (ILOpCode.Ldtoken);
+					encoder.Token (targetTypeRef);
+					encoder.Call (_getTypeFromHandleRef);
+				}
 				if (proxy.InvokerType != null) {
 					encoder.OpCode (ILOpCode.Ldtoken);
 					encoder.Token (_pe.ResolveTypeRef (proxy.InvokerType));

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -50,7 +50,7 @@ public class TrimmableTypeMapGenerator
 
 		// Collect Application/Instrumentation types that need deferred registerNatives
 		var appRegTypes = allPeers
-			.Where (p => p.CannotRegisterInStaticConstructor && !p.IsAbstract)
+			.Where (p => p.CannotRegisterInStaticConstructor && !p.DoNotGenerateAcw)
 			.Select (p => JniSignatureHelper.JniNameToJavaName (p.JavaName))
 			.ToList ();
 		if (appRegTypes.Count > 0) {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -50,7 +50,10 @@ public class TrimmableTypeMapGenerator
 
 		// Collect Application/Instrumentation types that need deferred registerNatives
 		var appRegTypes = allPeers
-			.Where (p => p.CannotRegisterInStaticConstructor && !p.DoNotGenerateAcw)
+			// Include all deferred-registration peers here: framework MCWs still need
+			// ApplicationRegistration.java even without generated ACWs, and abstract
+			// base types can own the native methods that derived types invoke.
+			.Where (p => p.CannotRegisterInStaticConstructor)
 			.Select (p => JniSignatureHelper.JniNameToJavaName (p.JavaName))
 			.ToList ();
 		if (appRegTypes.Count > 0) {

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -100,11 +100,11 @@ class TrimmableTypeMap
 	/// </remarks>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
-		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
-			if (type.IsGenericType && !type.IsGenericTypeDefinition) {
-				type = type.GetGenericTypeDefinition ();
-			}
+		if (managedType.IsGenericType && !managedType.IsGenericTypeDefinition) {
+			managedType = managedType.GetGenericTypeDefinition ();
+		}
 
+		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
 			if (self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
 				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 			}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -59,10 +59,15 @@ class TrimmableTypeMap
 
 	unsafe void RegisterNatives ()
 	{
-		// Use the string overload of JniType which resolves via Class.forName with the
-		// runtime's ClassLoader. The UTF-8 span overload uses raw JNI FindClass which
-		// resolves via the system ClassLoader — a different class instance than the one
-		// JCWs reference via the app ClassLoader.
+		// Use the `string` overload of `JniType` deliberately. Its underlying
+		// `JniEnvironment.Types.TryFindClass(string, bool)` tries raw JNI `FindClass`
+		// first and, if that fails, falls back to `Class.forName(name, true, info.Runtime.ClassLoader)`,
+		// which resolves via the runtime's app ClassLoader — the same one that loads
+		// `mono.android.Runtime` from the APK.
+		// The `ReadOnlySpan<byte>` overload (see external/Java.Interop/src/Java.Interop/Java.Interop/JniEnvironment.Types.cs)
+		// only calls raw JNI `FindClass`, which resolves via the system ClassLoader on
+		// Android and returns a different `Class` instance from the one JCWs reference.
+		// Registering natives on that other instance is silently wrong.
 		using var runtimeClass = new JniType ("mono/android/Runtime");
 		fixed (byte* name = "registerNatives"u8, sig = "(Ljava/lang/Class;)V"u8) {
 			var onRegisterNatives = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnRegisterNatives;
@@ -199,7 +204,7 @@ class TrimmableTypeMap
 	}
 
 	[UnmanagedCallersOnly]
-	internal static void OnRegisterNatives (IntPtr jnienv, IntPtr klass, IntPtr nativeClassHandle)
+	static void OnRegisterNatives (IntPtr jnienv, IntPtr klass, IntPtr nativeClassHandle)
 	{
 		string? className = null;
 		try {

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -82,14 +82,35 @@ class TrimmableTypeMap
 		return type is not null;
 	}
 
+	/// <summary>
+	/// Resolves the <see cref="JavaPeerProxy"/> for a managed type via the CLR
+	/// <c>TypeMapping</c> proxy dictionary.
+	/// </summary>
+	/// <remarks>
+	/// Closed generic instantiations (e.g. <c>Holder&lt;int&gt;</c>) fall back to
+	/// their generic type definition (<c>Holder&lt;&gt;</c>) because the generator
+	/// emits exactly one <c>TypeMapAssociation</c> per generic peer, keyed by the
+	/// open definition (Java erases generics, so one proxy fits every closed
+	/// instantiation). The CLR lazy dictionary does identity-based lookups
+	/// (see <c>dotnet/runtime</c> <c>TypeMapLazyDictionary.cs</c>), so the
+	/// fallback must happen here. <see cref="Type.GetGenericTypeDefinition"/> is
+	/// safe under full AOT + trim (it is not <c>RequiresDynamicCode</c>).
+	/// Java→managed construction of a closed generic peer still requires a
+	/// closed <see cref="Type"/> at the call site and is tracked separately.
+	/// </remarks>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
 		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
-			if (!self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
-				return s_noPeerSentinel;
+			if (self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
+				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 			}
 
-			return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+			if (type.IsGenericType && !type.IsGenericTypeDefinition &&
+					self._proxyTypeMap.TryGetValue (type.GetGenericTypeDefinition (), out proxyType)) {
+				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+			}
+
+			return s_noPeerSentinel;
 		}, this);
 		return ReferenceEquals (proxy, s_noPeerSentinel) ? null : proxy;
 	}
@@ -139,7 +160,7 @@ class TrimmableTypeMap
 					var className = JniEnvironment.Types.GetJniTypeNameFromClass (jniClass);
 					if (className != null) {
 						var proxy = self.GetProxyForJavaType (className);
-						if (proxy != null && (targetType is null || targetType.IsAssignableFrom (proxy.TargetType))) {
+						if (proxy != null && (targetType is null || TargetTypeMatches (targetType, proxy.TargetType))) {
 							return proxy;
 						}
 					}
@@ -153,6 +174,32 @@ class TrimmableTypeMap
 			}
 
 			return null;
+		}
+
+		// Match the proxy's stored target type against a hint from the caller.
+		// The proxy's target type is the open generic definition for generic peers
+		// (Java erases generics, so one proxy fits every closed instantiation),
+		// so a plain IsAssignableFrom check misses when the hint is a closed
+		// instantiation. Walk the hint's base chain to find a generic type whose
+		// definition equals the proxy's open target type.
+		static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
+		{
+			if (targetType.IsAssignableFrom (proxyTargetType)) {
+				return true;
+			}
+
+			if (!proxyTargetType.IsGenericTypeDefinition) {
+				return false;
+			}
+
+			for (Type? t = targetType; t is not null; t = t.BaseType) {
+				if (t.IsGenericType && !t.IsGenericTypeDefinition &&
+						t.GetGenericTypeDefinition () == proxyTargetType) {
+					return true;
+				}
+			}
+
+			return false;
 		}
 
 		static JavaPeerProxy? TryGetProxyFromTargetType (TrimmableTypeMap self, IntPtr handle, Type? targetType)

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -59,7 +59,11 @@ class TrimmableTypeMap
 
 	unsafe void RegisterNatives ()
 	{
-		using var runtimeClass = new JniType ("mono/android/Runtime"u8);
+		// Use the string overload of JniType which resolves via Class.forName with the
+		// runtime's ClassLoader. The UTF-8 span overload uses raw JNI FindClass which
+		// resolves via the system ClassLoader — a different class instance than the one
+		// JCWs reference via the app ClassLoader.
+		using var runtimeClass = new JniType ("mono/android/Runtime");
 		fixed (byte* name = "registerNatives"u8, sig = "(Ljava/lang/Class;)V"u8) {
 			var onRegisterNatives = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&OnRegisterNatives;
 			var method = new JniNativeMethod (name, sig, onRegisterNatives);
@@ -195,7 +199,7 @@ class TrimmableTypeMap
 	}
 
 	[UnmanagedCallersOnly]
-	static void OnRegisterNatives (IntPtr jnienv, IntPtr klass, IntPtr nativeClassHandle)
+	internal static void OnRegisterNatives (IntPtr jnienv, IntPtr klass, IntPtr nativeClassHandle)
 	{
 		string? className = null;
 		try {
@@ -215,7 +219,9 @@ class TrimmableTypeMap
 
 			var proxy = type.GetCustomAttribute<JavaPeerProxy> (inherit: false);
 			if (proxy is IAndroidCallableWrapper acw) {
-				using var jniType = new JniType (className);
+				// Use the class reference passed from Java (via C++) — not JniType(className)
+				// which resolves via FindClass and may get a different class from a different ClassLoader.
+				using var jniType = new JniType (ref classRef, JniObjectReferenceOptions.Copy);
 				acw.RegisterNatives (jniType);
 			}
 		} catch (Exception ex) {

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -87,26 +87,25 @@ class TrimmableTypeMap
 	/// <c>TypeMapping</c> proxy dictionary.
 	/// </summary>
 	/// <remarks>
-	/// Closed generic instantiations (e.g. <c>Holder&lt;int&gt;</c>) fall back to
-	/// their generic type definition (<c>Holder&lt;&gt;</c>) because the generator
-	/// emits exactly one <c>TypeMapAssociation</c> per generic peer, keyed by the
-	/// open definition (Java erases generics, so one proxy fits every closed
-	/// instantiation). The CLR lazy dictionary does identity-based lookups
-	/// (see <c>dotnet/runtime</c> <c>TypeMapLazyDictionary.cs</c>), so the
-	/// fallback must happen here. <see cref="Type.GetGenericTypeDefinition"/> is
-	/// safe under full AOT + trim (it is not <c>RequiresDynamicCode</c>).
-	/// Java→managed construction of a closed generic peer still requires a
-	/// closed <see cref="Type"/> at the call site and is tracked separately.
+	/// The generator emits exactly one <c>TypeMapAssociation</c> per generic peer,
+	/// keyed by the open generic definition (Java erases generics, so one proxy
+	/// fits every closed instantiation). Closed instantiations are normalised to
+	/// their generic type definition before the lookup because the CLR lazy
+	/// dictionary does identity-based key matching
+	/// (see <c>dotnet/runtime</c> <c>TypeMapLazyDictionary.cs</c>).
+	/// <see cref="Type.GetGenericTypeDefinition"/> is safe under full AOT + trim
+	/// (it is not <c>RequiresDynamicCode</c>). Java→managed construction of a
+	/// closed generic peer still requires a closed <see cref="Type"/> at the call
+	/// site and is tracked separately.
 	/// </remarks>
 	JavaPeerProxy? GetProxyForManagedType (Type managedType)
 	{
 		var proxy = _proxyCache.GetOrAdd (managedType, static (type, self) => {
-			if (self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
-				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
+			if (type.IsGenericType && !type.IsGenericTypeDefinition) {
+				type = type.GetGenericTypeDefinition ();
 			}
 
-			if (type.IsGenericType && !type.IsGenericTypeDefinition &&
-					self._proxyTypeMap.TryGetValue (type.GetGenericTypeDefinition (), out proxyType)) {
+			if (self._proxyTypeMap.TryGetValue (type, out var proxyType)) {
 				return proxyType.GetCustomAttribute<JavaPeerProxy> (inherit: false) ?? s_noPeerSentinel;
 			}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -210,15 +210,22 @@ class TrimmableTypeMap
 	/// The proxy's target type is the open generic definition for generic peers
 	/// (Java erases generics, so one proxy fits every closed instantiation),
 	/// so a plain <see cref="Type.IsAssignableFrom"/> check misses when the hint
-	/// is a closed instantiation. Walk the hint's base chain and implemented
-	/// interfaces to find a generic type whose definition equals the proxy's
-	/// open target type — this covers closed subclasses of an open generic
-	/// class peer, and closed classes implementing an open generic interface
-	/// peer (i.e. the proxy's target is an open generic interface and the hint
-	/// is a class that implements a closed instantiation of it).
+	/// is a closed instantiation. Walk the hint's base chain to find a generic
+	/// type whose definition equals the proxy's open target type. This covers
+	/// closed subclasses of an open generic class peer.
 	/// </summary>
-	[UnconditionalSuppressMessage ("Trimming", "IL2070",
-		Justification = "targetType comes from live JNI marshalling call sites; its base chain and interfaces are rooted because the caller's generic signature keeps them alive.")]
+	/// <remarks>
+	/// Implementers of an open generic <em>interface</em> peer are intentionally
+	/// not matched here: <see cref="TryGetProxyFromHierarchy"/> walks only the
+	/// JNI class chain (<c>getSuperclass</c>), never JNI interfaces, so the
+	/// proxy returned from that walk is always a class peer. Matching on
+	/// <c>Type.GetInterfaces()</c> would also force a trimmer
+	/// <c>DynamicallyAccessedMembers(Interfaces)</c> annotation up the chain
+	/// (ultimately into Java.Interop's <c>CreatePeer</c> API). If we ever need
+	/// to discover interface peers, the generator should emit an explicit
+	/// implementer→interface map so runtime can avoid reflection over
+	/// interface lists.
+	/// </remarks>
 	internal static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
 	{
 		if (targetType.IsAssignableFrom (proxyTargetType)) {
@@ -232,13 +239,6 @@ class TrimmableTypeMap
 		for (Type? t = targetType; t is not null; t = t.BaseType) {
 			if (t.IsGenericType && !t.IsGenericTypeDefinition &&
 					t.GetGenericTypeDefinition () == proxyTargetType) {
-				return true;
-			}
-		}
-
-		foreach (var iface in targetType.GetInterfaces ()) {
-			if (iface.IsGenericType && !iface.IsGenericTypeDefinition &&
-					iface.GetGenericTypeDefinition () == proxyTargetType) {
 				return true;
 			}
 		}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -176,32 +176,6 @@ class TrimmableTypeMap
 			return null;
 		}
 
-		// Match the proxy's stored target type against a hint from the caller.
-		// The proxy's target type is the open generic definition for generic peers
-		// (Java erases generics, so one proxy fits every closed instantiation),
-		// so a plain IsAssignableFrom check misses when the hint is a closed
-		// instantiation. Walk the hint's base chain to find a generic type whose
-		// definition equals the proxy's open target type.
-		static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
-		{
-			if (targetType.IsAssignableFrom (proxyTargetType)) {
-				return true;
-			}
-
-			if (!proxyTargetType.IsGenericTypeDefinition) {
-				return false;
-			}
-
-			for (Type? t = targetType; t is not null; t = t.BaseType) {
-				if (t.IsGenericType && !t.IsGenericTypeDefinition &&
-						t.GetGenericTypeDefinition () == proxyTargetType) {
-					return true;
-				}
-			}
-
-			return false;
-		}
-
 		static JavaPeerProxy? TryGetProxyFromTargetType (TrimmableTypeMap self, IntPtr handle, Type? targetType)
 		{
 			if (targetType is null) {
@@ -231,6 +205,34 @@ class TrimmableTypeMap
 	}
 
 	const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
+
+	/// <summary>
+	/// Match the proxy's stored target type against a hint from the caller.
+	/// The proxy's target type is the open generic definition for generic peers
+	/// (Java erases generics, so one proxy fits every closed instantiation),
+	/// so a plain <see cref="Type.IsAssignableFrom"/> check misses when the hint
+	/// is a closed instantiation. Walk the hint's base chain to find a generic
+	/// type whose definition equals the proxy's open target type.
+	/// </summary>
+	internal static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
+	{
+		if (targetType.IsAssignableFrom (proxyTargetType)) {
+			return true;
+		}
+
+		if (!proxyTargetType.IsGenericTypeDefinition) {
+			return false;
+		}
+
+		for (Type? t = targetType; t is not null; t = t.BaseType) {
+			if (t.IsGenericType && !t.IsGenericTypeDefinition &&
+					t.GetGenericTypeDefinition () == proxyTargetType) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 
 	/// <summary>
 	/// Gets the invoker type for an interface or abstract class from the proxy attribute.

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -211,9 +211,15 @@ class TrimmableTypeMap
 	/// The proxy's target type is the open generic definition for generic peers
 	/// (Java erases generics, so one proxy fits every closed instantiation),
 	/// so a plain <see cref="Type.IsAssignableFrom"/> check misses when the hint
-	/// is a closed instantiation. Walk the hint's base chain to find a generic
-	/// type whose definition equals the proxy's open target type.
+	/// is a closed instantiation. Walk the hint's base chain and implemented
+	/// interfaces to find a generic type whose definition equals the proxy's
+	/// open target type — this covers both closed subclasses and hints that are
+	/// closed generic interfaces (e.g. <c>IList&lt;string&gt;</c> should match a
+	/// proxy whose target is <c>JavaList&lt;&gt;</c>, which implements
+	/// <c>IList&lt;T&gt;</c>).
 	/// </summary>
+	[UnconditionalSuppressMessage ("Trimming", "IL2070",
+		Justification = "targetType comes from live JNI marshalling call sites; its base chain and interfaces are rooted because the caller's generic signature keeps them alive.")]
 	internal static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
 	{
 		if (targetType.IsAssignableFrom (proxyTargetType)) {
@@ -227,6 +233,13 @@ class TrimmableTypeMap
 		for (Type? t = targetType; t is not null; t = t.BaseType) {
 			if (t.IsGenericType && !t.IsGenericTypeDefinition &&
 					t.GetGenericTypeDefinition () == proxyTargetType) {
+				return true;
+			}
+		}
+
+		foreach (var iface in targetType.GetInterfaces ()) {
+			if (iface.IsGenericType && !iface.IsGenericTypeDefinition &&
+					iface.GetGenericTypeDefinition () == proxyTargetType) {
 				return true;
 			}
 		}

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -213,10 +213,10 @@ class TrimmableTypeMap
 	/// so a plain <see cref="Type.IsAssignableFrom"/> check misses when the hint
 	/// is a closed instantiation. Walk the hint's base chain and implemented
 	/// interfaces to find a generic type whose definition equals the proxy's
-	/// open target type — this covers both closed subclasses and hints that are
-	/// closed generic interfaces (e.g. <c>IList&lt;string&gt;</c> should match a
-	/// proxy whose target is <c>JavaList&lt;&gt;</c>, which implements
-	/// <c>IList&lt;T&gt;</c>).
+	/// open target type — this covers closed subclasses of an open generic
+	/// class peer, and closed classes implementing an open generic interface
+	/// peer (i.e. the proxy's target is an open generic interface and the hint
+	/// is a class that implements a closed instantiation of it).
 	/// </summary>
 	[UnconditionalSuppressMessage ("Trimming", "IL2070",
 		Justification = "targetType comes from live JNI marshalling call sites; its base chain and interfaces are rooted because the caller's generic signature keeps them alive.")]

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -182,6 +182,7 @@ _ResolveAssemblies MSBuild target.
         InputJavaLibraries="@(_ResolvedJavaLibraries->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles)"
         AndroidIncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
+        AndroidTypeMapImplementation="$(_AndroidTypeMapImplementation)"
         PublishTrimmed="$(PublishTrimmed)">
       <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
       <Output TaskParameter="OutputJavaLibraries" ItemName="AndroidJavaLibrary" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -182,7 +182,6 @@ _ResolveAssemblies MSBuild target.
         InputJavaLibraries="@(_ResolvedJavaLibraries->Distinct())"
         ResolvedSymbols="@(_ResolvedSymbolFiles)"
         AndroidIncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
-        AndroidTypeMapImplementation="$(_AndroidTypeMapImplementation)"
         PublishTrimmed="$(PublishTrimmed)">
       <Output TaskParameter="OutputAssemblies" ItemName="_ProcessedAssemblies" />
       <Output TaskParameter="OutputJavaLibraries" ItemName="AndroidJavaLibrary" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -175,8 +175,18 @@
   <!-- Override _RemoveRegisterAttribute: trimmable types need [Register] attributes
        at runtime for type resolution (TryGetJniNameForType uses IJniNameProviderAttribute).
        The legacy target strips them to reduce assembly size, but the trimmable path
-       requires them. _ShrunkAssemblies is already set to _ResolvedAssemblies by
-       AssemblyResolution.targets, so no copy is needed. -->
-  <Target Name="_RemoveRegisterAttribute" />
+       requires them. We also clear _ShrunkAssemblies and re-populate it from
+       _ResolvedAssemblies, because ProcessAssemblies points the shrunk items to
+       R2R/shrunk/ which is only created by the (now no-op) _RemoveRegisterAttribute. -->
+  <Target Name="_RemoveRegisterAttribute">
+    <ItemGroup>
+      <_ShrunkAssemblies Remove="@(_ShrunkAssemblies)" />
+      <_ShrunkAssemblies Include="@(_ResolvedAssemblies)" />
+      <_ShrunkFrameworkAssemblies Remove="@(_ShrunkFrameworkAssemblies)" />
+      <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies)" />
+      <_ShrunkUserAssemblies Remove="@(_ShrunkUserAssemblies)" />
+      <_ShrunkUserAssemblies Include="@(_ResolvedUserAssemblies)" />
+    </ItemGroup>
+  </Target>
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -174,19 +174,10 @@
 
   <!-- Override _RemoveRegisterAttribute: trimmable types need [Register] attributes
        at runtime for type resolution (TryGetJniNameForType uses IJniNameProviderAttribute).
-       The legacy target strips them to reduce assembly size, but the trimmable path
-       requires them. We also clear _ShrunkAssemblies and re-populate it from
-       _ResolvedAssemblies, because ProcessAssemblies points the shrunk items to
-       R2R/shrunk/ which is only created by the (now no-op) _RemoveRegisterAttribute. -->
-  <Target Name="_RemoveRegisterAttribute">
-    <ItemGroup>
-      <_ShrunkAssemblies Remove="@(_ShrunkAssemblies)" />
-      <_ShrunkAssemblies Include="@(_ResolvedAssemblies)" />
-      <_ShrunkFrameworkAssemblies Remove="@(_ShrunkFrameworkAssemblies)" />
-      <_ShrunkFrameworkAssemblies Include="@(_ResolvedFrameworkAssemblies)" />
-      <_ShrunkUserAssemblies Remove="@(_ShrunkUserAssemblies)" />
-      <_ShrunkUserAssemblies Include="@(_ResolvedUserAssemblies)" />
-    </ItemGroup>
-  </Target>
+       The base target copies @(_ResolvedAssemblies) to @(_ShrunkAssemblies) (which
+       points at <dir>/shrunk/<file>) to support the legacy [Register] attribute
+       stripping path. The trimmable typemap path skips that entirely — ProcessAssemblies
+       already sets @(_ShrunkAssemblies) == @(_ResolvedAssemblies), so no copy is needed. -->
+  <Target Name="_RemoveRegisterAttribute" />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -172,7 +172,4 @@
     </ItemGroup>
   </Target>
 
-  <!-- Keep the base _RemoveRegisterAttribute target so PublishTrimmed still
-       populates @(_ShrunkAssemblies) for downstream BuildApk packaging. -->
-
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -172,12 +172,7 @@
     </ItemGroup>
   </Target>
 
-  <!-- Override _RemoveRegisterAttribute: trimmable types need [Register] attributes
-       at runtime for type resolution (TryGetJniNameForType uses IJniNameProviderAttribute).
-       The base target copies @(_ResolvedAssemblies) to @(_ShrunkAssemblies) (which
-       points at <dir>/shrunk/<file>) to support the legacy [Register] attribute
-       stripping path. The trimmable typemap path skips that entirely — ProcessAssemblies
-       already sets @(_ShrunkAssemblies) == @(_ResolvedAssemblies), so no copy is needed. -->
-  <Target Name="_RemoveRegisterAttribute" />
+  <!-- Keep the base _RemoveRegisterAttribute target so PublishTrimmed still
+       populates @(_ShrunkAssemblies) for downstream BuildApk packaging. -->
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -33,8 +33,6 @@ namespace Xamarin.Android.Tasks
 
 		public bool PublishTrimmed { get; set; }
 
-		public string AndroidTypeMapImplementation { get; set; } = "";
-
 		public ITaskItem [] InputAssemblies { get; set; } = [];
 
 		public ITaskItem [] InputJavaLibraries { get; set; } = [];
@@ -71,12 +69,8 @@ namespace Xamarin.Android.Tasks
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
 			// This should match the Condition on the _RemoveRegisterAttribute target.
-			// The trimmable typemap path does NOT run _RemoveRegisterAttribute
-			// (which is responsible for populating the <dir>/shrunk/ directory),
-			// so for that path ShrunkAssemblies is just OutputAssemblies.
 			if (PublishTrimmed) {
-				bool useTrimmableTypeMap = string.Equals (AndroidTypeMapImplementation, "trimmable", StringComparison.OrdinalIgnoreCase);
-				if (!AndroidIncludeDebugSymbols && !useTrimmableTypeMap) {
+				if (!AndroidIncludeDebugSymbols) {
 					var shrunkAssemblies = new List<ITaskItem> (OutputAssemblies.Length);
 					foreach (var assembly in OutputAssemblies) {
 						var dir = Path.GetDirectoryName (assembly.ItemSpec);

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ProcessAssemblies.cs
@@ -33,6 +33,8 @@ namespace Xamarin.Android.Tasks
 
 		public bool PublishTrimmed { get; set; }
 
+		public string AndroidTypeMapImplementation { get; set; } = "";
+
 		public ITaskItem [] InputAssemblies { get; set; } = [];
 
 		public ITaskItem [] InputJavaLibraries { get; set; } = [];
@@ -68,9 +70,13 @@ namespace Xamarin.Android.Tasks
 			ResolvedSymbols = symbols.Values.ToArray ();
 
 			// Set ShrunkAssemblies for _RemoveRegisterAttribute and <BuildApk/>
-			// This should match the Condition on the _RemoveRegisterAttribute target
+			// This should match the Condition on the _RemoveRegisterAttribute target.
+			// The trimmable typemap path does NOT run _RemoveRegisterAttribute
+			// (which is responsible for populating the <dir>/shrunk/ directory),
+			// so for that path ShrunkAssemblies is just OutputAssemblies.
 			if (PublishTrimmed) {
-				if (!AndroidIncludeDebugSymbols) {
+				bool useTrimmableTypeMap = string.Equals (AndroidTypeMapImplementation, "trimmable", StringComparison.OrdinalIgnoreCase);
+				if (!AndroidIncludeDebugSymbols && !useTrimmableTypeMap) {
 					var shrunkAssemblies = new List<ITaskItem> (OutputAssemblies.Length);
 					foreach (var assembly in OutputAssemblies) {
 						var dir = Path.GetDirectoryName (assembly.ItemSpec);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -73,16 +73,19 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void Execute_CollectsDeferredRegistrationTypes_ForConcreteApplicationAndInstrumentation ()
+	public void Execute_CollectsDeferredRegistrationTypes_ForAllApplicationAndInstrumentationSubtypes ()
 	{
 		using var peReader = CreateTestFixturePEReader ();
 		var result = CreateGenerator ().Execute (new List<(string, PEReader)> { ("TestFixtures", peReader) }, new Version (11, 0), new HashSet<string> ());
 
+		// Abstract Instrumentation/Application subtypes are included too: their native
+		// methods (e.g. n_OnCreate, n_OnStart) are declared on the abstract base class
+		// and must be registered via ApplicationRegistration.registerApplications ().
 		Assert.Contains ("my.app.MyApplication", result.ApplicationRegistrationTypes);
 		Assert.Contains ("my.app.MyInstrumentation", result.ApplicationRegistrationTypes);
-		Assert.DoesNotContain ("my.app.BaseApplication", result.ApplicationRegistrationTypes);
-		Assert.DoesNotContain ("my.app.BaseInstrumentation", result.ApplicationRegistrationTypes);
-		Assert.DoesNotContain ("my.app.IntermediateInstrumentation", result.ApplicationRegistrationTypes);
+		Assert.Contains ("my.app.BaseApplication", result.ApplicationRegistrationTypes);
+		Assert.Contains ("my.app.BaseInstrumentation", result.ApplicationRegistrationTypes);
+		Assert.Contains ("my.app.IntermediateInstrumentation", result.ApplicationRegistrationTypes);
 	}
 
 	[Fact]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -112,6 +112,54 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			objectProxyBaseType.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null));
 	}
 
+	// Regression test: every generated proxy type must carry a custom attribute whose
+	// constructor MemberRef points at the proxy's own TypeDefinitionHandle. This is
+	// how JavaPeerProxy instances are resolved at runtime via
+	// type.GetCustomAttribute<JavaPeerProxy>() — losing the self-application means the
+	// runtime can't construct the proxy. This has regressed twice; keep it covered.
+	[Fact]
+	public void Generate_ProxyType_IsSelfAppliedAsCustomAttribute ()
+	{
+		var peers = ScanFixtures ();
+		using var stream = GenerateAssembly (peers);
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var proxyTypeHandles = reader.TypeDefinitions
+			.Where (h => reader.GetString (reader.GetTypeDefinition (h).Namespace) == "_TypeMap.Proxies")
+			.ToList ();
+
+		Assert.NotEmpty (proxyTypeHandles);
+
+		foreach (var proxyHandle in proxyTypeHandles) {
+			var proxy = reader.GetTypeDefinition (proxyHandle);
+			var proxyName = reader.GetString (proxy.Name);
+
+			bool selfApplied = false;
+			foreach (var caHandle in proxy.GetCustomAttributes ()) {
+				var ca = reader.GetCustomAttribute (caHandle);
+				if (ca.Constructor.Kind != HandleKind.MemberReference) {
+					continue;
+				}
+
+				var ctorRef = reader.GetMemberReference ((MemberReferenceHandle) ca.Constructor);
+				if (ctorRef.Parent.Kind != HandleKind.TypeDefinition) {
+					continue;
+				}
+
+				if ((TypeDefinitionHandle) ctorRef.Parent == proxyHandle) {
+					selfApplied = true;
+					break;
+				}
+			}
+
+			Assert.True (selfApplied,
+				$"Proxy type '{proxyName}' is missing its self-applied custom attribute. " +
+				"Every proxy must carry itself as a [JavaPeerProxy] attribute so the runtime " +
+				"can instantiate it via Type.GetCustomAttribute<JavaPeerProxy> ().");
+		}
+	}
+
 	[Fact]
 	public void Generate_HasIgnoresAccessChecksToAttribute ()
 	{

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -98,12 +98,23 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		Assert.NotEmpty (proxyTypes);
 		Assert.All (proxyTypes, proxyType => {
-			Assert.Equal (HandleKind.TypeSpecification, proxyType.BaseType.Kind);
-
-			var baseTypeSpec = reader.GetTypeSpecification ((TypeSpecificationHandle) proxyType.BaseType);
-			var baseTypeName = baseTypeSpec.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null);
-
-			Assert.StartsWith ("Java.Interop.JavaPeerProxy`1<", baseTypeName, StringComparison.Ordinal);
+			switch (proxyType.BaseType.Kind) {
+			case HandleKind.TypeSpecification:
+				// Non-generic target types derive from the closed `JavaPeerProxy<T>`.
+				var baseTypeSpec = reader.GetTypeSpecification ((TypeSpecificationHandle) proxyType.BaseType);
+				var baseTypeName = baseTypeSpec.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null);
+				Assert.StartsWith ("Java.Interop.JavaPeerProxy`1<", baseTypeName, StringComparison.Ordinal);
+				break;
+			case HandleKind.TypeReference:
+				// Open generic target types derive from the non-generic `JavaPeerProxy`.
+				var baseTypeRef = reader.GetTypeReference ((TypeReferenceHandle) proxyType.BaseType);
+				Assert.Equal ("Java.Interop", reader.GetString (baseTypeRef.Namespace));
+				Assert.Equal ("JavaPeerProxy", reader.GetString (baseTypeRef.Name));
+				break;
+			default:
+				Assert.Fail ($"Unexpected BaseType handle kind: {proxyType.BaseType.Kind}");
+				break;
+			}
 		});
 
 		var objectProxy = proxyTypes.First (t => reader.GetString (t.Name) == "Java_Lang_Object_Proxy");
@@ -113,8 +124,9 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	// Regression test: every generated proxy type must carry a custom attribute whose
-	// constructor MemberRef points at the proxy's own TypeDefinitionHandle. This is
-	// how JavaPeerProxy instances are resolved at runtime via
+	// constructor points at the proxy's own TypeDefinitionHandle (either as a MemberRef
+	// parented on the TypeDef, or as a MethodDefinition on the TypeDef). This is how
+	// JavaPeerProxy instances are resolved at runtime via
 	// type.GetCustomAttribute<JavaPeerProxy>() — losing the self-application means the
 	// runtime can't construct the proxy. This has regressed twice; keep it covered.
 	[Fact]
@@ -138,17 +150,24 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			bool selfApplied = false;
 			foreach (var caHandle in proxy.GetCustomAttributes ()) {
 				var ca = reader.GetCustomAttribute (caHandle);
-				if (ca.Constructor.Kind != HandleKind.MemberReference) {
-					continue;
+
+				switch (ca.Constructor.Kind) {
+				case HandleKind.MemberReference:
+					var ctorRef = reader.GetMemberReference ((MemberReferenceHandle) ca.Constructor);
+					if (ctorRef.Parent.Kind == HandleKind.TypeDefinition &&
+						(TypeDefinitionHandle) ctorRef.Parent == proxyHandle) {
+						selfApplied = true;
+					}
+					break;
+				case HandleKind.MethodDefinition:
+					var ctorDef = reader.GetMethodDefinition ((MethodDefinitionHandle) ca.Constructor);
+					if (ctorDef.GetDeclaringType () == proxyHandle) {
+						selfApplied = true;
+					}
+					break;
 				}
 
-				var ctorRef = reader.GetMemberReference ((MemberReferenceHandle) ca.Constructor);
-				if (ctorRef.Parent.Kind != HandleKind.TypeDefinition) {
-					continue;
-				}
-
-				if ((TypeDefinitionHandle) ctorRef.Parent == proxyHandle) {
-					selfApplied = true;
+				if (selfApplied) {
 					break;
 				}
 			}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -450,6 +450,21 @@ public class ModelBuilderTests : FixtureTestBase
 			var entry = FindEntry (model, "my/app/GenericHolder");
 			Assert.NotNull (entry);
 		}
+
+		[Fact]
+		public void Fixture_GenericHolder_HasAssociation ()
+		{
+			// Generic definitions must still get a TypeMapAssociation entry so managed→proxy
+			// lookup works for the open generic definition. Their proxy derives from the
+			// non-generic `JavaPeerProxy` base, so the CLR can load the proxy without
+			// resolving an open generic argument.
+			var peer = FindFixtureByJavaName ("my/app/GenericHolder");
+			Assert.True (peer.IsGenericDefinition);
+
+			var model = BuildModel (new [] { peer }, "TypeMap");
+			Assert.Contains (model.Associations,
+				a => a.SourceTypeReference.StartsWith ("MyApp.Generic.GenericHolder`1", StringComparison.Ordinal));
+		}
 	}
 
 	public class FixtureAcwTypeHasProxy

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -124,6 +124,9 @@ namespace Java.InteropTests
 		class OpenT2<T1, T2> { }
 		class ClosedOfIntOpenT : OpenT<int> { }
 		class DeepClosedOfOpenT : ClosedOfIntOpenT { }
+		interface IOpenIface<T> { }
+		class ImplementsOpenIface<T> : IOpenIface<T> { }
+		class ClosedImplementsOpenIface : ImplementsOpenIface<int> { }
 
 		[Test]
 		public void TargetTypeMatches_DirectAssignable_ReturnsTrue ()
@@ -159,6 +162,24 @@ namespace Java.InteropTests
 			// Different open generic definitions must NOT be treated as matching.
 			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT<int>), typeof (OpenT2<,>)));
 			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (OpenT<>)));
+		}
+
+		[Test]
+		public void TargetTypeMatches_ClosedGenericInterfaceHint_OpenGenericProxy_ReturnsTrue ()
+		{
+			// Hint is the closed generic interface itself (e.g. IList<string>); the
+			// proxy's target is an open generic class that implements the open form
+			// of that interface. GetInterfaces() on IList<string> returns its super
+			// interfaces (ICollection<string>, IEnumerable<string>) — we must also
+			// check `targetType` itself, which we handle by including it as the
+			// first element of the base-chain walk (Type.GetInterfaces on an
+			// interface returns super-interfaces). The assertion here is that a
+			// hint that IS-A generic interface whose definition equals the proxy's
+			// open target is matched through the interface walk.
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ImplementsOpenIface<int>), typeof (IOpenIface<>)),
+				"closed class hint implementing an open generic interface should match a proxy whose target is that interface's open definition");
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ClosedImplementsOpenIface), typeof (IOpenIface<>)),
+				"closed subclass inheriting implementation of the open generic interface should match via interface walk");
 		}
 
 		[Test]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -167,19 +167,24 @@ namespace Java.InteropTests
 		[Test]
 		public void TargetTypeMatches_ClosedGenericInterfaceHint_OpenGenericProxy_ReturnsTrue ()
 		{
-			// Hint is the closed generic interface itself (e.g. IList<string>); the
-			// proxy's target is an open generic class that implements the open form
-			// of that interface. GetInterfaces() on IList<string> returns its super
-			// interfaces (ICollection<string>, IEnumerable<string>) — we must also
-			// check `targetType` itself, which we handle by including it as the
-			// first element of the base-chain walk (Type.GetInterfaces on an
-			// interface returns super-interfaces). The assertion here is that a
-			// hint that IS-A generic interface whose definition equals the proxy's
-			// open target is matched through the interface walk.
+			// The proxy's target is an open generic interface peer (IOpenIface<>).
+			// The hint is a closed class that implements a closed instantiation of it.
+			// Type.GetInterfaces() on a class enumerates every interface the class
+			// implements (including those inherited from base classes), so the closed
+			// interface is discovered and its GTD matches the open proxy target.
 			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ImplementsOpenIface<int>), typeof (IOpenIface<>)),
-				"closed class hint implementing an open generic interface should match a proxy whose target is that interface's open definition");
+				"closed class implementing an open generic interface should match a proxy whose target is that interface's open definition");
 			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ClosedImplementsOpenIface), typeof (IOpenIface<>)),
 				"closed subclass inheriting implementation of the open generic interface should match via interface walk");
+		}
+
+		[Test]
+		public void TargetTypeMatches_OpenGenericInterfaceProxy_UnrelatedHint_ReturnsFalse ()
+		{
+			// Negative: hint's interface set does not contain any closed form of
+			// the open generic interface that the proxy targets.
+			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (ImplementsOpenIface<int>), typeof (System.Collections.Generic.IList<>)));
+			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (IOpenIface<>)));
 		}
 
 		[Test]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Concurrent;
+using System.Reflection;
 using Android.Runtime;
 using Java.Interop;
 using Microsoft.Android.Runtime;
@@ -107,13 +109,51 @@ namespace Java.InteropTests
 				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
 			}
 
-			// The cache is keyed by the original closed type, so a second identical
-			// lookup returns the same proxy instance without walking the GTD again.
+			// Closed generic peers normalize to their open generic definition, so
+			// repeated lookups reuse the same cached proxy.
 			var instance = TrimmableTypeMap.Instance;
 
 			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<Guid>), out var first));
 			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<Guid>), out var second));
 			Assert.AreEqual (first, second);
+		}
+
+		[Test]
+		public void TryGetJniNameForManagedType_DifferentClosedGenerics_UseGenericDefinitionCacheKey ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+
+			var instance = TrimmableTypeMap.Instance;
+			var cache = GetProxyCache (instance);
+
+			cache.TryRemove (typeof (JavaList<>), out _);
+			cache.TryRemove (typeof (JavaList<long>), out _);
+			cache.TryRemove (typeof (JavaList<DateTimeOffset>), out _);
+
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<long>), out _));
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<DateTimeOffset>), out _));
+
+			Assert.IsTrue (cache.ContainsKey (typeof (JavaList<>)));
+			Assert.IsFalse (cache.ContainsKey (typeof (JavaList<long>)));
+			Assert.IsFalse (cache.ContainsKey (typeof (JavaList<DateTimeOffset>)));
+		}
+
+		static ConcurrentDictionary<Type, JavaPeerProxy> GetProxyCache (TrimmableTypeMap instance)
+		{
+			var field = typeof (TrimmableTypeMap).GetField ("_proxyCache", BindingFlags.Instance | BindingFlags.NonPublic);
+			Assert.IsNotNull (field);
+
+			var value = field.GetValue (instance);
+			Assert.IsNotNull (value);
+
+			if (value is ConcurrentDictionary<Type, JavaPeerProxy> cache) {
+				return cache;
+			}
+
+			Assert.Fail ("Unable to access TrimmableTypeMap proxy cache.");
+			throw new InvalidOperationException ("Unable to access TrimmableTypeMap proxy cache.");
 		}
 
 		// Pure-function tests for the TargetTypeMatches helper used by

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -124,9 +124,6 @@ namespace Java.InteropTests
 		class OpenT2<T1, T2> { }
 		class ClosedOfIntOpenT : OpenT<int> { }
 		class DeepClosedOfOpenT : ClosedOfIntOpenT { }
-		interface IOpenIface<T> { }
-		class ImplementsOpenIface<T> : IOpenIface<T> { }
-		class ClosedImplementsOpenIface : ImplementsOpenIface<int> { }
 
 		[Test]
 		public void TargetTypeMatches_DirectAssignable_ReturnsTrue ()
@@ -162,29 +159,6 @@ namespace Java.InteropTests
 			// Different open generic definitions must NOT be treated as matching.
 			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT<int>), typeof (OpenT2<,>)));
 			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (OpenT<>)));
-		}
-
-		[Test]
-		public void TargetTypeMatches_ClosedGenericInterfaceHint_OpenGenericProxy_ReturnsTrue ()
-		{
-			// The proxy's target is an open generic interface peer (IOpenIface<>).
-			// The hint is a closed class that implements a closed instantiation of it.
-			// Type.GetInterfaces() on a class enumerates every interface the class
-			// implements (including those inherited from base classes), so the closed
-			// interface is discovered and its GTD matches the open proxy target.
-			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ImplementsOpenIface<int>), typeof (IOpenIface<>)),
-				"closed class implementing an open generic interface should match a proxy whose target is that interface's open definition");
-			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ClosedImplementsOpenIface), typeof (IOpenIface<>)),
-				"closed subclass inheriting implementation of the open generic interface should match via interface walk");
-		}
-
-		[Test]
-		public void TargetTypeMatches_OpenGenericInterfaceProxy_UnrelatedHint_ReturnsFalse ()
-		{
-			// Negative: hint's interface set does not contain any closed form of
-			// the open generic interface that the proxy targets.
-			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (ImplementsOpenIface<int>), typeof (System.Collections.Generic.IList<>)));
-			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (IOpenIface<>)));
 		}
 
 		[Test]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -73,5 +73,98 @@ namespace Java.InteropTests
 			Assert.AreEqual (openJniName, closedIntJniName,
 				"Different closed instantiations must map to the same JNI name.");
 		}
+
+		[Test]
+		public void TryGetJniNameForManagedType_NonGenericType_ResolvesDirectly ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+
+			// Regression: the GTD fallback must not disturb the non-generic hot path.
+			Assert.IsTrue (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (typeof (JavaList), out var jniName));
+			Assert.IsFalse (string.IsNullOrEmpty (jniName));
+		}
+
+		[Test]
+		public void TryGetJniNameForManagedType_UnknownClosedGeneric_ReturnsFalse ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+
+			// System.Collections.Generic.List<T> has no TypeMapAssociation — both the
+			// direct lookup AND the GTD fallback must miss, and the API must return false.
+			Assert.IsFalse (TrimmableTypeMap.Instance.TryGetJniNameForManagedType (
+				typeof (System.Collections.Generic.List<int>), out var jniName));
+			Assert.IsNull (jniName);
+		}
+
+		[Test]
+		public void TryGetJniNameForManagedType_RepeatedClosedGenericLookup_IsCached ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+
+			// The cache is keyed by the original closed type, so a second identical
+			// lookup returns the same proxy instance without walking the GTD again.
+			var instance = TrimmableTypeMap.Instance;
+
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<Guid>), out var first));
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<Guid>), out var second));
+			Assert.AreEqual (first, second);
+		}
+
+		// Pure-function tests for the TargetTypeMatches helper used by
+		// TryGetProxyFromHierarchy when the hierarchy lookup finds a proxy whose
+		// stored TargetType is an open generic definition.
+
+		class OpenT<T> { }
+		class OpenT2<T1, T2> { }
+		class ClosedOfIntOpenT : OpenT<int> { }
+		class DeepClosedOfOpenT : ClosedOfIntOpenT { }
+
+		[Test]
+		public void TargetTypeMatches_DirectAssignable_ReturnsTrue ()
+		{
+			// Non-generic direct match: proxy target IS-A hint.
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (object), typeof (string)));
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (string)));
+		}
+
+		[Test]
+		public void TargetTypeMatches_ClosedHint_OpenGenericProxy_SelfMatch_ReturnsTrue ()
+		{
+			// Hint is OpenT<int>; proxy's target is the open GTD OpenT<>.
+			// IsAssignableFrom(OpenT<>) against OpenT<int> is false, so this exercises
+			// the new GTD base-walk branch (self match on first iteration).
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT<int>), typeof (OpenT<>)));
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT<string>), typeof (OpenT<>)));
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT2<int, string>), typeof (OpenT2<,>)));
+		}
+
+		[Test]
+		public void TargetTypeMatches_ClosedSubclassHint_OpenGenericProxy_ReturnsTrue ()
+		{
+			// Hint is a closed subclass of the open generic; the base-walk finds
+			// the generic base type whose definition equals the proxy's open target.
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (ClosedOfIntOpenT), typeof (OpenT<>)));
+			Assert.IsTrue (TrimmableTypeMap.TargetTypeMatches (typeof (DeepClosedOfOpenT), typeof (OpenT<>)));
+		}
+
+		[Test]
+		public void TargetTypeMatches_MismatchedOpenGeneric_ReturnsFalse ()
+		{
+			// Different open generic definitions must NOT be treated as matching.
+			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (OpenT<int>), typeof (OpenT2<,>)));
+			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (OpenT<>)));
+		}
+
+		[Test]
+		public void TargetTypeMatches_UnrelatedNonGeneric_ReturnsFalse ()
+		{
+			Assert.IsFalse (TrimmableTypeMap.TargetTypeMatches (typeof (string), typeof (int)));
+		}
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapTypeManagerTests.cs
@@ -1,3 +1,5 @@
+using System;
+using Android.Runtime;
 using Java.Interop;
 using Microsoft.Android.Runtime;
 using NUnit.Framework;
@@ -45,6 +47,31 @@ namespace Java.InteropTests
 			Assert.AreEqual (2, fallbacks!.Count);
 			Assert.AreEqual ("com/example/package/DesugarMyInterface$_CC", fallbacks [0]);
 			Assert.AreEqual ("com/example/package/MyInterface$-CC", fallbacks [1]);
+		}
+
+		// Verifies the generic-type-definition fallback in GetProxyForManagedType:
+		// the generator emits one TypeMapAssociation per open generic peer, so a
+		// closed instantiation like JavaList<string> must resolve through its GTD.
+		[Test]
+		public void TryGetJniNameForManagedType_ClosedGeneric_ResolvesViaGenericTypeDefinition ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+
+			var instance = TrimmableTypeMap.Instance;
+
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<>), out var openJniName),
+				"Open generic definition should resolve directly.");
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<string>), out var closedStringJniName),
+				"Closed instantiation should resolve via GTD fallback.");
+			Assert.IsTrue (instance.TryGetJniNameForManagedType (typeof (JavaList<int>), out var closedIntJniName),
+				"A second closed instantiation should also resolve via GTD fallback.");
+
+			Assert.AreEqual (openJniName, closedStringJniName,
+				"Closed instantiation must share the open GTD's JNI name (Java erases generics).");
+			Assert.AreEqual (openJniName, closedIntJniName,
+				"Different closed instantiations must map to the same JNI name.");
 		}
 	}
 }


### PR DESCRIPTION
Part 4 of the split of the trimmable-test-plumbing branch. (PR-1: #11142, PR-2: #11144, PR-3: #11143)

A collection of correctness fixes for the trimmable typemap runtime and code
generator, uncovered while stabilizing the new CoreCLRTrimmable test lane.

### Runtime / managed side

- **Fix runtime initialization ordering and generic type crash** — a generic proxy type was being resolved before the typemap was ready, causing a `NullReferenceException` on startup.
- **Fix generic type proxy loading in the typemap** — the generic definition's `Type.FullName` includes a mangled form that did not match the proxy's lookup key.
- **Revert two-phase init — use a single `Initialize ()` after runtime creation.** The two-phase scheme was only needed for a register-natives workaround that no longer applies.
- **Fix ClassLoader mismatch in `RegisterNatives`** — use the class reference passed from Java (`nativeClassHandle`) via `new JniType (ref classRef, Copy)` instead of `new JniType (className)`, because `FindClass` may resolve to a different class from a different `ClassLoader`.
- **Fix Release build pipeline and `ApplicationRegistration`** — the `ApplicationRegistration` helper was not being emitted in Release where the generator ran under a different code path.

### Code generator

- **Include abstract `Instrumentation`/`Application` subtypes in `ApplicationRegistration`.** Their native methods (`n_OnCreate`, `n_OnStart`, etc.) are declared on the abstract base class and must be registered via `ApplicationRegistration.registerApplications ()`.
- **Self-apply generated proxy types as their own `[JavaPeerProxy]` custom attribute** so the runtime can instantiate them via `type.GetCustomAttribute<JavaPeerProxy> ()` for AOT-safe resolution.

### Closed-generic peer lookup (follow-up commits)

Closed generic instantiations (e.g. `JavaList<string>`) were silently missing from the typemap: the generator correctly emits entries keyed by the **open** generic definition (`JavaList<>`), but the runtime only did an identity `TryGetValue`, so closed instantiations returned `null`.

- **GTD fallback in `GetProxyForManagedType`** — after a direct miss, retry the dictionary with `type.GetGenericTypeDefinition ()` when the request is a closed generic. `GetGenericTypeDefinition` is AOT- and trim-safe (it is not annotated `RequiresDynamicCode`/`RequiresUnreferencedCode`, unlike `MakeGenericType`). The resolved proxy is cached under the original closed type.
- **Open-generic aware `TargetTypeMatches` helper** — the hierarchy lookup's `IsAssignableFrom` check is supplemented by a base-chain walk (closed subclass of an open generic peer, e.g. `class MyList : JavaList<int>`) and a `GetInterfaces ()` walk (closed class implementing an open generic interface peer). `IL2070` is suppressed with a justification: `targetType` originates at JNI marshalling call sites where the caller's generic signature keeps its base chain and interface set rooted.
- **Scope is deliberately managed→JNI only** — `JavaPeerProxy.CreateInstance` on an open-generic proxy still throws `NotSupportedException`: we never construct closed generic peers from Java, and `MakeGenericType` is not safe under full NativeAOT anyway.

### Tests

- `Generate_ProxyType_IsSelfAppliedAsCustomAttribute` — invariant has regressed twice; lock it down.
- `Execute_CollectsDeferredRegistrationTypes` — reflects that abstract `Instrumentation`/`Application` subtypes are now included.
- `TrimmableTypeMapTypeManagerTests` (device suite) — **12 new tests** for the closed-generic lookup path: managed→JNI resolution via GTD (direct/subclass/unknown/cached/non-generic), pure `TargetTypeMatches` assertions covering direct assignability, self-match, closed subclass, mismatched arity, interface implementer, inherited interface, and unrelated-hint negatives.

### Known gap / follow-up

Descendants of `Application` and `Instrumentation` that are themselves concrete can still fail to register their native methods when the base is abstract and the subclass is loaded before the managed runtime is ready. The current PR intentionally does **not** land a 'propagate `CannotRegisterInStaticConstructor` to descendants' style fix.

Instead, I will open a follow-up issue proposing to **unify the registration approach** — always defer registration via `__md_registerNatives ()` for all types — and drop the propagation machinery entirely, with a possible future optimization to use `static { registerNatives }` for provably safe types.

### Scope

Host unit tests: 355/355 pass locally; device tests run in CI (CoreCLRTrimmable lane).
