### PR TITLE
[xabt] Fix redundant ternary in GenerateResourceDesignerAssembly

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesignerAssembly.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateResourceDesignerAssembly.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Android.Tasks
 			TypeDefinition? constDesigner = null;
 			if (IsApplication) {
 				// The Constant based class
-				TypeAttributes attrib = AssemblyName.IsNullOrEmpty () ? TypeAttributes.Public : TypeAttributes.Public;
+				TypeAttributes attrib = TypeAttributes.Public;
 				constDesigner = new TypeDefinition (
 					FixLegacyResourceDesignerStep.DesignerAssemblyNamespace,
 					"ResourceConstant",


### PR DESCRIPTION
## Summary

Simplify a dead conditional in `GenerateResourceDesignerAssembly.cs` where both ternary branches produced the same value (`TypeAttributes.Public`).

## Changes

**Before:**
```csharp
TypeAttributes attrib = AssemblyName.IsNullOrEmpty () ? TypeAttributes.Public : TypeAttributes.Public;
```

**After:**
```csharp
TypeAttributes attrib = TypeAttributes.Public;
```

## Context

This dead conditional was introduced in the original commit (`dc3ccf28c`, PR #6427). The IVT attribute added at lines 108-114 suggests one branch may have been intended to use `TypeAttributes.NotPublic`, but since the `ResourceConstant` type has been public since inception, changing visibility would be a behavioral change. The IVT attribute is harmless when the type is already public, so this PR simply removes the redundant ternary without altering behavior.

This is a zero-semantic-difference simplification — no behavioral change.
