### PR TITLE
[TrimmableTypeMap] Fix UCO constructor activation

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JniSignatureHelper.cs
@@ -109,14 +109,15 @@ static class JniSignatureHelper
 	/// Encodes a JNI type as its CLR equivalent for [UnmanagedCallersOnly] UCO wrapper signatures.
 	/// </summary>
 	/// <remarks>
-	/// JNI boolean (Z) maps to <c>byte</c> (unsigned, blittable for the JNI ABI).
+	/// JNI boolean (Z) maps to <c>byte</c> and JNI char (C) maps to <c>ushort</c>,
+	/// preserving the JNI ABI with blittable UCO parameter types.
 	/// </remarks>
 	public static void EncodeClrType (SignatureTypeEncoder encoder, JniParamKind kind)
 	{
 		switch (kind) {
 		case JniParamKind.Boolean: encoder.Byte (); break;   // JNI jboolean is unsigned byte; blittable for UCO
 		case JniParamKind.Byte:    encoder.SByte (); break;
-		case JniParamKind.Char:    encoder.Char (); break;
+		case JniParamKind.Char:    encoder.UInt16 (); break;
 		case JniParamKind.Short:   encoder.Int16 (); break;
 		case JniParamKind.Int:     encoder.Int32 (); break;
 		case JniParamKind.Long:    encoder.Int64 (); break;

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -204,6 +204,7 @@ sealed record UcoMethodData
 	/// JNI method signature, e.g., "(Landroid/os/Bundle;)V". Used to determine CLR parameter types.
 	/// </summary>
 	public required string JniSignature { get; init; }
+
 }
 
 /// <summary>
@@ -228,6 +229,16 @@ sealed record UcoConstructorData
 	/// JNI constructor signature, e.g., "(Landroid/content/Context;)V". Used for RegisterNatives registration.
 	/// </summary>
 	public required string JniSignature { get; init; }
+
+	/// <summary>
+	/// True if the target type declares a public parameterless managed constructor.
+	/// </summary>
+	public bool HasPublicParameterlessConstructor { get; init; }
+
+	/// <summary>
+	/// Managed constructor parameter type names, in declaration order.
+	/// </summary>
+	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -231,14 +231,14 @@ sealed record UcoConstructorData
 	public required string JniSignature { get; init; }
 
 	/// <summary>
-	/// True if the target type declares a public parameterless managed constructor.
-	/// </summary>
-	public bool HasPublicParameterlessConstructor { get; init; }
-
-	/// <summary>
 	/// Managed constructor parameter type names, in declaration order.
 	/// </summary>
 	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
+
+	/// <summary>
+	/// True when this Java constructor has a matching managed constructor on the target type.
+	/// </summary>
+	public bool HasManagedConstructor { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -365,8 +365,8 @@ static class ModelBuilder
 					ManagedTypeName = peer.ManagedTypeName,
 					AssemblyName = peer.AssemblyName,
 				},
-				HasPublicParameterlessConstructor = peer.HasPublicParameterlessConstructor,
 				ManagedParameterTypes = ctor.ManagedParameterTypes,
+				HasManagedConstructor = ctor.HasManagedConstructor,
 			});
 		}
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -365,6 +365,8 @@ static class ModelBuilder
 					ManagedTypeName = peer.ManagedTypeName,
 					AssemblyName = peer.AssemblyName,
 				},
+				HasPublicParameterlessConstructor = peer.HasPublicParameterlessConstructor,
+				ManagedParameterTypes = ctor.ManagedParameterTypes,
 			});
 		}
 	}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/PEAssemblyBuilder.cs
@@ -611,6 +611,12 @@ sealed class PEAssemblyBuilder
 			SetStack (0);
 		}
 
+		public void PopValue ()
+		{
+			Encoder.OpCode (ILOpCode.Pop);
+			Pop (1);
+		}
+
 		public void OpCode (ILOpCode code)
 		{
 			Encoder.OpCode (code);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -101,6 +101,8 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _jniObjectReferenceCtorRef;
 	MemberReferenceHandle _jniEnvDeleteRefRef;
 	MemberReferenceHandle _shouldSkipActivationRef;
+	MemberReferenceHandle _activateDefaultConstructorRef;
+	MemberReferenceHandle _markActivationPeerReplaceableRef;
 	MemberReferenceHandle _waitForBridgeProcessingRef;
 	MemberReferenceHandle _androidEnvironmentUnhandledExceptionRef;
 	MemberReferenceHandle _ucoAttrCtorRef;
@@ -362,6 +364,19 @@ sealed class TypeMapAssemblyEmitter
 			sig => sig.MethodSignature ().Parameters (1,
 				rt => rt.Type ().Boolean (),
 				p => { p.AddParameter ().Type ().IntPtr (); }));
+
+		_activateDefaultConstructorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "ActivateDefaultConstructor",
+			sig => sig.MethodSignature ().Parameters (2,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().IntPtr ();
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
+		_markActivationPeerReplaceableRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "MarkActivationPeerReplaceable",
+			sig => sig.MethodSignature ().Parameters (1,
+				rt => rt.Void (),
+				p => p.AddParameter ().Type ().IntPtr ()));
 
 		_waitForBridgeProcessingRef = _pe.AddMemberRef (_androidRuntimeInternalRef, "WaitForBridgeProcessing",
 			sig => sig.MethodSignature ().Parameters (0, rt => rt.Void (), p => { }));
@@ -1041,6 +1056,22 @@ sealed class TypeMapAssemblyEmitter
 			return openGenericHandle;
 		}
 
+		if (jniParams.Count == 0) {
+			var defaultCtorHandle = _pe.EmitBody (uco.WrapperName,
+				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+				encodeSig,
+				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+					enc.LoadArgument (1); // self
+					enc.OpCode (ILOpCode.Ldtoken);
+					enc.Token (targetTypeRef);
+					enc.Call (_getTypeFromHandleRef);
+					enc.Call (_activateDefaultConstructorRef);
+				}),
+				EncodeUcoConstructorLocals_Standard);
+			AddUnmanagedCallersOnlyAttribute (defaultCtorHandle);
+			return defaultCtorHandle;
+		}
+
 		MethodDefinitionHandle handle;
 		if (activationCtor.Style == ActivationCtorStyle.JavaInterop) {
 			var ctorRef = AddJavaInteropActivationCtorRef (
@@ -1077,6 +1108,8 @@ sealed class TypeMapAssemblyEmitter
 						enc.LoadConstantI4 (1);   // JniObjectReferenceOptions.Copy
 						enc.Call (ctorRef, parameterCount: 2, isInstance: true);
 					}
+					enc.LoadArgument (1); // self
+					enc.Call (_markActivationPeerReplaceableRef);
 				}),
 				EncodeUcoConstructorLocals_JavaInterop);
 		} else {
@@ -1106,6 +1139,8 @@ sealed class TypeMapAssemblyEmitter
 						enc.LoadConstantI4 (0);  // JniHandleOwnership.DoNotTransfer
 						enc.Call (ctorRef, parameterCount: 2, isInstance: true);
 					}
+					enc.LoadArgument (1); // self
+					enc.Call (_markActivationPeerReplaceableRef);
 				}),
 				EncodeUcoConstructorLocals_Standard);
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -1117,6 +1117,49 @@ sealed class TypeMapAssemblyEmitter
 			return openGenericHandle;
 		}
 
+		if (proxy.InvokerType != null) {
+			var invokerTypeRef = _pe.ResolveTypeRef (proxy.InvokerType);
+			MethodDefinitionHandle invokerHandle;
+			if (proxy.InvokerActivationCtorStyle == ActivationCtorStyle.JavaInterop) {
+				var ctorRef = AddJavaInteropActivationCtorRef (invokerTypeRef);
+				invokerHandle = _pe.EmitBody (uco.WrapperName,
+					MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+					encodeSig,
+					(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+						enc.LoadLocalAddress (3); // jniRef
+						enc.LoadArgument (1);     // self
+						enc.LoadConstantI4 (0);   // JniObjectReferenceType.Invalid
+						enc.Call (_jniObjectReferenceCtorRef, parameterCount: 2, isInstance: true);
+
+						enc.LoadLocalAddress (3); // ref jniRef
+						enc.LoadConstantI4 (1);   // JniObjectReferenceOptions.Copy
+						enc.NewObject (ctorRef, parameterCount: 2);
+						enc.OpCode (ILOpCode.Pop);
+
+						enc.LoadArgument (1); // self
+						enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
+					}),
+					EncodeUcoConstructorLocals_JavaInterop);
+			} else {
+				var ctorRef = AddActivationCtorRef (invokerTypeRef);
+				invokerHandle = _pe.EmitBody (uco.WrapperName,
+					MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+					encodeSig,
+					(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+						enc.LoadArgument (1);    // self
+						enc.LoadConstantI4 (0);  // JniHandleOwnership.DoNotTransfer
+						enc.NewObject (ctorRef, parameterCount: 2);
+						enc.OpCode (ILOpCode.Pop);
+
+						enc.LoadArgument (1); // self
+						enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
+					}),
+					EncodeUcoConstructorLocals_Standard);
+			}
+			AddUnmanagedCallersOnlyAttribute (invokerHandle);
+			return invokerHandle;
+		}
+
 		if (jniParams.Count == 0 && uco.HasPublicParameterlessConstructor) {
 			var defaultCtorRef = AddDefaultCtorRef (targetTypeRef);
 			var defaultCtorHandle = _pe.EmitBody (uco.WrapperName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -1067,29 +1067,26 @@ sealed class TypeMapAssemblyEmitter
 				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
 				encodeSig,
 				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
-					enc.OpCode (ILOpCode.Ldtoken);
-					enc.Token (targetTypeRef);
-					enc.Call (_getTypeFromHandleRef);
-					enc.Call (_getUninitializedObjectRef);
-					enc.OpCode (ILOpCode.Castclass);
-					enc.Token (targetTypeRef);
+					enc.LoadToken (targetTypeRef);
+					enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+					enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
+					enc.CastClass (targetTypeRef);
 					enc.StoreLocal (4);
 
 					enc.LoadLocalAddress (3); // jniRef
 					enc.LoadArgument (1);     // self
 					enc.LoadConstantI4 (0);   // JniObjectReferenceType.Invalid
-					enc.Call (_jniObjectReferenceCtorRef);
+					enc.Call (_jniObjectReferenceCtorRef, parameterCount: 2, isInstance: true);
 
 					enc.LoadLocal (4);
 					enc.LoadLocal (3);
-					enc.OpCode (ILOpCode.Callvirt);
-					enc.Token (_setPeerReferenceRef);
+					enc.Callvirt (_setPeerReferenceRef, parameterCount: 1);
 
 					enc.LoadLocal (4);
-					enc.Call (defaultCtorRef);
+					enc.Call (defaultCtorRef, parameterCount: 0, isInstance: true);
 
 					enc.LoadArgument (1); // self
-					enc.Call (_markActivationPeerReplaceableRef);
+					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
 				}),
 				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
 			AddUnmanagedCallersOnlyAttribute (defaultCtorHandle);
@@ -1133,7 +1130,7 @@ sealed class TypeMapAssemblyEmitter
 						enc.Call (ctorRef, parameterCount: 2, isInstance: true);
 					}
 					enc.LoadArgument (1); // self
-					enc.Call (_markActivationPeerReplaceableRef);
+					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
 				}),
 				EncodeUcoConstructorLocals_JavaInterop);
 		} else {
@@ -1164,7 +1161,7 @@ sealed class TypeMapAssemblyEmitter
 						enc.Call (ctorRef, parameterCount: 2, isInstance: true);
 					}
 					enc.LoadArgument (1); // self
-					enc.Call (_markActivationPeerReplaceableRef);
+					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
 				}),
 				EncodeUcoConstructorLocals_Standard);
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -87,7 +87,9 @@ sealed class TypeMapAssemblyEmitter
 	TypeReferenceHandle _jniObjectReferenceOptionsRef;
 	TypeReferenceHandle _iAndroidCallableWrapperRef;
 	TypeReferenceHandle _jniEnvRef;
+	TypeReferenceHandle _javaLangObjectRef;
 	TypeReferenceHandle _systemTypeRef;
+	TypeReferenceHandle _systemArrayRef;
 	TypeReferenceHandle _runtimeTypeHandleRef;
 	TypeReferenceHandle _jniTypeRef;
 	TypeReferenceHandle _notSupportedExceptionRef;
@@ -99,9 +101,13 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _getUninitializedObjectRef;
 	MemberReferenceHandle _notSupportedExceptionCtorRef;
 	MemberReferenceHandle _jniObjectReferenceCtorRef;
-	MemberReferenceHandle _setPeerReferenceRef;
 	MemberReferenceHandle _jniEnvDeleteRefRef;
+	MemberReferenceHandle _jniEnvGetStringRef;
+	MemberReferenceHandle _jniEnvGetArrayRef;
+	MemberReferenceHandle _javaLangObjectGetObjectRef;
 	MemberReferenceHandle _shouldSkipActivationRef;
+	MemberReferenceHandle _getActivationPeerRef;
+	MemberReferenceHandle _setActivationPeerReferenceRef;
 	MemberReferenceHandle _markActivationPeerReplaceableRef;
 	MemberReferenceHandle _waitForBridgeProcessingRef;
 	MemberReferenceHandle _androidEnvironmentUnhandledExceptionRef;
@@ -230,6 +236,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("Android.Runtime"), metadata.GetOrAddString ("JniHandleOwnership"));
 		_jniEnvRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
 			metadata.GetOrAddString ("Android.Runtime"), metadata.GetOrAddString ("JNIEnv"));
+		_javaLangObjectRef = metadata.AddTypeReference (_pe.MonoAndroidRef,
+			metadata.GetOrAddString ("Java.Lang"), metadata.GetOrAddString ("Object"));
 		_jniObjectReferenceRef = metadata.AddTypeReference (_javaInteropRef,
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("JniObjectReference"));
 		_jniObjectReferenceTypeRef = metadata.AddTypeReference (_javaInteropRef,
@@ -240,6 +248,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.GetOrAddString ("Java.Interop"), metadata.GetOrAddString ("IAndroidCallableWrapper"));
 		_systemTypeRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Type"));
+		_systemArrayRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
+			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("Array"));
 		_runtimeTypeHandleRef = metadata.AddTypeReference (_pe.SystemRuntimeRef,
 			metadata.GetOrAddString ("System"), metadata.GetOrAddString ("RuntimeTypeHandle"));
 		_jniTypeRef = metadata.AddTypeReference (_javaInteropRef,
@@ -348,11 +358,6 @@ sealed class TypeMapAssemblyEmitter
 					p.AddParameter ().Type ().Type (_jniObjectReferenceTypeRef, true);
 				}));
 
-		_setPeerReferenceRef = _pe.AddMemberRef (_iJavaPeerableRef, "SetPeerReference",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
-				rt => rt.Void (),
-				p => p.AddParameter ().Type ().Type (_jniObjectReferenceRef, true)));
-
 		// JNIEnv.DeleteRef(IntPtr, JniHandleOwnership) — static, internal
 		// Used by JI-style activation to clean up the original handle after constructing the peer.
 		// Matches the legacy TypeManager.CreateProxy behavior.
@@ -364,11 +369,50 @@ sealed class TypeMapAssemblyEmitter
 					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
 				}));
 
+		_jniEnvGetStringRef = _pe.AddMemberRef (_jniEnvRef, "GetString",
+			sig => sig.MethodSignature ().Parameters (2,
+				rt => rt.Type ().String (),
+				p => {
+					p.AddParameter ().Type ().IntPtr ();
+					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
+				}));
+
+		_jniEnvGetArrayRef = _pe.AddMemberRef (_jniEnvRef, "GetArray",
+			sig => sig.MethodSignature ().Parameters (3,
+				rt => rt.Type ().Type (_systemArrayRef, false),
+				p => {
+					p.AddParameter ().Type ().IntPtr ();
+					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
+		_javaLangObjectGetObjectRef = _pe.AddMemberRef (_javaLangObjectRef, "GetObject",
+			sig => sig.MethodSignature ().Parameters (3,
+				rt => rt.Type ().Type (_iJavaPeerableRef, false),
+				p => {
+					p.AddParameter ().Type ().IntPtr ();
+					p.AddParameter ().Type ().Type (_jniHandleOwnershipRef, true);
+					p.AddParameter ().Type ().Type (_systemTypeRef, false);
+				}));
+
 		// JavaPeerProxy.ShouldSkipActivation(IntPtr) -> bool (static method)
 		_shouldSkipActivationRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "ShouldSkipActivation",
 			sig => sig.MethodSignature ().Parameters (1,
 				rt => rt.Type ().Boolean (),
 				p => { p.AddParameter ().Type ().IntPtr (); }));
+
+		_getActivationPeerRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "GetActivationPeer",
+			sig => sig.MethodSignature ().Parameters (1,
+				rt => rt.Type ().Type (_iJavaPeerableRef, false),
+				p => { p.AddParameter ().Type ().IntPtr (); }));
+
+		_setActivationPeerReferenceRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "SetActivationPeerReference",
+			sig => sig.MethodSignature ().Parameters (2,
+				rt => rt.Void (),
+				p => {
+					p.AddParameter ().Type ().Type (_iJavaPeerableRef, false);
+					p.AddParameter ().Type ().IntPtr ();
+				}));
 
 		_markActivationPeerReplaceableRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "MarkActivationPeerReplaceable",
 			sig => sig.MethodSignature ().Parameters (1,
@@ -938,6 +982,18 @@ sealed class TypeMapAssemblyEmitter
 				p => { }));
 	}
 
+	MemberReferenceHandle AddManagedCtorRef (EntityHandle declaringTypeRef, IReadOnlyList<string> parameterTypes, string defaultAssemblyName)
+	{
+		var blob = new BlobBuilder (32);
+		blob.WriteByte (0x20); // HASTHIS
+		blob.WriteCompressedInteger (parameterTypes.Count);
+		blob.WriteByte (0x01); // ELEMENT_TYPE_VOID
+		foreach (var parameterType in parameterTypes) {
+			WriteManagedTypeSignature (blob, parameterType, defaultAssemblyName);
+		}
+		return _pe.Metadata.AddMemberReference (declaringTypeRef, _pe.Metadata.GetOrAddString (".ctor"), _pe.Metadata.GetOrAddBlob (blob));
+	}
+
 	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco, JavaPeerProxyData proxy)
 	{
 		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
@@ -1061,27 +1117,33 @@ sealed class TypeMapAssemblyEmitter
 			return openGenericHandle;
 		}
 
-		if (jniParams.Count == 0) {
+		if (jniParams.Count == 0 && uco.HasPublicParameterlessConstructor) {
 			var defaultCtorRef = AddDefaultCtorRef (targetTypeRef);
 			var defaultCtorHandle = _pe.EmitBody (uco.WrapperName,
 				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
 				encodeSig,
 				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+					var havePeer = enc.DefineLabel ();
+
+					enc.LoadArgument (1);
+					enc.Call (_getActivationPeerRef, parameterCount: 1, returnsValue: true);
+					enc.CastClass (targetTypeRef);
+					enc.StoreLocal (4);
+
+					enc.LoadLocal (4);
+					enc.Branch (ILOpCode.Brtrue, havePeer);
+
 					enc.LoadToken (targetTypeRef);
 					enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
 					enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
 					enc.CastClass (targetTypeRef);
 					enc.StoreLocal (4);
 
-					enc.LoadLocalAddress (3); // jniRef
-					enc.LoadArgument (1);     // self
-					enc.LoadConstantI4 (0);   // JniObjectReferenceType.Invalid
-					enc.Call (_jniObjectReferenceCtorRef, parameterCount: 2, isInstance: true);
-
 					enc.LoadLocal (4);
-					enc.LoadLocal (3);
-					enc.Callvirt (_setPeerReferenceRef, parameterCount: 1);
+					enc.LoadArgument (1); // self
+					enc.Call (_setActivationPeerReferenceRef, parameterCount: 2);
 
+					enc.MarkLabel (havePeer);
 					enc.LoadLocal (4);
 					enc.Call (defaultCtorRef, parameterCount: 0, isInstance: true);
 
@@ -1091,6 +1153,47 @@ sealed class TypeMapAssemblyEmitter
 				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
 			AddUnmanagedCallersOnlyAttribute (defaultCtorHandle);
 			return defaultCtorHandle;
+		}
+
+		if (jniParams.Count > 0 && uco.ManagedParameterTypes.Count == jniParams.Count) {
+			var ctorRef = AddManagedCtorRef (targetTypeRef, uco.ManagedParameterTypes, uco.TargetType.AssemblyName);
+			var managedCtorHandle = _pe.EmitBody (uco.WrapperName,
+				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+				encodeSig,
+				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+					var havePeer = enc.DefineLabel ();
+
+					enc.LoadArgument (1);
+					enc.Call (_getActivationPeerRef, parameterCount: 1, returnsValue: true);
+					enc.CastClass (targetTypeRef);
+					enc.StoreLocal (4);
+
+					enc.LoadLocal (4);
+					enc.Branch (ILOpCode.Brtrue, havePeer);
+
+					enc.LoadToken (targetTypeRef);
+					enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+					enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
+					enc.CastClass (targetTypeRef);
+					enc.StoreLocal (4);
+
+					enc.LoadLocal (4);
+					enc.LoadArgument (1); // self
+					enc.Call (_setActivationPeerReferenceRef, parameterCount: 2);
+
+					enc.MarkLabel (havePeer);
+					enc.LoadLocal (4);
+					for (int i = 0; i < uco.ManagedParameterTypes.Count; i++) {
+						EmitManagedConstructorArgument (enc, uco.ManagedParameterTypes [i], jniParams [i], i + 2, uco.TargetType.AssemblyName);
+					}
+					enc.Call (ctorRef, uco.ManagedParameterTypes.Count, isInstance: true);
+
+					enc.LoadArgument (1); // self
+					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
+				}),
+				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
+			AddUnmanagedCallersOnlyAttribute (managedCtorHandle);
+			return managedCtorHandle;
 		}
 
 		MethodDefinitionHandle handle;
@@ -1239,6 +1342,111 @@ sealed class TypeMapAssemblyEmitter
 		// Finally region: try [tryStart, finallyStart), handler [finallyStart, afterAll)
 		cfb.AddCatchRegion (tryStart, catchStart, catchStart, finallyStart, _exceptionRef);
 		cfb.AddFinallyRegion (tryStart, finallyStart, finallyStart, afterAll);
+	}
+
+	void EmitManagedConstructorArgument (TrackedInstructionEncoder encoder, string managedType, JniParamKind jniKind, int argumentIndex, string defaultAssemblyName)
+	{
+		if (jniKind != JniParamKind.Object) {
+			encoder.LoadArgument (argumentIndex);
+			return;
+		}
+
+		if (managedType == "System.String") {
+			encoder.LoadArgument (argumentIndex);
+			encoder.LoadConstantI4 (0); // JniHandleOwnership.DoNotTransfer
+			encoder.Call (_jniEnvGetStringRef, parameterCount: 2, returnsValue: true);
+			return;
+		}
+
+		if (TryGetSzArrayElementType (managedType, out var elementType)) {
+			var arrayType = ResolveManagedTypeHandle (managedType, defaultAssemblyName);
+			var elementTypeHandle = ResolveManagedTypeHandle (elementType, defaultAssemblyName);
+
+			encoder.LoadArgument (argumentIndex);
+			encoder.LoadConstantI4 (0); // JniHandleOwnership.DoNotTransfer
+			encoder.LoadToken (elementTypeHandle);
+			encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+			encoder.Call (_jniEnvGetArrayRef, parameterCount: 3, returnsValue: true);
+			encoder.CastClass (arrayType);
+			return;
+		}
+
+		var managedTypeHandle = ResolveManagedTypeHandle (managedType, defaultAssemblyName);
+		encoder.LoadArgument (argumentIndex);
+		encoder.LoadConstantI4 (0); // JniHandleOwnership.DoNotTransfer
+		encoder.LoadToken (managedTypeHandle);
+		encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+		encoder.Call (_javaLangObjectGetObjectRef, parameterCount: 3, returnsValue: true);
+		encoder.CastClass (managedTypeHandle);
+	}
+
+	EntityHandle ResolveManagedTypeHandle (string managedType, string defaultAssemblyName)
+	{
+		if (TryGetSzArrayElementType (managedType, out var elementType)) {
+			var blob = new BlobBuilder (32);
+			blob.WriteByte (0x1D); // ELEMENT_TYPE_SZARRAY
+			WriteManagedTypeSignature (blob, elementType, defaultAssemblyName);
+			return _pe.Metadata.AddTypeSpecification (_pe.Metadata.GetOrAddBlob (blob));
+		}
+
+		return _pe.ResolveTypeRef (new TypeRefData {
+			ManagedTypeName = managedType,
+			AssemblyName = GetAssemblyNameForManagedType (managedType, defaultAssemblyName),
+		});
+	}
+
+	static bool TryGetSzArrayElementType (string managedType, out string elementType)
+	{
+		if (managedType.EndsWith ("[]", StringComparison.Ordinal)) {
+			elementType = managedType.Substring (0, managedType.Length - 2);
+			return true;
+		}
+
+		elementType = "";
+		return false;
+	}
+
+	void WriteManagedTypeSignature (BlobBuilder blob, string managedType, string defaultAssemblyName)
+	{
+		if (TryGetSzArrayElementType (managedType, out var elementType)) {
+			blob.WriteByte (0x1D); // ELEMENT_TYPE_SZARRAY
+			WriteManagedTypeSignature (blob, elementType, defaultAssemblyName);
+			return;
+		}
+
+		switch (managedType) {
+		case "System.Boolean": blob.WriteByte (0x02); return;
+		case "System.Char":    blob.WriteByte (0x03); return;
+		case "System.SByte":   blob.WriteByte (0x04); return;
+		case "System.Byte":    blob.WriteByte (0x05); return;
+		case "System.Int16":   blob.WriteByte (0x06); return;
+		case "System.UInt16":  blob.WriteByte (0x07); return;
+		case "System.Int32":   blob.WriteByte (0x08); return;
+		case "System.UInt32":  blob.WriteByte (0x09); return;
+		case "System.Int64":   blob.WriteByte (0x0A); return;
+		case "System.UInt64":  blob.WriteByte (0x0B); return;
+		case "System.Single":  blob.WriteByte (0x0C); return;
+		case "System.Double":  blob.WriteByte (0x0D); return;
+		case "System.String":  blob.WriteByte (0x0E); return;
+		case "System.Object":  blob.WriteByte (0x1C); return;
+		}
+
+		var typeHandle = ResolveManagedTypeHandle (managedType, defaultAssemblyName);
+		blob.WriteByte (0x12); // ELEMENT_TYPE_CLASS
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (typeHandle));
+	}
+
+	static string GetAssemblyNameForManagedType (string managedType, string defaultAssemblyName)
+	{
+		if (managedType.StartsWith ("System.", StringComparison.Ordinal)) {
+			return "System.Runtime";
+		}
+		if (managedType.StartsWith ("Android.", StringComparison.Ordinal) ||
+		    managedType.StartsWith ("Java.", StringComparison.Ordinal) ||
+		    managedType.StartsWith ("Javax.", StringComparison.Ordinal)) {
+			return "Mono.Android";
+		}
+		return defaultAssemblyName;
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -99,9 +99,9 @@ sealed class TypeMapAssemblyEmitter
 	MemberReferenceHandle _getUninitializedObjectRef;
 	MemberReferenceHandle _notSupportedExceptionCtorRef;
 	MemberReferenceHandle _jniObjectReferenceCtorRef;
+	MemberReferenceHandle _setPeerReferenceRef;
 	MemberReferenceHandle _jniEnvDeleteRefRef;
 	MemberReferenceHandle _shouldSkipActivationRef;
-	MemberReferenceHandle _activateDefaultConstructorRef;
 	MemberReferenceHandle _markActivationPeerReplaceableRef;
 	MemberReferenceHandle _waitForBridgeProcessingRef;
 	MemberReferenceHandle _androidEnvironmentUnhandledExceptionRef;
@@ -348,6 +348,11 @@ sealed class TypeMapAssemblyEmitter
 					p.AddParameter ().Type ().Type (_jniObjectReferenceTypeRef, true);
 				}));
 
+		_setPeerReferenceRef = _pe.AddMemberRef (_iJavaPeerableRef, "SetPeerReference",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
+				rt => rt.Void (),
+				p => p.AddParameter ().Type ().Type (_jniObjectReferenceRef, true)));
+
 		// JNIEnv.DeleteRef(IntPtr, JniHandleOwnership) — static, internal
 		// Used by JI-style activation to clean up the original handle after constructing the peer.
 		// Matches the legacy TypeManager.CreateProxy behavior.
@@ -364,14 +369,6 @@ sealed class TypeMapAssemblyEmitter
 			sig => sig.MethodSignature ().Parameters (1,
 				rt => rt.Type ().Boolean (),
 				p => { p.AddParameter ().Type ().IntPtr (); }));
-
-		_activateDefaultConstructorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "ActivateDefaultConstructor",
-			sig => sig.MethodSignature ().Parameters (2,
-				rt => rt.Void (),
-				p => {
-					p.AddParameter ().Type ().IntPtr ();
-					p.AddParameter ().Type ().Type (_systemTypeRef, false);
-				}));
 
 		_markActivationPeerReplaceableRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, "MarkActivationPeerReplaceable",
 			sig => sig.MethodSignature ().Parameters (1,
@@ -933,6 +930,14 @@ sealed class TypeMapAssemblyEmitter
 				}));
 	}
 
+	MemberReferenceHandle AddDefaultCtorRef (EntityHandle declaringTypeRef)
+	{
+		return _pe.AddMemberRef (declaringTypeRef, ".ctor",
+			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
+				rt => rt.Void (),
+				p => { }));
+	}
+
 	MethodDefinitionHandle EmitUcoMethod (UcoMethodData uco, JavaPeerProxyData proxy)
 	{
 		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
@@ -1057,17 +1062,36 @@ sealed class TypeMapAssemblyEmitter
 		}
 
 		if (jniParams.Count == 0) {
+			var defaultCtorRef = AddDefaultCtorRef (targetTypeRef);
 			var defaultCtorHandle = _pe.EmitBody (uco.WrapperName,
 				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
 				encodeSig,
 				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
-					enc.LoadArgument (1); // self
 					enc.OpCode (ILOpCode.Ldtoken);
 					enc.Token (targetTypeRef);
 					enc.Call (_getTypeFromHandleRef);
-					enc.Call (_activateDefaultConstructorRef);
+					enc.Call (_getUninitializedObjectRef);
+					enc.OpCode (ILOpCode.Castclass);
+					enc.Token (targetTypeRef);
+					enc.StoreLocal (4);
+
+					enc.LoadLocalAddress (3); // jniRef
+					enc.LoadArgument (1);     // self
+					enc.LoadConstantI4 (0);   // JniObjectReferenceType.Invalid
+					enc.Call (_jniObjectReferenceCtorRef);
+
+					enc.LoadLocal (4);
+					enc.LoadLocal (3);
+					enc.OpCode (ILOpCode.Callvirt);
+					enc.Token (_setPeerReferenceRef);
+
+					enc.LoadLocal (4);
+					enc.Call (defaultCtorRef);
+
+					enc.LoadArgument (1); // self
+					enc.Call (_markActivationPeerReplaceableRef);
 				}),
-				EncodeUcoConstructorLocals_Standard);
+				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
 			AddUnmanagedCallersOnlyAttribute (defaultCtorHandle);
 			return defaultCtorHandle;
 		}
@@ -1259,6 +1283,31 @@ sealed class TypeMapAssemblyEmitter
 		// local 3: JniObjectReference (valuetype)
 		blob.WriteByte (0x11); // ELEMENT_TYPE_VALUETYPE
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniObjectReferenceRef));
+	}
+
+	/// <summary>
+	/// LOCAL_SIG for UCO constructors that invoke a no-arg managed constructor.
+	/// Locals: 0=JniTransition, 1=JniRuntime, 2=Exception, 3=JniObjectReference, 4=target type.
+	/// </summary>
+	void EncodeUcoConstructorLocals_DefaultConstructor (BlobBuilder blob, EntityHandle targetTypeRef)
+	{
+		blob.WriteByte (0x07); // LOCAL_SIG
+		blob.WriteCompressedInteger (5);
+		// local 0: JniTransition (valuetype)
+		blob.WriteByte (0x11); // ELEMENT_TYPE_VALUETYPE
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniTransitionRef));
+		// local 1: JniRuntime (class)
+		blob.WriteByte (0x12); // ELEMENT_TYPE_CLASS
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniRuntimeRef));
+		// local 2: Exception (class)
+		blob.WriteByte (0x12); // ELEMENT_TYPE_CLASS
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_exceptionRef));
+		// local 3: JniObjectReference (valuetype)
+		blob.WriteByte (0x11); // ELEMENT_TYPE_VALUETYPE
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (_jniObjectReferenceRef));
+		// local 4: target type (class)
+		blob.WriteByte (0x12); // ELEMENT_TYPE_CLASS
+		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (targetTypeRef));
 	}
 
 	void EmitRegisterNatives (JavaPeerProxyData proxy,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -974,14 +974,6 @@ sealed class TypeMapAssemblyEmitter
 				}));
 	}
 
-	MemberReferenceHandle AddDefaultCtorRef (EntityHandle declaringTypeRef)
-	{
-		return _pe.AddMemberRef (declaringTypeRef, ".ctor",
-			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0,
-				rt => rt.Void (),
-				p => { }));
-	}
-
 	MemberReferenceHandle AddManagedCtorRef (EntityHandle declaringTypeRef, IReadOnlyList<string> parameterTypes, string defaultAssemblyName)
 	{
 		var blob = new BlobBuilder (32);
@@ -1087,9 +1079,8 @@ sealed class TypeMapAssemblyEmitter
 			$"UCO constructor wrapper requires an activation ctor for '{uco.TargetType.ManagedTypeName}'");
 
 		// UCO constructor wrappers must match the JNI native method signature exactly.
-		// Only jnienv (arg 0) and self (arg 1) are used — the constructor parameters
-		// are not forwarded because we create the managed peer using the
-		// activation ctor (IntPtr, JniHandleOwnership), not the user-visible constructor.
+		// jnienv and self are followed by the Java constructor parameters, which are
+		// forwarded when scanner metadata can identify the matching managed constructor.
 		var jniParams = JniSignatureHelper.ParseParameterTypes (uco.JniSignature);
 		int paramCount = 2 + jniParams.Count;
 
@@ -1104,14 +1095,12 @@ sealed class TypeMapAssemblyEmitter
 
 		// Open generic types can't be activated because Java construction cannot provide the type arguments.
 		if (proxy.IsGenericDefinition) {
-			var openGenericHandle = _pe.EmitBody (uco.WrapperName,
-				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-				encodeSig,
-				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+			var openGenericHandle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+				enc => {
 					enc.LoadString (_pe.Metadata.GetOrAddUserString ("Constructing instances of generic types from Java is not supported, as the type parameters cannot be determined."));
 					enc.NewObject (_notSupportedExceptionCtorRef, parameterCount: 1);
 					enc.Throw ();
-				}),
+				},
 				EncodeUcoConstructorLocals_Standard);
 			AddUnmanagedCallersOnlyAttribute (openGenericHandle);
 			return openGenericHandle;
@@ -1122,10 +1111,8 @@ sealed class TypeMapAssemblyEmitter
 			MethodDefinitionHandle invokerHandle;
 			if (proxy.InvokerActivationCtorStyle == ActivationCtorStyle.JavaInterop) {
 				var ctorRef = AddJavaInteropActivationCtorRef (invokerTypeRef);
-				invokerHandle = _pe.EmitBody (uco.WrapperName,
-					MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-					encodeSig,
-					(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+				invokerHandle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+					enc => {
 						enc.LoadLocalAddress (3); // jniRef
 						enc.LoadArgument (1);     // self
 						enc.LoadConstantI4 (0);   // JniObjectReferenceType.Invalid
@@ -1134,106 +1121,34 @@ sealed class TypeMapAssemblyEmitter
 						enc.LoadLocalAddress (3); // ref jniRef
 						enc.LoadConstantI4 (1);   // JniObjectReferenceOptions.Copy
 						enc.NewObject (ctorRef, parameterCount: 2);
-						enc.OpCode (ILOpCode.Pop);
+						enc.PopValue ();
 
 						enc.LoadArgument (1); // self
 						enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-					}),
+					},
 					EncodeUcoConstructorLocals_JavaInterop);
 			} else {
 				var ctorRef = AddActivationCtorRef (invokerTypeRef);
-				invokerHandle = _pe.EmitBody (uco.WrapperName,
-					MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-					encodeSig,
-					(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+				invokerHandle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+					enc => {
 						enc.LoadArgument (1);    // self
 						enc.LoadConstantI4 (0);  // JniHandleOwnership.DoNotTransfer
 						enc.NewObject (ctorRef, parameterCount: 2);
-						enc.OpCode (ILOpCode.Pop);
+						enc.PopValue ();
 
 						enc.LoadArgument (1); // self
 						enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-					}),
+					},
 					EncodeUcoConstructorLocals_Standard);
 			}
 			AddUnmanagedCallersOnlyAttribute (invokerHandle);
 			return invokerHandle;
 		}
 
-		if (jniParams.Count == 0 && uco.HasPublicParameterlessConstructor) {
-			var defaultCtorRef = AddDefaultCtorRef (targetTypeRef);
-			var defaultCtorHandle = _pe.EmitBody (uco.WrapperName,
-				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-				encodeSig,
-				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
-					var havePeer = enc.DefineLabel ();
-
-					enc.LoadArgument (1);
-					enc.Call (_getActivationPeerRef, parameterCount: 1, returnsValue: true);
-					enc.CastClass (targetTypeRef);
-					enc.StoreLocal (4);
-
-					enc.LoadLocal (4);
-					enc.Branch (ILOpCode.Brtrue, havePeer);
-
-					enc.LoadToken (targetTypeRef);
-					enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
-					enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
-					enc.CastClass (targetTypeRef);
-					enc.StoreLocal (4);
-
-					enc.LoadLocal (4);
-					enc.LoadArgument (1); // self
-					enc.Call (_setActivationPeerReferenceRef, parameterCount: 2);
-
-					enc.MarkLabel (havePeer);
-					enc.LoadLocal (4);
-					enc.Call (defaultCtorRef, parameterCount: 0, isInstance: true);
-
-					enc.LoadArgument (1); // self
-					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-				}),
-				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
-			AddUnmanagedCallersOnlyAttribute (defaultCtorHandle);
-			return defaultCtorHandle;
-		}
-
-		if (jniParams.Count > 0 && uco.ManagedParameterTypes.Count == jniParams.Count) {
+		if (uco.HasManagedConstructor && uco.ManagedParameterTypes.Count == jniParams.Count) {
 			var ctorRef = AddManagedCtorRef (targetTypeRef, uco.ManagedParameterTypes, uco.TargetType.AssemblyName);
-			var managedCtorHandle = _pe.EmitBody (uco.WrapperName,
-				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-				encodeSig,
-				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
-					var havePeer = enc.DefineLabel ();
-
-					enc.LoadArgument (1);
-					enc.Call (_getActivationPeerRef, parameterCount: 1, returnsValue: true);
-					enc.CastClass (targetTypeRef);
-					enc.StoreLocal (4);
-
-					enc.LoadLocal (4);
-					enc.Branch (ILOpCode.Brtrue, havePeer);
-
-					enc.LoadToken (targetTypeRef);
-					enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
-					enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
-					enc.CastClass (targetTypeRef);
-					enc.StoreLocal (4);
-
-					enc.LoadLocal (4);
-					enc.LoadArgument (1); // self
-					enc.Call (_setActivationPeerReferenceRef, parameterCount: 2);
-
-					enc.MarkLabel (havePeer);
-					enc.LoadLocal (4);
-					for (int i = 0; i < uco.ManagedParameterTypes.Count; i++) {
-						EmitManagedConstructorArgument (enc, uco.ManagedParameterTypes [i], jniParams [i], i + 2, uco.TargetType.AssemblyName);
-					}
-					enc.Call (ctorRef, uco.ManagedParameterTypes.Count, isInstance: true);
-
-					enc.LoadArgument (1); // self
-					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-				}),
+			var managedCtorHandle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+				enc => EmitManagedConstructorActivation (enc, targetTypeRef, ctorRef, uco.ManagedParameterTypes, jniParams, uco.TargetType.AssemblyName),
 				blob => EncodeUcoConstructorLocals_DefaultConstructor (blob, targetTypeRef));
 			AddUnmanagedCallersOnlyAttribute (managedCtorHandle);
 			return managedCtorHandle;
@@ -1249,10 +1164,8 @@ sealed class TypeMapAssemblyEmitter
 			//   1: JniRuntime?    (runtime) — out-parameter for BeginMarshalMethod
 			//   2: Exception      (e)       — catch variable
 			//   3: JniObjectReference (jniRef) — needed for JavaInterop-style activation
-			handle = _pe.EmitBody (uco.WrapperName,
-				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-				encodeSig,
-				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+			handle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+				enc => {
 					if (!activationCtor.IsOnLeafType) {
 						enc.LoadToken (targetTypeRef);
 						enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
@@ -1269,7 +1182,7 @@ sealed class TypeMapAssemblyEmitter
 						enc.LoadLocalAddress (3); // ref jniRef
 						enc.LoadConstantI4 (1);   // JniObjectReferenceOptions.Copy
 						enc.NewObject (ctorRef, parameterCount: 2);
-						enc.OpCode (ILOpCode.Pop);
+						enc.PopValue ();
 					} else {
 						enc.LoadLocalAddress (3); // ref jniRef
 						enc.LoadConstantI4 (1);   // JniObjectReferenceOptions.Copy
@@ -1277,7 +1190,7 @@ sealed class TypeMapAssemblyEmitter
 					}
 					enc.LoadArgument (1); // self
 					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-				}),
+				},
 				EncodeUcoConstructorLocals_JavaInterop);
 		} else {
 			var ctorRef = AddActivationCtorRef (
@@ -1287,15 +1200,13 @@ sealed class TypeMapAssemblyEmitter
 			//   0: JniTransition  (envp)    — out-parameter for BeginMarshalMethod
 			//   1: JniRuntime?    (runtime) — out-parameter for BeginMarshalMethod
 			//   2: Exception      (e)       — catch variable
-			handle = _pe.EmitBody (uco.WrapperName,
-				MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
-				encodeSig,
-				(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, enc => {
+			handle = EmitUcoConstructorBody (uco.WrapperName, encodeSig,
+				enc => {
 					if (activationCtor.IsOnLeafType) {
 						enc.LoadArgument (1);    // self
 						enc.LoadConstantI4 (0);  // JniHandleOwnership.DoNotTransfer
 						enc.NewObject (ctorRef, parameterCount: 2);
-						enc.OpCode (ILOpCode.Pop);
+						enc.PopValue ();
 					} else {
 						enc.LoadToken (targetTypeRef);
 						enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
@@ -1308,11 +1219,63 @@ sealed class TypeMapAssemblyEmitter
 					}
 					enc.LoadArgument (1); // self
 					enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
-				}),
+				},
 				EncodeUcoConstructorLocals_Standard);
 		}
 		AddUnmanagedCallersOnlyAttribute (handle);
 		return handle;
+	}
+
+	MethodDefinitionHandle EmitUcoConstructorBody (
+		string wrapperName,
+		Action<BlobEncoder> encodeSig,
+		Action<TrackedInstructionEncoder> emitActivation,
+		Action<BlobBuilder> encodeLocals)
+	{
+		return _pe.EmitBody (wrapperName,
+			MethodAttributes.Public | MethodAttributes.Static | MethodAttributes.HideBySig,
+			encodeSig,
+			(encoder, cfb) => EmitUcoConstructorBodyWithMarshal (encoder, cfb, emitActivation),
+			encodeLocals);
+	}
+
+	void EmitManagedConstructorActivation (
+		TrackedInstructionEncoder enc,
+		EntityHandle targetTypeRef,
+		MemberReferenceHandle ctorRef,
+		IReadOnlyList<string> managedParameterTypes,
+		IReadOnlyList<JniParamKind> jniParams,
+		string defaultAssemblyName)
+	{
+		var havePeer = enc.DefineLabel ();
+
+		enc.LoadArgument (1);
+		enc.Call (_getActivationPeerRef, parameterCount: 1, returnsValue: true);
+		enc.CastClass (targetTypeRef);
+		enc.StoreLocal (4);
+
+		enc.LoadLocal (4);
+		enc.Branch (ILOpCode.Brtrue, havePeer);
+
+		enc.LoadToken (targetTypeRef);
+		enc.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
+		enc.Call (_getUninitializedObjectRef, parameterCount: 1, returnsValue: true);
+		enc.CastClass (targetTypeRef);
+		enc.StoreLocal (4);
+
+		enc.LoadLocal (4);
+		enc.LoadArgument (1); // self
+		enc.Call (_setActivationPeerReferenceRef, parameterCount: 2);
+
+		enc.MarkLabel (havePeer);
+		enc.LoadLocal (4);
+		for (int i = 0; i < managedParameterTypes.Count; i++) {
+			EmitManagedConstructorArgument (enc, managedParameterTypes [i], jniParams [i], i + 2, defaultAssemblyName);
+		}
+		enc.Call (ctorRef, managedParameterTypes.Count, isInstance: true);
+
+		enc.LoadArgument (1); // self
+		enc.Call (_markActivationPeerReplaceableRef, parameterCount: 1);
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -139,6 +139,11 @@ public sealed record JavaPeerInfo
 	public bool IsGenericDefinition { get; init; }
 
 	/// <summary>
+	/// True if this non-abstract type declares a public parameterless managed constructor.
+	/// </summary>
+	public bool HasPublicParameterlessConstructor { get; init; }
+
+	/// <summary>
 	/// Android component attribute data ([Activity], [Service], [BroadcastReceiver], [ContentProvider],
 	/// [Application], [Instrumentation]) if present on this type. Used for manifest generation.
 	/// </summary>
@@ -225,6 +230,11 @@ public sealed record MarshalMethodInfo
 	public string? SuperArgumentsString { get; init; }
 
 	/// <summary>
+	/// Managed method parameter type names, in declaration order.
+	/// </summary>
+	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
+
+	/// <summary>
 	/// True if this method was collected from an implemented interface
 	/// (Pass 4: CollectInterfaceMethodImplementations), not from the type itself.
 	/// </summary>
@@ -267,6 +277,11 @@ public sealed record JavaConstructorInfo
 	/// Null for [Register] constructors.
 	/// </summary>
 	public string? SuperArgumentsString { get; init; }
+
+	/// <summary>
+	/// Managed constructor parameter type names, in declaration order.
+	/// </summary>
+	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -139,11 +139,6 @@ public sealed record JavaPeerInfo
 	public bool IsGenericDefinition { get; init; }
 
 	/// <summary>
-	/// True if this non-abstract type declares a public parameterless managed constructor.
-	/// </summary>
-	public bool HasPublicParameterlessConstructor { get; init; }
-
-	/// <summary>
 	/// Android component attribute data ([Activity], [Service], [BroadcastReceiver], [ContentProvider],
 	/// [Application], [Instrumentation]) if present on this type. Used for manifest generation.
 	/// </summary>
@@ -235,6 +230,12 @@ public sealed record MarshalMethodInfo
 	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
 
 	/// <summary>
+	/// True when this constructor registration maps to an actual managed constructor on the target type.
+	/// False for constructors inherited from Java base types that only exist to generate Java source.
+	/// </summary>
+	public bool HasManagedConstructor { get; init; }
+
+	/// <summary>
 	/// True if this method was collected from an implemented interface
 	/// (Pass 4: CollectInterfaceMethodImplementations), not from the type itself.
 	/// </summary>
@@ -282,6 +283,11 @@ public sealed record JavaConstructorInfo
 	/// Managed constructor parameter type names, in declaration order.
 	/// </summary>
 	public IReadOnlyList<string> ManagedParameterTypes { get; init; } = [];
+
+	/// <summary>
+	/// True when this Java constructor has a matching managed constructor on the target type.
+	/// </summary>
+	public bool HasManagedConstructor { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -268,6 +268,7 @@ public sealed class JavaPeerScanner : IDisposable
 				InvokerTypeName = invokerTypeName,
 				InvokerActivationCtorStyle = invokerActivationCtorStyle,
 				IsGenericDefinition = isGenericDefinition,
+				HasPublicParameterlessConstructor = !isAbstract && !isGenericDefinition && HasPublicParameterlessConstructor (typeDef, index),
 				ComponentAttribute = ToComponentInfo (attrInfo),
 			};
 
@@ -563,6 +564,7 @@ public sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = ".ctor",
 					NativeCallbackName = "n_ctor",
 					IsConstructor = true,
+					ManagedParameterTypes = [],
 				});
 				alreadyRegisteredSignatures.Add (signature);
 			}
@@ -614,6 +616,7 @@ public sealed class JavaPeerScanner : IDisposable
 						NativeCallbackName = "n_ctor",
 						IsConstructor = true,
 						SuperArgumentsString = "",
+						ManagedParameterTypes = sig.ParameterTypes,
 					});
 					alreadyRegisteredSignatures.Add (jniSignature);
 				}
@@ -892,6 +895,7 @@ public sealed class JavaPeerScanner : IDisposable
 		bool isExport = exportInfo is not null;
 		string managedName = index.Reader.GetString (methodDef.Name);
 		string jniSignature = registerInfo.Signature ?? "()V";
+		var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 
 		string declaringTypeName = "";
 		string declaringAssemblyName = "";
@@ -911,6 +915,7 @@ public sealed class JavaPeerScanner : IDisposable
 			JavaAccess = isExport ? GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask) : null,
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,
+			ManagedParameterTypes = sig.ParameterTypes,
 		});
 	}
 
@@ -1177,6 +1182,25 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 
 		return null;
+	}
+
+	static bool HasPublicParameterlessConstructor (TypeDefinition typeDef, AssemblyIndex index)
+	{
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var method = index.Reader.GetMethodDefinition (methodHandle);
+			if (index.Reader.GetString (method.Name) != ".ctor") {
+				continue;
+			}
+			if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) {
+				continue;
+			}
+			var sig = method.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			if (sig.ParameterTypes.Length == 0) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	static ActivationCtorStyle? FindActivationCtorOnType (TypeDefinition typeDef, AssemblyIndex index)
@@ -1553,6 +1577,7 @@ public sealed class JavaPeerScanner : IDisposable
 				JniSignature = mm.JniSignature,
 				ConstructorIndex = ctorIndex,
 				SuperArgumentsString = mm.SuperArgumentsString,
+				ManagedParameterTypes = mm.ManagedParameterTypes,
 			});
 			ctorIndex++;
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -268,7 +268,6 @@ public sealed class JavaPeerScanner : IDisposable
 				InvokerTypeName = invokerTypeName,
 				InvokerActivationCtorStyle = invokerActivationCtorStyle,
 				IsGenericDefinition = isGenericDefinition,
-				HasPublicParameterlessConstructor = !isAbstract && !isGenericDefinition && HasPublicParameterlessConstructor (typeDef, index),
 				ComponentAttribute = ToComponentInfo (attrInfo),
 			};
 
@@ -557,6 +556,7 @@ public sealed class JavaPeerScanner : IDisposable
 				continue;
 			}
 			if (!alreadyRegisteredSignatures.Contains (signature)) {
+				var managedParameterTypes = TryGetMatchingPublicConstructorParameterTypes (typeDef, index, baseCtor.Method);
 				methods.Add (new MarshalMethodInfo {
 					JniName = baseCtor.RegisterInfo.JniName,
 					JniSignature = signature,
@@ -564,7 +564,8 @@ public sealed class JavaPeerScanner : IDisposable
 					ManagedMethodName = ".ctor",
 					NativeCallbackName = "n_ctor",
 					IsConstructor = true,
-					ManagedParameterTypes = [],
+					ManagedParameterTypes = managedParameterTypes ?? [],
+					HasManagedConstructor = managedParameterTypes != null,
 				});
 				alreadyRegisteredSignatures.Add (signature);
 			}
@@ -617,11 +618,33 @@ public sealed class JavaPeerScanner : IDisposable
 						IsConstructor = true,
 						SuperArgumentsString = "",
 						ManagedParameterTypes = sig.ParameterTypes,
+						HasManagedConstructor = true,
 					});
 					alreadyRegisteredSignatures.Add (jniSignature);
 				}
 			}
 		}
+	}
+
+	IReadOnlyList<string>? TryGetMatchingPublicConstructorParameterTypes (TypeDefinition typeDef, AssemblyIndex index, MethodDefinition baseCtor)
+	{
+		foreach (var methodHandle in typeDef.GetMethods ()) {
+			var methodDef = index.Reader.GetMethodDefinition (methodHandle);
+			if (index.Reader.GetString (methodDef.Name) != ".ctor") {
+				continue;
+			}
+			if ((methodDef.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) {
+				continue;
+			}
+			if (!HaveIdenticalParameterTypes (methodDef, baseCtor)) {
+				continue;
+			}
+
+			var sig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
+			return sig.ParameterTypes;
+		}
+
+		return null;
 	}
 
 	string? BuildJniCtorSignature (MethodSignature<string> sig)
@@ -916,6 +939,7 @@ public sealed class JavaPeerScanner : IDisposable
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,
 			ManagedParameterTypes = sig.ParameterTypes,
+			HasManagedConstructor = isConstructor,
 		});
 	}
 
@@ -1182,25 +1206,6 @@ public sealed class JavaPeerScanner : IDisposable
 		}
 
 		return null;
-	}
-
-	static bool HasPublicParameterlessConstructor (TypeDefinition typeDef, AssemblyIndex index)
-	{
-		foreach (var methodHandle in typeDef.GetMethods ()) {
-			var method = index.Reader.GetMethodDefinition (methodHandle);
-			if (index.Reader.GetString (method.Name) != ".ctor") {
-				continue;
-			}
-			if ((method.Attributes & MethodAttributes.MemberAccessMask) != MethodAttributes.Public) {
-				continue;
-			}
-			var sig = method.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
-			if (sig.ParameterTypes.Length == 0) {
-				return true;
-			}
-		}
-
-		return false;
 	}
 
 	static ActivationCtorStyle? FindActivationCtorOnType (TypeDefinition typeDef, AssemblyIndex index)
@@ -1578,6 +1583,7 @@ public sealed class JavaPeerScanner : IDisposable
 				ConstructorIndex = ctorIndex,
 				SuperArgumentsString = mm.SuperArgumentsString,
 				ManagedParameterTypes = mm.ManagedParameterTypes,
+				HasManagedConstructor = mm.HasManagedConstructor,
 			});
 			ctorIndex++;
 		}

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -96,12 +96,24 @@ namespace Java.Interop
 		{
 			var reference = new JniObjectReference (jniSelf, JniObjectReferenceType.Invalid);
 			var peer = JniEnvironment.Runtime.ValueManager.PeekPeer (reference);
-			if (peer == null) {
-				return false;
+			if (peer != null && !IsActivationPeer (peer)) {
+				return true;
 			}
-			var state = peer.JniManagedPeerState;
-			return (state & JniManagedPeerStates.Activatable) != JniManagedPeerStates.Activatable
-				&& (state & JniManagedPeerStates.Replaceable) != JniManagedPeerStates.Replaceable;
+			return JniEnvironment.WithinNewObjectScope;
+		}
+
+		public static IJavaPeerable? GetActivationPeer (IntPtr jniSelf)
+		{
+			var reference = new JniObjectReference (jniSelf, JniObjectReferenceType.Invalid);
+			var peer = JniEnvironment.Runtime.ValueManager.PeekPeer (reference);
+			return peer != null && IsActivationPeer (peer) ? peer : null;
+		}
+
+		public static void SetActivationPeerReference (IJavaPeerable peer, IntPtr jniSelf)
+		{
+			var reference = new JniObjectReference (jniSelf, JniObjectReferenceType.Invalid);
+			peer.SetPeerReference (reference);
+			peer.SetJniIdentityHashCode (JniEnvironment.References.GetIdentityHashCode (reference));
 		}
 
 		public static void MarkActivationPeerReplaceable (IntPtr jniSelf)
@@ -113,6 +125,13 @@ namespace Java.Interop
 			}
 
 			peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+		}
+
+		static bool IsActivationPeer (IJavaPeerable peer)
+		{
+			var state = peer.JniManagedPeerState;
+			return (state & JniManagedPeerStates.Activatable) == JniManagedPeerStates.Activatable
+				|| (state & JniManagedPeerStates.Replaceable) == JniManagedPeerStates.Replaceable;
 		}
 	}
 

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using Android.Runtime;
 
 namespace Java.Interop
@@ -102,6 +103,31 @@ namespace Java.Interop
 			var state = peer.JniManagedPeerState;
 			return (state & JniManagedPeerStates.Activatable) != JniManagedPeerStates.Activatable
 				&& (state & JniManagedPeerStates.Replaceable) != JniManagedPeerStates.Replaceable;
+		}
+
+		public static void ActivateDefaultConstructor (
+			IntPtr jniSelf,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
+			Type targetType)
+		{
+			var cinfo = targetType.GetConstructor (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, binder: null, Type.EmptyTypes, modifiers: null);
+			if (cinfo == null) {
+				throw new NotSupportedException ($"Unable to find a default constructor for type `{targetType.FullName}`.");
+			}
+
+			JniEnvironment.Runtime.ValueManager.ActivatePeer (null, new JniObjectReference (jniSelf), cinfo, null);
+			MarkActivationPeerReplaceable (jniSelf);
+		}
+
+		public static void MarkActivationPeerReplaceable (IntPtr jniSelf)
+		{
+			var reference = new JniObjectReference (jniSelf, JniObjectReferenceType.Invalid);
+			var peer = JniEnvironment.Runtime.ValueManager.PeekPeer (reference);
+			if (peer == null) {
+				return;
+			}
+
+			peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
 		}
 	}
 

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Reflection;
 using Android.Runtime;
 
 namespace Java.Interop
@@ -103,20 +102,6 @@ namespace Java.Interop
 			var state = peer.JniManagedPeerState;
 			return (state & JniManagedPeerStates.Activatable) != JniManagedPeerStates.Activatable
 				&& (state & JniManagedPeerStates.Replaceable) != JniManagedPeerStates.Replaceable;
-		}
-
-		public static void ActivateDefaultConstructor (
-			IntPtr jniSelf,
-			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)]
-			Type targetType)
-		{
-			var cinfo = targetType.GetConstructor (BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance, binder: null, Type.EmptyTypes, modifiers: null);
-			if (cinfo == null) {
-				throw new NotSupportedException ($"Unable to find a default constructor for type `{targetType.FullName}`.");
-			}
-
-			JniEnvironment.Runtime.ValueManager.ActivatePeer (null, new JniObjectReference (jniSelf), cinfo, null);
-			MarkActivationPeerReplaceable (jniSelf);
 		}
 
 		public static void MarkActivationPeerReplaceable (IntPtr jniSelf)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -102,6 +102,7 @@ public abstract class FixtureTestBase
 					IsConstructor = true,
 				},
 			},
+			HasPublicParameterlessConstructor = true,
 		};
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/FixtureTestBase.cs
@@ -91,7 +91,7 @@ public abstract class FixtureTestBase
 		return MakePeerWithActivation (jniName, managedName, asmName) with {
 			DoNotGenerateAcw = false,
 			JavaConstructors = new List<JavaConstructorInfo> {
-				new JavaConstructorInfo { ConstructorIndex = 0, JniSignature = "()V" },
+				new JavaConstructorInfo { ConstructorIndex = 0, JniSignature = "()V", HasManagedConstructor = true },
 			},
 			MarshalMethods = new List<MarshalMethodInfo> {
 				new MarshalMethodInfo {
@@ -100,9 +100,9 @@ public abstract class FixtureTestBase
 					JniSignature = "()V",
 					ManagedMethodName = ".ctor",
 					IsConstructor = true,
+					HasManagedConstructor = true,
 				},
 			},
-			HasPublicParameterlessConstructor = true,
 		};
 	}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -553,6 +553,43 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void Generate_UcoConstructor_InvokerUsesXamarinAndroidActivationCtor ()
+	{
+		var peer = MakeAcwPeer ("test/AbstractCtorTarget", "Test.AbstractCtorTarget", "TestAsm") with {
+			InvokerTypeName = "Test.AbstractCtorInvoker",
+			HasPublicParameterlessConstructor = false,
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "InvokerCtorUcoTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "AbstractCtorInvoker",
+			"System.IntPtr", "Android.Runtime.JniHandleOwnership"));
+		Assert.Empty (FindCtorMemberRefs (reader, "Test", "AbstractCtorTarget",
+			"System.IntPtr", "Android.Runtime.JniHandleOwnership"));
+	}
+
+	[Fact]
+	public void Generate_UcoConstructor_InvokerUsesJavaInteropActivationCtor ()
+	{
+		var peer = MakeAcwPeer ("test/AbstractJiCtorTarget", "Test.AbstractJiCtorTarget", "TestAsm") with {
+			InvokerTypeName = "Test.AbstractJiCtorInvoker",
+			InvokerActivationCtorStyle = ActivationCtorStyle.JavaInterop,
+			HasPublicParameterlessConstructor = false,
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "JiInvokerCtorUcoTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "AbstractJiCtorInvoker",
+			"Java.Interop.JniObjectReference&", "Java.Interop.JniObjectReferenceOptions"));
+		Assert.Empty (FindCtorMemberRefs (reader, "Test", "AbstractJiCtorTarget",
+			"Java.Interop.JniObjectReference&", "Java.Interop.JniObjectReferenceOptions"));
+	}
+
+	[Fact]
 	public void Generate_JiStyleCtor_EmitsDeleteRefCall ()
 	{
 		var peers = ScanFixtures ();

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -288,7 +288,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
-	public void Generate_InheritedCtor_ReferencesGuardAndActivationCtor ()
+	public void Generate_InheritedCtor_NctorUcoCallsDefaultConstructor ()
 	{
 		var peers = ScanFixtures ();
 		var simpleActivity = peers.First (p => p.JavaName == "my/app/SimpleActivity");
@@ -302,18 +302,24 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		Assert.Contains ("ShouldSkipActivation", memberNames);
 		Assert.Contains ("GetUninitializedObject", memberNames);
+		Assert.Contains ("SetPeerReference", memberNames);
+		Assert.Contains ("MarkActivationPeerReplaceable", memberNames);
 		Assert.DoesNotContain ("Invoke", memberNames);
 		Assert.DoesNotContain ("ActivateInstance", memberNames);
 		Assert.DoesNotContain ("ActivatePeerFromJavaConstructor", memberNames);
 
-		Assert.NotEmpty (FindCtorMemberRefs (reader, "Android.App", "Activity",
+		// The new no-arg nctor codegen calls the target type's parameterless .ctor()
+		// directly, not the legacy (IntPtr, JniHandleOwnership) activation ctor on the base.
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "MyApp", "SimpleActivity"));
+		Assert.Empty (FindCtorMemberRefs (reader, "Android.App", "Activity",
 			"System.IntPtr", "Android.Runtime.JniHandleOwnership"));
+
 		var nctorMethodHandle = FindNctorUcoMethod (reader);
 		Assert.False (nctorMethodHandle.IsNil, "SimpleActivity should have a nctor_*_uco method");
 	}
 
 	[Fact]
-	public void Generate_InheritedJavaInteropCtor_ReferencesActivationCtor ()
+	public void Generate_InheritedJavaInteropCtor_NctorUcoCallsDefaultConstructor ()
 	{
 		var peer = MakeAcwPeer ("test/JiInheritedTarget", "Test.JiInheritedTarget", "TestAsm") with {
 			ActivationCtor = new ActivationCtorInfo {
@@ -332,10 +338,17 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		var memberNames = GetMemberRefNames (reader);
 		Assert.Contains ("GetUninitializedObject", memberNames);
+		Assert.Contains ("SetPeerReference", memberNames);
+		Assert.Contains ("MarkActivationPeerReplaceable", memberNames);
 		Assert.DoesNotContain ("Invoke", memberNames);
 
-		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "JiInheritedBase",
+		// The new no-arg nctor codegen calls the target type's parameterless .ctor()
+		// directly, not the JI-style (JniObjectReference&, JniObjectReferenceOptions)
+		// activation ctor on the inherited base.
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "JiInheritedTarget"));
+		Assert.Empty (FindCtorMemberRefs (reader, "Test", "JiInheritedBase",
 			"Java.Interop.JniObjectReference&", "Java.Interop.JniObjectReferenceOptions"));
+
 		var nctorMethodHandle = FindNctorUcoMethod (reader);
 		Assert.False (nctorMethodHandle.IsNil, "The ACW peer should have a nctor_*_uco method");
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -557,7 +557,6 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	{
 		var peer = MakeAcwPeer ("test/AbstractCtorTarget", "Test.AbstractCtorTarget", "TestAsm") with {
 			InvokerTypeName = "Test.AbstractCtorInvoker",
-			HasPublicParameterlessConstructor = false,
 		};
 
 		using var stream = GenerateAssembly (new [] { peer }, "InvokerCtorUcoTest");
@@ -576,7 +575,6 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var peer = MakeAcwPeer ("test/AbstractJiCtorTarget", "Test.AbstractJiCtorTarget", "TestAsm") with {
 			InvokerTypeName = "Test.AbstractJiCtorInvoker",
 			InvokerActivationCtorStyle = ActivationCtorStyle.JavaInterop,
-			HasPublicParameterlessConstructor = false,
 		};
 
 		using var stream = GenerateAssembly (new [] { peer }, "JiInvokerCtorUcoTest");
@@ -1229,6 +1227,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 					ConstructorIndex = 0,
 					JniSignature = jniSignature,
 					ManagedParameterTypes = managedTypes,
+					HasManagedConstructor = true,
 				},
 			},
 			MarshalMethods = new List<MarshalMethodInfo> {
@@ -1272,6 +1271,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 					ConstructorIndex = 0,
 					JniSignature = jniSignature,
 					ManagedParameterTypes = managedTypes,
+					HasManagedConstructor = true,
 				},
 			},
 			MarshalMethods = new List<MarshalMethodInfo> {

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -302,7 +302,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		Assert.Contains ("ShouldSkipActivation", memberNames);
 		Assert.Contains ("GetUninitializedObject", memberNames);
-		Assert.Contains ("SetPeerReference", memberNames);
+		Assert.Contains ("SetActivationPeerReference", memberNames);
 		Assert.Contains ("MarkActivationPeerReplaceable", memberNames);
 		Assert.DoesNotContain ("Invoke", memberNames);
 		Assert.DoesNotContain ("ActivateInstance", memberNames);
@@ -338,7 +338,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 		var memberNames = GetMemberRefNames (reader);
 		Assert.Contains ("GetUninitializedObject", memberNames);
-		Assert.Contains ("SetPeerReference", memberNames);
+		Assert.Contains ("SetActivationPeerReference", memberNames);
 		Assert.Contains ("MarkActivationPeerReplaceable", memberNames);
 		Assert.DoesNotContain ("Invoke", memberNames);
 
@@ -685,7 +685,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	[Theory]
 	[InlineData (1, 0x05)]  // Boolean → byte (unsigned) for JNI ABI
 	[InlineData (2, 0x04)]  // Byte → sbyte
-	[InlineData (3, 0x03)]  // Char → char
+	[InlineData (3, 0x07)]  // Char → uint16 (blittable JNI jchar)
 	[InlineData (4, 0x06)]  // Short → int16
 	[InlineData (5, 0x08)]  // Int → int32
 	[InlineData (6, 0x0A)]  // Long → int64
@@ -752,7 +752,6 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 	[Theory]
 	[InlineData (2)]  // Byte
-	[InlineData (3)]  // Char
 	[InlineData (4)]  // Short
 	[InlineData (5)]  // Int
 	[InlineData (6)]  // Long
@@ -1171,6 +1170,96 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			$"UCO constructor should have at least 2 exception regions (catch + finally), found {regions.Length}");
 		Assert.Contains (regions, r => r.Kind == ExceptionRegionKind.Catch);
 		Assert.Contains (regions, r => r.Kind == ExceptionRegionKind.Finally);
+	}
+
+	[Fact]
+	public void Generate_UcoConstructor_ParameterizedPrimitiveCtorCallsManagedConstructor ()
+	{
+		string jniSignature = "(ZBCSIJFD)V";
+		var managedTypes = new [] {
+			"System.Boolean",
+			"System.SByte",
+			"System.Char",
+			"System.Int16",
+			"System.Int32",
+			"System.Int64",
+			"System.Single",
+			"System.Double",
+		};
+		var peer = MakeAcwPeer ("test/PrimitiveCtorArgs", "Test.PrimitiveCtorArgs", "TestAsm") with {
+			JavaConstructors = new List<JavaConstructorInfo> {
+				new JavaConstructorInfo {
+					ConstructorIndex = 0,
+					JniSignature = jniSignature,
+					ManagedParameterTypes = managedTypes,
+				},
+			},
+			MarshalMethods = new List<MarshalMethodInfo> {
+				new MarshalMethodInfo {
+					JniName = "<init>",
+					NativeCallbackName = "n_ctor",
+					JniSignature = jniSignature,
+					ManagedMethodName = ".ctor",
+					IsConstructor = true,
+					ManagedParameterTypes = managedTypes,
+				},
+			},
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "ParameterizedPrimitiveCtorTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "PrimitiveCtorArgs", managedTypes));
+
+		var nctorMethod = reader.GetMethodDefinition (FindNctorUcoMethod (reader));
+		var nctorSignature = nctorMethod.DecodeSignature (SignatureTypeProvider.Instance, null);
+		Assert.Equal (
+			new [] { "System.IntPtr", "System.IntPtr", "System.Byte", "System.SByte", "System.UInt16", "System.Int16", "System.Int32", "System.Int64", "System.Single", "System.Double" },
+			nctorSignature.ParameterTypes);
+	}
+
+	[Fact]
+	public void Generate_UcoConstructor_ParameterizedObjectCtorUsesExplicitMarshalHelpers ()
+	{
+		string jniSignature = "(Ljava/lang/String;[I[Ljava/lang/String;Landroid/content/Context;)V";
+		var managedTypes = new [] {
+			"System.String",
+			"System.Int32[]",
+			"System.String[]",
+			"Android.Content.Context",
+		};
+		var peer = MakeAcwPeer ("test/ObjectCtorArgs", "Test.ObjectCtorArgs", "TestAsm") with {
+			JavaConstructors = new List<JavaConstructorInfo> {
+				new JavaConstructorInfo {
+					ConstructorIndex = 0,
+					JniSignature = jniSignature,
+					ManagedParameterTypes = managedTypes,
+				},
+			},
+			MarshalMethods = new List<MarshalMethodInfo> {
+				new MarshalMethodInfo {
+					JniName = "<init>",
+					NativeCallbackName = "n_ctor",
+					JniSignature = jniSignature,
+					ManagedMethodName = ".ctor",
+					IsConstructor = true,
+					ManagedParameterTypes = managedTypes,
+				},
+			},
+		};
+
+		using var stream = GenerateAssembly (new [] { peer }, "ParameterizedObjectCtorTest");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		Assert.NotEmpty (FindCtorMemberRefs (reader, "Test", "ObjectCtorArgs", managedTypes));
+
+		var memberNames = GetMemberRefNames (reader);
+		Assert.Contains ("GetString", memberNames);
+		Assert.Contains ("GetArray", memberNames);
+		Assert.Contains ("GetObject", memberNames);
+		Assert.DoesNotContain ("FromJniHandle", memberNames);
 	}
 
 	[Fact]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
@@ -75,6 +75,17 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void JavaSideThrowingConstructorPropagatesException ()
+		{
+			ConstructorActivationThrowing.Reset ();
+
+			var exception = Assert.Catch<Exception> (() => CreateFromJavaExpectingConstructorException<ConstructorActivationThrowing> ("()V"));
+			Assert.IsNotNull (exception);
+			Assert.AreEqual (1, ConstructorActivationThrowing.ConstructorInvocations);
+			Assert.IsTrue (exception.ToString ().Contains (ConstructorActivationThrowing.ExceptionMessage));
+		}
+
+		[Test]
 		public void JavaSideContextConstructorForwardsArgument ()
 		{
 			ConstructorActivationContextView.Reset ();
@@ -223,6 +234,23 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void JavaSidePrimitiveMixedConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> (
+					"(IZJ)V",
+					new JValue (12345),
+					new JValue (true),
+					new JValue (9876543210L))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (12345, instance.MultiIntValue);
+				Assert.AreEqual (true, instance.MultiBooleanValue);
+				Assert.AreEqual (9876543210L, instance.MultiLongValue);
+			}
+		}
+
+		[Test]
 		public void JavaSideStringConstructorForwardsValue ()
 		{
 			ConstructorActivationMarshalObject.Reset ();
@@ -283,6 +311,23 @@ namespace Java.InteropTests
 		}
 
 		[Test]
+		public void JavaSideStringIntConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var text = new Java.Lang.String ("string-int"))
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> (
+					"(Ljava/lang/String;I)V",
+					new JValue (text),
+					new JValue (17))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ("string-int", instance.StringIntStringValue);
+				Assert.AreEqual (17, instance.StringIntValue);
+			}
+		}
+
+		[Test]
 		public void JavaSideIntArrayConstructorForwardsValues ()
 		{
 			ConstructorActivationMarshalObject.Reset ();
@@ -320,6 +365,30 @@ namespace Java.InteropTests
 			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("([I)V", JValue.Zero)) {
 				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
 				Assert.IsNull (instance.IntArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringIntArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var label = new Java.Lang.String ("string-array"))
+			{
+				IntPtr array = JNIEnv.NewArray (new [] { 8, 13, 21 });
+				try {
+					using (var instance = CreateFromJava<ConstructorActivationMarshalObject> (
+							"(Ljava/lang/String;[I)V",
+							new JValue (label),
+							new JValue (array))) {
+						Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+						Assert.AreEqual ("string-array", instance.StringArrayLabel);
+						Assert.AreEqual (new [] { 8, 13, 21 }, instance.StringArrayValues);
+					}
+				} finally {
+					JNIEnv.DeleteLocalRef (array);
+				}
 			}
 		}
 
@@ -467,6 +536,20 @@ namespace Java.InteropTests
 			}
 		}
 
+		static void CreateFromJavaExpectingConstructorException<T> (string constructorSignature, params JValue [] arguments)
+			where T : Java.Lang.Object
+		{
+			IntPtr instance = IntPtr.Zero;
+			try {
+				instance = JNIEnv.StartCreateInstance (typeof (T), constructorSignature, arguments);
+				JNIEnv.FinishCreateInstance (instance, constructorSignature, arguments);
+			} finally {
+				if (instance != IntPtr.Zero) {
+					JNIEnv.DeleteLocalRef (instance);
+				}
+			}
+		}
+
 		static void AssertRegisteredSame<T> (T instance)
 			where T : Java.Lang.Object
 		{
@@ -480,6 +563,25 @@ namespace Java.InteropTests
 				if (registered != null && !object.ReferenceEquals (instance, registered))
 					registered.Dispose ();
 			}
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationThrowing")]
+	public class ConstructorActivationThrowing : Java.Lang.Object
+	{
+		public const string ExceptionMessage = "constructor activation throw";
+
+		public static int ConstructorInvocations;
+
+		public ConstructorActivationThrowing ()
+		{
+			ConstructorInvocations++;
+			throw new InvalidOperationException (ExceptionMessage);
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
 		}
 	}
 
@@ -522,6 +624,10 @@ namespace Java.InteropTests
 		{
 		}
 
+		public ConstructorActivationBase (int number, bool flag, long longValue)
+		{
+		}
+
 		public ConstructorActivationBase (string value)
 		{
 		}
@@ -530,7 +636,15 @@ namespace Java.InteropTests
 		{
 		}
 
+		public ConstructorActivationBase (string text, int number)
+		{
+		}
+
 		public ConstructorActivationBase (int[] value)
+		{
+		}
+
+		public ConstructorActivationBase (string label, int[] value)
 		{
 		}
 
@@ -591,10 +705,17 @@ namespace Java.InteropTests
 		public long LongValue;
 		public float FloatValue;
 		public double DoubleValue;
+		public int MultiIntValue;
+		public bool MultiBooleanValue;
+		public long MultiLongValue;
 		public string StringValue;
 		public string FirstStringValue;
 		public string SecondStringValue;
+		public string StringIntStringValue;
+		public int StringIntValue;
 		public int[] IntArrayValue;
+		public string StringArrayLabel;
+		public int[] StringArrayValues;
 		public bool[] BooleanArrayValue;
 		public byte[] ByteArrayValue;
 		public string[] StringArrayValue;
@@ -665,6 +786,16 @@ namespace Java.InteropTests
 			DoubleValue = value;
 		}
 
+		[Register (".ctor", "(IZJ)V", "")]
+		public ConstructorActivationMarshalObject (int number, bool flag, long longValue)
+			: base (number, flag, longValue)
+		{
+			ConstructorInvocations++;
+			MultiIntValue = number;
+			MultiBooleanValue = flag;
+			MultiLongValue = longValue;
+		}
+
 		[Register (".ctor", "(Ljava/lang/String;)V", "")]
 		public ConstructorActivationMarshalObject (string value)
 			: base (value)
@@ -682,12 +813,30 @@ namespace Java.InteropTests
 			SecondStringValue = second;
 		}
 
+		[Register (".ctor", "(Ljava/lang/String;I)V", "")]
+		public ConstructorActivationMarshalObject (string text, int number)
+			: base (text, number)
+		{
+			ConstructorInvocations++;
+			StringIntStringValue = text;
+			StringIntValue = number;
+		}
+
 		[Register (".ctor", "([I)V", "")]
 		public ConstructorActivationMarshalObject (int[] value)
 			: base (value)
 		{
 			ConstructorInvocations++;
 			IntArrayValue = value;
+		}
+
+		[Register (".ctor", "(Ljava/lang/String;[I)V", "")]
+		public ConstructorActivationMarshalObject (string label, int[] value)
+			: base (label, value)
+		{
+			ConstructorInvocations++;
+			StringArrayLabel = label;
+			StringArrayValues = value;
 		}
 
 		[Register (".ctor", "([Z)V", "")]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ConstructorActivationTests.cs
@@ -1,0 +1,807 @@
+using System;
+
+using Android.App;
+using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+
+using Java.Interop;
+
+using NUnit.Framework;
+
+namespace Java.InteropTests
+{
+	[TestFixture]
+	public class ConstructorActivationTests
+	{
+		[Test]
+		public void JavaSideDefaultConstructorRunsOnceAndRegistersPeer ()
+		{
+			ConstructorActivationDefault.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationDefault> ("()V")) {
+				Assert.IsNotNull (instance);
+				Assert.AreEqual (1, ConstructorActivationDefault.ConstructorInvocations);
+				Assert.AreEqual (1, instance.ConstructorOrdinal);
+				AssertRegisteredSame (instance);
+			}
+		}
+
+		[Test]
+		public void ManagedConstructionDoesNotReenterThroughJavaConstructorActivation ()
+		{
+			ConstructorActivationDefault.Reset ();
+
+			using (var instance = new ConstructorActivationDefault ()) {
+				Assert.IsNotNull (instance);
+				Assert.AreEqual (1, ConstructorActivationDefault.ConstructorInvocations);
+				Assert.AreEqual (1, instance.ConstructorOrdinal);
+				AssertRegisteredSame (instance);
+			}
+		}
+
+		[Test]
+		public void CreateInstanceDoesNotActivateManagedConstructorInsideNewObjectScope ()
+		{
+			ConstructorActivationDefault.Reset ();
+
+			IntPtr handle = JNIEnv.CreateInstance (typeof (ConstructorActivationDefault), "()V");
+			try {
+				var peer = JniEnvironment.Runtime.ValueManager.PeekPeer (new JniObjectReference (handle));
+
+				Assert.AreEqual (0, ConstructorActivationDefault.ConstructorInvocations);
+				Assert.IsNull (peer);
+			} finally {
+				JNIEnv.DeleteLocalRef (handle);
+			}
+		}
+
+		[Test]
+		public void JavaSideConstructorReinvokesExistingActivatablePeer ()
+		{
+			ConstructorActivationDefault.Reset ();
+
+			using (var instance = new ConstructorActivationDefault ()) {
+				var peer = (IJavaPeerable) instance;
+				peer.SetJniManagedPeerState (instance.JniManagedPeerState | JniManagedPeerStates.Activatable | JniManagedPeerStates.Replaceable);
+
+				JNIEnv.FinishCreateInstance (instance.Handle, "()V");
+
+				Assert.AreEqual (2, ConstructorActivationDefault.ConstructorInvocations);
+				Assert.AreEqual (2, instance.ConstructorOrdinal);
+				AssertRegisteredSame (instance);
+			}
+		}
+
+		[Test]
+		public void JavaSideContextConstructorForwardsArgument ()
+		{
+			ConstructorActivationContextView.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationContextView> (
+					"(Landroid/content/Context;)V",
+					new JValue (Application.Context))) {
+				Assert.AreEqual (1, ConstructorActivationContextView.ConstructorInvocations);
+				Assert.IsNotNull (instance.ContextValue);
+				Assert.AreEqual (Application.Context.Handle, instance.ContextValue.Handle);
+			}
+		}
+
+		[Test]
+		public void JavaSideContextAttributeSetConstructorForwardsArguments ()
+		{
+			ConstructorActivationAttributeSetView.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationAttributeSetView> (
+					"(Landroid/content/Context;Landroid/util/AttributeSet;)V",
+					new JValue (Application.Context),
+					JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationAttributeSetView.ConstructorInvocations);
+				Assert.IsNotNull (instance.ContextValue);
+				Assert.AreEqual (Application.Context.Handle, instance.ContextValue.Handle);
+				Assert.IsNull (instance.AttributeSetValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideContextAttributeSetStyleConstructorForwardsArguments ()
+		{
+			ConstructorActivationStyledView.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationStyledView> (
+					"(Landroid/content/Context;Landroid/util/AttributeSet;I)V",
+					new JValue (Application.Context),
+					JValue.Zero,
+					new JValue (42))) {
+				Assert.AreEqual (1, ConstructorActivationStyledView.ConstructorInvocations);
+				Assert.IsNotNull (instance.ContextValue);
+				Assert.AreEqual (Application.Context.Handle, instance.ContextValue.Handle);
+				Assert.IsNull (instance.AttributeSetValue);
+				Assert.AreEqual (42, instance.DefStyleAttrValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideBooleanConstructorForwardsTrue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(Z)V", new JValue (true))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (true, instance.BooleanValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideBooleanConstructorForwardsFalse ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(Z)V", new JValue (false))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (false, instance.BooleanValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideByteConstructorForwardsSignedValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(B)V", new JValue ((sbyte) -12))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ((sbyte) -12, instance.ByteValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideCharConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(C)V", new JValue ('Q'))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ('Q', instance.CharValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideShortConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(S)V", new JValue ((short) -1234))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ((short) -1234, instance.ShortValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideIntConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(I)V", new JValue (0x1234567))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (0x1234567, instance.IntValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideLongConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(J)V", new JValue (0x123456789L))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (0x123456789L, instance.LongValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideFloatConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(F)V", new JValue (12.5f))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (12.5f, instance.FloatValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideDoubleConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(D)V", new JValue (-42.25))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (-42.25, instance.DoubleValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringConstructorForwardsValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var value = new Java.Lang.String ("hello constructor"))
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(Ljava/lang/String;)V", new JValue (value))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ("hello constructor", instance.StringValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringConstructorForwardsNull ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("(Ljava/lang/String;)V", JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNull (instance.StringValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideTwoStringConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var first = new Java.Lang.String ("first"))
+			using (var second = new Java.Lang.String ("second"))
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> (
+					"(Ljava/lang/String;Ljava/lang/String;)V",
+					new JValue (first),
+					new JValue (second))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ("first", instance.FirstStringValue);
+				Assert.AreEqual ("second", instance.SecondStringValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideTwoStringConstructorForwardsNullSecondValue ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var first = new Java.Lang.String ("first"))
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> (
+					"(Ljava/lang/String;Ljava/lang/String;)V",
+					new JValue (first),
+					JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual ("first", instance.FirstStringValue);
+				Assert.IsNull (instance.SecondStringValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideIntArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([I)V",
+					JNIEnv.NewArray (new [] { 1, 2, 3, 5 }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (new [] { 1, 2, 3, 5 }, instance.IntArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideIntArrayConstructorForwardsEmptyArray ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([I)V",
+					JNIEnv.NewArray (Array.Empty<int> ()))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNotNull (instance.IntArrayValue);
+				Assert.AreEqual (0, instance.IntArrayValue.Length);
+			}
+		}
+
+		[Test]
+		public void JavaSideIntArrayConstructorForwardsNull ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("([I)V", JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNull (instance.IntArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideBooleanArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([Z)V",
+					JNIEnv.NewArray (new [] { true, false, true }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (new [] { true, false, true }, instance.BooleanArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideByteArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([B)V",
+					JNIEnv.NewArray (new byte [] { 1, 127, 255 }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (new byte [] { 1, 127, 255 }, instance.ByteArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([Ljava/lang/String;)V",
+					JNIEnv.NewArray (new [] { "red", "green", "blue" }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (new [] { "red", "green", "blue" }, instance.StringArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringArrayConstructorForwardsNullElement ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([Ljava/lang/String;)V",
+					JNIEnv.NewArray (new [] { "red", null, "blue" }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.AreEqual (new [] { "red", null, "blue" }, instance.StringArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideStringArrayConstructorForwardsNull ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("([Ljava/lang/String;)V", JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNull (instance.StringArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideObjectArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var first = new Java.Lang.String ("object-array-value"))
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([Ljava/lang/Object;)V",
+					JNIEnv.NewArray (new Java.Lang.Object [] { first, Application.Context }))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNotNull (instance.ObjectArrayValue);
+				Assert.AreEqual (2, instance.ObjectArrayValue.Length);
+				Assert.AreEqual ("object-array-value", instance.ObjectArrayValue [0].ToString ());
+				Assert.AreEqual (Application.Context.Handle, instance.ObjectArrayValue [1].Handle);
+			}
+		}
+
+		[Test]
+		public void JavaSideObjectArrayConstructorForwardsNull ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJava<ConstructorActivationMarshalObject> ("([Ljava/lang/Object;)V", JValue.Zero)) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNull (instance.ObjectArrayValue);
+			}
+		}
+
+		[Test]
+		public void JavaSideNestedIntArrayConstructorForwardsValues ()
+		{
+			ConstructorActivationMarshalObject.Reset ();
+			AssumeTrimmableConstructorParameterMarshalling ();
+
+			using (var instance = CreateFromJavaWithLocalArray<ConstructorActivationMarshalObject> (
+					"([[I)V",
+					JNIEnv.NewArray<int[]> (new [] {
+						new [] { 1, 2 },
+						new [] { 3, 4, 5 },
+					}))) {
+				Assert.AreEqual (1, ConstructorActivationMarshalObject.ConstructorInvocations);
+				Assert.IsNotNull (instance.NestedIntArrayValue);
+				Assert.AreEqual (new [] { 1, 2 }, instance.NestedIntArrayValue [0]);
+				Assert.AreEqual (new [] { 3, 4, 5 }, instance.NestedIntArrayValue [1]);
+			}
+		}
+
+		static void AssumeTrimmableConstructorParameterMarshalling ()
+		{
+			if (!Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("Legacy TypeManager.n_Activate does not marshal string, short, or array constructor parameters; this case validates trimmable constructor UCO parameter marshalling.");
+			}
+		}
+
+		static T CreateFromJava<T> (string constructorSignature, params JValue [] arguments)
+			where T : Java.Lang.Object
+		{
+			var instance = JNIEnv.StartCreateInstance (typeof (T), constructorSignature, arguments);
+			JNIEnv.FinishCreateInstance (instance, constructorSignature, arguments);
+			var result = Java.Lang.Object.GetObject<T> (instance, JniHandleOwnership.TransferLocalRef);
+			Assert.IsNotNull (result);
+			return result;
+		}
+
+		static T CreateFromJavaWithLocalArray<T> (string constructorSignature, IntPtr array)
+			where T : Java.Lang.Object
+		{
+			try {
+				return CreateFromJava<T> (constructorSignature, new JValue (array));
+			} finally {
+				JNIEnv.DeleteLocalRef (array);
+			}
+		}
+
+		static void AssertRegisteredSame<T> (T instance)
+			where T : Java.Lang.Object
+		{
+			var registered = Java.Lang.Object.GetObject<T> (instance.Handle, JniHandleOwnership.DoNotTransfer);
+			try {
+				Assert.AreSame (instance, registered);
+				if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+					Assert.AreEqual (Java.Lang.JavaSystem.IdentityHashCode (instance), instance.JniIdentityHashCode);
+				}
+			} finally {
+				if (registered != null && !object.ReferenceEquals (instance, registered))
+					registered.Dispose ();
+			}
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationBase", DoNotGenerateAcw = true)]
+	public class ConstructorActivationBase : Java.Lang.Object
+	{
+		public ConstructorActivationBase ()
+		{
+		}
+
+		public ConstructorActivationBase (bool value)
+		{
+		}
+
+		public ConstructorActivationBase (sbyte value)
+		{
+		}
+
+		public ConstructorActivationBase (char value)
+		{
+		}
+
+		public ConstructorActivationBase (short value)
+		{
+		}
+
+		public ConstructorActivationBase (int value)
+		{
+		}
+
+		public ConstructorActivationBase (long value)
+		{
+		}
+
+		public ConstructorActivationBase (float value)
+		{
+		}
+
+		public ConstructorActivationBase (double value)
+		{
+		}
+
+		public ConstructorActivationBase (string value)
+		{
+		}
+
+		public ConstructorActivationBase (string first, string second)
+		{
+		}
+
+		public ConstructorActivationBase (int[] value)
+		{
+		}
+
+		public ConstructorActivationBase (bool[] value)
+		{
+		}
+
+		public ConstructorActivationBase (byte[] value)
+		{
+		}
+
+		public ConstructorActivationBase (string[] value)
+		{
+		}
+
+		public ConstructorActivationBase (Java.Lang.Object[] value)
+		{
+		}
+
+		public ConstructorActivationBase (int[][] value)
+		{
+		}
+
+		public ConstructorActivationBase (IntPtr handle, JniHandleOwnership transfer)
+			: base (handle, transfer)
+		{
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationDefault")]
+	public class ConstructorActivationDefault : Java.Lang.Object
+	{
+		public static int ConstructorInvocations;
+
+		public int ConstructorOrdinal;
+
+		public ConstructorActivationDefault ()
+		{
+			ConstructorOrdinal = ++ConstructorInvocations;
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationMarshalObject")]
+	public class ConstructorActivationMarshalObject : ConstructorActivationBase
+	{
+		public static int ConstructorInvocations;
+
+		public bool BooleanValue;
+		public sbyte ByteValue;
+		public char CharValue;
+		public short ShortValue;
+		public int IntValue;
+		public long LongValue;
+		public float FloatValue;
+		public double DoubleValue;
+		public string StringValue;
+		public string FirstStringValue;
+		public string SecondStringValue;
+		public int[] IntArrayValue;
+		public bool[] BooleanArrayValue;
+		public byte[] ByteArrayValue;
+		public string[] StringArrayValue;
+		public Java.Lang.Object[] ObjectArrayValue;
+		public int[][] NestedIntArrayValue;
+
+		[Register (".ctor", "(Z)V", "")]
+		public ConstructorActivationMarshalObject (bool value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			BooleanValue = value;
+		}
+
+		[Register (".ctor", "(B)V", "")]
+		public ConstructorActivationMarshalObject (sbyte value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			ByteValue = value;
+		}
+
+		[Register (".ctor", "(C)V", "")]
+		public ConstructorActivationMarshalObject (char value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			CharValue = value;
+		}
+
+		[Register (".ctor", "(S)V", "")]
+		public ConstructorActivationMarshalObject (short value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			ShortValue = value;
+		}
+
+		[Register (".ctor", "(I)V", "")]
+		public ConstructorActivationMarshalObject (int value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			IntValue = value;
+		}
+
+		[Register (".ctor", "(J)V", "")]
+		public ConstructorActivationMarshalObject (long value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			LongValue = value;
+		}
+
+		[Register (".ctor", "(F)V", "")]
+		public ConstructorActivationMarshalObject (float value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			FloatValue = value;
+		}
+
+		[Register (".ctor", "(D)V", "")]
+		public ConstructorActivationMarshalObject (double value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			DoubleValue = value;
+		}
+
+		[Register (".ctor", "(Ljava/lang/String;)V", "")]
+		public ConstructorActivationMarshalObject (string value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			StringValue = value;
+		}
+
+		[Register (".ctor", "(Ljava/lang/String;Ljava/lang/String;)V", "")]
+		public ConstructorActivationMarshalObject (string first, string second)
+			: base (first, second)
+		{
+			ConstructorInvocations++;
+			FirstStringValue = first;
+			SecondStringValue = second;
+		}
+
+		[Register (".ctor", "([I)V", "")]
+		public ConstructorActivationMarshalObject (int[] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			IntArrayValue = value;
+		}
+
+		[Register (".ctor", "([Z)V", "")]
+		public ConstructorActivationMarshalObject (bool[] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			BooleanArrayValue = value;
+		}
+
+		[Register (".ctor", "([B)V", "")]
+		public ConstructorActivationMarshalObject (byte[] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			ByteArrayValue = value;
+		}
+
+		[Register (".ctor", "([Ljava/lang/String;)V", "")]
+		public ConstructorActivationMarshalObject (string[] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			StringArrayValue = value;
+		}
+
+		[Register (".ctor", "([Ljava/lang/Object;)V", "")]
+		public ConstructorActivationMarshalObject (Java.Lang.Object[] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			ObjectArrayValue = value;
+		}
+
+		[Register (".ctor", "([[I)V", "")]
+		public ConstructorActivationMarshalObject (int[][] value)
+			: base (value)
+		{
+			ConstructorInvocations++;
+			NestedIntArrayValue = value;
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationContextView")]
+	public class ConstructorActivationContextView : View
+	{
+		public static int ConstructorInvocations;
+
+		public Context ContextValue;
+
+		[Register (".ctor", "(Landroid/content/Context;)V", "")]
+		public ConstructorActivationContextView (Context context)
+			: base (context)
+		{
+			ConstructorInvocations++;
+			ContextValue = context;
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationAttributeSetView")]
+	public class ConstructorActivationAttributeSetView : View
+	{
+		public static int ConstructorInvocations;
+
+		public Context ContextValue;
+		public IAttributeSet AttributeSetValue;
+
+		[Register (".ctor", "(Landroid/content/Context;Landroid/util/AttributeSet;)V", "")]
+		public ConstructorActivationAttributeSetView (Context context, IAttributeSet attrs)
+			: base (context, attrs)
+		{
+			ConstructorInvocations++;
+			ContextValue = context;
+			AttributeSetValue = attrs;
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/ConstructorActivationStyledView")]
+	public class ConstructorActivationStyledView : View
+	{
+		public static int ConstructorInvocations;
+
+		public Context ContextValue;
+		public IAttributeSet AttributeSetValue;
+		public int DefStyleAttrValue;
+
+		[Register (".ctor", "(Landroid/content/Context;Landroid/util/AttributeSet;I)V", "")]
+		public ConstructorActivationStyledView (Context context, IAttributeSet attrs, int defStyleAttr)
+			: base (context, attrs, defStyleAttr)
+		{
+			ConstructorInvocations++;
+			ContextValue = context;
+			AttributeSetValue = attrs;
+			DefStyleAttrValue = defStyleAttr;
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -301,14 +301,11 @@ namespace Java.InteropTests
 			}
 		}
 
-		// TODO: https://github.com/dotnet/android/issues/11170 — throwable subclass not registered under trimmable typemap
 		[Test]
 		public void ActivatedDirectThrowableSubclassesShouldBeRegistered ()
 		{
 			if (Build.VERSION.SdkInt <= BuildVersionCodes.GingerbreadMr1)
 				Assert.Ignore ("Skipping test due to Bug #34141");
-			
-			Console.Error.WriteLine ($"# jonp: BEGIN ActivatedDirectThrowableSubclassesShouldBeRegistered!!!");
 
 			using (var ThrowableActivatedFromJava_class  = Java.Lang.Class.FromType (typeof (ThrowableActivatedFromJava))) {
 				var ThrowableActivatedFromJava_init = JNIEnv.GetMethodID (ThrowableActivatedFromJava_class.Handle, "<init>", "()V");
@@ -324,7 +321,6 @@ namespace Java.InteropTests
 				Assert.IsTrue (v.Constructed);
 				v.Dispose ();
 			}
-			Console.Error.WriteLine ($"# jonp:   END ActivatedDirectThrowableSubclassesShouldBeRegistered!!!");
 		}
 
 		[Test]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Lang/ObjectTest.cs
@@ -19,7 +19,6 @@ namespace Java.LangTests
 	[TestFixture]
 	public class ObjectTest
 	{
-		// TODO: https://github.com/dotnet/android/issues/11170 — trimmable typemap doesn't resolve most-derived managed type
 		[Test]
 		public void GetObject_ReturnsMostDerivedType ()
 		{

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -102,6 +102,7 @@
     <Compile Include="Android.Views\LayoutInflaterTest.cs" />
     <Compile Include="Android.Widget\AdapterTests.cs" />
     <Compile Include="Android.Widget\CustomWidgetTests.cs" />
+    <Compile Include="Java.Interop\ConstructorActivationTests.cs" />
     <Compile Include="Java.Interop\JavaConvertTest.cs" />
     <Compile Include="Java.Interop\JavaListTest.cs" />
     <Compile Include="Java.Interop\JavaObjectExtensionsTests.cs" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -34,12 +34,6 @@ namespace Xamarin.Android.RuntimeTests
                     // net.dot.jni.test.CallVirtualFromConstructorDerived Java class not in APK
                     "Java.InteropTests.InvokeVirtualFromConstructorTests",
 
-                    // Throwable subclass registration
-                    "Java.InteropTests.JnienvTest.ActivatedDirectThrowableSubclassesShouldBeRegistered",
-
-                    // Instance identity after JNI round-trip
-                    "Java.LangTests.ObjectTest.JnienvCreateInstance_RegistersMultipleInstances",
-
                     // Global ref leak when inflating custom views
                     "Xamarin.Android.RuntimeTests.CustomWidgetTests.InflateCustomView_ShouldNotLeakGlobalRefs",
                 };

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/java/net/dot/android/test/ConstructorActivationBase.java
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/java/net/dot/android/test/ConstructorActivationBase.java
@@ -1,0 +1,21 @@
+package net.dot.android.test;
+
+public class ConstructorActivationBase {
+	public ConstructorActivationBase() {}
+	public ConstructorActivationBase(boolean value) {}
+	public ConstructorActivationBase(byte value) {}
+	public ConstructorActivationBase(char value) {}
+	public ConstructorActivationBase(short value) {}
+	public ConstructorActivationBase(int value) {}
+	public ConstructorActivationBase(long value) {}
+	public ConstructorActivationBase(float value) {}
+	public ConstructorActivationBase(double value) {}
+	public ConstructorActivationBase(String value) {}
+	public ConstructorActivationBase(String first, String second) {}
+	public ConstructorActivationBase(int[] value) {}
+	public ConstructorActivationBase(boolean[] value) {}
+	public ConstructorActivationBase(byte[] value) {}
+	public ConstructorActivationBase(String[] value) {}
+	public ConstructorActivationBase(Object[] value) {}
+	public ConstructorActivationBase(int[][] value) {}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/java/net/dot/android/test/ConstructorActivationBase.java
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/java/net/dot/android/test/ConstructorActivationBase.java
@@ -10,9 +10,12 @@ public class ConstructorActivationBase {
 	public ConstructorActivationBase(long value) {}
 	public ConstructorActivationBase(float value) {}
 	public ConstructorActivationBase(double value) {}
+	public ConstructorActivationBase(int number, boolean flag, long longValue) {}
 	public ConstructorActivationBase(String value) {}
 	public ConstructorActivationBase(String first, String second) {}
+	public ConstructorActivationBase(String text, int number) {}
 	public ConstructorActivationBase(int[] value) {}
+	public ConstructorActivationBase(String label, int[] value) {}
 	public ConstructorActivationBase(boolean[] value) {}
 	public ConstructorActivationBase(byte[] value) {}
 	public ConstructorActivationBase(String[] value) {}


### PR DESCRIPTION
## Summary
- fixes Java-side constructor activation for the trimmable typemap by emitting constructor UCO bodies that directly activate managed peers, set the JNI peer reference/identity hash, and mark temporary activation peers replaceable
- supports default, parameterized, existing-peer, invoker, and exception paths without a parameterless-constructor special case; constructor metadata now tracks whether each registered Java constructor has a matching managed constructor
- expands constructor parameter marshalling coverage for primitives, strings, Java objects, arrays, nested arrays, null values, and multi-argument constructors
- keeps legacy typemap behavior explicit in tests: cases that legacy `TypeManager.n_Activate` cannot marshal are ignored there, while trimmable typemap validates the new generated UCO path

## Contribution to the trimmable typemap epic
This PR closes the UCO constructor activation gap required for trimmable typemap parity. Generated native callbacks can now create or re-enter the correct managed peer for Java-initiated construction instead of falling back to unsupported reflection/native-member registration paths, moving the trimmable typemap closer to replacing the legacy runtime typemap for app/device execution.

## Validation
- `./dotnet-local.sh test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -v:minimal` — 465 passed
- `MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh msbuild tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -restore -t:RunTestApp -p:Configuration=Debug -p:_AndroidTypeMapImplementation=llvm-ir -p:UseMonoRuntime=true -p:TestFixture=Java.InteropTests.ConstructorActivationTests -nr:false -v:minimal` — constructor fixture passed; legacy-incompatible cases ignored by design
- `MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh msbuild tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -restore -t:RunTestApp -p:Configuration=Debug -p:_AndroidTypeMapImplementation=trimmable -p:UseMonoRuntime=false -p:TestFixture=Java.InteropTests.ConstructorActivationTests -nr:false -v:minimal` — all 35 constructor activation cases passed; command exits nonzero only because the target still runs unrelated tests and `JavaObjectTest.DisposeAccessesThis` currently fails in the trimmable path
- `make all CONFIGURATION=Release MSBUILD_ARGS="--no-restore -m:1"` after explicit restore — passed
- `MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -t:RunTestApp -c Release -p:_AndroidTypeMapImplementation=trimmable -p:UseMonoRuntime=false -p:TestFixture=Java.InteropTests.ConstructorActivationTests -nr:false -v:minimal` — all 35 constructor activation cases passed; same unrelated `JavaObjectTest.DisposeAccessesThis` trimmable failure remains outside this fixture

## Known follow-up
- dotnet/android#11019 tracks adding trimmable typemap coverage to `MSBuildDeviceIntegration` `DotNetRun`; this PR focuses on constructor activation and does not add that test-project matrix coverage.

## Related issues
- Fixes #11179
- Reference #10788
- Reference #11170
- Reference #11019
