### PR TITLE
[tests] Skip PerformanceTest on slow CI machines using evaluation time

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging.StructuredLogger;
+using StructuredBuild = Microsoft.Build.Logging.StructuredLogger.Build;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 using Xamarin.Android.Tools;
@@ -61,7 +62,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			double total = 0;
-			Build build = null;
+			StructuredBuild build = null;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
 				build = ReadBinLog (builder);
@@ -85,7 +86,7 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Fail ($"No timeout value found for a key of {caller}");
 			}
 			double total = 0;
-			Build build = null;
+			StructuredBuild build = null;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
 				build = ReadBinLog (builder);
@@ -101,7 +102,7 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		void AssertSlowMachine (Build build, int expected, double actual)
+		void AssertSlowMachine (StructuredBuild build, int expected, double actual)
 		{
 			var evaluations = build.FindChildrenRecursive<ProjectEvaluation> ();
 			var maxEval = evaluations.Any () ? evaluations.Max (e => e.Duration.TotalMilliseconds) : 0;
@@ -111,14 +112,14 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
-		Build ReadBinLog (ProjectBuilder builder)
+		StructuredBuild ReadBinLog (ProjectBuilder builder)
 		{
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, $"{Path.GetFileNameWithoutExtension (builder.BuildLogFile)}.binlog");
 			FileAssert.Exists (binlog);
 			return BinaryLog.ReadBuild (binlog);
 		}
 
-		double GetTaskDuration (Build build, ProjectBuilder builder, string task)
+		double GetTaskDuration (StructuredBuild build, ProjectBuilder builder, string task)
 		{
 			var duration = build
 				.FindChildrenRecursive<Task> (t => t.Name == task)
@@ -132,7 +133,7 @@ namespace Xamarin.Android.Build.Tests
 			return duration.TotalMilliseconds;
 		}
 
-		double GetDuration (Build build, ProjectBuilder builder)
+		double GetDuration (StructuredBuild build, ProjectBuilder builder)
 		{
 			var duration = build
 				.FindChildrenRecursive<Project> ()

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Android.Build.Tests
 	public class PerformanceTest : DeviceTest
 	{
 		const int Retry = 2;
+		const int MaxEvaluationTimeInMs = 500;
 		static readonly Dictionary<string, int> csv_values = new Dictionary<string, int> ();
 
 		[OneTimeSetUp]
@@ -60,9 +61,11 @@ namespace Xamarin.Android.Build.Tests
 			}
 
 			double total = 0;
+			Build build = null;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
-				var actual = GetDurationFromBinLog (builder);
+				build = ReadBinLog (builder);
+				var actual = GetDuration (build, builder);
 				TestContext.Out.WriteLine ($"run {i} took: {actual}ms");
 				total += actual;
 				if (afterRun is not null)
@@ -71,6 +74,7 @@ namespace Xamarin.Android.Build.Tests
 			total /= iterations;
 			TestContext.Out.WriteLine ($"expected: {expected}ms, actual: {total}ms");
 			if (total > expected) {
+				AssertSlowMachine (build, expected, total);
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {total}ms");
 			}
 		}
@@ -81,47 +85,63 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Fail ($"No timeout value found for a key of {caller}");
 			}
 			double total = 0;
+			Build build = null;
 			for (int i=0; i < iterations; i++) {
 				action (builder);
-				var duration = GetTaskDurationFromBinLog (builder, task);
+				build = ReadBinLog (builder);
+				var duration = GetTaskDuration (build, builder, task);
 				TestContext.Out.WriteLine($"run {i} took: {duration}ms");
 				total += duration;
 			}
 			total /= iterations;
 			TestContext.Out.WriteLine($"expected: {expected}ms, actual: {total}ms");
 			if (total > expected) {
+				AssertSlowMachine (build, expected, total);
 				Assert.Fail ($"Exceeded expected time of {expected}ms, actual {total}ms");
 			}
 		}
 
-		double GetTaskDurationFromBinLog (ProjectBuilder builder, string task)
+		void AssertSlowMachine (Build build, int expected, double actual)
+		{
+			var evaluations = build.FindChildrenRecursive<ProjectEvaluation> ();
+			var maxEval = evaluations.Any () ? evaluations.Max (e => e.Duration.TotalMilliseconds) : 0;
+			TestContext.Out.WriteLine ($"max evaluation time: {maxEval}ms (threshold: {MaxEvaluationTimeInMs}ms)");
+			if (maxEval > MaxEvaluationTimeInMs) {
+				Assert.Inconclusive ($"Exceeded expected time of {expected}ms, actual {actual}ms, but evaluation time was {maxEval:F0}ms (threshold: {MaxEvaluationTimeInMs}ms), indicating a slow CI machine.");
+			}
+		}
+
+		Build ReadBinLog (ProjectBuilder builder)
 		{
 			var binlog = Path.Combine (Root, builder.ProjectDirectory, $"{Path.GetFileNameWithoutExtension (builder.BuildLogFile)}.binlog");
 			FileAssert.Exists (binlog);
+			return BinaryLog.ReadBuild (binlog);
+		}
 
-			var build = BinaryLog.ReadBuild (binlog);
+		double GetTaskDuration (Build build, ProjectBuilder builder, string task)
+		{
 			var duration = build
 				.FindChildrenRecursive<Task> (t => t.Name == task)
 				.Aggregate (TimeSpan.Zero, (duration, target) => duration + target.Duration);
 
-			if (duration == TimeSpan.Zero)
+			if (duration == TimeSpan.Zero) {
+				var binlog = Path.Combine (Root, builder.ProjectDirectory, $"{Path.GetFileNameWithoutExtension (builder.BuildLogFile)}.binlog");
 				throw new InvalidDataException ($"No task build duration found in {binlog}");
+			}
 
 			return duration.TotalMilliseconds;
 		}
 
-		double GetDurationFromBinLog (ProjectBuilder builder)
+		double GetDuration (Build build, ProjectBuilder builder)
 		{
-			var binlog = Path.Combine (Root, builder.ProjectDirectory, $"{Path.GetFileNameWithoutExtension (builder.BuildLogFile)}.binlog");
-			FileAssert.Exists (binlog);
-
-			var build = BinaryLog.ReadBuild (binlog);
 			var duration = build
 				.FindChildrenRecursive<Project> ()
 				.Aggregate (TimeSpan.Zero, (duration, project) => duration + project.Duration);
 
-			if (duration == TimeSpan.Zero)
+			if (duration == TimeSpan.Zero) {
+				var binlog = Path.Combine (Root, builder.ProjectDirectory, $"{Path.GetFileNameWithoutExtension (builder.BuildLogFile)}.binlog");
 				throw new InvalidDataException ($"No project build duration found in {binlog}");
+			}
 
 			return duration.TotalMilliseconds;
 		}


### PR DESCRIPTION
## Summary

Performance tests commonly fail on slow CI machines, not due to actual regressions but because the machine is too slow for reliable measurements. This PR detects slow machines by checking the MSBuild project evaluation time from the binlog.

## Changes

When a performance test exceeds its expected time, we now check the max `ProjectEvaluation` duration from the binlog:
- If evaluation > **500ms** → `Assert.Inconclusive()` (test skipped, not failed)
- If evaluation ≤ 500ms → `Assert.Fail()` (genuine regression)

Also refactored binlog reading so `BinaryLog.ReadBuild()` is called once per iteration, with the `Build` object passed to helper methods instead of each method re-reading the file.

## Data

Analysis of 10 recent CI failure binlogs:

| Eval (ms) | Build (ms) |
|-----------|------------|
| 810 | 3027 |
| 854 | 4183 |
| 783 | 4877 |
| 558 | 2816 |
| 751 | 7253 |
| 795 | 5706 |
| 842 | 9680 |
| 660 | 3599 |
| 628 | 5079 |
| 778 | 5379 |

All failures had eval times **558–854ms**. Normal machines should be ~200–350ms, so the **500ms threshold** catches slow machines with comfortable margin.