### PR TITLE
[Build] Fix apidocs pipeline (template repo, DocsApiLevel, JAVA_HOME)

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -13,6 +13,7 @@ resources:
   - repository: 1esPipelines
     type: git
     name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
 
 parameters:
 - name: apiLevel

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -12,7 +12,7 @@ resources:
   repositories:
   - repository: 1esPipelines
     type: git
-    name: 1ESPipelineTemplates/MicroBuildTemplate
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
     ref: refs/tags/release
 
 parameters:

--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -101,8 +101,6 @@ extends:
           submodules: recursive
 
         - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
-          parameters:
-            useAgentJdkPath: false
 
         # Set MSBuild property overrides if parameters are set
         - ${{ if ne(parameters.apiLevel, 'default') }}:

--- a/src/Mono.Android/Mono.Android.targets
+++ b/src/Mono.Android/Mono.Android.targets
@@ -240,7 +240,7 @@
 
   <PropertyGroup>
     <!-- Override these properties to generate docs against a specific API level -->
-    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">36</DocsApiLevel>
+    <DocsApiLevel Condition=" '$(DocsApiLevel)' == '' ">$(AndroidApiLevel)</DocsApiLevel>
     <DocsPlatformId Condition=" '$(DocsPlatformId)' == '' ">$(DocsApiLevel)</DocsPlatformId>
     <DocsFxMoniker Condition=" '$(DocsFxMoniker)' == '' ">net-android-$(DocsApiLevel).0</DocsFxMoniker>
     <DocsExportOutput Condition=" '$(DocsExportOutput)' == '' ">$(_MonoAndroidNETDefaultOutDir)Mono.Android.xml</DocsExportOutput>


### PR DESCRIPTION
Fixes multiple issues preventing the apidocs pipeline ([definitionId 15262](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=15262)) from running on `main`:

## 1. Template repo migration

The `MicroBuildTemplate` repo in `1ESPipelineTemplates` has been deprecated — all its refs point to a commit that no longer contains the `v1/` template files:

```
File /v1/1ES.Official.PipelineTemplate.yml not found in repository
https://devdiv.visualstudio.com/1ESPipelineTemplates/_git/MicroBuildTemplate
```

**Fix:** Update the repository resource from `MicroBuildTemplate` to `1ESPipelineTemplates` and pin to `refs/tags/release`.

## 2. DocsApiLevel hardcoded to 36

`DocsApiLevel` was hardcoded to `36`, but `AndroidApiLevel` is now `36.1`. This caused a path mismatch: `_UpdateExternalDocumentation` built assemblies into the `36.1/` output directory, but `_RunMdoc` looked for them in `36/`, resulting in `mdoc: No assemblies specified`.

**Fix:** Default `DocsApiLevel` to `$(AndroidApiLevel)` so it stays in sync.

## 3. Invalid JAVA_HOME path

The pipeline set `useAgentJdkPath: false`, which pointed `JAVA_HOME` to `~/android-toolchain/jdk-17` — a path that no longer exists on the Mac build agents. This caused the Gradle-based `manifestmerger` build to fail.

**Fix:** Remove the `useAgentJdkPath: false` override to use the agent's preinstalled JDK (the default behavior).