### PR TITLE
[Build] Add Inputs/Outputs to `_GenerateCompressedAssembliesNativeSourceFiles`

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -41,6 +41,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (
 					b.Output.IsTargetSkipped ("_Sign"),
 					"the _Sign target should not run");
+				b.Output.AssertTargetIsSkipped ("_GenerateCompressedAssembliesNativeSourceFiles");
 				var item = proj.AndroidResources.First (x => x.Include () == "Resources\\values\\Strings.xml");
 				item.TextContent = () => proj.StringsXml.Replace ("${PROJECT_NAME}", "Foo");
 				item.Timestamp = null;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1997,7 +1997,9 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Target Name="_GenerateCompressedAssembliesNativeSourceFiles"
-        Condition=" '$(_AndroidRuntime)' != 'NativeAOT' ">
+        Condition=" '$(_AndroidRuntime)' != 'NativeAOT' "
+        Inputs="@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies)"
+        Outputs="@(_CompressedAssembliesAssemblySource)">
   <GenerateCompressedAssembliesNativeSourceFiles
       ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies)"
       EnvironmentOutputDirectory="$(IntermediateOutputPath)android"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1998,7 +1998,7 @@ because xbuild doesn't support framework reference assemblies.
 
 <Target Name="_GenerateCompressedAssembliesNativeSourceFiles"
         Condition=" '$(_AndroidRuntime)' != 'NativeAOT' "
-        Inputs="@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies)"
+        Inputs="@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies);$(_AndroidBuildPropertiesCache)"
         Outputs="@(_CompressedAssembliesAssemblySource)">
   <GenerateCompressedAssembliesNativeSourceFiles
       ResolvedAssemblies="@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -988,6 +988,7 @@ because xbuild doesn't support framework reference assemblies.
 		<_PropertyCacheItems Include="_NuGetAssetsFileHash=%(_NuGetAssetsFileHash.FileHash)" />
 		<_PropertyCacheItems Include="AndroidManifestPlaceholders=$(AndroidManifestPlaceholders)" />
 		<_PropertyCacheItems Include="ProjectFullPath=$(MSBuildProjectFullPath)" />
+		<_PropertyCacheItems Include="AndroidEnableAssemblyCompression=$(AndroidEnableAssemblyCompression)" />
 		<_PropertyCacheItems Include="AndroidUseDesignerAssembly=$(AndroidUseDesignerAssembly)" />
 		<_PropertyCacheItems Include="_AndroidTypeMapImplementation=$(_AndroidTypeMapImplementation)" />
 	</ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2008,6 +2008,7 @@ because xbuild doesn't support framework reference assemblies.
       EnableCompression="$(AndroidEnableAssemblyCompression)"
       ProjectFullPath="$(MSBuildProjectFullPath)"
   />
+  <Touch Files="@(_CompressedAssembliesAssemblySource)" />
   <ItemGroup>
     <FileWrites Include="@(_CompressedAssembliesAssemblySource)" />
   </ItemGroup>


### PR DESCRIPTION
## Description

`_GenerateCompressedAssembliesNativeSourceFiles` took **147ms** on an
incremental build because it had no `Inputs`/`Outputs` — it ran every
time regardless of whether any assemblies changed.

This PR adds:

- **Inputs**: `@(_ResolvedUserAssemblies);@(_ResolvedFrameworkAssemblies);$(_AndroidBuildPropertiesCache)`
- **Outputs**: `@(_CompressedAssembliesAssemblySource)` (the `.ll` files,
  already populated by `_PrepareNativeAssemblySourceItems`)

This should prevent the target from running on a build with no changes.

Also updates `BasicApplicationRepetitiveBuild` to assert the target is
skipped on a no-change rebuild.