### PR TITLE
[tests] Use MSTestPackageVersion in DotNetNewAndroidTest

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -44,5 +44,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>ab01524bbb2ef1eea0ffaef161b3ef5686e8f256</Sha>
     </Dependency>
+    <Dependency Name="MSTest" Version="4.3.0-preview.26224.6">
+      <Uri>https://github.com/microsoft/testfx</Uri>
+      <Sha>7d4c0f051d6e8d52daaa0f7f354d57e95c475a03</Sha>
+    </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -15,6 +15,7 @@
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
     <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.4.26215.121</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
     <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26215.121</MicrosoftDotNetCecilPackageVersion>
+    <MSTestPackageVersion>4.3.0-preview.26224.6</MSTestPackageVersion>
     <SystemIOHashingPackageVersion>10.0.7</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataPackageVersion>11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>
     <!-- Previous .NET Android version -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Xml.Linq;
@@ -26,6 +27,21 @@ namespace Xamarin.Android.Build.Tests
 		protected bool IsWindows => TestEnvironment.IsWindows;
 
 		public string Root => Path.GetFullPath (XABuildPaths.TestOutputDirectory);
+
+		/// <summary>
+		/// Retrieves the value of an <see cref="AssemblyMetadataAttribute"/> embedded in the test assembly.
+		/// </summary>
+		protected string GetAssemblyMetadataValue (string key)
+		{
+			var assembly = GetType ().Assembly;
+			var value = assembly
+				.GetCustomAttributes<AssemblyMetadataAttribute> ()
+				.FirstOrDefault (a => a.Key == key)?.Value;
+			if (value == null) {
+				throw new InvalidOperationException ($"AssemblyMetadata '{key}' not found in {assembly.GetName ().Name}");
+			}
+			return value;
+		}
 
 		/// <summary>
 		/// Checks if a commercial .NET for Android is available

--- a/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
+++ b/tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj
@@ -46,6 +46,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>MSTestPackageVersion</_Parameter1>
+      <_Parameter2>$(MSTestPackageVersion)</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Xamarin.Android.Build.Tasks\Xamarin.Android.Build.Tasks.csproj" />
     <ProjectReference Include="..\..\src\Xamarin.Android.Build.Tasks\Tests\Xamarin.ProjectTools\Xamarin.ProjectTools.csproj" />
     <ProjectReference Include="..\..\external\debugger-libs\Mono.Debugging.Soft\Mono.Debugging.Soft.csproj" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2248,14 +2248,21 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			var dotnet = new DotNetCLI (Path.Combine (projectDirectory, $"{templateName}.csproj"));
 			Assert.IsTrue (dotnet.New ("androidtest"), "`dotnet new androidtest` should succeed");
 
+			// Override the MSTest version from the template with the version used by our build
+			var msTestVersion = GetAssemblyMetadataValue ("MSTestPackageVersion");
+			var csprojPath = Path.Combine (projectDirectory, $"{templateName}.csproj");
+			var doc = XDocument.Load (csprojPath);
+			var ns = doc.Root?.Name.Namespace ?? XNamespace.None;
+			var msTestRef = doc.Descendants (ns + "PackageReference")
+				.FirstOrDefault (e => e.Attribute ("Include")?.Value == "MSTest");
+			Assert.IsNotNull (msTestRef, "MSTest PackageReference should exist in the generated project");
+			msTestRef.SetAttributeValue ("Version", msTestVersion);
+			doc.Save (csprojPath);
+
 			bool useMonoRuntime = runtime == AndroidRuntime.MonoVM;
 			var buildParameters = new List<string> {
 				$"UseMonoRuntime={useMonoRuntime}",
 			};
-
-			if (runtime == AndroidRuntime.CoreCLR) {
-				Assert.Ignore ("https://github.com/dotnet/android/issues/11174");
-			}
 
 			// Build and assert 0 warnings
 			Assert.IsTrue (dotnet.Build (parameters: buildParameters.ToArray ()), "`dotnet build` should succeed");

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2262,6 +2262,7 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			bool useMonoRuntime = runtime == AndroidRuntime.MonoVM;
 			var buildParameters = new List<string> {
 				$"UseMonoRuntime={useMonoRuntime}",
+				"RestoreAdditionalProjectSources=https://pkgs.dev.azure.com/dnceng/public/_packaging/test-tools/nuget/v3/index.json",
 			};
 
 			// Build and assert 0 warnings


### PR DESCRIPTION
After `dotnet new androidtest` creates the template project, override the stable MSTest version with the preview version from `eng/Versions.props`. This let's us validate nightly/weekly microsoft/testfx changes, while the template keeps the stable version for customers.

The version is embedded as assembly metadata in MSBuildDeviceIntegration.csproj and read at runtime to update the generated .csproj before building.

After this is merged, I'll setup a Maestro/darc subscription on a weekly cadence.