### PR TITLE
[Xamarin.Android.Build.Tasks] Retry RemoveDirFixed on ERROR_DIR_NOT_EMPTY

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/RemoveDirFixed.cs
@@ -42,8 +42,15 @@ namespace Xamarin.Android.Tasks
 	{
 		public override string TaskPrefix => "RDF";
 
-		const int ERROR_ACCESS_DENIED = -2147024891;
-		const int ERROR_SHARING_VIOLATION = -2147024864;
+		const int ERROR_ACCESS_DENIED      = -2147024891; // 0x80070005
+		const int ERROR_SHARING_VIOLATION  = -2147024864; // 0x80070020
+		// On Unix, .NET maps `ENOTEMPTY` from `rmdir(2)` to this Win32 HResult,
+		// so the same constant covers both Windows and Unix sources of
+		// "Directory not empty". This is observed on NTFS volumes mounted via
+		// the Linux `ntfs3` driver, where directory metadata can momentarily
+		// report children that have just been unlinked, but is not specific
+		// to that filesystem.
+		const int ERROR_DIR_NOT_EMPTY      = -2147024751; // 0x80070091
 
 		public override bool RunTask ()
 		{
@@ -80,7 +87,7 @@ namespace Xamarin.Android.Tasks
 								case UnauthorizedAccessException:
 								case IOException:
 									int code = Marshal.GetHRForException(e);
-									if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount >= attempts) {
+									if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION && code != ERROR_DIR_NOT_EMPTY) || retryCount >= attempts) {
 										throw;
 									};
 									break;


### PR DESCRIPTION
Fixes #10124.

@jonathanpeppers — challenge accepted 🌶️ (with the disclaimer that the AI sounded confident *because the fix is genuinely tiny* 😄).

### Diagnosis

`RemoveDirFixed` already has a perfectly good retry-with-backoff loop. The catch is that it only re-tries when the underlying `IOException` carries one of two HResults:

| Constant | HResult | Win32 |
|---|---|---|
| `ERROR_ACCESS_DENIED` | `0x80070005` | 5 |
| `ERROR_SHARING_VIOLATION` | `0x80070020` | 32 |

The transient failure people are hitting on Linux during `dotnet publish` for Android is a third one:

```
error XARDF7024: System.IO.IOException: Directory not empty :
  '.../obj/Release/net10.0-android/android/assets/arm64-v8a'
   at System.IO.FileSystem.RemoveDirectoryRecursive(String fullPath)
   at Xamarin.Android.Tasks.RemoveDirFixed.RunTask()
```

On Unix, `Directory.Delete(recursive: true)` ultimately calls `rmdir(2)`. When that returns `ENOTEMPTY` (POSIX errno 39), .NET maps it to `ERROR_DIR_NOT_EMPTY` = `0x80070091` (Win32 145), which is *not* in the whitelist — so the very first hiccup re-throws and the build fails.

The race is real (the SDK is recursively deleting `obj/.../android/assets/<abi>` while files in it are still being unlinked) but the window is usually microscopic on ext4/btrfs. It widens dramatically on NTFS volumes mounted via the Linux `ntfs3` driver because NTFS directory metadata is non-POSIX-coherent — a directory can briefly report children that have just been unlinked. Same race, different filesystem clock.

### Fix

Three lines: one new constant, and one extra term in the existing condition.

```diff
 const int ERROR_ACCESS_DENIED      = -2147024891; // 0x80070005
 const int ERROR_SHARING_VIOLATION  = -2147024864; // 0x80070020
+const int ERROR_DIR_NOT_EMPTY      = -2147024751; // 0x80070091
…
-if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION) || retryCount >= attempts)
+if ((code != ERROR_ACCESS_DENIED && code != ERROR_SHARING_VIOLATION && code != ERROR_DIR_NOT_EMPTY) || retryCount >= attempts)
```

I prefer this over the "just warn if we can't delete" idea floated in the issue: this keeps the contract intact — if the directory still can't be removed after `RetryAttempts` (default backoff already in place), the task fails loudly as before. We're only widening *which* HResult is considered worth retrying, not how many retries or what happens after.

### Test

I deliberately didn't add a new NUnit test for this. The existing `DirectoryInUseWithRetry` already covers the retry mechanics; the only thing this PR changes is one constant in a whitelist. Reproducing `ENOTEMPTY` deterministically on a CI agent without an `ntfs3` mount would require either:

- a refactor to inject `Directory.Delete` and throw a synthetic `IOException` (intrusive for a 3-line change), or
- a flaky concurrent-writer test similar to the sharing-violation one (but `ENOTEMPTY` is hard to win against a non-NTFS FS).

Happy to add either if you'd prefer — just say the word.

### Repro / verification

Repro steps and full system context (Pop!_OS 24.04 LTS, kernel 6.18, .NET 10.0.201, Android SDK 36.1.53, NTFS via `ntfs3`) are in [my comment on #10124](https://github.com/dotnet/android/issues/10124#issuecomment-4299721300).

Locally, the issue reproduces ~30% of the time on the affected setup. With this patch applied to a local build of the SDK it stops reproducing across many consecutive runs, because the very small ntfs3 inconsistency window is comfortably covered by the first `Files.GetFileWriteRetryDelay()` backoff.

---

It's also worth noting that `DotnetDeployer` (the tool I use to publish .NET projects, [SuperJMN/DotnetDeployer](https://github.com/SuperJMN/DotnetDeployer)) already ships a [client-side mitigation](https://github.com/SuperJMN/DotnetDeployer/commit/e391f57) that detects this exact error, cleans `obj/Release/<tfm>/android`, and retries `dotnet publish` once. With this PR landed, that workaround becomes unnecessary 🎉.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>