### PR TITLE
Enable Hot Reload on CoreCLR for Android

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
@@ -25,7 +25,11 @@ See: https://github.com/dotnet/sdk/pull/52581
     Configures Hot Reload when dotnet-watch passes environment variables via @(RuntimeEnvironmentVariable).
     - Adds the Hot Reload agent DLL as a reference so it gets deployed
     - Updates DOTNET_STARTUP_HOOKS to use just the assembly name (not the full path)
-    - Sets up STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM
+    - Sets up STARTUP_HOOKS via RuntimeHostConfigurationOption so the runtime picks
+      up the agent from runtimeconfig.json (works for both MonoVM and CoreCLR on
+      Android, where DOTNET_STARTUP_HOOKS env var injection is not available)
+    - On CoreCLR, also enables modifiable assemblies via runtimeconfig so metadata
+      updates are accepted (Mono picks this up from __environment__.txt instead)
   -->
   <Target Name="_AndroidConfigureHotReloadEnvironment"
           Condition=" '@(RuntimeEnvironmentVariable)' != '' ">
@@ -56,8 +60,26 @@ See: https://github.com/dotnet/sdk/pull/52581
           Value="$(_AndroidHotReloadAgentAssemblyName)"
           Condition=" '@(_ExistingStartupHooks)' == '' " />
       <_ExistingStartupHooks Remove="@(_ExistingStartupHooks)" />
-      <!-- Set STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM (read by Mono runtime) -->
-      <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" Condition=" '$(UseMonoRuntime)' == 'true' " />
+      <!--
+        Set STARTUP_HOOKS via RuntimeHostConfigurationOption.
+        Both MonoVM and CoreCLR read this from runtimeconfig.json at host init,
+        which is required on Android where the DOTNET_STARTUP_HOOKS env var written
+        to __environment__.txt is only consumed by Mono via libmonodroid.so;
+        CoreCLR's PAL snapshots the OS environment at startup and never reads it.
+      -->
+      <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" />
+    </ItemGroup>
+
+    <!--
+      On CoreCLR, also enable modifiable assemblies via runtimeconfig so the
+      runtime accepts metadata updates from the Hot Reload agent. Mono picks
+      this up from DOTNET_MODIFIABLE_ASSEMBLIES in __environment__.txt
+      (see Xamarin.Android.Common.targets _GenerateEnvironmentFiles), which
+      CoreCLR does not consume.
+    -->
+    <ItemGroup Condition=" '$(_AndroidRuntime)' == 'CoreCLR' and '$(AndroidIncludeDebugSymbols)' == 'true' ">
+      <RuntimeHostConfigurationOption Include="System.Reflection.Metadata.MetadataUpdater.IsSupported" Value="true" />
+      <RuntimeHostConfigurationOption Include="ModifiableAssemblies" Value="debug" />
     </ItemGroup>
 
   </Target>


### PR DESCRIPTION
## Description

This PR routes the Hot Reload settings through `runtimeconfig.json` `configProperties` so they reach CoreCLR at host init on Android. In `Microsoft.Android.Sdk.HotReload.targets` the `STARTUP_HOOKS` `RuntimeHostConfigurationOption` is no longer gated on `UseMonoRuntime=true`, and for CoreCLR debug builds two additional options are emitted: `ModifiableAssemblies=debug` and `System.Reflection.Metadata.MetadataUpdater.IsSupported=true`. Today these settings only reach Mono via `__environment__.txt`, which `libmonodroid.so` consumes before runtime init; CoreCLR's PAL snapshots the OS environment at startup and never reads that file, so the existing Mono path was a no-op for CoreCLR. The Mono path is unchanged.

With this PR, end-to-end `dotnet watch` Hot Reload works on the Android emulator with `RuntimeFlavor=CoreCLR`.