### PR TITLE
Attempt to fix `dotnet restore` hang during prepare step

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -76,3 +76,5 @@ variables:
   value: true
 - name: DOTNET_CLI_TELEMETRY_OPTOUT
   value: true
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -55,9 +55,9 @@ namespace Xamarin.Android.Prepare
 			for (int attempt = 1; attempt <= maxAttempts; attempt++) {
 				var logPath = $"{logPathBase}-attempt{attempt}.binlog";
 				var runner = new ProcessRunner (Configurables.Paths.DotNetPreviewTool, "restore",
-					ProcessRunner.QuoteArgument (packageDownloadProj),
+					packageDownloadProj,
 					"--configfile", Path.Combine (BuildPaths.XamarinAndroidSourceRoot, "NuGet.config"),
-					ProcessRunner.QuoteArgument ($"-bl:{logPath}"),
+					$"-bl:{logPath}",
 					"--verbosity", "normal"
 				) {
 					EchoStandardOutput = true,


### PR DESCRIPTION
[Build 14008410](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14008410) failed during the prepare phase because `dotnet restore` of `package-download.proj` timed out after 10 minutes on all 3 attempts, with **zero stdout output** — indicating the process was hanging, not just slow.

While investigating, we found two things that look wrong and might help:

1. **Double-quoting of arguments**: `ProcessRunner.QuoteArgument()` was called before passing args to the `ProcessRunner` constructor, but the constructor already quotes all arguments via `AddQuotedArgument()`. This caused paths to be double-quoted (e.g. `"\"/path/to/file\""`).

2. **Missing `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true`** in the shared pipeline variables — the first-run experience was triggering on CI (we saw the "Welcome to .NET 11.0!" banner on stderr right before the hang).
