### PR TITLE
[ci] Only run dnceng-public pipeline for fork PRs

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -1,17 +1,10 @@
 # .NET for Android Pipeline - Public Build
-# This pipeline runs on the public dnceng instance for:
-# - PRs from forks (contributors)
-# - Main or release branch CI builds
+# This pipeline runs on the public dnceng instance for PRs from forks (contributors).
 # Internal branches use the DevDiv pipeline (azure-pipelines.yaml)
 
 name: $(Build.SourceBranchName)-$(Build.SourceVersion)-$(Rev:r)
 
-trigger:
-  branches:
-    include:
-    - main
-    - release/*
-    - feature/*
+trigger: none
 
 pr:
   branches:
@@ -74,6 +67,7 @@ stages:
 # macOS Build Stage
 - stage: mac_build
   displayName: Mac
+  condition: eq(variables['System.PullRequest.IsFork'], 'True')
   jobs:
   - job: mac_build_create_installers
     displayName: macOS > Build
@@ -109,6 +103,7 @@ stages:
 - stage: win_build_test
   displayName: Windows
   dependsOn: []
+  condition: eq(variables['System.PullRequest.IsFork'], 'True')
   jobs:
   - job: win_build_test
     displayName: Windows > Build & Smoke Test
@@ -130,6 +125,7 @@ stages:
 - stage: linux_build
   displayName: Linux
   dependsOn: []
+  condition: eq(variables['System.PullRequest.IsFork'], 'True')
   jobs:
   - job: linux_build_create_sdk_pack
     displayName: Linux > Build
@@ -177,7 +173,7 @@ stages:
   dependsOn: 
   - mac_build
   - linux_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'), ne(variables['SkipTestStages'], 'true'))
   jobs:
   - job: linux_tests_smoke_1
     displayName: Linux > Tests > MSBuild 1
@@ -273,7 +269,7 @@ stages:
 - stage: msbuild_dotnet
   displayName: MSBuild Tests
   dependsOn: mac_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'), ne(variables['SkipTestStages'], 'true'))
   jobs:
   - job: mac_msbuild_tests
     strategy:
@@ -364,7 +360,7 @@ stages:
 - stage: msbuilddevice_tests
   displayName: MSBuild Emulator Tests
   dependsOn: mac_build
-  condition: and(succeeded(), ne(variables['SkipTestStages'], 'true'))
+  condition: and(succeeded(), eq(variables['System.PullRequest.IsFork'], 'True'), ne(variables['SkipTestStages'], 'true'))
   jobs:
   - job: mac_dotnetdevice_tests
     strategy:


### PR DESCRIPTION
## Description

The dnceng-public pipeline (`azure-pipelines-public.yaml`) currently runs CI
builds on pushes to `main`, `release/*`, and `feature/*`, and also triggers for
all PRs (not just forks). This duplicates work already handled by the internal
DevDiv pipeline, wasting public pool resources.

This PR restricts the dnceng-public pipeline to only run for fork PRs:

- **Remove CI trigger** -- set `trigger: none` so pushes to main/release/feature
  no longer trigger builds on dnceng-public.
- **Add fork-only condition to all stages** -- every stage now checks
  `eq(variables['System.PullRequest.IsFork'], 'True')` so non-fork PRs that
  still trigger the pipeline will skip all stages immediately.

The `pr:` trigger cannot filter by fork status in YAML, so non-fork PRs will
still trigger the pipeline, but no stages will execute.

- [x] Useful description of *why the change is necessary*.
- N/A -- no issue linked
- N/A -- CI pipeline config change, no unit tests applicable