### PR TITLE
[tests] Improve NUnit runner reporting and dry-run auditing

### DIFF
--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunInstrumentationTests.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 				new CommandInfo {
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
 					StdoutFilePath = LogcatFilename,
-					StdoutAppend = true,
+					StdoutAppend = false,
 				},
 
 				new CommandInfo {

--- a/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
+++ b/build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks/RunUITests.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Android.Tools.BootstrapTasks
 					ArgumentsString = $"{AdbTarget} {AdbOptions} logcat -v threadtime -d",
 					MergeStdoutAndStderr = false,
 					StdoutFilePath = LogcatFilename,
-					StdoutAppend = true,
+					StdoutAppend = false,
 				},
 
 				new CommandInfo {

--- a/build-tools/scripts/TestApks.targets
+++ b/build-tools/scripts/TestApks.targets
@@ -274,6 +274,8 @@
     <PropertyGroup>
       <_IncludeCategories Condition=" '$(IncludeCategories)' != '' ">include=$(IncludeCategories)</_IncludeCategories>
       <_ExcludeCategories Condition=" '$(ExcludeCategories)' != '' ">exclude=$(ExcludeCategories)</_ExcludeCategories>
+      <_DryRunTests Condition=" '$(DryRunTests)' == 'true' ">dryrun=true</_DryRunTests>
+      <_NoTestExclusions Condition=" '$(NoTestExclusions)' == 'true' ">noexclusions=true</_NoTestExclusions>
       <PlotDataLabelSuffix Condition=" '$(PlotDataLabelSuffix)' == '' ">$(TestsFlavor)</PlotDataLabelSuffix>
     </PropertyGroup>
     <RunInstrumentationTests
@@ -287,7 +289,7 @@
         Component="%(TestApkInstrumentation.Package)/%(TestApkInstrumentation.Identity)"
         NUnit2TestResultsFile="%(TestApkInstrumentation.ResultsPath)"
         LogcatFilename="$(_LogcatFilenameBase)-%(TestApkInstrumentation.Package)%(TestApkInstrumentation.LogcatFilenameDistincion).txt"
-        InstrumentationArguments="$(_IncludeCategories);$(_ExcludeCategories)"
+        InstrumentationArguments="$(_IncludeCategories);$(_ExcludeCategories);$(_DryRunTests);$(_NoTestExclusions)"
         TestFixture="$(TestFixture)"
         ToolExe="$(AdbToolExe)"
         ToolPath="$(AdbToolPath)"

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -110,18 +110,20 @@ namespace Xamarin.Android.UnitTests
 			}
 
 			if (StringExtrasInBundle.TryGetValue (KnownArguments.DryRun, out string dryRunValue)) {
-				DryRunRequested =
-					String.Equals (dryRunValue?.Trim (), "true", StringComparison.OrdinalIgnoreCase) ||
-					String.Equals (dryRunValue?.Trim (), "1", StringComparison.OrdinalIgnoreCase) ||
-					String.Equals (dryRunValue?.Trim (), "yes", StringComparison.OrdinalIgnoreCase);
+				DryRunRequested = ParseBool (dryRunValue);
 			}
 
 			if (StringExtrasInBundle.TryGetValue (KnownArguments.NoExclusions, out string noExclusionsValue)) {
-				NoExclusionsRequested =
-					String.Equals (noExclusionsValue?.Trim (), "true", StringComparison.OrdinalIgnoreCase) ||
-					String.Equals (noExclusionsValue?.Trim (), "1", StringComparison.OrdinalIgnoreCase) ||
-					String.Equals (noExclusionsValue?.Trim (), "yes", StringComparison.OrdinalIgnoreCase);
+				NoExclusionsRequested = ParseBool (noExclusionsValue);
 			}
+		}
+
+		static bool ParseBool (string value)
+		{
+			string trimmed = value?.Trim ();
+			return String.Equals (trimmed, "true", StringComparison.OrdinalIgnoreCase) ||
+				String.Equals (trimmed, "1", StringComparison.OrdinalIgnoreCase) ||
+				String.Equals (trimmed, "yes", StringComparison.OrdinalIgnoreCase);
 		}
 
 		public override void OnStart ()

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Android.UnitTests
 			public const string Suite = "suite";
 			public const string Include = "include";
 			public const string Exclude = "exclude";
+			public const string DryRun = "dryrun";
+			public const string NoExclusions = "noexclusions";
 		}
 
 		const string ResultExecutedTests = "run";
@@ -40,6 +42,8 @@ namespace Xamarin.Android.UnitTests
 		protected LogWriter Logger { get; } = new LogWriter ();
 		protected Dictionary<string, string> StringExtrasInBundle { get; set; } = new Dictionary<string, string> ();
 		protected string TestSuiteToRun { get; set; }
+		protected bool DryRunRequested { get; set; }
+		protected bool NoExclusionsRequested { get; set; }
 
 		protected TestInstrumentation ()
 		{}
@@ -103,6 +107,20 @@ namespace Xamarin.Android.UnitTests
 
 			if (StringExtrasInBundle.ContainsKey (KnownArguments.Suite)) {
 				TestSuiteToRun = StringExtrasInBundle [KnownArguments.Suite]?.Trim ();
+			}
+
+			if (StringExtrasInBundle.TryGetValue (KnownArguments.DryRun, out string dryRunValue)) {
+				DryRunRequested =
+					String.Equals (dryRunValue?.Trim (), "true", StringComparison.OrdinalIgnoreCase) ||
+					String.Equals (dryRunValue?.Trim (), "1", StringComparison.OrdinalIgnoreCase) ||
+					String.Equals (dryRunValue?.Trim (), "yes", StringComparison.OrdinalIgnoreCase);
+			}
+
+			if (StringExtrasInBundle.TryGetValue (KnownArguments.NoExclusions, out string noExclusionsValue)) {
+				NoExclusionsRequested =
+					String.Equals (noExclusionsValue?.Trim (), "true", StringComparison.OrdinalIgnoreCase) ||
+					String.Equals (noExclusionsValue?.Trim (), "1", StringComparison.OrdinalIgnoreCase) ||
+					String.Equals (noExclusionsValue?.Trim (), "yes", StringComparison.OrdinalIgnoreCase);
 			}
 		}
 
@@ -259,7 +277,12 @@ namespace Xamarin.Android.UnitTests
 
 			TRunner runner = CreateRunner (Logger, arguments);
 			runner.LogTag = LogTag;
+			runner.DryRun = DryRunRequested;
 			ConfigureFilters (runner);
+
+			if (runner.DryRun) {
+				Log.Info (LogTag, "Dry-run discovery mode enabled; tests will be enumerated but not executed.");
+			}
 
 			Log.Info (LogTag, "Starting unit tests");
 			runner.Run (assemblies);

--- a/tests/TestRunner.Core/TestRunner.cs
+++ b/tests/TestRunner.Core/TestRunner.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Android.UnitTests
 		public long ExecutedTests { get; protected set; } = 0;
 		public long TotalTests { get; protected set; } = 0;
 		public long FilteredTests { get; protected set; } = 0;
+		public bool DryRun { get; set; } = false;
 		public bool RunInParallel { get; set; } = false;
 		public string TestsRootDirectory { get; set; }
 		public Context Context { get; }

--- a/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
+++ b/tests/TestRunner.NUnit/NUnitTestInstrumentation.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Android.UnitTests.NUnit
 		protected IEnumerable<string> IncludedCategories { get; set; }
 		protected IEnumerable<string> ExcludedCategories { get; set; }
 		protected IEnumerable<string> ExcludedTestNames { get; set; }
+		protected IDictionary<string, string> ExcludedCategoryReasons { get; set; }
+		protected IDictionary<string, string> ExcludedTestReasons { get; set; }
 		protected string TestsDirectory { get; set; }
 
 		protected NUnitTestInstrumentation ()
@@ -67,14 +69,22 @@ namespace Xamarin.Android.UnitTests.NUnit
 			Log.Info (LogTag, "Configuring test categories to include from extras:");
 			ChainCategoryFilter (GetFilterValuesFromExtras (KnownArguments.Include), false, ref filter);
 
-			Log.Info (LogTag, "Configuring test categories to exclude:");
-			ChainCategoryFilter (ExcludedCategories, true, ref filter);
+			if (NoExclusionsRequested) {
+				Log.Info (LogTag, "Skipping built-in test exclusions due to noexclusions=true.");
+			} else {
+				Log.Info (LogTag, "Configuring test categories to exclude:");
+				RegisterExcludedCategories (runner, ExcludedCategories);
+			}
 
 			Log.Info(LogTag, "Configuring test categories to exclude from extras:");
-			ChainCategoryFilter (GetFilterValuesFromExtras (KnownArguments.Exclude), true, ref filter);
+			RegisterExcludedCategories (runner, GetFilterValuesFromExtras (KnownArguments.Exclude));
 
-			Log.Info (LogTag, "Configuring tests to exclude (by name):");
-			ChainTestNameFilter (ExcludedTestNames?.ToArray (), ref filter);
+			if (NoExclusionsRequested) {
+				Log.Info (LogTag, "Skipping built-in test-name exclusions due to noexclusions=true.");
+			} else {
+				Log.Info (LogTag, "Configuring tests to exclude (by name):");
+				RegisterExcludedTestNames (runner, ExcludedTestNames?.ToArray ());
+			}
 
 			if (filter.IsEmpty)
 				return;
@@ -104,7 +114,31 @@ namespace Xamarin.Android.UnitTests.NUnit
 				Log.Info (LogTag, "  none");
 		}
 
-		void ChainTestNameFilter (string[] testNames, ref ITestFilter filter)
+		void RegisterExcludedCategories (NUnitTestRunner runner, IEnumerable<string> categories)
+		{
+			bool gotCategories = false;
+			if (categories != null) {
+				foreach (string c in categories) {
+					Log.Info (LogTag, $"  {c}");
+					runner.AddExcludedCategory (c, GetExcludedCategoryReason (c));
+					gotCategories = true;
+				}
+			}
+
+			if (!gotCategories)
+				Log.Info (LogTag, "  none");
+		}
+
+		string GetExcludedCategoryReason (string category)
+		{
+			if (ExcludedCategoryReasons != null && !String.IsNullOrEmpty (category) && ExcludedCategoryReasons.TryGetValue (category, out string reason)) {
+				return reason;
+			}
+
+			return $"Excluded category '{category}'.";
+		}
+
+		void RegisterExcludedTestNames (NUnitTestRunner runner, string[] testNames)
 		{
 			if (testNames == null || testNames.Length == 0) {
 				Log.Info (LogTag, "  none");
@@ -115,10 +149,17 @@ namespace Xamarin.Android.UnitTests.NUnit
 				if (String.IsNullOrEmpty (name))
 					continue;
 				Log.Info (LogTag, $"  {name}");
+				runner.AddExcludedTestName (name, GetExcludedTestReason (name));
+			}
+		}
+
+		string GetExcludedTestReason (string testName)
+		{
+			if (ExcludedTestReasons != null && !String.IsNullOrEmpty (testName) && ExcludedTestReasons.TryGetValue (testName, out string reason)) {
+				return reason;
 			}
 
-			var excludeTestNamesFilter  = new SimpleNameFilter (testNames);
-			filter = new AndFilter (filter, new NotFilter (excludeTestNamesFilter));
+			return $"Excluded test '{testName}'.";
 		}
 	}
 }

--- a/tests/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/TestRunner.NUnit/NUnitTestRunner.cs
@@ -72,9 +72,23 @@ namespace Xamarin.Android.UnitTests.NUnit
 				if (testResult == null)
 					throw new InvalidOperationException ($"Unexpected test result type '{result.GetType ()}'");
 				results.AddResult (testResult);
+				UpdateSummaryCounts ();
 			}
 
 			LogFailureSummary ();
+		}
+
+		void UpdateSummaryCounts ()
+		{
+			if (results == null) {
+				return;
+			}
+
+			PassedTests = results.PassCount;
+			FailedTests = results.FailCount;
+			SkippedTests = results.SkipCount;
+			InconclusiveTests = results.InconclusiveCount;
+			ExecutedTests = PassedTests + FailedTests + SkippedTests + InconclusiveTests;
 		}
 
 		public bool Pass (ITest test)

--- a/tests/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/TestRunner.NUnit/NUnitTestRunner.cs
@@ -210,9 +210,9 @@ namespace Xamarin.Android.UnitTests.NUnit
 			if (fullName == excludedName ||
 				fullName.StartsWith (excludedName + ".", StringComparison.Ordinal) ||
 				fullName.StartsWith (excludedName + "+", StringComparison.Ordinal) ||
-				fullName.Contains (", " + excludedName, StringComparison.Ordinal) ||
-				fullName.Contains (excludedName + ".", StringComparison.Ordinal) ||
-				fullName.Contains (excludedName + "+", StringComparison.Ordinal)) {
+				fullName.Contains ("." + excludedName + ".", StringComparison.Ordinal) ||
+				fullName.Contains ("." + excludedName + "+", StringComparison.Ordinal) ||
+				fullName.Contains (", " + excludedName, StringComparison.Ordinal)) {
 				return true;
 			}
 
@@ -257,10 +257,8 @@ namespace Xamarin.Android.UnitTests.NUnit
 				Action<string, string> log = Logger.OnInfo;
 				StringBuilder failedMessage = null;
 
-				ExecutedTests++;
 				if (result.ResultState.Status == TestStatus.Passed) {
 					Logger.OnInfo (LogTag, $"\t{result.ResultState.ToString ()}");
-					PassedTests++;
 				} else if (result.ResultState.Status == TestStatus.Failed) {
 					Logger.OnError (LogTag, "\t[FAIL]");
 					log = Logger.OnError;
@@ -269,24 +267,12 @@ namespace Xamarin.Android.UnitTests.NUnit
 					if (result.Test.FixtureType != null)
 						failedMessage.Append ($" ({result.Test.FixtureType.Assembly.GetName ().Name})");
 					failedMessage.AppendLine ();
-					FailedTests++;
 				} else {
-					string status;
-					switch (result.ResultState.Status) {
-						case TestStatus.Skipped:
-							SkippedTests++;
-							status = "SKIPPED";
-							break;
-
-						case TestStatus.Inconclusive:
-							InconclusiveTests++;
-							status = "INCONCLUSIVE";
-							break;
-
-						default:
-							status = "UNKNOWN";
-							break;
-					}
+					string status = result.ResultState.Status switch {
+						TestStatus.Skipped => "SKIPPED",
+						TestStatus.Inconclusive => "INCONCLUSIVE",
+						_ => "UNKNOWN",
+					};
 					Logger.OnInfo (LogTag, $"\t[{status}]");
 				}
 

--- a/tests/TestRunner.NUnit/NUnitTestRunner.cs
+++ b/tests/TestRunner.NUnit/NUnitTestRunner.cs
@@ -20,8 +20,12 @@ namespace Xamarin.Android.UnitTests.NUnit
 {
 	public class NUnitTestRunner : TestRunner, ITestListener
 	{
+		const string DryRunSkipReason = "Dry run: discovery only.";
+
 		Dictionary<string, object> builderSettings;
 		TestSuiteResult results;
+		readonly Dictionary<string, string> excludedCategories = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase);
+		readonly Dictionary<string, string> excludedTestNames = new Dictionary<string, string> (StringComparer.Ordinal);
 
 		public ITestFilter Filter { get; set; } = TestFilter.Empty;
 		public bool GCAfterEachFixture { get; set; }
@@ -31,6 +35,24 @@ namespace Xamarin.Android.UnitTests.NUnit
 		public NUnitTestRunner (Context context, LogWriter logger, Bundle bundle) : base (context, logger, bundle)
 		{
 			builderSettings = new Dictionary<string, object> (StringComparer.OrdinalIgnoreCase);
+		}
+
+		public void AddExcludedCategory (string category, string reason)
+		{
+			if (String.IsNullOrEmpty (category)) {
+				return;
+			}
+
+			excludedCategories [category] = reason;
+		}
+
+		public void AddExcludedTestName (string testName, string reason)
+		{
+			if (String.IsNullOrEmpty (testName)) {
+				return;
+			}
+
+			excludedTestNames [testName] = reason;
 		}
 
 		public override void Run (IList<TestAssemblyInfo> testAssemblies)
@@ -51,8 +73,14 @@ namespace Xamarin.Android.UnitTests.NUnit
 					OnWarning ($"Failed to load tests from assembly '{assemblyInfo.Assembly}");
 					continue;
 				}
-				if (runner.LoadedTest is NUnitTest tests)
+				if (runner.LoadedTest is NUnitTest tests) {
 					testSuite.Add (tests);
+					ApplyIgnoredExclusions (tests);
+					UpdateDiscoveredTestCounts (tests);
+					if (DryRun) {
+						ApplyDryRunToMatchingTests (tests);
+					}
+				}
 				
 				// Messy API. .Run returns ITestResult which is, in reality, an instance of TestResult since that's
 				// what WorkItem returns and we need an instance of TestResult to add it to TestSuiteResult. So, cast
@@ -89,6 +117,120 @@ namespace Xamarin.Android.UnitTests.NUnit
 			SkippedTests = results.SkipCount;
 			InconclusiveTests = results.InconclusiveCount;
 			ExecutedTests = PassedTests + FailedTests + SkippedTests + InconclusiveTests;
+		}
+
+		void ApplyIgnoredExclusions (NUnitTest test)
+		{
+			if (test.RunState != RunState.Runnable && test.RunState != RunState.Explicit) {
+				return;
+			}
+
+			if (!TryGetSkipReason (test, out string reason)) {
+				if (test is TestSuite suite) {
+					foreach (NUnitTest child in suite.Tests) {
+						ApplyIgnoredExclusions (child);
+					}
+				}
+				return;
+			}
+
+			test.RunState = RunState.Ignored;
+			test.Properties.Set (PropertyNames.SkipReason, reason);
+		}
+
+		void UpdateDiscoveredTestCounts (NUnitTest test)
+		{
+			if (test is TestSuite suite) {
+				foreach (NUnitTest child in suite.Tests) {
+					UpdateDiscoveredTestCounts (child);
+				}
+				return;
+			}
+
+			TotalTests++;
+			if (Filter == null || Filter.IsEmpty || Filter.Pass (test)) {
+				FilteredTests++;
+			}
+		}
+
+		void ApplyDryRunToMatchingTests (NUnitTest test)
+		{
+			if (test is TestSuite suite) {
+				foreach (NUnitTest child in suite.Tests) {
+					ApplyDryRunToMatchingTests (child);
+				}
+				return;
+			}
+
+			if (Filter != null && !Filter.IsEmpty && !Filter.Pass (test)) {
+				return;
+			}
+
+			if (test.RunState == RunState.Runnable || test.RunState == RunState.Explicit) {
+				test.RunState = RunState.Ignored;
+				test.Properties.Set (PropertyNames.SkipReason, DryRunSkipReason);
+			}
+
+			string reason = test.Properties.Get (PropertyNames.SkipReason) as string;
+			if (String.IsNullOrEmpty (reason)) {
+				Logger.OnInfo (LogTag, $"[DRY-RUN] {test.FullName}");
+			} else {
+				Logger.OnInfo (LogTag, $"[DRY-RUN] {test.FullName} [{reason}]");
+			}
+		}
+
+		bool TryGetSkipReason (NUnitTest test, out string reason)
+		{
+			if (TryGetNamedSkipReason (test, out reason)) {
+				return true;
+			}
+
+			return TryGetCategorySkipReason (test, out reason);
+		}
+
+		bool TryGetNamedSkipReason (NUnitTest test, out string reason)
+		{
+			foreach (var kvp in excludedTestNames) {
+				if (TestNameMatches (test.FullName, kvp.Key)) {
+					reason = kvp.Value;
+					return true;
+				}
+			}
+
+			reason = String.Empty;
+			return false;
+		}
+
+		static bool TestNameMatches (string fullName, string excludedName)
+		{
+			if (String.IsNullOrEmpty (fullName) || String.IsNullOrEmpty (excludedName)) {
+				return false;
+			}
+
+			if (fullName == excludedName ||
+				fullName.StartsWith (excludedName + ".", StringComparison.Ordinal) ||
+				fullName.StartsWith (excludedName + "+", StringComparison.Ordinal) ||
+				fullName.Contains (", " + excludedName, StringComparison.Ordinal) ||
+				fullName.Contains (excludedName + ".", StringComparison.Ordinal) ||
+				fullName.Contains (excludedName + "+", StringComparison.Ordinal)) {
+				return true;
+			}
+
+			return false;
+		}
+
+		bool TryGetCategorySkipReason (NUnitTest test, out string reason)
+		{
+			if (test.Properties [PropertyNames.Category] is IList categories) {
+				foreach (object value in categories) {
+					if (value is string category && excludedCategories.TryGetValue (category, out reason)) {
+						return true;
+					}
+				}
+			}
+
+			reason = String.Empty;
+			return false;
 		}
 
 		public bool Pass (ITest test)


### PR DESCRIPTION
## Summary
Improve the Android NUnit harness so trimmable and test-lane investigations can audit discovery and exclusions reliably.

## Changes
- fix final Passed/Failed/Skipped summary counts to match NUnit aggregate results
- add a discovery-only dry-run mode
- add noexclusions=true to bypass built-in exclusions for auditing
- surface excluded tests as ignored results with explicit reasons
- overwrite logcat output per run so stale logs do not masquerade as current crashes

## Why
These generic test-runner improvements were useful while working on #11091. I had problems identifying which tests were discovered, but did not run, as passed + skipped + failed < total.