### PR TITLE
Add `.lscache` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ TestResult-*.xml
 TestResult-*.csv
 .vs/
 .vscode/
+.lscache/
 .gradle/
 Resource.designer.cs
 logcat-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*.lscache
 *.userprefs
 *.user
 bin
@@ -13,7 +14,6 @@ TestResult-*.xml
 TestResult-*.csv
 .vs/
 .vscode/
-.lscache
 .gradle/
 Resource.designer.cs
 logcat-*.txt

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ TestResult-*.xml
 TestResult-*.csv
 .vs/
 .vscode/
-.lscache/
+.lscache
 .gradle/
 Resource.designer.cs
 logcat-*.txt


### PR DESCRIPTION
C# Dev Kit creates `.lscache` files for language server cache. Add them to `.gitignore` so they are not accidentally committed.