### PR TITLE
[Build] Add Inputs/Outputs to _AddTypeManagerResources to skip on incremental builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -349,7 +349,7 @@
   <Target Name="_AddTypeManagerResources"
       AfterTargets="_AddStaticResources"
       Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
-      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar;$(_AndroidIntermediateJavaSourceDirectory)mono\TypeManager.java">
+      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar">
     <CreateTypeManagerJava
         Condition=" '$(_AndroidUseMarshalMethods)' == 'True' "
         ResourceName="JavaInteropTypeManager.java"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -346,10 +346,14 @@
   </Target>
 
   <!-- TypeManager.java generation and prebuilt mono.android.jar copy -->
+  <PropertyGroup>
+    <_AddTypeManagerResourcesOutput Condition=" '$(_AndroidUseMarshalMethods)' == 'True' ">$(_AndroidIntermediateJavaSourceDirectory)mono\TypeManager.java</_AddTypeManagerResourcesOutput>
+    <_AddTypeManagerResourcesOutput Condition=" '$(_AndroidUseMarshalMethods)' != 'True' ">$(IntermediateOutputPath)android\bin\mono.android.jar</_AddTypeManagerResourcesOutput>
+  </PropertyGroup>
   <Target Name="_AddTypeManagerResources"
       AfterTargets="_AddStaticResources"
       Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
-      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar">
+      Outputs="$(_AddTypeManagerResourcesOutput)">
     <CreateTypeManagerJava
         Condition=" '$(_AndroidUseMarshalMethods)' == 'True' "
         ResourceName="JavaInteropTypeManager.java"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -349,7 +349,7 @@
   <Target Name="_AddTypeManagerResources"
       AfterTargets="_AddStaticResources"
       Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
-      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar">
+      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar;$(_AndroidIntermediateJavaSourceDirectory)mono\TypeManager.java">
     <CreateTypeManagerJava
         Condition=" '$(_AndroidUseMarshalMethods)' == 'True' "
         ResourceName="JavaInteropTypeManager.java"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -347,7 +347,9 @@
 
   <!-- TypeManager.java generation and prebuilt mono.android.jar copy -->
   <Target Name="_AddTypeManagerResources"
-      AfterTargets="_AddStaticResources">
+      AfterTargets="_AddStaticResources"
+      Inputs="$(MonoPlatformJarPath);$(_AndroidBuildPropertiesCache)"
+      Outputs="$(IntermediateOutputPath)android\bin\mono.android.jar">
     <CreateTypeManagerJava
         Condition=" '$(_AndroidUseMarshalMethods)' == 'True' "
         ResourceName="JavaInteropTypeManager.java"

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -41,7 +41,9 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_Sign"),
 					"the _Sign target should not run");
-				b.Output.AssertTargetIsSkipped ("_AddTypeManagerResources");
+				if (runtime != AndroidRuntime.NativeAOT) {
+					b.Output.AssertTargetIsSkipped ("_AddTypeManagerResources");
+				}
 				var item = proj.AndroidResources.First (x => x.Include () == "Resources\\values\\Strings.xml");
 				item.TextContent = () => proj.StringsXml.Replace ("${PROJECT_NAME}", "Foo");
 				item.Timestamp = null;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_Sign"),
 					"the _Sign target should not run");
+				b.Output.AssertTargetIsSkipped ("_AddTypeManagerResources");
 				var item = proj.AndroidResources.First (x => x.Include () == "Resources\\values\\Strings.xml");
 				item.TextContent = () => proj.StringsXml.Replace ("${PROJECT_NAME}", "Foo");
 				item.Timestamp = null;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -990,6 +990,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
 		<_PropertyCacheItems Include="AndroidUseDesignerAssembly=$(AndroidUseDesignerAssembly)" />
 		<_PropertyCacheItems Include="_AndroidTypeMapImplementation=$(_AndroidTypeMapImplementation)" />
+		<_PropertyCacheItems Include="_AndroidUseMarshalMethods=$(_AndroidUseMarshalMethods)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -991,6 +991,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="AndroidUseDesignerAssembly=$(AndroidUseDesignerAssembly)" />
 		<_PropertyCacheItems Include="_AndroidTypeMapImplementation=$(_AndroidTypeMapImplementation)" />
 		<_PropertyCacheItems Include="_AndroidUseMarshalMethods=$(_AndroidUseMarshalMethods)" />
+		<_PropertyCacheItems Include="_AndroidJcwCodegenTarget=$(_AndroidJcwCodegenTarget)" />
 	</ItemGroup>
 	<WriteLinesToFile
 			File="$(_AndroidBuildPropertiesCache)"


### PR DESCRIPTION
## Summary

A `.binlog` analysis showed that the `_AddTypeManagerResources` target costs **~90ms on every incremental build** because it had no `Inputs`/`Outputs` and always ran, even when nothing changed.

## Changes

**`Microsoft.Android.Sdk.TypeMap.LlvmIr.targets`**

Added `Inputs`/`Outputs` to `_AddTypeManagerResources` using a conditional `_AddTypeManagerResourcesOutput` property that resolves to the correct output file for each code path:

- **Marshal methods** (`_AndroidUseMarshalMethods=True`): output is `TypeManager.java` (written by `CreateTypeManagerJava`)
- **Non-marshal methods** (common path): output is `mono.android.jar` (copied and touched)

Inputs are `$(MonoPlatformJarPath)` and `$(_AndroidBuildPropertiesCache)`.

**`Xamarin.Android.Common.targets`**

Added `_AndroidUseMarshalMethods` and `_AndroidJcwCodegenTarget` to `@(_PropertyCacheItems)` so that `build.props` changes when these settings change, correctly invalidating `_AddTypeManagerResources`.

**`IncrementalBuildTest.cs`**

Added an assertion to `BasicApplicationRepetitiveBuild` verifying `_AddTypeManagerResources` is skipped on a no-change rebuild (skipped for NativeAOT, where the target is a no-op and produces no output file).