### PR TITLE
Fix NonShipping casing for Xamarin.Android.Tools.AndroidSdk package

### DIFF
--- a/build-tools/create-packs/Directory.Build.targets
+++ b/build-tools/create-packs/Directory.Build.targets
@@ -167,7 +167,7 @@
 
     <ItemGroup>
       <ItemsToPush Include="$(OutputPath)*.nupkg" Kind="Package" Exclude="$(OutputPath)Xamarin.Android.Tools.AndroidSdk.*.nupkg" />
-      <ItemsToPush Include="$(OutputPath)Xamarin.Android.Tools.AndroidSdk.*.nupkg" Kind="Package" IsShipping="false" ManifestArtifactData="Nonshipping=true" />
+      <ItemsToPush Include="$(OutputPath)Xamarin.Android.Tools.AndroidSdk.*.nupkg" Kind="Package" ManifestArtifactData="NonShipping=true" />
       <WorkloadArtifacts Include="$(OutputPath)*.zip" />
       <ItemsToPush Include="@(WorkloadArtifacts)" PublishFlatContainer="true" RelativeBlobPath="android/$(AndroidPackVersionLong)/%(Filename)%(Extension)" Kind="Blob" />
     </ItemGroup>


### PR DESCRIPTION
## Description

`darc gather-drop` was downloading the `Xamarin.Android.Tools.AndroidSdk` package as if it were a "shipping" package, even though it was intended to be non-shipping.

The root cause is a casing mismatch in `ManifestArtifactData`. We had `Nonshipping=true` (lowercase 's'), but Arcade's [`ArtifactModel.NonShipping`](https://github.com/dotnet/arcade/blob/9755ced952a046def3fc22cf2e12583d388ece32/src/Microsoft.DotNet.Build.Manifest/ArtifactModel.cs#L37) property looks up the key using `nameof(NonShipping)` (capital 'S'). During the build, this worked because [`MSBuildListSplitter.GetNamedProperties()`](https://github.com/dotnet/arcade/blob/9755ced952a046def3fc22cf2e12583d388ece32/src/Microsoft.DotNet.Build.Manifest/MSBuildListSplitter.cs#L14) creates a **case-insensitive** dictionary. However, when the manifest XML is later parsed back (by `PublishBuildAssets` to register in BAR, or by `darc gather-drop`), [`CreateAttributeDictionary()`](https://github.com/dotnet/arcade/blob/9755ced952a046def3fc22cf2e12583d388ece32/src/Microsoft.DotNet.Build.Manifest/XElementParsingExtensions.cs#L23) creates a **case-sensitive** dictionary, so the lookup for `"NonShipping"` fails to find `"Nonshipping"` and defaults to `false` (i.e., shipping).

## Changes

- Fixed casing: `Nonshipping=true` -> `NonShipping=true`
- Removed the unused `IsShipping="false"` metadata, which is not read by Arcade's `PackageArtifactModelFactory`

## Checklist

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests: N/A -- build infrastructure metadata fix
