### PR TITLE
Fix JavaList.Remove() always-false guard condition (`&&` -> `||`)

### DIFF
--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -627,7 +627,7 @@ namespace Android.Runtime {
 		public virtual bool Remove (Java.Lang.Object? item)
 		{
 			int i = IndexOf (item);
-			if (i < 0 && i >= Count)
+			if (i < 0 || i >= Count)
 				return false;
 			RemoveAt (i);
 			return true;
@@ -964,7 +964,7 @@ namespace Android.Runtime {
 		public bool Remove (T item)
 		{
 			int i = IndexOf (item);
-			if (i < 0 && i >= Count)
+			if (i < 0 || i >= Count)
 				return false;
 			RemoveAt (i);
 			return true;

--- a/src/Mono.Android/Android.Runtime/JavaList.cs
+++ b/src/Mono.Android/Android.Runtime/JavaList.cs
@@ -392,7 +392,7 @@ namespace Android.Runtime {
 		public void Remove (object? item)
 		{
 			int i = IndexOf (item);
-			if (i < 0 && i >= Count)
+			if (i < 0 || i >= Count)
 				return;
 			RemoveAt (i);
 		}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs
@@ -131,6 +131,14 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void RemoveNonExistentItemDoesNotThrow ()
+		{
+			list.Add ("foo");
+			Assert.DoesNotThrow (() => list.Remove ("bar"));
+			Assert.AreEqual (1, list.Count);
+		}
+
+		[Test]
 		public void Set ()
 		{
 			list.Add ("foo");


### PR DESCRIPTION
## Problem

`JavaList.Remove(object?)` had an always-false guard condition at line 395:

```csharp
if (i < 0 && i >= Count)
    return;
RemoveAt (i);
```

A value cannot simultaneously be `< 0` **and** `>= Count` (Count is always non-negative), so this guard could never fire. The practical consequence: when `IndexOf` returns `-1` (item not found), the dead guard passes and `RemoveAt(-1)` is called, throwing an exception instead of silently no-op-ing as the `IList.Remove` contract requires.

## Fix

Change `&&` to `||`:

```csharp
if (i < 0 || i >= Count)
    return;
RemoveAt (i);
```

This correctly returns early when:
- `IndexOf` returns `-1` (item not in list) — the `i < 0` branch
- A race condition shrinks the list between `IndexOf` and `RemoveAt` — the `i >= Count` branch

## Changes

- `src/Mono.Android/Android.Runtime/JavaList.cs`: one-character fix (`&&` → `||`)
- `tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaListTest.cs`: added `RemoveNonExistentItemDoesNotThrow` test — adds `"foo"`, calls `Remove("bar")`, asserts no exception is thrown and count remains 1
