### PR TITLE
[xabt] Use Load() in RunPipeline instead of pre-loading all assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/AssemblyModifierPipeline.cs
@@ -102,18 +102,12 @@ public class AssemblyModifierPipeline : AndroidTask
 
 				var resolver = new DirectoryAssemblyResolver (this.CreateTaskLogger (), loadDebugSymbols: ReadSymbols, loadReaderParameters: readerParameters);
 
-				// Add SearchDirectories and pre-load ResolvedAssemblies into the resolver cache.
-				// Pre-loading ensures the correct TFM version is cached before any Cecil lazy
-				// reference resolution can find wrong-TFM copies from search directories (e.g.,
-				// a net11.0 copy in a referencing project's output directory).
+				// Add SearchDirectories for the current architecture's ResolvedAssemblies
 				foreach (var kvp in perArchAssemblies [sourceArch]) {
 					ITaskItem assembly = kvp.Value;
 					var path = Path.GetFullPath (Path.GetDirectoryName (assembly.ItemSpec));
 					if (!resolver.SearchDirectories.Contains (path)) {
 						resolver.SearchDirectories.Add (path);
-					}
-					if (resolver.Load (assembly.ItemSpec) == null) {
-						Log.LogDebugMessage ($"Could not pre-load assembly '{assembly.ItemSpec}' into resolver cache.");
 					}
 				}
 
@@ -166,7 +160,11 @@ public class AssemblyModifierPipeline : AndroidTask
 
 	void RunPipeline (AssemblyPipeline pipeline, ITaskItem source, ITaskItem destination)
 	{
-		var assembly = pipeline.Resolver.GetAssembly (source.ItemSpec);
+		// Use Load with the exact ItemSpec path to ensure the correct TFM version
+		// is loaded, rather than GetAssembly which strips the path and resolves by
+		// name through search directories (which may find wrong-TFM copies).
+		var assembly = pipeline.Resolver.Load (source.ItemSpec)
+			?? throw new FileNotFoundException ($"Could not load assembly '{source.ItemSpec}'.", source.ItemSpec);
 
 		var context = new StepContext (source, destination) {
 			CodeGenerationTarget = codeGenerationTarget,


### PR DESCRIPTION
Follow-up to #11208.

The pre-loading approach eagerly loads ALL `ResolvedAssemblies` into the resolver cache via `resolver.Load()`. If any of those assemblies reference `netstandard.dll` (e.g. `netstandard2.1` NuGet packages), Cecil's lazy reference resolution will fail with `FileNotFoundException` since `netstandard.dll` is not in the search directories.

This was discovered while backporting #11208 to `release/10.0.1xx` (#11248), where AppCompat dependencies still target `netstandard2.1`. While `main` doesn't currently hit this, it's a latent bug — any future dependency that references `netstandard` would trigger the same failure.

**Fix:** Use `resolver.Load(source.ItemSpec)` in `RunPipeline` to load each assembly from its exact path when it's processed, rather than pre-loading all assemblies upfront. This ensures the correct TFM version is loaded (the original goal of #11208) without the side effects of eager loading.
