### PR TITLE
[release/10.0.1xx] [xabt] Fix wrong-TFM assembly loading -> empty `.jlo.xml` files

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -102,12 +102,18 @@ public class AssemblyModifierPipeline : AndroidTask
 
 				var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: ReadSymbols, loadReaderParameters: readerParameters);
 
-				// Add SearchDirectories for the current architecture's ResolvedAssemblies
+				// Add SearchDirectories and pre-load ResolvedAssemblies into the resolver cache.
+				// Pre-loading ensures the correct TFM version is cached before any Cecil lazy
+				// reference resolution can find wrong-TFM copies from search directories (e.g.,
+				// a net10.0 copy in a referencing project's output directory).
 				foreach (var kvp in perArchAssemblies [sourceArch]) {
 					ITaskItem assembly = kvp.Value;
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
 					if (!resolver.SearchDirectories.Contains (path)) {
 						resolver.SearchDirectories.Add (path);
+					}
+					if (resolver.Load (assembly.ItemSpec) == null) {
+						Log.LogDebugMessage ($"Could not pre-load assembly '{assembly.ItemSpec}' into resolver cache.");
 					}
 				}
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -163,11 +163,8 @@ public class AssemblyModifierPipeline : AndroidTask
 		// Use Load with the exact ItemSpec path to ensure the correct TFM version
 		// is loaded, rather than GetAssembly which strips the path and resolves by
 		// name through search directories (which may find wrong-TFM copies).
-		var assembly = pipeline.Resolver.Load (source.ItemSpec);
-		if (assembly == null) {
-			Log.LogDebugMessage ($"Could not load assembly '{source.ItemSpec}', skipping.");
-			return;
-		}
+		var assembly = pipeline.Resolver.Load (source.ItemSpec)
+			?? throw new FileNotFoundException ($"Could not load assembly '{source.ItemSpec}'.", source.ItemSpec);
 
 		var context = new StepContext (source, destination) {
 			CodeGenerationTarget = codeGenerationTarget,

--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -102,18 +102,12 @@ public class AssemblyModifierPipeline : AndroidTask
 
 				var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: ReadSymbols, loadReaderParameters: readerParameters);
 
-				// Add SearchDirectories and pre-load ResolvedAssemblies into the resolver cache.
-				// Pre-loading ensures the correct TFM version is cached before any Cecil lazy
-				// reference resolution can find wrong-TFM copies from search directories (e.g.,
-				// a net10.0 copy in a referencing project's output directory).
+				// Add SearchDirectories for the current architecture's ResolvedAssemblies
 				foreach (var kvp in perArchAssemblies [sourceArch]) {
 					ITaskItem assembly = kvp.Value;
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
 					if (!resolver.SearchDirectories.Contains (path)) {
 						resolver.SearchDirectories.Add (path);
-					}
-					if (resolver.Load (assembly.ItemSpec) == null) {
-						Log.LogDebugMessage ($"Could not pre-load assembly '{assembly.ItemSpec}' into resolver cache.");
 					}
 				}
 
@@ -166,7 +160,14 @@ public class AssemblyModifierPipeline : AndroidTask
 
 	void RunPipeline (AssemblyPipeline pipeline, ITaskItem source, ITaskItem destination)
 	{
-		var assembly = pipeline.Resolver.GetAssembly (source.ItemSpec);
+		// Use Load with the exact ItemSpec path to ensure the correct TFM version
+		// is loaded, rather than GetAssembly which strips the path and resolves by
+		// name through search directories (which may find wrong-TFM copies).
+		var assembly = pipeline.Resolver.Load (source.ItemSpec);
+		if (assembly == null) {
+			Log.LogDebugMessage ($"Could not load assembly '{source.ItemSpec}', skipping.");
+			return;
+		}
 
 		var context = new StepContext (source, destination) {
 			CodeGenerationTarget = codeGenerationTarget,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -9,6 +9,8 @@ using Microsoft.Android.Build.Tasks;
 using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
+using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -893,6 +895,131 @@ namespace Xamarin.Android.Build.Tests
 				aar.AssertEntryContents (aarPath, "res/raw/foo.txt", contents: "foo");
 				aar.AssertDoesNotContainEntry (aarPath, "res/raw/bar.txt");
 			}
+		}
+
+		/// <summary>
+		/// Regression test for https://github.com/dotnet/android/issues/10858
+		///
+		/// When a solution has the structure:
+		///   App (net10.0-android) → CoreLib (net10.0) → MultiTfmLib (net10.0;net10.0-android)
+		///
+		/// And MultiTfmLib contains Java-interop types (e.g. BroadcastReceiver) that only
+		/// exist in the net10.0-android TFM, the build tasks must load the Android-TFM assembly
+		/// and generate JCWs for those types. Previously, the net10.0 (non-Android) assembly
+		/// could be loaded instead, causing FindJavaObjectsStep to report "Found 0 Java types"
+		/// and producing empty .jlo.xml files.
+		/// </summary>
+		[Test]
+		public void MultiTfmTransitiveReference ([Values] AndroidRuntime runtime)
+		{
+			if (IgnoreUnsupportedConfiguration (runtime, release: false)) {
+				return;
+			}
+
+			var path = Path.Combine ("temp", TestName);
+			var dotnetVersion = XABuildConfig.LatestDotNetTargetFramework;
+
+			// 1. Multi-TFM library (net10.0 + net10.0-android) with a BroadcastReceiver
+			var multiTfmLib = new DotNetStandard {
+				ProjectName = "MultiTfmLib",
+				Sdk = "Microsoft.NET.Sdk",
+				Sources = {
+					new BuildItem.Source ("MyReceiver.cs") {
+						TextContent = () =>
+@"#if ANDROID
+using Android.Content;
+
+namespace MultiTfmLib
+{
+	public class MyReceiver : BroadcastReceiver
+	{
+		public override void OnReceive (Context? context, Intent? intent) { }
+	}
+}
+#endif
+"
+					},
+					new BuildItem.Source ("SharedClass.cs") {
+						TextContent = () =>
+@"namespace MultiTfmLib
+{
+	public class SharedClass
+	{
+		public string Name => ""Hello"";
+	}
+}
+"
+					},
+				},
+			};
+			multiTfmLib.TargetFrameworks = $"{dotnetVersion};{dotnetVersion}-android";
+			multiTfmLib.SetProperty ("Nullable", "enable");
+			multiTfmLib.SetProperty ("AndroidGenerateResourceDesigner", "false");
+			multiTfmLib.SetProperty ("SupportedOSPlatformVersion", "24",
+				"$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'");
+			if (runtime != AndroidRuntime.NativeAOT) {
+				multiTfmLib.SetRuntime (runtime);
+			}
+
+			// 2. Non-Android library (net10.0 only) referencing the multi-TFM library
+			var coreLib = new DotNetStandard {
+				ProjectName = "CoreLib",
+				Sdk = "Microsoft.NET.Sdk",
+				Sources = {
+					new BuildItem.Source ("CoreClass.cs") {
+						TextContent = () =>
+@"namespace CoreLib
+{
+	public class CoreClass
+	{
+		public MultiTfmLib.SharedClass Shared => new ();
+	}
+}
+"
+					},
+				},
+			};
+			coreLib.TargetFramework = dotnetVersion;
+			coreLib.AddReference (multiTfmLib);
+
+			// 3. Android app that references CoreLib (NOT MultiTfmLib directly)
+			var app = new XamarinAndroidApplicationProject {
+				ProjectName = "MyApp",
+				Sources = {
+					new BuildItem.Source ("Usage.cs") {
+						TextContent = () =>
+@"public class Usage
+{
+	public CoreLib.CoreClass Core => new ();
+}
+"
+					},
+				},
+			};
+			app.SetRuntime (runtime);
+			app.AddReference (coreLib);
+
+			using var multiTfmBuilder = CreateDllBuilder (Path.Combine (path, multiTfmLib.ProjectName));
+			Assert.IsTrue (multiTfmBuilder.Build (multiTfmLib), $"{multiTfmLib.ProjectName} should build");
+
+			using var coreBuilder = CreateDllBuilder (Path.Combine (path, coreLib.ProjectName));
+			Assert.IsTrue (coreBuilder.Build (coreLib), $"{coreLib.ProjectName} should build");
+
+			using var appBuilder = CreateApkBuilder (Path.Combine (path, app.ProjectName));
+			Assert.IsTrue (appBuilder.Build (app), $"{app.ProjectName} should build");
+
+			// Verify: MultiTfmLib.jlo.xml should NOT be empty (i.e. the assembly was scanned as an Android assembly)
+			var jloXml = appBuilder.Output.GetIntermediaryPath (
+				Path.Combine ("android", "assets", "arm64-v8a", "MultiTfmLib.jlo.xml"));
+			FileAssert.Exists (jloXml);
+
+			var jloXmlInfo = new FileInfo (jloXml);
+			Assert.IsTrue (jloXmlInfo.Length > 0,
+				"MultiTfmLib.jlo.xml should not be empty — the Android-TFM assembly was not loaded (wrong TFM loaded instead)");
+
+			var jloContent = File.ReadAllText (jloXml);
+			Assert.IsTrue (jloContent.Contains ("MyReceiver"),
+				$"MultiTfmLib.jlo.xml should contain the MyReceiver JCW type, but got: {jloContent}");
 		}
 
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -10,7 +10,6 @@ using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
 using Xamarin.Android.Tasks;
-using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -910,12 +909,8 @@ namespace Xamarin.Android.Build.Tests
 		/// and producing empty .jlo.xml files.
 		/// </summary>
 		[Test]
-		public void MultiTfmTransitiveReference ([Values] AndroidRuntime runtime)
+		public void MultiTfmTransitiveReference ()
 		{
-			if (IgnoreUnsupportedConfiguration (runtime, release: false)) {
-				return;
-			}
-
 			var path = Path.Combine ("temp", TestName);
 			var dotnetVersion = XABuildConfig.LatestDotNetTargetFramework;
 
@@ -957,11 +952,7 @@ namespace MultiTfmLib
 			multiTfmLib.SetProperty ("AndroidGenerateResourceDesigner", "false");
 			multiTfmLib.SetProperty ("SupportedOSPlatformVersion", "24",
 				"$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'");
-			if (runtime != AndroidRuntime.NativeAOT) {
-				multiTfmLib.SetRuntime (runtime);
-			}
-
-			// 2. Non-Android library (net10.0 only) referencing the multi-TFM library
+			// 2.Non-Android library (net10.0 only) referencing the multi-TFM library
 			var coreLib = new DotNetStandard {
 				ProjectName = "CoreLib",
 				Sdk = "Microsoft.NET.Sdk",
@@ -996,7 +987,6 @@ namespace MultiTfmLib
 					},
 				},
 			};
-			app.SetRuntime (runtime);
 			app.AddReference (coreLib);
 
 			using var multiTfmBuilder = CreateDllBuilder (Path.Combine (path, multiTfmLib.ProjectName));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -9,7 +9,7 @@ using Microsoft.Android.Build.Tasks;
 using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
-using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Build.Tests
 {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -9,7 +9,6 @@ using Microsoft.Android.Build.Tasks;
 using Mono.Cecil;
 using NUnit.Framework;
 using Xamarin.ProjectTools;
-using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Build.Tests
 {
@@ -912,7 +911,7 @@ namespace Xamarin.Android.Build.Tests
 		public void MultiTfmTransitiveReference ()
 		{
 			var path = Path.Combine ("temp", TestName);
-			var dotnetVersion = XABuildConfig.LatestDotNetTargetFramework;
+			var dotnetVersion = "net10.0";
 
 			// 1. Multi-TFM library (net10.0 + net10.0-android) with a BroadcastReceiver
 			var multiTfmLib = new DotNetStandard {


### PR DESCRIPTION
Backport of #11208 (7bc3bbb22b1b80fbb5fd5b82bca8db16552e08a3) to `release/10.0.1xx`.

Fixes: https://github.com/dotnet/android/issues/10858

The cherry-pick had a minor conflict in the test file's `using` statements (the release branch was missing `using Xamarin.Android.Tasks;`). Comments referencing `net11.0` were updated to `net10.0` for this branch.

---

**Original PR description:**

The fix pre-loads all `ResolvedAssemblies` into the resolver cache from their exact `ItemSpec` paths during resolver setup. This ensures that both `GetAssembly` (which checks the cache first) and Cecil's lazy reference resolution always find the correct TFM version.