### PR TITLE
[Hot Reload] Parameterize DotNetWatchHotReload test and remove Mono STARTUP_HOOKS workaround

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
@@ -25,7 +25,6 @@ See: https://github.com/dotnet/sdk/pull/52581
     Configures Hot Reload when dotnet-watch passes environment variables via @(RuntimeEnvironmentVariable).
     - Adds the Hot Reload agent DLL as a reference so it gets deployed
     - Updates DOTNET_STARTUP_HOOKS to use just the assembly name (not the full path)
-    - Sets up STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM
   -->
   <Target Name="_AndroidConfigureHotReloadEnvironment"
           Condition=" '@(RuntimeEnvironmentVariable)' != '' ">
@@ -35,7 +34,7 @@ See: https://github.com/dotnet/sdk/pull/52581
       <_AndroidHotReloadAgentAssemblyPath>@(RuntimeEnvironmentVariable->WithMetadataValue('Identity', 'DOTNET_STARTUP_HOOKS')->'%(Value)'->Exists())</_AndroidHotReloadAgentAssemblyPath>
     </PropertyGroup>
 
-    <!-- Extract just the assembly name for STARTUP_HOOKS config -->
+    <!-- Extract just the assembly name for DOTNET_STARTUP_HOOKS -->
     <PropertyGroup Condition=" '$(_AndroidHotReloadAgentAssemblyPath)' != '' ">
       <_AndroidHotReloadAgentAssemblyName>$([System.IO.Path]::GetFileNameWithoutExtension('$(_AndroidHotReloadAgentAssemblyPath)'))</_AndroidHotReloadAgentAssemblyName>
     </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.HotReload.targets
@@ -56,8 +56,6 @@ See: https://github.com/dotnet/sdk/pull/52581
           Value="$(_AndroidHotReloadAgentAssemblyName)"
           Condition=" '@(_ExistingStartupHooks)' == '' " />
       <_ExistingStartupHooks Remove="@(_ExistingStartupHooks)" />
-      <!-- Set STARTUP_HOOKS via RuntimeHostConfigurationOption for MonoVM (read by Mono runtime) -->
-      <RuntimeHostConfigurationOption Include="STARTUP_HOOKS" Value="$(_AndroidHotReloadAgentAssemblyName)" Condition=" '$(UseMonoRuntime)' == 'true' " />
     </ItemGroup>
 
   </Target>

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -254,14 +254,13 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-
-		public void DotNetWatchHotReload ()
+		public void DotNetWatchHotReload ([Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
 			const string initialMessage = "DOTNET_WATCH_INITIAL_12345";
 			const string hotReloadMessage = "DOTNET_WATCH_HOT_RELOAD_APPLIED";
 
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetRuntime (AndroidRuntime.MonoVM); // MonoVM only for now, until we get: https://github.com/dotnet/sdk/pull/53501
+			proj.SetRuntime (runtime);
 
 			// Enable hot reload log messages from the delta client
 			proj.OtherBuildItems.Add (new BuildItem ("AndroidEnvironment", "env.txt") {


### PR DESCRIPTION
## Summary

Two related Hot Reload improvements:

1. **Parameterize `DotNetWatchHotReload` test** for both `MonoVM` and `CoreCLR` runtimes instead of hardcoding `MonoVM`.

2. **Remove the `RuntimeHostConfigurationOption` workaround** for `STARTUP_HOOKS` in `HotReload.targets`. This workaround was needed because Mono was not reading `DOTNET_STARTUP_HOOKS` from the environment. The upstream fix is now included in our pinned dotnet/dotnet:
   - **Runtime fix:** https://github.com/dotnet/runtime/commit/c8e2a6110c69601540c25f2099053505fa088b9e
   - **Pinned dotnet/dotnet SHA:** https://github.com/dotnet/dotnet/commit/ab01524bbb2ef1eea0ffaef161b3ef5686e8f256