### PR TITLE
[TrimmableTypeMap] JavaCast/JavaAs + container support

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/MetadataHelper.cs
@@ -41,6 +41,7 @@ static class MetadataHelper
 			writer.Write (proxy.TargetType.ManagedTypeName);
 			writer.Write (proxy.TargetType.AssemblyName);
 			writer.Write ((byte)(proxy.ActivationCtor?.Style ?? 0));
+			writer.Write ((byte)(proxy.InvokerActivationCtorStyle ?? 0));
 		}
 		foreach (var assoc in data.Associations) {
 			writer.Write (assoc.SourceTypeReference);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -111,6 +111,11 @@ sealed class JavaPeerProxyData
 	public TypeRefData? InvokerType { get; set; }
 
 	/// <summary>
+	/// Activation constructor style to use when creating <see cref="InvokerType"/>.
+	/// </summary>
+	public ActivationCtorStyle? InvokerActivationCtorStyle { get; set; }
+
+	/// <summary>
 	/// Whether this proxy has a CreateInstance that can actually create instances.
 	/// </summary>
 	public bool HasActivation => ActivationCtor != null || InvokerType != null;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -277,6 +277,7 @@ static class ModelBuilder
 				ManagedTypeName = peer.InvokerTypeName,
 				AssemblyName = peer.AssemblyName,
 			};
+			proxy.InvokerActivationCtorStyle = peer.InvokerActivationCtorStyle ?? ActivationCtorStyle.XamarinAndroid;
 		}
 
 		if (peer.ActivationCtor != null) {

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -615,7 +615,9 @@ sealed class TypeMapAssemblyEmitter
 				if (jiCtor.IsOnLeafType) {
 					EmitCreateInstanceViaJavaInteropNewobj (targetRef);
 				} else {
-					EmitCreateInstanceInheritedJavaInteropCtor (targetRef, jiCtor);
+					// Legacy GetConstructor() doesn't find inherited ctors —
+					// match that behavior by returning null.
+					EmitCreateInstanceNoActivation ();
 				}
 			}
 			return;
@@ -633,7 +635,9 @@ sealed class TypeMapAssemblyEmitter
 		if (activationCtor.IsOnLeafType) {
 			EmitCreateInstanceViaNewobj (targetTypeRef);
 		} else {
-			EmitCreateInstanceInheritedCtor (targetTypeRef, activationCtor);
+			// Legacy GetConstructor() doesn't find inherited ctors —
+			// match that behavior by returning null.
+			EmitCreateInstanceNoActivation ();
 		}
 	}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -604,27 +604,28 @@ sealed class TypeMapAssemblyEmitter
 			return;
 		}
 
-		// JavaInterop-style activation ctors (ref JniObjectReference, JniObjectReferenceOptions)
-		// require parameter conversion from (IntPtr, JniHandleOwnership).
-		if (proxy.ActivationCtor?.Style == ActivationCtorStyle.JavaInterop) {
-			if (proxy.InvokerType != null) {
-				EmitCreateInstanceViaJavaInteropNewobj (_pe.ResolveTypeRef (proxy.InvokerType));
+		if (proxy.InvokerType != null) {
+			var invokerType = _pe.ResolveTypeRef (proxy.InvokerType);
+			if (proxy.InvokerActivationCtorStyle == ActivationCtorStyle.JavaInterop) {
+				EmitCreateInstanceViaJavaInteropNewobj (invokerType);
 			} else {
-				var targetRef = _pe.ResolveTypeRef (proxy.TargetType);
-				var jiCtor = proxy.ActivationCtor ?? throw new InvalidOperationException ("ActivationCtor should not be null");
-				if (jiCtor.IsOnLeafType) {
-					EmitCreateInstanceViaJavaInteropNewobj (targetRef);
-				} else {
-					// Legacy GetConstructor() doesn't find inherited ctors —
-					// match that behavior by returning null.
-					EmitCreateInstanceNoActivation ();
-				}
+				EmitCreateInstanceViaNewobj (invokerType);
 			}
 			return;
 		}
 
-		if (proxy.InvokerType != null) {
-			EmitCreateInstanceViaNewobj (_pe.ResolveTypeRef (proxy.InvokerType));
+		// JavaInterop-style activation ctors (ref JniObjectReference, JniObjectReferenceOptions)
+		// require parameter conversion from (IntPtr, JniHandleOwnership).
+		if (proxy.ActivationCtor?.Style == ActivationCtorStyle.JavaInterop) {
+			var targetRef = _pe.ResolveTypeRef (proxy.TargetType);
+			var jiCtor = proxy.ActivationCtor ?? throw new InvalidOperationException ("ActivationCtor should not be null");
+			if (jiCtor.IsOnLeafType) {
+				EmitCreateInstanceViaJavaInteropNewobj (targetRef);
+			} else {
+				// Legacy GetConstructor() doesn't find inherited ctors —
+				// match that behavior by returning null.
+				EmitCreateInstanceNoActivation ();
+			}
 			return;
 		}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/AssemblyIndex.cs
@@ -235,10 +235,13 @@ sealed class AssemblyIndex : IDisposable
 			doNotGenerateAcw = !generateJavaPeer;
 		}
 
+		var isArrayType = TryGetNamedArgument<int> (value, "ArrayRank", out var rank) && rank > 0;
+
 		return new RegisterInfo {
 			JniName = jniName.Replace ('.', '/'),
 			DoNotGenerateAcw = doNotGenerateAcw,
 			IsFromJniTypeSignature = true,
+			IsArrayType = isArrayType,
 		};
 	}
 
@@ -529,6 +532,7 @@ sealed record RegisterInfo
 	public string? Connector { get; init; }
 	public bool DoNotGenerateAcw { get; init; }
 	public bool IsFromJniTypeSignature { get; init; }
+	public bool IsArrayType { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -126,6 +126,13 @@ public sealed record JavaPeerInfo
 	public string? InvokerTypeName { get; init; }
 
 	/// <summary>
+	/// Activation constructor style declared by <see cref="InvokerTypeName"/>.
+	/// Kept separate from <see cref="ActivationCtor"/>, which describes the
+	/// target type or its base types.
+	/// </summary>
+	public ActivationCtorStyle? InvokerActivationCtorStyle { get; init; }
+
+	/// <summary>
 	/// True if this is an open generic type definition.
 	/// Generic types get TypeMap entries but CreateInstance throws NotSupportedException.
 	/// </summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -182,6 +182,15 @@ public sealed class JavaPeerScanner : IDisposable
 			index.AttributesByType.TryGetValue (typeHandle, out var attrInfo);
 
 			if (registerInfo is not null && !string.IsNullOrEmpty (registerInfo.JniName)) {
+				// [JniTypeSignature] with ArrayRank > 0 represents a JNI array wrapper
+				// (e.g., JavaBooleanArray, JavaObjectArray<T>, JavaPrimitiveArray<T>).
+				// These are handled by the built-in tables in JniRuntime.JniTypeManager
+				// and must not be added to the typemap — keyword types (Z, B, etc.)
+				// would collide with GetPrimitiveArrayTypesForSimpleReference, and
+				// non-keyword array types would add unnecessary aliases.
+				if (registerInfo.IsArrayType) {
+					continue;
+				}
 				jniName = registerInfo.JniName;
 				compatJniName = jniName;
 				doNotGenerateAcw = registerInfo.DoNotGenerateAcw;
@@ -227,6 +236,14 @@ public sealed class JavaPeerScanner : IDisposable
 			// For interfaces/abstract types, try to find invoker type name
 			if (isInterface || isAbstract) {
 				invokerTypeName = TryFindInvokerTypeName (fullName, typeHandle, index);
+			}
+
+			// Interface peers have no constructors of their own, so ResolveActivationCtor
+			// returns null. The invoker type holds the activation ctor — resolve it from
+			// there so the generator can pick the correct ctor signature
+			// (XamarinAndroid (IntPtr, JniHandleOwnership) vs JavaInterop (ref JniObjectReference, JniObjectReferenceOptions)).
+			if (activationCtor is null && invokerTypeName is not null) {
+				activationCtor = TryResolveActivationCtorOnInvoker (invokerTypeName);
 			}
 
 			var peer = new JavaPeerInfo {
@@ -1276,6 +1293,24 @@ public sealed class JavaPeerScanner : IDisposable
 		var invokerName = $"{typeName}Invoker";
 		if (index.TypesByFullName.ContainsKey (invokerName)) {
 			return invokerName;
+		}
+		return null;
+	}
+
+	/// <summary>
+	/// Resolve the activation ctor on a known invoker type (search all loaded assemblies).
+	/// Used for interface peers, whose own type definition has no constructors.
+	/// The assemblyCache typically contains 10–30 entries (app + framework assemblies),
+	/// and each lookup is an O(1) dictionary probe, so the linear scan is cheap.
+	/// </summary>
+	ActivationCtorInfo? TryResolveActivationCtorOnInvoker (string invokerTypeName)
+	{
+		foreach (var assembly in assemblyCache.Values) {
+			if (!assembly.TypesByFullName.TryGetValue (invokerTypeName, out var invokerHandle)) {
+				continue;
+			}
+			var invokerDef = assembly.Reader.GetTypeDefinition (invokerHandle);
+			return ResolveActivationCtor (invokerTypeName, invokerDef, assembly);
 		}
 		return null;
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -217,6 +217,7 @@ public sealed class JavaPeerScanner : IDisposable
 			var isUnconditional = attrInfo is not null;
 			var cannotRegisterInStaticConstructor = attrInfo is ApplicationAttributeInfo or InstrumentationAttributeInfo;
 			string? invokerTypeName = null;
+			ActivationCtorStyle? invokerActivationCtorStyle = null;
 
 			// Resolve base Java type name
 			var baseJavaName = ResolveBaseJavaName (typeDef, index, results);
@@ -238,12 +239,11 @@ public sealed class JavaPeerScanner : IDisposable
 				invokerTypeName = TryFindInvokerTypeName (fullName, typeHandle, index);
 			}
 
-			// Interface peers have no constructors of their own, so ResolveActivationCtor
-			// returns null. The invoker type holds the activation ctor — resolve it from
-			// there so the generator can pick the correct ctor signature
-			// (XamarinAndroid (IntPtr, JniHandleOwnership) vs JavaInterop (ref JniObjectReference, JniObjectReferenceOptions)).
-			if (activationCtor is null && invokerTypeName is not null) {
-				activationCtor = TryResolveActivationCtorOnInvoker (invokerTypeName);
+			// Interface/abstract peers create their invoker, not the target type.
+			// Keep ActivationCtor scoped to the target/base hierarchy for legacy parity,
+			// and store the invoker ctor style separately for CreateInstance emission.
+			if (invokerTypeName is not null) {
+				invokerActivationCtorStyle = TryResolveActivationCtorOnInvoker (invokerTypeName)?.Style;
 			}
 
 			var peer = new JavaPeerInfo {
@@ -266,6 +266,7 @@ public sealed class JavaPeerScanner : IDisposable
 				JavaFields = exportFields,
 				ActivationCtor = activationCtor,
 				InvokerTypeName = invokerTypeName,
+				InvokerActivationCtorStyle = invokerActivationCtorStyle,
 				IsGenericDefinition = isGenericDefinition,
 				ComponentAttribute = ToComponentInfo (attrInfo),
 			};

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -514,9 +514,28 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 		if (RuntimeFeature.TrimmableTypeMap) {
 			try {
+				// Mirror legacy GetPeerType: callers commonly request universal
+				// interfaces / boxes (IJavaPeerable, object, Exception) — map these
+				// to a concrete peer type so the proxy lookup can succeed.
+				var resolvedTargetType = ResolvePeerType (targetType);
+
 				var typeMap = TrimmableTypeMap.Instance;
-				var proxy = typeMap.GetProxyForJavaObject (reference.Handle, targetType);
-				var peer = proxy?.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
+				var proxy = typeMap.GetProxyForJavaObject (reference.Handle, resolvedTargetType);
+
+				// Open-generic proxies (e.g. JavaList<>) cannot create closed
+				// instantiations (e.g. JavaList<int>) via CreateInstance because
+				// the generated IL can't newobj an open generic type. Activate the
+				// closed targetType directly via its (IntPtr, JniHandleOwnership)
+				// ctor — [DAM(Constructors)] on targetType guarantees the trimmer
+				// preserves the ctor metadata.
+				IJavaPeerable? peer;
+				if (proxy is not null && proxy.TargetType.IsGenericTypeDefinition &&
+						resolvedTargetType is not null &&
+						resolvedTargetType.IsGenericType && !resolvedTargetType.IsGenericTypeDefinition) {
+					peer = ActivateUsingReflection (resolvedTargetType, reference.Handle, JniHandleOwnership.DoNotTransfer);
+				} else {
+					peer = proxy?.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
+				}
 				if (peer is not null) {
 					var peerState = peer.JniManagedPeerState | JniManagedPeerStates.Replaceable;
 					if (global::Java.Interop.Runtime.IsGCUserPeer (peer.PeerReference.Handle)) {
@@ -526,7 +545,22 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 					return peer;
 				}
 
-				var targetName = targetType?.AssemblyQualifiedName ?? "<null>";
+				// Disambiguate the failure — match the contract of the base
+				// JniRuntime.JniValueManager.CreatePeer so JavaCast / JavaAs
+				// surface the right exception (or null) to callers:
+				//
+				//  (a) target type has no Java mapping at all → ArgumentException
+				//  (b) Java instance is not assignable to the target's Java class
+				//      → return null (JavaAs returns null; JavaCast wraps to
+				//      InvalidCastException via its `??` clause)
+				//  (c) classes are compatible but no proxy / activation failed
+				//      → NotSupportedException (genuine generator gap)
+				if (resolvedTargetType is not null &&
+						IsIncompatibleCast (typeMap, ref reference, resolvedTargetType)) {
+					return null;
+				}
+
+				var targetName = resolvedTargetType?.AssemblyQualifiedName ?? "<null>";
 				var javaType = JniEnvironment.Types.GetJniTypeNameFromInstance (reference);
 
 				throw new NotSupportedException (
@@ -539,6 +573,80 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		}
 
 		return base.CreatePeer (ref reference, transfer, targetType);
+	}
+
+	[return: DynamicallyAccessedMembers (Constructors)]
+	static Type? ResolvePeerType ([DynamicallyAccessedMembers (Constructors)] Type? type)
+	{
+		if (type is null) {
+			return null;
+		}
+		if (type == typeof (object) || type == typeof (IJavaPeerable)) {
+			return typeof (global::Java.Interop.JavaObject);
+		}
+		if (type == typeof (Exception)) {
+			return typeof (JavaException);
+		}
+		return type;
+	}
+
+	static IJavaPeerable? ActivateUsingReflection (
+			[DynamicallyAccessedMembers (Constructors)]
+			Type closedType,
+			IntPtr handle,
+			JniHandleOwnership transfer)
+	{
+		var ctor = closedType.GetConstructor (ActivationConstructorBindingFlags, null, XAConstructorSignature, null);
+		if (ctor is null) {
+			return null;
+		}
+
+		return (IJavaPeerable) ctor.Invoke ([handle, transfer]);
+	}
+
+	/// <summary>
+	/// When the trimmable typemap proxy lookup yields no peer for a non-null
+	/// <paramref name="targetType"/>, decide whether the caller's request is a
+	/// genuine bad cast (return true → caller returns null) or a missing typemap
+	/// entry (throw <see cref="ArgumentException"/>).
+	/// Returns false when the target's Java class IS compatible with the
+	/// instance — letting the caller fall through to its NotSupportedException
+	/// branch.
+	/// </summary>
+	static bool IsIncompatibleCast (
+			TrimmableTypeMap typeMap,
+			ref JniObjectReference reference,
+			Type targetType)
+	{
+		if (!typeMap.TryGetJniNameForManagedType (targetType, out var targetJniName)) {
+			throw new ArgumentException (
+				$"Could not determine Java type corresponding to '{targetType.AssemblyQualifiedName}'.",
+				nameof (targetType));
+		}
+
+		var instanceClass = JniEnvironment.Types.GetObjectClass (reference);
+		JniObjectReference targetClass = default;
+		try {
+			try {
+				targetClass = JniEnvironment.Types.FindClass (targetJniName);
+			} catch (Exception e) {
+				throw new ArgumentException (
+					$"Could not find Java class '{targetJniName}'.",
+					nameof (targetType), e);
+			}
+
+			if (!JniEnvironment.Types.IsAssignableFrom (instanceClass, targetClass)) {
+				// Genuine bad cast — return null, callers translate this.
+				return true;
+			}
+		} finally {
+			JniObjectReference.Dispose (ref instanceClass);
+			JniObjectReference.Dispose (ref targetClass);
+		}
+
+		// Classes are compatible — caller should throw NotSupportedException
+		// (real proxy/activation gap).
+		return false;
 	}
 
 	protected override bool TryConstructPeer (

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -514,24 +514,15 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 		if (RuntimeFeature.TrimmableTypeMap) {
 			try {
-				// Mirror legacy GetPeerType: callers commonly request universal
-				// interfaces / boxes (IJavaPeerable, object, Exception) — map these
-				// to a concrete peer type so the proxy lookup can succeed.
+				// Map universal request types to concrete peers before proxy lookup.
 				var resolvedTargetType = ResolvePeerType (targetType);
 
 				var typeMap = TrimmableTypeMap.Instance;
 				var proxy = typeMap.GetProxyForJavaObject (reference.Handle, resolvedTargetType);
 
-				// Open-generic proxies (e.g. JavaList<>) cannot create closed
-				// instantiations (e.g. JavaList<int>) via CreateInstance because
-				// the generated IL can't newobj an open generic type. Activate the
-				// closed targetType directly via its (IntPtr, JniHandleOwnership)
-				// ctor — [DAM(Constructors)] on targetType guarantees the trimmer
-				// preserves the ctor metadata.
+				// Open-generic proxies cannot instantiate closed targets.
 				IJavaPeerable? peer;
-				if (proxy is not null && proxy.TargetType.IsGenericTypeDefinition &&
-						resolvedTargetType is not null &&
-						resolvedTargetType.IsGenericType && !resolvedTargetType.IsGenericTypeDefinition) {
+				if (ShouldActivateClosedGenericTarget (proxy, resolvedTargetType)) {
 					peer = ActivateUsingReflection (resolvedTargetType, reference.Handle, JniHandleOwnership.DoNotTransfer);
 				} else {
 					peer = proxy?.CreateInstance (reference.Handle, JniHandleOwnership.DoNotTransfer);
@@ -545,16 +536,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 					return peer;
 				}
 
-				// Disambiguate the failure — match the contract of the base
-				// JniRuntime.JniValueManager.CreatePeer so JavaCast / JavaAs
-				// surface the right exception (or null) to callers:
-				//
-				//  (a) target type has no Java mapping at all → ArgumentException
-				//  (b) Java instance is not assignable to the target's Java class
-				//      → return null (JavaAs returns null; JavaCast wraps to
-				//      InvalidCastException via its `??` clause)
-				//  (c) classes are compatible but no proxy / activation failed
-				//      → NotSupportedException (genuine generator gap)
+				// Preserve CreatePeer's bad-cast vs missing-mapping behavior.
 				if (resolvedTargetType is not null &&
 						IsIncompatibleCast (typeMap, ref reference, resolvedTargetType)) {
 					return null;
@@ -590,6 +572,17 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		return type;
 	}
 
+	static bool ShouldActivateClosedGenericTarget (
+			[NotNullWhen (true)] JavaPeerProxy? proxy,
+			[NotNullWhen (true)] Type? resolvedTargetType)
+	{
+		return proxy is not null &&
+			proxy.TargetType.IsGenericTypeDefinition &&
+			resolvedTargetType is not null &&
+			resolvedTargetType.IsGenericType &&
+			!resolvedTargetType.IsGenericTypeDefinition;
+	}
+
 	static IJavaPeerable? ActivateUsingReflection (
 			[DynamicallyAccessedMembers (Constructors)]
 			Type closedType,
@@ -605,13 +598,8 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 	}
 
 	/// <summary>
-	/// When the trimmable typemap proxy lookup yields no peer for a non-null
-	/// <paramref name="targetType"/>, decide whether the caller's request is a
-	/// genuine bad cast (return true → caller returns null) or a missing typemap
-	/// entry (throw <see cref="ArgumentException"/>).
-	/// Returns false when the target's Java class IS compatible with the
-	/// instance — letting the caller fall through to its NotSupportedException
-	/// branch.
+	/// Returns true when <paramref name="targetType"/>'s Java class is not assignable from
+	/// <paramref name="reference"/>. Throws when <paramref name="targetType"/> has no usable mapping.
 	/// </summary>
 	static bool IsIncompatibleCast (
 			TrimmableTypeMap typeMap,
@@ -629,14 +617,14 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		try {
 			try {
 				targetClass = JniEnvironment.Types.FindClass (targetJniName);
-			} catch (Exception e) {
+			} catch (Java.Lang.ClassNotFoundException e) {
 				throw new ArgumentException (
 					$"Could not find Java class '{targetJniName}'.",
 					nameof (targetType), e);
 			}
 
 			if (!JniEnvironment.Types.IsAssignableFrom (instanceClass, targetClass)) {
-				// Genuine bad cast — return null, callers translate this.
+				// Bad cast: callers translate null to the expected result.
 				return true;
 			}
 		} finally {
@@ -644,8 +632,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			JniObjectReference.Dispose (ref targetClass);
 		}
 
-		// Classes are compatible — caller should throw NotSupportedException
-		// (real proxy/activation gap).
+		// Compatible classes mean a proxy/activation gap.
 		return false;
 	}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -238,7 +238,16 @@ public class TrimmableTypeMap
 			var targetClass = default (JniObjectReference);
 			try {
 				objClass = JniEnvironment.Types.GetObjectClass (selfRef);
-				targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				try {
+					targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				} catch (Java.Lang.ClassNotFoundException) {
+					// FindClass throws for managed types whose Java peer class is
+					// not present in the APK (e.g. test types annotated with
+					// [JniTypeSignature("__missing__")]). Treat as "no match" so
+					// JavaMarshalValueManager.CreatePeer can surface the correct
+					// ArgumentException instead of leaking ClassNotFoundException.
+					return null;
+				}
 				var isAssignable = JniEnvironment.Types.IsAssignableFrom (objClass, targetClass);
 				return isAssignable ? proxy : null;
 			} finally {
@@ -273,22 +282,22 @@ public class TrimmableTypeMap
 	/// </remarks>
 	internal static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
 	{
-		if (targetType.IsAssignableFrom (proxyTargetType)) {
-			return true;
-		}
-
-		if (!proxyTargetType.IsGenericTypeDefinition) {
+		// Open generic proxy: match only when targetType is a closed instantiation
+		// of this generic (e.g. JavaList<int> matches the JavaList<> proxy).
+		// IsAssignableFrom alone would incorrectly match unrelated open generics
+		// that are technically subclasses (e.g. JavaArray<> is assignable to
+		// JavaObject), and proxy.CreateInstance for an open generic always throws.
+		if (proxyTargetType.IsGenericTypeDefinition) {
+			for (Type? t = targetType; t is not null; t = t.BaseType) {
+				if (t.IsGenericType && !t.IsGenericTypeDefinition &&
+						t.GetGenericTypeDefinition () == proxyTargetType) {
+					return true;
+				}
+			}
 			return false;
 		}
 
-		for (Type? t = targetType; t is not null; t = t.BaseType) {
-			if (t.IsGenericType && !t.IsGenericTypeDefinition &&
-					t.GetGenericTypeDefinition () == proxyTargetType) {
-				return true;
-			}
-		}
-
-		return false;
+		return targetType.IsAssignableFrom (proxyTargetType);
 	}
 
 	/// <summary>

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -282,6 +282,10 @@ public class TrimmableTypeMap
 	/// </remarks>
 	internal static bool TargetTypeMatches (Type targetType, Type proxyTargetType)
 	{
+		if (targetType == proxyTargetType) {
+			return true;
+		}
+
 		// Open generic proxy: match only when targetType is a closed instantiation
 		// of this generic (e.g. JavaList<int> matches the JavaList<> proxy).
 		// IsAssignableFrom alone would incorrectly match unrelated open generics

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -472,6 +472,36 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Generate_JiStyleInvoker_FirstParamIsByRef ()
+	{
+		var peer = MakeInterfacePeer ("test/IJiInvoker", "Test.IJiInvoker", "TestAsm", "Test.IJiInvokerInvoker") with {
+			InvokerActivationCtorStyle = ActivationCtorStyle.JavaInterop,
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "JiInvokerByRefTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var ctorRefs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
+			.Select (i => reader.GetMemberReference (MetadataTokens.MemberReferenceHandle (i)))
+			.Where (m => reader.GetString (m.Name) == ".ctor")
+			.ToList ();
+
+		bool foundByRefCtor = false;
+		foreach (var ctor in ctorRefs) {
+			var sig = ctor.DecodeMethodSignature (SignatureTypeProvider.Instance, null);
+			if (sig.ParameterTypes.Length == 2 &&
+				sig.ParameterTypes [0].Contains ("JniObjectReference")) {
+				Assert.True (sig.ParameterTypes [0].EndsWith ("&"),
+					$"JI-style invoker .ctor first param must be byref, got: {sig.ParameterTypes [0]}");
+				foundByRefCtor = true;
+			}
+		}
+
+		Assert.True (foundByRefCtor, "Expected to find a JI-style invoker .ctor with byref JniObjectReference parameter");
+	}
+
+	[Fact]
 	public void Generate_JiStyleCtor_EmitsDeleteRefCall ()
 	{
 		var peers = ScanFixtures ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.Behavior.cs
@@ -44,13 +44,14 @@ public partial class JavaPeerScannerTests
 		Assert.NotNull (onStart);
 		Assert.Equal ("", onStart.Connector);
 
-		var onClick = FindFixtureByManagedName ("Android.Views.IOnClickListener")
-			.MarshalMethods.FirstOrDefault (m => m.JniName == "onClick");
+		var listener = FindFixtureByManagedName ("Android.Views.IOnClickListener");
+		var onClick = listener.MarshalMethods.FirstOrDefault (m => m.JniName == "onClick");
 		Assert.NotNull (onClick);
 		Assert.Equal ("(Landroid/view/View;)V", onClick.JniSignature);
 
-		Assert.Equal ("Android.Views.IOnClickListenerInvoker",
-			FindFixtureByManagedName ("Android.Views.IOnClickListener").InvokerTypeName);
+		Assert.Equal ("Android.Views.IOnClickListenerInvoker", listener.InvokerTypeName);
+		Assert.Null (listener.ActivationCtor);
+		Assert.Equal (ActivationCtorStyle.XamarinAndroid, listener.InvokerActivationCtorStyle);
 	}
 
 	[Theory]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/JavaPeerScannerTests.cs
@@ -131,4 +131,20 @@ public partial class JavaPeerScannerTests : FixtureTestBase
 		var peer = FindFixtureByJavaName ("net/dot/jni/test/JavaDisposedObject");
 		Assert.NotNull (peer);
 	}
+
+	[Fact]
+	public void Scan_JniTypeSignature_ArrayRank_IsExcluded ()
+	{
+		// Types with [JniTypeSignature(ArrayRank > 0)] represent JNI array wrappers
+		// (e.g., JavaBooleanArray with IsKeyword=true, or JavaObjectArray<T> without).
+		// The scanner must skip all of them — they are handled by the built-in tables
+		// in JniRuntime.JniTypeManager, not the typemap.
+		var peers = ScanFixtures ();
+
+		// Keyword primitive array (e.g., JavaBooleanArray with "Z")
+		Assert.DoesNotContain (peers, p => p.ManagedTypeName == "Java.Interop.TestTypes.KeywordPrimitiveArray");
+
+		// Non-keyword array (e.g., JavaObjectArray<T> with "java/lang/Object", ArrayRank=1)
+		Assert.DoesNotContain (peers, p => p.ManagedTypeName == "Java.Interop.TestTypes.NonKeywordArrayType");
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/TestFixtures/TestTypes.cs
@@ -969,4 +969,23 @@ namespace Java.Interop.TestTypes
 	{
 		public NonGeneratedJavaObject () { }
 	}
+
+	/// <summary>
+	/// Mimics Java.Interop.JavaBooleanArray — a primitive array type with IsKeyword=true.
+	/// The scanner must skip all ArrayRank > 0 types because they are handled by the
+	/// built-in tables in JniRuntime.JniTypeManager.
+	/// </summary>
+	[Java.Interop.JniTypeSignature ("Z", IsKeyword = true, ArrayRank = 1, GenerateJavaPeer = false)]
+	public sealed class KeywordPrimitiveArray : JavaObject
+	{
+	}
+
+	/// <summary>
+	/// Mimics Java.Interop.JavaObjectArray — a non-keyword array type with ArrayRank=1.
+	/// The scanner must also skip these to avoid adding unnecessary aliases.
+	/// </summary>
+	[Java.Interop.JniTypeSignature ("java/lang/Object", ArrayRank = 1, GenerateJavaPeer = false)]
+	public class NonKeywordArrayType : JavaObject
+	{
+	}
 }

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.targets
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.targets
@@ -10,7 +10,40 @@
     </TestJarEntry>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <TestJarEntry Include="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\**\*.java" />
+    <!--
+      java-trimmable/net/dot/jni/test/GetThis.java is added explicitly via
+      TestJarEntry below when building for the trimmable typemap; it must be
+      removed from the implicit AndroidJavaSource glob so the .NET SDK does
+      not also try to compile it as a regular AndroidJavaSource (which would
+      collide with the desktop GetThis.java in the test JAR).
+    -->
+    <AndroidJavaSource Remove="java-trimmable\**\*.java" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!--
+      java-trimmable/net/dot/jni/test/GetThis.java is the Android trimmable
+      typemap variant of the Java.Interop GetThis.java test fixture. It omits
+      the desktop-JVM static initializer (net.dot.jni.ManagedPeer.registerNativeMembers /
+      ManagedPeer.construct) that is only registered by the Java.Interop test
+      JVM and throws UnsatisfiedLinkError on Android. Both files declare
+      `public class net.dot.jni.test.GetThis`, so include exactly one based on
+      $(_AndroidTypeMapImplementation). The trimmable variant lives in this
+      project (not the submodule) and in a parallel directory because javac
+      requires the file name match the public class name.
+    -->
+    <!--
+      Both branches below are mutually exclusive on $(_AndroidTypeMapImplementation).
+      Switching between trimmable and non-trimmable requires a clean rebuild because
+      MSBuild's up-to-date check doesn't track the conditional swap automatically.
+    -->
+    <TestJarEntry Include="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\**\*.java"
+                  Exclude="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\net\dot\jni\test\GetThis.java"
+                  Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' " />
+    <TestJarEntry Include="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\**\*.java"
+                  Condition=" '$(_AndroidTypeMapImplementation)' != 'trimmable' " />
+    <TestJarEntry Include="$(MSBuildThisFileDirectory)java-trimmable\net\dot\jni\test\GetThis.java"
+                  Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' " />
   </ItemGroup>
   <Target Name="_CopyTestJarFiles">
     <Copy

--- a/tests/Mono.Android-Tests/Java.Interop-Tests/java-trimmable/net/dot/jni/test/GetThis.java
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/java-trimmable/net/dot/jni/test/GetThis.java
@@ -1,0 +1,41 @@
+package net.dot.jni.test;
+
+import java.util.ArrayList;
+
+import net.dot.jni.GCUserPeerable;
+
+// Variant of GetThis used by the Mono.Android.NET-Tests trimmable typemap lane.
+//
+// The desktop-JVM variant (../../../java/net/dot/jni/test/GetThis.java) relies
+// on net.dot.jni.ManagedPeer.registerNativeMembers / ManagedPeer.construct;
+// those native methods are only registered by the Java.Interop test JVM and
+// throw UnsatisfiedLinkError on Android, which makes the static initializer
+// here fail when the class is loaded on a real device.
+//
+// Under the Android trimmable typemap, the C# `GetThis : JavaObject` peer is
+// constructed via the standard Java.Interop / Mono.Android peer construction
+// path, so the Java class only needs:
+//   - getThis() — exercised by JavaObjectTest.DisposeAccessesThis
+//   - GCUserPeerable implementation so the runtime registers managed-side
+//     references (see Android.Runtime.JNIEnv.IsGCUserPeer)
+public class GetThis implements GCUserPeerable {
+
+	ArrayList<Object> managedReferences = new ArrayList<Object>();
+
+	public GetThis () {
+	}
+
+	public final GetThis getThis () {
+		return this;
+	}
+
+	public void jiAddManagedReference (java.lang.Object obj)
+	{
+		managedReferences.add (obj);
+	}
+
+	public void jiClearManagedReferences ()
+	{
+		managedReferences.clear ();
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaObjectExtensionsTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaObjectExtensionsTests.cs
@@ -15,7 +15,6 @@ namespace Java.InteropTests {
 	[TestFixture]
 	public class JavaObjectExtensionsTests {
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — cannot create instance of open generic type under trimmable typemap
 		[Test]
 		public void JavaCast_BaseToGenericWrapper ()
 		{
@@ -42,7 +41,6 @@ namespace Java.InteropTests {
 			}
 		}
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — throws NotSupportedException instead of InvalidCastException under trimmable typemap
 		[Test]
 		public void JavaCast_BadInterfaceCast ()
 		{
@@ -69,7 +67,6 @@ namespace Java.InteropTests {
 			Assert.AreSame (list, al);
 		}
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — throws NotSupportedException instead of InvalidCastException under trimmable typemap
 		[Test]
 		public void JavaCast_InvalidTypeCastThrows ()
 		{
@@ -78,7 +75,6 @@ namespace Java.InteropTests {
 			}
 		}
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — throws NotSupportedException instead of InvalidCastException under trimmable typemap
 		[Test]
 		public void JavaCast_CheckForManagedSubclasses ()
 		{

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -34,10 +34,17 @@ namespace Xamarin.Android.RuntimeTests
                     // net.dot.jni.test.CallVirtualFromConstructorDerived Java class not in APK
                     "Java.InteropTests.InvokeVirtualFromConstructorTests",
 
-                    // net.dot.jni.internal.JavaProxyObject Java class not in APK — fixture setup fails (16 tests)
+                    // net.dot.jni.internal.JavaProxyObject.<clinit> calls
+                    // net.dot.jni.ManagedPeer.registerNativeMembers, which the trimmable
+                    // typemap path rejects (Native methods must be registered by JCW
+                    // static initializer blocks). Fixing this requires a parallel
+                    // Android-trimmable variant of JavaProxyObject.java that registers
+                    // its native equals/hashCode/toString via mono.android.Runtime.register
+                    // — an architectural change tracked separately from the JavaCast / JavaAs
+                    // work in this PR. See https://github.com/dotnet/android/issues/11170.
                     "Java.InteropTests.JavaObjectArray_object_ContractTest",
 
-                    // net.dot.jni.internal.JavaProxyObject Java class not in APK
+                    // Same root cause as above (JavaProxyObject static init).
                     "Java.InteropTests.JniValueMarshaler_object_ContractTests.JniValueMarshalerContractTests`1.CreateArgumentState",
                     "Java.InteropTests.JniValueMarshaler_object_ContractTests.JniValueMarshalerContractTests`1.CreateGenericArgumentState",
                     "Java.InteropTests.JniValueMarshaler_object_ContractTests.JniValueMarshalerContractTests`1.CreateGenericObjectReferenceArgumentState",
@@ -46,17 +53,9 @@ namespace Xamarin.Android.RuntimeTests
                     "Java.InteropTests.JniValueMarshaler_object_ContractTests.JniValueMarshalerContractTests`1.CreateValue",
                     "Java.InteropTests.JniValueMarshaler_object_ContractTests.SpecificTypesAreUsed",
 
-                    // No generated JavaPeerProxy for java/lang/Object with IJavaPeerable target type
-                    "Java.InteropTests.JniValueMarshaler_IJavaPeerable_ContractTests.JniValueMarshalerContractTests`1.CreateGenericValue",
-                    "Java.InteropTests.JniValueMarshaler_IJavaPeerable_ContractTests.JniValueMarshalerContractTests`1.CreateValue",
-
-                    // net.dot.jni.internal.JavaProxyThrowable — proxy throwable creation fails
+                    // net.dot.jni.internal.JavaProxyThrowable static init — same JavaProxy*
+                    // root cause as the JavaProxyObject exclusions above.
                     "Java.InteropTests.JavaExceptionTests.InnerExceptionIsNotAProxy",
-
-                    // IJavaInterfaceInvoker ctor trimmed / missing JavaPeerProxy for test types
-                    "Java.InteropTests.JavaPeerableExtensionsTests.JavaAs",
-                    "Java.InteropTests.JavaPeerableExtensionsTests.JavaAs_Exceptions",
-                    "Java.InteropTests.JavaPeerableExtensionsTests.JavaAs_InstanceThatDoesNotImplementInterfaceReturnsNull",
 
                     // JNI method remapping not supported in trimmable typemap
                     "Java.InteropTests.JniPeerMembersTests.ReplaceInstanceMethodName",
@@ -67,17 +66,11 @@ namespace Xamarin.Android.RuntimeTests
                     // net.dot.jni.test.GenericHolder Java class not in APK
                     "Java.InteropTests.JniTypeManagerTests.CannotCreateGenericHolderFromJava",
 
-                    // JniPrimitiveArrayInfo lookup fails for JavaBooleanArray
+                    // JniPrimitiveArrayInfo lookup fails for JavaBooleanArray —
+                    // our typemap returns JavaBooleanArray for "Z" via JavaPrimitiveArray<>
+                    // alias, which collides with the legacy GetPrimitiveArrayTypesForSimpleReference
+                    // that expects only primitive CLR types. Out of scope for this PR.
                     "Java.InteropTests.JniTypeManagerTests.GetType",
-
-                    // net.dot.jni.test.GetThis — cannot register native members
-                    "Java.InteropTests.JavaObjectTest.DisposeAccessesThis",
-
-                    // NotSupportedException instead of InvalidCastException — no generated JavaPeerProxy
-                    "Java.InteropTests.JavaObjectExtensionsTests.JavaCast_BadInterfaceCast",
-                    "Java.InteropTests.JavaObjectExtensionsTests.JavaCast_BaseToGenericWrapper",
-                    "Java.InteropTests.JavaObjectExtensionsTests.JavaCast_CheckForManagedSubclasses",
-                    "Java.InteropTests.JavaObjectExtensionsTests.JavaCast_InvalidTypeCastThrows",
 
                     // Open generic type handling differs from non-trimmable
                     "Java.InteropTests.JnienvTest.NewOpenGenericTypeThrows",


### PR DESCRIPTION
## Summary

Fix `JavaCast` / `JavaAs` behavior under the trimmable typemap and re-enable 7 device tests that were previously excluded. Consolidates the JavaCast/JavaAs work and the trimmable container support that was previously split across two PRs.

### Cast error disambiguation

When a trimmable typemap proxy lookup fails, `CreatePeer` now distinguishes between:
- **Incompatible Java types** → returns `null` (JavaCast wraps to `InvalidCastException`, JavaAs returns `null`)
- **Missing typemap entry** → throws `ArgumentException`
- **Compatible types but no proxy** → throws `NotSupportedException`

Previously all failures threw `NotSupportedException`, breaking `JavaCast` / `JavaAs` contracts.

Also adds `ResolvePeerType` to map universal interfaces (`IJavaPeerable`, `object`, `Exception`) to concrete peer types before proxy lookup, and catches `ClassNotFoundException` from `FindClass` so missing Java classes surface as `ArgumentException`.

### Closed-generic peer activation

Open-generic proxies (e.g. `JavaList<>`) cannot `newobj` closed instantiations (e.g. `JavaList<int>`) in generated IL. Adds `ActivateUsingReflection` which uses `Type.GetConstructor` + `ConstructorInfo.Invoke` on the closed `targetType` — safe because `[DynamicallyAccessedMembers(Constructors)]` annotations on the parameter ensure the trimmer preserves the ctor metadata.

`TargetTypeMatches` is restructured so open-generic proxies match only closed instantiations of their definition — preventing incorrect matches like `JavaArray<>` matching any `JavaObject`-targeted cast.

### Interface invoker activation ctor

Interface peers have no constructors. `TryResolveActivationCtorOnInvoker` resolves the activation ctor from the invoker type so the generator picks the correct ctor signature (XA-style vs JI-style).

### Don't synthesize activation from inherited ctors

The generator no longer emits `GetUninitializedObject` + base-ctor IL when the activation ctor is on a base type (`IsOnLeafType=false`) and there's no invoker type. This matches legacy `Type.GetConstructor()` behavior, which doesn't find inherited constructors. Without this, types like `MyJavaInterfaceImpl` that lack their own activation ctor would unexpectedly succeed in the trimmable path.

### Scanner: skip JNI keyword and array types

The scanner was incorrectly adding primitive array wrapper types (`JavaBooleanArray` etc.) to the typemap under single-letter keyword keys (Z, B, C, S, I, J, F, D), colliding with the built-in primitive type handling in `JniRuntime.JniTypeManager.GetPrimitiveArrayTypesForSimpleReference`. Skip all `[JniTypeSignature]` types with `ArrayRank > 0` (which covers both primitive array wrappers and `JavaArray<>`/`JavaObjectArray<>`/`JavaPrimitiveArray<>`).

### Trimmable GetThis.java

The `net.dot.jni.test.GetThis` Java class (in the Java.Interop submodule) registers native methods via `ManagedPeer.registerNativeMembers`, which the trimmable path rejects. Adds an Android-trimmable variant that omits the desktop static block. `Java.Interop-Tests.targets` swaps variants based on `$(_AndroidTypeMapImplementation)`.

### Test exclusion updates

**Re-enabled** (7 tests):
- `JavaObjectExtensionsTests.JavaCast_BadInterfaceCast`
- `JavaObjectExtensionsTests.JavaCast_BaseToGenericWrapper` (closed-generic activation)
- `JavaObjectExtensionsTests.JavaCast_CheckForManagedSubclasses`
- `JavaObjectExtensionsTests.JavaCast_InvalidTypeCastThrows`
- `JavaPeerableExtensionsTests.JavaAs_Exceptions` (inherited-ctor fix)
- `JavaObjectTest.DisposeAccessesThis` (trimmable GetThis.java)
- `JniValueMarshaler_IJavaPeerable_ContractTests.CreateGenericValue` (ArrayRank scanner fix)

Updated remaining exclusion comments with accurate root-cause descriptions. Removed resolved TODO comments from `JavaObjectExtensionsTests`.

The remaining `JavaProxyObject` / `JavaProxyThrowable` exclusions are tracked at #11170.

## Test results

Trimmable + CoreCLR lane: **917 total, 0 errors, 3 failures** (pre-existing `TryGetJniNameForManagedType_*`, out of scope).

## Follow-up

`JavaPeerContainerFactory<T>` is still used and causes per-type bloat under NativeAOT (~2000 instantiations for a typical MAUI app). Tracked at #11234 for a separate refactor PR.

## Related issues
- Reference #11170
- Reference #11234
