### PR TITLE
[CoreCLR] Exclude diagnostic libraries from release APKs

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -294,6 +294,8 @@ _ResolveAssemblies MSBuild target.
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'MonoVM' Or '$(_AndroidRuntime)' == '' " Include="libnet-android.release" />
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " Include="libmono-android.debug" />
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " Include="libmono-android.release" />
+      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(DebuggerSupport)' == 'false' " Include="libmscordaccore" />
+      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(DebuggerSupport)' == 'false' " Include="libmscordbi" />
     </ItemGroup>
 
     <!-- Let's keep the item group close to the task that uses them, the list is irrelevant for

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.AssemblyResolution.targets
@@ -294,8 +294,8 @@ _ResolveAssemblies MSBuild target.
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'MonoVM' Or '$(_AndroidRuntime)' == '' " Include="libnet-android.release" />
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " Include="libmono-android.debug" />
       <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' " Include="libmono-android.release" />
-      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(DebuggerSupport)' == 'false' " Include="libmscordaccore" />
-      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(DebuggerSupport)' == 'false' " Include="libmscordbi" />
+      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(AndroidIncludeDebugSymbols)' != 'true' " Include="libmscordaccore" />
+      <_ExcludedNativeLibraries Condition=" '$(_AndroidRuntime)' == 'CoreCLR' And '$(AndroidIncludeDebugSymbols)' != 'true' " Include="libmscordbi" />
     </ItemGroup>
 
     <!-- Let's keep the item group close to the task that uses them, the list is irrelevant for

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
@@ -19,12 +19,6 @@
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 1366648
     },
-    "lib/arm64-v8a/libmscordaccore.so": {
-      "Size": 2463848
-    },
-    "lib/arm64-v8a/libmscordbi.so": {
-      "Size": 1899720
-    },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72344
     },
@@ -74,5 +68,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 9238298
+  "PackageSize": 4874730
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc
@@ -8,7 +8,7 @@
       "Size": 400044
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 3099384
+      "Size": 3098192
     },
     "lib/arm64-v8a/libclrjit.so": {
       "Size": 3223752
@@ -32,16 +32,16 @@
       "Size": 162000
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 20744
+      "Size": 20424
     },
     "META-INF/BNDLTOOL.RSA": {
-      "Size": 1221
+      "Size": 1223
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 2295
+      "Size": 2091
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 2168
+      "Size": 1964
     },
     "res/drawable-hdpi-v4/icon.png": {
       "Size": 2178
@@ -68,5 +68,5 @@
       "Size": 1904
     }
   },
-  "PackageSize": 4874730
+  "PackageSize": 7632514
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
@@ -43,12 +43,6 @@
     "lib/arm64-v8a/libmonodroid.so": {
       "Size": 1366648
     },
-    "lib/arm64-v8a/libmscordaccore.so": {
-      "Size": 2463848
-    },
-    "lib/arm64-v8a/libmscordbi.so": {
-      "Size": 1899720
-    },
     "lib/arm64-v8a/libSystem.Globalization.Native.so": {
       "Size": 72344
     },
@@ -2285,5 +2279,5 @@
       "Size": 812848
     }
   },
-  "PackageSize": 22873019
+  "PackageSize": 18509451
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Resources/Base/BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc
@@ -32,7 +32,7 @@
       "Size": 2396
     },
     "lib/arm64-v8a/libassembly-store.so": {
-      "Size": 14078456
+      "Size": 14076232
     },
     "lib/arm64-v8a/libclrjit.so": {
       "Size": 3223752
@@ -56,7 +56,7 @@
       "Size": 162000
     },
     "lib/arm64-v8a/libxamarin-app.so": {
-      "Size": 147584
+      "Size": 147264
     },
     "META-INF/androidx.activity_activity.version": {
       "Size": 6
@@ -212,7 +212,7 @@
       "Size": 1221
     },
     "META-INF/BNDLTOOL.SF": {
-      "Size": 90346
+      "Size": 90142
     },
     "META-INF/com.android.tools/proguard/coroutines.pro": {
       "Size": 1345
@@ -239,7 +239,7 @@
       "Size": 5
     },
     "META-INF/MANIFEST.MF": {
-      "Size": 90219
+      "Size": 90015
     },
     "META-INF/maven/com.google.guava/listenablefuture/pom.properties": {
       "Size": 96
@@ -2279,5 +2279,5 @@
       "Size": 812848
     }
   },
-  "PackageSize": 18509451
+  "PackageSize": 21263139
 }


### PR DESCRIPTION
## Summary
- exclude CoreCLR DAC/DBI diagnostic native libraries from Android APK packaging when debugger support is explicitly disabled
- update CoreCLR Release arm64 APK descriptor baselines to remove `libmscordaccore.so` and `libmscordbi.so`, including `PackageSize` reductions

## APK descriptor size impact

| Descriptor | Before | After | Delta |
|---|---:|---:|---:|
| `BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc` | `9,238,298` | `4,874,730` | `-4,363,568` |
| `BuildReleaseArm64XFormsDotNet.CoreCLR.apkdesc` | `22,873,019` | `18,509,451` | `-4,363,568` |

The `PackageSize` delta is exactly the raw size of the two removed APK entries:

| Entry | Size |
|---|---:|
| `lib/arm64-v8a/libmscordaccore.so` | `2,463,848` |
| `lib/arm64-v8a/libmscordbi.so` | `1,899,720` |
| **Total** | **`4,363,568`** |

## Local `dotnet new maui` APK size impact

Local Release publish of a blank `dotnet new maui` app for `.apk (android-arm64)`:

| APK | Size | Delta vs Mono | Delta vs CoreCLR before |
|---|---:|---:|---:|
| CoreCLR Release before | `22,039,645` | `+2,882,672` (`+15.0%`) | - |
| CoreCLR Release after | `20,433,861` | `+1,276,888` (`+6.7%`) | `-1,605,784` (`-7.3%`) |
| Mono Release | `19,156,973` | - | - |

This saves about **1.53 MiB compressed** in the CoreCLR APK and reduces the blank-app CoreCLR-vs-Mono gap from about **2.75 MiB** to about **1.22 MiB**.

## Notes
`libmscordbi.so` and `libmscordaccore.so` are present in the CoreCLR runtime pack as native assets, so the Android packaging pipeline currently treats them as framework native libraries and includes them in APKs. Normal Android CoreCLR app startup does not load these libraries; they are debugger/diagnostic sidecars.

The exclusion is gated on `DebuggerSupport == false`. Android defaults `DebuggerSupport=false` for optimized Release apps, while Debug builds can leave the property unset; using an explicit `false` check avoids treating an unset Debug value as disabled. Projects that set `DebuggerSupport=true` continue to package these libraries.

Local investigation with a blank MAUI CoreCLR R2R app showed that removing both libraries reduced the APK by about 1.5 MiB compressed and the app still installed and cold-launched successfully on an Android device.

Additional local validation with a project-level target matching this PR showed:
- Debug CoreCLR with packaged assets and unset `DebuggerSupport`: DAC/DBI remain packaged
- Release default where `DebuggerSupport=false`: DAC/DBI are removed
- Release with `DebuggerSupport=true`: DAC/DBI remain packaged

## Validation
- `git diff --check`
- parsed updated `.apkdesc` files with `jq empty`
- local blank MAUI Debug/Release publishes with binlogs for Debug CoreCLR packaged assets, Release default, and Release `DebuggerSupport=true`
- targeted repo test was not run because this clean worktree requires `make prepare`