### PR TITLE
[tests] Skip InflateCustomView_ShouldNotLeakGlobalRefs until global ref leak is fully resolved

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Android.RuntimeTests
 
 		// https://github.com/dotnet/android/issues/11101
 		[Test]
+		[Ignore ("https://github.com/dotnet/android/issues/11201")]
 		public void InflateCustomView_ShouldNotLeakGlobalRefs ()
 		{
 			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Widget/CustomWidgetTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Android.RuntimeTests
 
 		// https://github.com/dotnet/android/issues/11101
 		[Test]
-		[Ignore ("https://github.com/dotnet/android/issues/11201")]
+		[Ignore ("Currently failing/flaky due to unresolved custom view global ref leak: https://github.com/dotnet/android/issues/11201")]
 		public void InflateCustomView_ShouldNotLeakGlobalRefs ()
 		{
 			var inflater = (LayoutInflater) Application.Context.GetSystemService (Context.LayoutInflaterService);


### PR DESCRIPTION
The test `CustomWidgetTests.InflateCustomView_ShouldNotLeakGlobalRefs` is failing across multiple CI configurations despite multiple merged fixes (#11112, dotnet/java-interop#1403, dotnet/java-interop#1410).

Skip the test with `[Ignore]` until the remaining global ref leak is fully investigated and resolved.

Context #11201