### PR TITLE
[TrimmableTypeMap] Reject open generic JNI construction

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -976,16 +976,20 @@ sealed class TypeMapAssemblyEmitter
 					JniSignatureHelper.EncodeClrType (p.AddParameter ().Type (), jniParams [j]);
 			});
 
-		// Open generic types can't be activated — emit a no-op UCO.
+		// Open generic types can't be activated because Java construction cannot provide the type arguments.
 		if (proxy.IsGenericDefinition) {
-			var noopHandle = _pe.EmitBody (uco.WrapperName,
+			var openGenericHandle = _pe.EmitBody (uco.WrapperName,
 				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
 				encodeSig,
-				encoder => {
-					encoder.OpCode (ILOpCode.Ret);
-				});
-			AddUnmanagedCallersOnlyAttribute (noopHandle);
-			return noopHandle;
+				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+					enc.LoadString (_pe.Metadata.GetOrAddUserString ("Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined."));
+					enc.OpCode (ILOpCode.Newobj);
+					enc.Token (_notSupportedExceptionCtorRef);
+					enc.OpCode (ILOpCode.Throw);
+				}),
+				EncodeUcoConstructorLocals_Standard);
+			AddUnmanagedCallersOnlyAttribute (openGenericHandle);
+			return openGenericHandle;
 		}
 
 		MethodDefinitionHandle handle;

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -170,9 +170,6 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (Type type, string jniCtorSignature, JValue* constructorParameters)
 		{
-			if (type.IsGenericTypeDefinition) {
-				throw new NotSupportedException ("Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined.");
-			}
 			return AllocObject (type);
 		}
 

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -170,6 +170,9 @@ namespace Android.Runtime {
 
 		public static unsafe IntPtr StartCreateInstance (Type type, string jniCtorSignature, JValue* constructorParameters)
 		{
+			if (type.IsGenericTypeDefinition) {
+				throw new NotSupportedException ("Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined.");
+			}
 			return AllocObject (type);
 		}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -149,7 +149,7 @@ public abstract class FixtureTestBase
 	/// </summary>
 	private protected static bool ILContainsCallToken (byte[] ilBytes, int token)
 	{
-		return ILContainsOpcodeToken (ilBytes, token, 0x28, 0x6F);
+		return ILContainsOpcodeToken (ilBytes, token, (byte) ILOpCode.Call, (byte) ILOpCode.Callvirt);
 	}
 
 	private protected static bool ILContainsNewobjToken (byte[] ilBytes, int token)
@@ -165,8 +165,8 @@ public abstract class FixtureTestBase
 		byte t3 = (byte)((token >> 24) & 0xFF);
 		for (int i = 0; i < ilBytes.Length - 4; i++) {
 			if (opcodes.Contains (ilBytes [i]) &&
-			    ilBytes[i + 1] == t0 && ilBytes[i + 2] == t1 &&
-			    ilBytes[i + 3] == t2 && ilBytes[i + 4] == t3)
+			    ilBytes [i + 1] == t0 && ilBytes [i + 2] == t1 &&
+			    ilBytes [i + 3] == t2 && ilBytes [i + 4] == t3)
 				return true;
 		}
 		return false;

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -143,4 +143,32 @@ public abstract class FixtureTestBase
 			.Select (m => reader.GetString (m.Name))
 			.ToList ();
 
+	/// <summary>
+	/// Returns true if the IL byte stream contains a Call (0x28) or Callvirt (0x6F) instruction
+	/// whose metadata token matches <paramref name="token"/>.
+	/// </summary>
+	private protected static bool ILContainsCallToken (byte[] ilBytes, int token)
+	{
+		return ILContainsOpcodeToken (ilBytes, token, 0x28, 0x6F);
+	}
+
+	private protected static bool ILContainsNewobjToken (byte[] ilBytes, int token)
+	{
+		return ILContainsOpcodeToken (ilBytes, token, (byte) ILOpCode.Newobj);
+	}
+
+	static bool ILContainsOpcodeToken (byte[] ilBytes, int token, params byte[] opcodes)
+	{
+		byte t0 = (byte)(token & 0xFF);
+		byte t1 = (byte)((token >> 8) & 0xFF);
+		byte t2 = (byte)((token >> 16) & 0xFF);
+		byte t3 = (byte)((token >> 24) & 0xFF);
+		for (int i = 0; i < ilBytes.Length - 4; i++) {
+			if (opcodes.Contains (ilBytes [i]) &&
+			    ilBytes[i + 1] == t0 && ilBytes[i + 2] == t1 &&
+			    ilBytes[i + 3] == t2 && ilBytes[i + 4] == t3)
+				return true;
+		}
+		return false;
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1207,12 +1207,24 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var memberRefHandles = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
 			.Select (i => MetadataTokens.MemberReferenceHandle (i))
 			.ToList ();
+		var notSupportedExceptionCtorHandle = memberRefHandles.First (h => {
+			var member = reader.GetMemberReference (h);
+			if (reader.GetString (member.Name) != ".ctor" || member.Parent.Kind != HandleKind.TypeReference) {
+				return false;
+			}
+
+			var parent = reader.GetTypeReference ((TypeReferenceHandle) member.Parent);
+			return reader.GetString (parent.Name) == "NotSupportedException";
+		});
 		var beginHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "BeginMarshalMethod");
 		var endHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "EndMarshalMethod");
 		var exHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "OnUserUnhandledException");
+		int notSupportedExceptionCtorToken = MetadataTokens.GetToken (notSupportedExceptionCtorHandle);
 		int beginToken = MetadataTokens.GetToken (beginHandle);
 		int endToken = MetadataTokens.GetToken (endHandle);
 		int exToken = MetadataTokens.GetToken (exHandle);
+		Assert.True (ILContainsNewobjToken (ilBytes, notSupportedExceptionCtorToken), "open-generic nctor_*_uco IL should construct NotSupportedException");
+		Assert.True (ilBytes.Contains ((byte) ILOpCode.Throw), "open-generic nctor_*_uco IL should throw");
 		Assert.True (ILContainsCallToken (ilBytes, beginToken), "open-generic nctor_*_uco IL should call BeginMarshalMethod");
 		Assert.True (ILContainsCallToken (ilBytes, endToken), "open-generic nctor_*_uco IL should call EndMarshalMethod");
 		Assert.True (ILContainsCallToken (ilBytes, exToken), "open-generic nctor_*_uco IL should call OnUserUnhandledException");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1173,28 +1173,49 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void Generate_UcoConstructor_GenericDefinition_NoExceptionRegions ()
+	public void Generate_UcoConstructor_GenericDefinition_ThrowsWithMarshalMethodPattern ()
 	{
-		// Open-generic UCO constructors are no-ops and must NOT have exception regions
-		// (a single 'ret' is emitted with no surrounding try/catch/finally).
-		var peers = ScanFixtures ();
-		var generic = peers.First (p => p.JavaName == "my/app/GenericHolder");
-		Assert.True (generic.IsGenericDefinition);
+		// Open-generic UCO constructors throw inside the same marshal-method wrapper used
+		// by normal UCO constructors, so the exception is surfaced through
+		// JniRuntime.OnUserUnhandledException instead of crossing the JNI boundary.
+		var generic = MakeAcwPeer ("test/GenericHolder", "Test.GenericHolder`1", "TestAsm") with {
+			IsGenericDefinition = true,
+		};
 
 		using var stream = GenerateAssembly (new [] { generic }, "GenericUcoCtorTest");
 		using var pe = new PEReader (stream);
 		var reader = pe.GetMetadataReader ();
 
 		var nctorMethodHandle = FindNctorUcoMethod (reader);
+		Assert.False (nctorMethodHandle.IsNil, "Open-generic ACWs should emit a throwing nctor_*_uco method");
 
-		if (!nctorMethodHandle.IsNil) {
-			// If a nctor_*_uco method exists for the generic type, it must be a no-op (no exception regions).
-			var nctorMethod = reader.GetMethodDefinition (nctorMethodHandle);
-			var body = pe.GetMethodBody (nctorMethod.RelativeVirtualAddress);
-			Assert.NotNull (body);
-			Assert.Empty (body.ExceptionRegions);
-		}
-		// Open-generic types do not get a nctor_*_uco wrapper — no UCO ctors for generics.
+		var nctorMethod = reader.GetMethodDefinition (nctorMethodHandle);
+		var body = pe.GetMethodBody (nctorMethod.RelativeVirtualAddress);
+		Assert.NotNull (body);
+
+		var regions = body.ExceptionRegions;
+		Assert.True (regions.Length >= 2,
+			$"Open-generic UCO constructor should have at least 2 exception regions, found {regions.Length}");
+		Assert.Contains (regions, r => r.Kind == ExceptionRegionKind.Catch);
+		Assert.Contains (regions, r => r.Kind == ExceptionRegionKind.Finally);
+
+		var typeNames = GetTypeRefNames (reader);
+		Assert.Contains ("NotSupportedException", typeNames);
+
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+		var memberRefHandles = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
+			.Select (i => MetadataTokens.MemberReferenceHandle (i))
+			.ToList ();
+		var beginHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "BeginMarshalMethod");
+		var endHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "EndMarshalMethod");
+		var exHandle = memberRefHandles.First (h => reader.GetString (reader.GetMemberReference (h).Name) == "OnUserUnhandledException");
+		int beginToken = MetadataTokens.GetToken (beginHandle);
+		int endToken = MetadataTokens.GetToken (endHandle);
+		int exToken = MetadataTokens.GetToken (exHandle);
+		Assert.True (ILContainsCallToken (ilBytes, beginToken), "open-generic nctor_*_uco IL should call BeginMarshalMethod");
+		Assert.True (ILContainsCallToken (ilBytes, endToken), "open-generic nctor_*_uco IL should call EndMarshalMethod");
+		Assert.True (ILContainsCallToken (ilBytes, exToken), "open-generic nctor_*_uco IL should call OnUserUnhandledException");
 	}
 
 	[Fact]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -121,7 +121,6 @@ namespace Java.InteropTests
 			}
 		}
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — open generic creation should throw but succeeds under trimmable typemap
 		[Test]
 		public void NewOpenGenericTypeThrows ()
 		{

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -67,9 +67,6 @@ namespace Xamarin.Android.RuntimeTests
                     "Java.InteropTests.JniPeerMembersTests.ReplacementTypeUsedForMethodLookup",
                     "Java.InteropTests.JniPeerMembersTests.ReplaceStaticMethodName",
 
-                    // net.dot.jni.test.GenericHolder Java class not in APK
-                    "Java.InteropTests.JniTypeManagerTests.CannotCreateGenericHolderFromJava",
-
                     // Throwable subclass registration
                     "Java.InteropTests.JnienvTest.ActivatedDirectThrowableSubclassesShouldBeRegistered",
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -70,6 +70,12 @@ namespace Xamarin.Android.RuntimeTests
                     // net.dot.jni.test.GenericHolder Java class not in APK
                     "Java.InteropTests.JniTypeManagerTests.CannotCreateGenericHolderFromJava",
 
+                    // JniPrimitiveArrayInfo lookup fails for JavaBooleanArray —
+                    // our typemap returns JavaBooleanArray for "Z" via JavaPrimitiveArray<>
+                    // alias, which collides with the legacy GetPrimitiveArrayTypesForSimpleReference
+                    // that expects only primitive CLR types. Out of scope for this PR.
+                    "Java.InteropTests.JniTypeManagerTests.GetType",
+
                     // Open generic type handling differs from non-trimmable
                     "Java.InteropTests.JnienvTest.NewOpenGenericTypeThrows",
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -70,15 +70,6 @@ namespace Xamarin.Android.RuntimeTests
                     // net.dot.jni.test.GenericHolder Java class not in APK
                     "Java.InteropTests.JniTypeManagerTests.CannotCreateGenericHolderFromJava",
 
-                    // JniPrimitiveArrayInfo lookup fails for JavaBooleanArray —
-                    // our typemap returns JavaBooleanArray for "Z" via JavaPrimitiveArray<>
-                    // alias, which collides with the legacy GetPrimitiveArrayTypesForSimpleReference
-                    // that expects only primitive CLR types. Out of scope for this PR.
-                    "Java.InteropTests.JniTypeManagerTests.GetType",
-
-                    // Open generic type handling differs from non-trimmable
-                    "Java.InteropTests.JnienvTest.NewOpenGenericTypeThrows",
-
                     // Throwable subclass registration
                     "Java.InteropTests.JnienvTest.ActivatedDirectThrowableSubclassesShouldBeRegistered",
 


### PR DESCRIPTION
Open generic managed types cannot be constructed from Java because Java construction cannot provide the missing type arguments.

The legacy typemap rejects this in `TypeManager.n_Activate()` after Java calls the managed activation native method. This PR mirrors that behavior for the trimmable typemap by emitting a throwing generated constructor callback for open generic proxies, while keeping `JNIEnv.StartCreateInstance(Type, ...)` allocation-only.

The generated open-generic constructor callback uses the same marshal-method wrapper as normal UCO constructors: `BeginMarshalMethod`, `try/catch/finally`, `JniRuntime.OnUserUnhandledException(ref envp, e)`, and `EndMarshalMethod`. The generator tests assert that the open-generic `nctor_*_uco` method has catch/finally regions and calls `OnUserUnhandledException`, so the managed exception is converted to a pending JNI exception instead of crossing the JNI boundary directly.

Re-enables the trimmable tests for:

- `Java.InteropTests.JnienvTest.NewOpenGenericTypeThrows`
- `Java.InteropTests.JniTypeManagerTests.CannotCreateGenericHolderFromJava`

Validation:

- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -v minimal`
- `make prepare CONFIGURATION=Release && make all CONFIGURATION=Release`
- `MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh build -t:RunTestApp tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -c Release -p:_AndroidTypeMapImplementation=trimmable -p:UseMonoRuntime=false -nr:false`
  - device NUnit log: `Passed: 837, Failed: 0, Skipped: 50, Inconclusive: 0, Total: 887, Filtered: 887`
  - confirmed `NewOpenGenericTypeThrows` ran and passed
  - confirmed `CannotCreateGenericHolderFromJava` ran and passed

## Related issues
- Reference #10788
- Reference #11099
- Reference #11170
