### PR TITLE
[TrimmableTypeMap] Replace startup hook with direct TypeMapLoader.Initialize() call

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
@@ -112,7 +112,7 @@ public sealed class RootTypeMapAssemblyGenerator
 		EmitAssemblyTargetAttributes (pe, anchorTypeHandle, perAssemblyTypeMapNames);
 
 		// Emit [assembly: IgnoresAccessChecksTo("...")] so TypeMapLoader.Initialize() can access
-		// internal types (SingleUniverseTypeMap, AggregateTypeMap in Mono.Android,
+		// internal types (TrimmableTypeMap, SingleUniverseTypeMap, AggregateTypeMap in Mono.Android,
 		// and __TypeMapAnchor in each per-assembly typemap DLL).
 		var accessTargets = new List<string> { "Mono.Android" };
 		if (!useSharedTypemapUniverse) {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
@@ -112,7 +112,7 @@ public sealed class RootTypeMapAssemblyGenerator
 		EmitAssemblyTargetAttributes (pe, anchorTypeHandle, perAssemblyTypeMapNames);
 
 		// Emit [assembly: IgnoresAccessChecksTo("...")] so TypeMapLoader.Initialize() can access
-		// internal types (TrimmableTypeMap, SingleUniverseTypeMap, AggregateTypeMap in Mono.Android,
+		// internal types (SingleUniverseTypeMap, AggregateTypeMap in Mono.Android,
 		// and __TypeMapAnchor in each per-assembly typemap DLL).
 		var accessTargets = new List<string> { "Mono.Android" };
 		if (!useSharedTypemapUniverse) {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/RootTypeMapAssemblyGenerator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// Generates the root <c>_Microsoft.Android.TypeMaps.dll</c> assembly that:
 /// <list type="bullet">
 /// <item>References all per-assembly typemap assemblies via <c>[assembly: TypeMapAssemblyTargetAttribute&lt;__TypeMapAnchor&gt;("name")]</c>.</item>
-/// <item>Emits a <c>StartupHook</c> class whose <c>Initialize()</c> method calls
+/// <item>Emits a <c>TypeMapLoader</c> class whose <c>Initialize()</c> method calls
 /// <see cref="Microsoft.Android.Runtime.TrimmableTypeMap.Initialize"/> with the appropriate
 /// type mapping dictionaries.</item>
 /// </list>
@@ -25,26 +25,29 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 /// [assembly: TypeMapAssemblyTarget&lt;__TypeMapAnchor&gt;("_Mono.Android.TypeMap")]
 /// [assembly: TypeMapAssemblyTarget&lt;__TypeMapAnchor&gt;("_MyApp.TypeMap")]
 ///
-/// // Startup hook — called by DOTNET_STARTUP_HOOKS:
-/// internal static class StartupHook
+/// namespace Microsoft.Android.Runtime
 /// {
-///     internal static void Initialize ()
+///     // Called directly from JNIEnvInit.Initialize():
+///     public static class TypeMapLoader
 ///     {
-///         // Option A: Shared universe
-///         TrimmableTypeMap.Initialize(
-///             TypeMapping.GetOrCreateExternalTypeMapping&lt;Java.Lang.Object&gt;(),
-///             TypeMapping.GetOrCreateProxyTypeMapping&lt;Java.Lang.Object&gt;());
+///         public static void Initialize ()
+///         {
+///             // Option A: Shared universe
+///             TrimmableTypeMap.Initialize(
+///                 TypeMapping.GetOrCreateExternalTypeMapping&lt;Java.Lang.Object&gt;(),
+///                 TypeMapping.GetOrCreateProxyTypeMapping&lt;Java.Lang.Object&gt;());
 ///
-///         // Option B: Per-assembly universes (aggregated)
-///         var typeMaps = new IReadOnlyDictionary&lt;string, Type&gt;[] {
-///             TypeMapping.GetOrCreateExternalTypeMapping&lt;_Mono_Android_TypeMap.__TypeMapAnchor&gt;(),
-///             TypeMapping.GetOrCreateExternalTypeMapping&lt;_MyApp_TypeMap.__TypeMapAnchor&gt;(),
-///         };
-///         var proxyMaps = new IReadOnlyDictionary&lt;Type, Type&gt;[] {
-///             TypeMapping.GetOrCreateProxyTypeMapping&lt;_Mono_Android_TypeMap.__TypeMapAnchor&gt;(),
-///             TypeMapping.GetOrCreateProxyTypeMapping&lt;_MyApp_TypeMap.__TypeMapAnchor&gt;(),
-///         };
-///         TrimmableTypeMap.Initialize(typeMaps, proxyMaps);
+///             // Option B: Per-assembly universes (aggregated)
+///             var typeMaps = new IReadOnlyDictionary&lt;string, Type&gt;[] {
+///                 TypeMapping.GetOrCreateExternalTypeMapping&lt;_Mono_Android_TypeMap.__TypeMapAnchor&gt;(),
+///                 TypeMapping.GetOrCreateExternalTypeMapping&lt;_MyApp_TypeMap.__TypeMapAnchor&gt;(),
+///             };
+///             var proxyMaps = new IReadOnlyDictionary&lt;Type, Type&gt;[] {
+///                 TypeMapping.GetOrCreateProxyTypeMapping&lt;_Mono_Android_TypeMap.__TypeMapAnchor&gt;(),
+///                 TypeMapping.GetOrCreateProxyTypeMapping&lt;_MyApp_TypeMap.__TypeMapAnchor&gt;(),
+///             };
+///             TrimmableTypeMap.Initialize(typeMaps, proxyMaps);
+///         }
 ///     }
 /// }
 /// </code>
@@ -108,8 +111,8 @@ public sealed class RootTypeMapAssemblyGenerator
 		// Emit [assembly: TypeMapAssemblyTargetAttribute<__TypeMapAnchor>("name")] for each per-assembly typemap
 		EmitAssemblyTargetAttributes (pe, anchorTypeHandle, perAssemblyTypeMapNames);
 
-		// Emit [assembly: IgnoresAccessChecksTo("...")] so the startup hook can access
-		// internal types (SingleUniverseTypeMap, AggregateTypeMap, TrimmableTypeMap in Mono.Android,
+		// Emit [assembly: IgnoresAccessChecksTo("...")] so TypeMapLoader.Initialize() can access
+		// internal types (SingleUniverseTypeMap, AggregateTypeMap in Mono.Android,
 		// and __TypeMapAnchor in each per-assembly typemap DLL).
 		var accessTargets = new List<string> { "Mono.Android" };
 		if (!useSharedTypemapUniverse) {
@@ -117,8 +120,8 @@ public sealed class RootTypeMapAssemblyGenerator
 		}
 		pe.EmitIgnoresAccessChecksToAttribute (accessTargets);
 
-		// Emit StartupHook class with Initialize() method
-		EmitStartupHook (pe, anchorTypeHandle, perAssemblyTypeMapNames, useSharedTypemapUniverse);
+		// Emit TypeMapLoader class with Initialize() method
+		EmitTypeMapLoader (pe, anchorTypeHandle, perAssemblyTypeMapNames, useSharedTypemapUniverse);
 
 		pe.WritePE (stream);
 	}
@@ -142,7 +145,7 @@ public sealed class RootTypeMapAssemblyGenerator
 		}
 	}
 
-	static void EmitStartupHook (PEAssemblyBuilder pe, EntityHandle anchorTypeHandle, IReadOnlyList<string> perAssemblyTypeMapNames, bool useSharedTypemapUniverse)
+	static void EmitTypeMapLoader (PEAssemblyBuilder pe, EntityHandle anchorTypeHandle, IReadOnlyList<string> perAssemblyTypeMapNames, bool useSharedTypemapUniverse)
 	{
 		var metadata = pe.Metadata;
 
@@ -167,11 +170,11 @@ public sealed class RootTypeMapAssemblyGenerator
 		var getProxyMemberRef = AddTypeMappingMethodRef (pe, typeMappingRef, "GetOrCreateProxyTypeMapping",
 			iReadOnlyDictOpenRef, systemTypeRef, keyIsString: false);
 
-		// Define the StartupHook type
+		// Define the TypeMapLoader type (public static class in Microsoft.Android.Runtime namespace)
 		metadata.AddTypeDefinition (
-			TypeAttributes.NotPublic | TypeAttributes.Sealed | TypeAttributes.Abstract | TypeAttributes.Class,
-			default,
-			metadata.GetOrAddString ("StartupHook"),
+			TypeAttributes.Public | TypeAttributes.Sealed | TypeAttributes.Abstract | TypeAttributes.Class,
+			metadata.GetOrAddString ("Microsoft.Android.Runtime"),
+			metadata.GetOrAddString ("TypeMapLoader"),
 			metadata.AddTypeReference (pe.SystemRuntimeRef,
 				metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Object")),
 			MetadataTokens.FieldDefinitionHandle (metadata.GetRowCount (TableIndex.Field) + 1),

--- a/src/Microsoft.Android.TypeMaps.Ref/Microsoft.Android.TypeMaps.Ref.csproj
+++ b/src/Microsoft.Android.TypeMaps.Ref/Microsoft.Android.TypeMaps.Ref.csproj
@@ -6,6 +6,8 @@
     <AssemblyName>_Microsoft.Android.TypeMaps</AssemblyName>
     <RootNamespace>Microsoft.Android.Runtime</RootNamespace>
     <Nullable>enable</Nullable>
+    <!-- ProduceOnlyReferenceAssembly (not ProduceReferenceAssembly) — we only need the ref assembly.
+         The real implementation is generated at app build time by the typemap generator. -->
     <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
     <!-- Do NOT sign — the generated implementation assembly (emitted by PEAssemblyBuilder)
          is unsigned, so the ref assembly must match to avoid identity mismatch. -->

--- a/src/Microsoft.Android.TypeMaps.Ref/Microsoft.Android.TypeMaps.Ref.csproj
+++ b/src/Microsoft.Android.TypeMaps.Ref/Microsoft.Android.TypeMaps.Ref.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\Configuration.props" />
+
+  <PropertyGroup>
+    <TargetFramework>$(DotNetTargetFramework)</TargetFramework>
+    <AssemblyName>_Microsoft.Android.TypeMaps</AssemblyName>
+    <RootNamespace>Microsoft.Android.Runtime</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ProduceOnlyReferenceAssembly>true</ProduceOnlyReferenceAssembly>
+    <!-- Do NOT sign — the generated implementation assembly (emitted by PEAssemblyBuilder)
+         is unsigned, so the ref assembly must match to avoid identity mismatch. -->
+  </PropertyGroup>
+
+</Project>

--- a/src/Microsoft.Android.TypeMaps.Ref/TypeMapLoader.cs
+++ b/src/Microsoft.Android.TypeMaps.Ref/TypeMapLoader.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Microsoft.Android.Runtime;
+
+/// <summary>
+/// Entry point for typemap initialization. The implementation is generated at build time
+/// by the trimmable typemap generator, replacing this reference assembly.
+/// </summary>
+public static class TypeMapLoader
+{
+	/// <summary>
+	/// Initializes the trimmable typemap by constructing the type mapping dictionaries
+	/// and calling <c>TrimmableTypeMap.Initialize()</c>.
+	/// </summary>
+	public static void Initialize () => throw new NotImplementedException (
+		"This is a reference assembly stub. The real implementation is generated at build time.");
+}

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -179,6 +179,9 @@ namespace Android.Runtime
 			if (!RuntimeFeature.TrimmableTypeMap) {
 				args->registerJniNativesFn = (IntPtr)(delegate* unmanaged<IntPtr, int, IntPtr, IntPtr, int, void>)&RegisterJniNatives;
 			}
+			if (RuntimeFeature.TrimmableTypeMap) {
+				TypeMapLoader.Initialize ();
+			}
 			RunStartupHooksIfNeeded ();
 			SetSynchronizationContext ();
 		}

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -180,7 +180,7 @@ namespace Android.Runtime
 				args->registerJniNativesFn = (IntPtr)(delegate* unmanaged<IntPtr, int, IntPtr, IntPtr, int, void>)&RegisterJniNatives;
 			}
 			if (RuntimeFeature.TrimmableTypeMap) {
-				TypeMapLoader.Initialize ();
+				InitializeTrimmableTypeMap ();
 			}
 			RunStartupHooksIfNeeded ();
 			SetSynchronizationContext ();
@@ -189,6 +189,14 @@ namespace Android.Runtime
 		[LibraryImport (RuntimeConstants.InternalDllName)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]
 		private static unsafe partial void xamarin_app_init (IntPtr env, delegate* unmanaged <int, int, int, IntPtr*, void> get_function_pointer);
+
+		// Separate method so the JIT doesn't try to resolve TypeMapLoader (from _Microsoft.Android.TypeMaps.dll)
+		// when compiling JNIEnvInit.Initialize() in non-trimmable builds where that assembly isn't present.
+		[MethodImpl (MethodImplOptions.NoInlining)]
+		static void InitializeTrimmableTypeMap ()
+		{
+			TypeMapLoader.Initialize ();
+		}
 
 		static void RunStartupHooksIfNeeded ()
 		{

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Android.Runtime;
 /// and provides peer creation, invoker resolution, container factories, and native
 /// method registration. All proxy attribute access is encapsulated here.
 /// </summary>
-class TrimmableTypeMap
+public class TrimmableTypeMap
 {
 	static readonly Lock s_initLock = new ();
 	static readonly JavaPeerProxy s_noPeerSentinel = new MissingJavaPeerProxy ();

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -38,10 +38,10 @@ class TrimmableTypeMap
 
 	/// <summary>
 	/// Initializes the singleton with a single merged typemap universe.
-	/// Called from the startup hook in the generated root assembly (_Microsoft.Android.TypeMaps)
-	/// when assembly typemaps are merged (Release builds).
+	/// Called from <see cref="TypeMapLoader.Initialize"/> in the generated root assembly
+	/// (_Microsoft.Android.TypeMaps) when assembly typemaps are merged (Release builds).
 	/// </summary>
-	internal static void Initialize (IReadOnlyDictionary<string, Type> typeMap, IReadOnlyDictionary<Type, Type> proxyMap)
+	public static void Initialize (IReadOnlyDictionary<string, Type> typeMap, IReadOnlyDictionary<Type, Type> proxyMap)
 	{
 		ArgumentNullException.ThrowIfNull (typeMap);
 		ArgumentNullException.ThrowIfNull (proxyMap);
@@ -50,10 +50,10 @@ class TrimmableTypeMap
 
 	/// <summary>
 	/// Initializes the singleton with multiple per-assembly typemap universes.
-	/// Called from the startup hook in the generated root assembly (_Microsoft.Android.TypeMaps)
-	/// when each assembly has its own typemap universe (Debug builds).
+	/// Called from <see cref="TypeMapLoader.Initialize"/> in the generated root assembly
+	/// (_Microsoft.Android.TypeMaps) when each assembly has its own typemap universe (Debug builds).
 	/// </summary>
-	internal static void Initialize (IReadOnlyDictionary<string, Type>[] typeMaps, IReadOnlyDictionary<Type, Type>[] proxyMaps)
+	public static void Initialize (IReadOnlyDictionary<string, Type>[] typeMaps, IReadOnlyDictionary<Type, Type>[] proxyMaps)
 	{
 		ArgumentNullException.ThrowIfNull (typeMaps);
 		ArgumentNullException.ThrowIfNull (proxyMaps);

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -61,6 +61,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
+    <!-- Compile-only reference: the real _Microsoft.Android.TypeMaps.dll is generated at app
+         build time by the trimmable typemap generator and replaces this ref assembly. -->
+    <ProjectReference Include="..\Microsoft.Android.TypeMaps.Ref\Microsoft.Android.TypeMaps.Ref.csproj">
+      <Private>false</Private>
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
     <EmbeddedResource Include="ILLink/ILLink.LinkAttributes.xml">
       <LogicalName>ILLink.LinkAttributes.xml</LogicalName>
     </EmbeddedResource>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
@@ -43,7 +43,7 @@ See: https://github.com/dotnet/sdk/pull/52581
     <!--
       Update DOTNET_STARTUP_HOOKS in @(RuntimeEnvironmentVariable) to use just the assembly name.
       The full path doesn't work on Android since the DLL is deployed alongside the app.
-      Preserve any existing DOTNET_STARTUP_HOOKS values (e.g., from trimmable typemap) by composing
+      Preserve any existing DOTNET_STARTUP_HOOKS values by composing
       with ':' (the path separator on Android/Linux).
     -->
     <ItemGroup Condition=" '$(_AndroidHotReloadAgentAssemblyName)' != '' ">

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -11,9 +11,6 @@
 
   <PropertyGroup>
     <_TypeMapAssemblyName>_Microsoft.Android.TypeMaps</_TypeMapAssemblyName>
-    <!-- Enable startup hooks for trimmable typemap — the root assembly acts as a startup hook
-         that constructs the type mapping dictionaries and calls TrimmableTypeMap.Initialize(). -->
-    <StartupHookSupport>true</StartupHookSupport>
     <!-- Use the outer IntermediateOutputPath when available (inner per-RID builds set
          _OuterIntermediateOutputPath) so that generated manifests/JCWs are written
          where the packaging phase expects them. -->
@@ -33,28 +30,6 @@
     <TrimmerRootDescriptor Include="$(MSBuildThisFileDirectory)../PreserveLists/Trimmable.CoreCLR.xml"
         Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " />
   </ItemGroup>
-
-  <!--
-    Configure the root typemap assembly as a startup hook.
-    This must run inside a Target (not a static ItemGroup) because composing with
-    existing DOTNET_STARTUP_HOOKS entries requires %(Identity) metadata batching,
-    which is only allowed inside Target ItemGroups (MSB4190).
-    Runs before _AndroidConfigureHotReloadEnvironment so HotReload can compose on top.
-  -->
-  <Target Name="_ConfigureTrimmableTypeMapStartupHook"
-      BeforeTargets="_AndroidConfigureHotReloadEnvironment;_GenerateEnvironmentFiles">
-    <ItemGroup>
-      <_ExistingStartupHooks Include="@(RuntimeEnvironmentVariable)" Condition=" '%(Identity)' == 'DOTNET_STARTUP_HOOKS' " />
-      <RuntimeEnvironmentVariable Remove="DOTNET_STARTUP_HOOKS" />
-      <RuntimeEnvironmentVariable Include="DOTNET_STARTUP_HOOKS"
-          Value="$(_TypeMapAssemblyName):@(_ExistingStartupHooks->'%(Value)', ':')"
-          Condition=" '@(_ExistingStartupHooks)' != '' " />
-      <RuntimeEnvironmentVariable Include="DOTNET_STARTUP_HOOKS"
-          Value="$(_TypeMapAssemblyName)"
-          Condition=" '@(_ExistingStartupHooks)' == '' " />
-      <_ExistingStartupHooks Remove="@(_ExistingStartupHooks)" />
-    </ItemGroup>
-  </Target>
 
   <Target Name="_ValidateTrimmableTypeMapRuntime"
       Condition=" '$(_AndroidRuntime)' != 'CoreCLR' And '$(_AndroidRuntime)' != 'NativeAOT' "

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
@@ -139,11 +139,11 @@ public class RootTypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		var reader = pe.GetMetadataReader ();
 
-		// Both modes should have StartupHook type with Initialize method
+		// Both modes should have TypeMapLoader type with Initialize method
 		var typeDefs = reader.TypeDefinitions
 			.Select (h => reader.GetTypeDefinition (h))
 			.ToList ();
-		Assert.Contains (typeDefs, t => reader.GetString (t.Name) == "StartupHook");
+		Assert.Contains (typeDefs, t => reader.GetString (t.Name) == "TypeMapLoader");
 
 		// Both modes should have assembly target attributes
 		var targetAttrs = GetTypeMapAssemblyTargetAttributes (reader);

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/RootTypeMapAssemblyGeneratorTests.cs
@@ -139,11 +139,13 @@ public class RootTypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		var reader = pe.GetMetadataReader ();
 
-		// Both modes should have TypeMapLoader type with Initialize method
+		// Both modes should have TypeMapLoader type in the correct namespace, with public visibility and Initialize method
 		var typeDefs = reader.TypeDefinitions
 			.Select (h => reader.GetTypeDefinition (h))
 			.ToList ();
-		Assert.Contains (typeDefs, t => reader.GetString (t.Name) == "TypeMapLoader");
+		var typeMapLoader = typeDefs.Single (t => reader.GetString (t.Name) == "TypeMapLoader");
+		Assert.Equal ("Microsoft.Android.Runtime", reader.GetString (typeMapLoader.Namespace));
+		Assert.True (typeMapLoader.Attributes.HasFlag (System.Reflection.TypeAttributes.Public));
 
 		// Both modes should have assembly target attributes
 		var targetAttrs = GetTypeMapAssemblyTargetAttributes (reader);


### PR DESCRIPTION
## Summary

Fixes https://github.com/dotnet/android/issues/11196

Replace the `DOTNET_STARTUP_HOOKS` mechanism for trimmable typemap initialization with a direct call from `JNIEnvInit.Initialize()` to `TypeMapLoader.Initialize()`.

### Problem

Startup hooks don't work with NativeAOT (`Assembly.Load` and reflection are not supported). The current approach also adds unnecessary latency via reflection-based discovery of `System.StartupHookProvider`.

### Approach

Introduce a **reference assembly** (`_Microsoft.Android.TypeMaps.dll`) with a public `TypeMapLoader.Initialize()` stub that Mono.Android compiles against. At app build time, the trimmable typemap generator produces the **real implementation assembly** with the same identity, which replaces the ref assembly before trimming/linking.

```
// Before:
JNIEnvInit.Initialize()
  → RunStartupHooksIfNeeded()
    → reflection to find System.StartupHookProvider
      → StartupHook.Initialize()  [generated _Microsoft.Android.TypeMaps.dll]
        → TrimmableTypeMap.Initialize(typeMap, proxyMap)

// After:
JNIEnvInit.Initialize()
  → TypeMapLoader.Initialize()  [generated _Microsoft.Android.TypeMaps.dll]
    → TrimmableTypeMap.Initialize(typeMap, proxyMap)
```

No reflection, no startup hook discovery, works with NativeAOT.

### Changes

- **New ref assembly project** (`src/Microsoft.Android.TypeMaps.Ref/`) — compile-only stub with `public static class TypeMapLoader`, using `ProduceOnlyReferenceAssembly=true` (unsigned, to match the generated assembly)
- **Mono.Android** — compile-only `ProjectReference` to ref assembly (`Private=false`, `PrivateAssets=all`); direct `TypeMapLoader.Initialize()` call from `JNIEnvInit.Initialize()` behind the `RuntimeFeature.TrimmableTypeMap` feature switch
- **`TrimmableTypeMap.Initialize()`** — made public (both overloads); the class itself remains `internal` (accessed via `[IgnoresAccessChecksTo]`)
- **Generator** — emits public `TypeMapLoader` in `Microsoft.Android.Runtime` namespace instead of internal `StartupHook`
- **MSBuild targets** — removed `_ConfigureTrimmableTypeMapStartupHook` target and `StartupHookSupport=true` override (startup hooks remain available for HotReload)
- **Tests** — updated generator test to verify `TypeMapLoader` type name, namespace (`Microsoft.Android.Runtime`), and public visibility (414/414 pass)
