### PR TITLE
[tests] Root StartupHook test assembly directly

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -76,8 +76,8 @@
   <ItemGroup>
     <TrimmerRootAssembly Include="Mono.Android.NET-Tests" RootMode="Visible" Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' " />
     <TrimmerRootAssembly Include="Java.Interop-Tests" RootMode="Visible" Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' " />
+    <TrimmerRootAssembly Include="StartupHook" RootMode="All" Condition=" '$(StartupHookSupport)' == 'true' " />
     <TrimmerRootDescriptor Include="TrimmerRoots.xml" Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' " />
-    <TrimmerRootDescriptor Include="StartupHookRoots.xml" Condition=" '$(StartupHookSupport)' == 'true' " />
     <_AndroidRemapMembers Include="Remaps.xml" />
     <_AndroidRemapMembers Include="IsAssignableFromRemaps.xml" Condition=" '$(_AndroidIsAssignableFromCheck)' == 'false' " />
     <ProguardConfiguration Include="proguard.cfg" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/StartupHookRoots.xml
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/StartupHookRoots.xml
@@ -1,5 +1,0 @@
-<linker>
-  <assembly fullname="StartupHook">
-    <type fullname="StartupHook" preserve="all" />
-  </assembly>
-</linker>


### PR DESCRIPTION
Stacked on #11252 via temporary base branch `pr-11252-startup-fixes-base`.

Follow-up to https://github.com/dotnet/android/pull/11252#discussion_r3181952148.

Replaces the dedicated `StartupHookRoots.xml` descriptor with a conditional `TrimmerRootAssembly` item for `StartupHook`. Once #11252 lands, this PR should be retargeted to `main` and should still contain only the StartupHook root simplification.

Validation:

```bash
MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -c Release -p:_AndroidTypeMapImplementation=trimmable -p:UseMonoRuntime=false -nr:false
```
