### PR TITLE
[TrimmableTypeMap] Emit alias-base entry as unconditional for now

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -177,10 +177,18 @@ static class ModelBuilder
 		}
 
 		// Base JNI name entry → alias holder (self-referencing trim target, kept alive by associations)
+		// When ForceUnconditionalEntries is true we MUST emit this as 2-arg (unconditional) just
+		// like BuildEntry does: dotnet/runtime#127004 strips the TypeMapAssociation that keeps the
+		// holder alive when a TypeMap entry references the same type, leaving the dictionary key
+		// missing at runtime and breaking hierarchy lookups for essential types like
+		// java/lang/String and java/lang/Object.
+		bool aliasBaseUnconditional = ForceUnconditionalEntries
+			|| EssentialRuntimeTypes.Contains (jniName)
+			|| peersForName.Any (IsUnconditionalEntry);
 		model.Entries.Add (new TypeMapAttributeData {
 			JniName = jniName,
 			ProxyTypeReference = holderRef,
-			TargetTypeReference = holderRef,
+			TargetTypeReference = aliasBaseUnconditional ? null : holderRef,
 		});
 
 		model.AliasHolders.Add (new AliasHolderData {

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -85,9 +85,6 @@ namespace Xamarin.Android.RuntimeTests
                     // Throwable subclass registration
                     "Java.InteropTests.JnienvTest.ActivatedDirectThrowableSubclassesShouldBeRegistered",
 
-                    // Typemap doesn't resolve most-derived type
-                    "Java.LangTests.ObjectTest.GetObject_ReturnsMostDerivedType",
-
                     // Instance identity after JNI round-trip
                     "Java.LangTests.ObjectTest.JnienvCreateInstance_RegistersMultipleInstances",
 


### PR DESCRIPTION
## Summary

Fixes `Java.LangTests.ObjectTest.GetObject_ReturnsMostDerivedType` under the trimmable typemap. `Java.Lang.Object.GetObject<Java.Lang.Object>(jstring)` was returning a `Java.Lang.Object` peer instead of the most-derived `Java.Lang.String`.

## Root cause

The alias-group base TypeMap entry (e.g. `java/lang/String` → alias holder) in `ModelBuilder.EmitPeers` was always emitted as a 3-arg conditional attribute, bypassing the `ForceUnconditionalEntries` workaround for [dotnet/runtime#127004](https://github.com/dotnet/runtime/issues/127004) that the indexed entries already use.

When that workaround is in effect, the indexed alias entries are 2-arg (unconditional) and the alias holder is reachable only via `TypeMapAssociation`. Per #127004 the trimmer strips the association when a TypeMap entry references the same type, removing the holder and making the dictionary key `java/lang/String` (and `java/lang/Object`, `java/lang/Throwable`, …) disappear at runtime. The hierarchy walker then advances past the most-derived JNI class and `CreatePeer` falls back to the targetType-based lookup, returning a base-class peer.

Concrete symptom (verified on device with diagnostic logging):

```
GetObject_ReturnsMostDerivedType
hierarchy: jni='java/lang/String' targetType='Java.Lang.Object' proxyCount=0
hierarchy: jni='java/lang/Object' targetType='Java.Lang.Object' proxyCount=0
-> Expected Java.Lang.String but was Java.Lang.Object
```

## Fix

Route the alias-base entry through the same unconditional decision used by `BuildEntry`: emit it as 2-arg whenever `ForceUnconditionalEntries` is on, the JNI name is in `EssentialRuntimeTypes`, or any peer in the alias group is itself unconditional.

After the fix, the same lookup reports `proxyCount=2` and selects `Java.Lang.String`. Test exclusion removed in the same change.

## Verification

Full `Mono.Android.NET-Tests` Release+CoreCLR+Trimmable run on device: **917 tests, 0 failures, 0 errors.**