### PR TITLE
[NativeAOT] Fix incremental build test with trimmable type map

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -37,12 +37,6 @@ namespace Xamarin.Android.Build.Tests {
 				return;
 			}
 
-			// NativeAOT incremental builds re-run CoreCompile due to AssemblyModifierPipeline
-			// touching assembly timestamps in-place. See https://github.com/dotnet/android/issues/11265
-			if (runtime == AndroidRuntime.NativeAOT) {
-				Assert.Ignore ("NativeAOT incremental builds affected by timestamp issue.");
-			}
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -57,12 +57,12 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
-		public void Build_WithTrimmableTypeMap_DoesNotHitCopyIfChangedMismatch ()
+		public void Build_WithTrimmableTypeMap_DoesNotHitCopyIfChangedMismatch ([Values (AndroidRuntime.CoreCLR, AndroidRuntime.NativeAOT)] AndroidRuntime runtime)
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};
-			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetRuntime (runtime);
 			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
 
 			using var builder = CreateApkBuilder ();

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1464,7 +1464,7 @@ because xbuild doesn't support framework reference assemblies.
 <!-- Runs additional steps after ILLink runs (_LinkAssemblies) -->
 <Target Name="_AfterILLinkAdditionalSteps"
     DependsOnTargets="_LinkAssembliesNoShrinkInputs"
-    Condition="'$(PublishTrimmed)' == 'true'"
+    Condition="'$(PublishTrimmed)' == 'true' and '$(_AndroidTypeMapImplementation)' != 'trimmable'"
     Inputs="$(_AndroidLinkFlag)"
     Outputs="$(_AdditionalPostLinkerStepsFlag)">
   <AssemblyModifierPipeline


### PR DESCRIPTION
Avoid running `_AfterILLinkAdditionalSteps` which as I understand should not be needed when using the trimmable type map. Fixes an incremental build issue with NativeAOT where this target was updating the timestamp of a shared designer assembly that is input into CoreCompile, causing CoreCompile to rerun on every incremental build.

## Related issues
- Reference #10788
- Reference #11020
- Reference #11265
