### PR TITLE
$(AndroidPackVersionSuffix)=preview.5; main is .NET 11 preview 5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.4</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview4

We branched for .NET 11 Preview 4 from 7bc3bbb22 into
`release/11.0.1xx-preview4`; the main branch is now .NET 11 Preview 5.