### PR TITLE
[tests] Mark ProxyTest as Inconclusive on network failure

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.Net/ProxyTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.Net/ProxyTest.cs
@@ -13,20 +13,27 @@ namespace System.NetTests {
 		[Test]
 		public void QuoteInvalidQuoteUrlsShouldWork ()
 		{
-			string url      = "http://www.msftconnecttest.com/connecttest.txt?query&foo|bar";
-			var request     = (HttpWebRequest) WebRequest.Create (url);
-			request.Method  = "GET";
-			var response    = (HttpWebResponse) request.GetResponse ();
-			int len = 0;
-			using (var _r = new StreamReader (response.GetResponseStream ())) {
-				char[] buf = new char [4096];
-				int n;
-				while ((n = _r.Read (buf, 0, buf.Length)) > 0) {
-					/* ignore; we just want to make sure we can read */
-					len += n;
+			try {
+				string url      = "http://www.msftconnecttest.com/connecttest.txt?query&foo|bar";
+				var request     = (HttpWebRequest) WebRequest.Create (url);
+				request.Method  = "GET";
+				var response    = (HttpWebResponse) request.GetResponse ();
+				int len = 0;
+				using (var _r = new StreamReader (response.GetResponseStream ())) {
+					char[] buf = new char [4096];
+					int n;
+					while ((n = _r.Read (buf, 0, buf.Length)) > 0) {
+						/* ignore; we just want to make sure we can read */
+						len += n;
+					}
 				}
+				Assert.IsTrue (len > 0);
+			} catch (WebException ex) when (
+				ex.Status == WebExceptionStatus.ConnectFailure ||
+				ex.Status == WebExceptionStatus.NameResolutionFailure ||
+				ex.Status == WebExceptionStatus.Timeout) {
+				Assert.Inconclusive ($"Network failure: {ex.Message}");
 			}
-			Assert.IsTrue (len > 0);
 		}
 	}
 }

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/System.Net/ProxyTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/System.Net/ProxyTest.cs
@@ -32,7 +32,7 @@ namespace System.NetTests {
 				ex.Status == WebExceptionStatus.ConnectFailure ||
 				ex.Status == WebExceptionStatus.NameResolutionFailure ||
 				ex.Status == WebExceptionStatus.Timeout) {
-				Assert.Inconclusive ($"Network failure: {ex.Message}");
+				Assert.Ignore ($"Ignoring network failure: {ex.Message}");
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Mark `ProxyTest.QuoteInvalidQuoteUrlsShouldWork` as `Assert.Inconclusive()` on network failure instead of failing the test. This matches the existing pattern used in `SslTest` and other network-dependent tests.

## Problem

The test fails when DNS resolution is unavailable on the test machine:

```
System.Net.WebException : hostname nor servname provided, or not known (www.msftconnecttest.com:80)
----> System.Net.Http.HttpRequestException : hostname nor servname provided, or not known (www.msftconnecttest.com:80)
----> System.Net.Sockets.SocketException : hostname nor servname provided, or not known

 at System.Net.HttpWebRequest.GetResponse()
 at System.NetTests.ProxyTest.QuoteInvalidQuoteUrlsShouldWork()
 at System.Reflection.DynamicInvokeInfo.Invoke(Object, IntPtr, Object[], BinderBundle, Boolean)
--HttpRequestException
 at System.Net.Http.HttpConnectionPool.<ConnectToTcpHostAsync>d__54.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.HttpConnectionPool.<ConnectAsync>d__53.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.HttpConnectionPool.<CreateHttp11ConnectionAsync>d__82.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.HttpConnectionPool.<InjectNewHttp11ConnectionAsync>d__81.MoveNext()
--- End of stack trace from previous location ---
 at System.Threading.Tasks.TaskCompletionSourceWithCancellation`1.WaitWithCancellation(CancellationToken)
 at System.Net.Http.HttpConnectionPool.<SendWithVersionDetectionAndRetryAsync>d__52.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.RedirectHandler.<SendAsync>d__4.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.HttpMessageHandlerStage.Send(HttpRequestMessage, CancellationToken)
 at System.Net.Http.SocketsHttpHandler.Send(HttpRequestMessage, CancellationToken)
 at System.Net.Http.HttpClient.Send(HttpRequestMessage, HttpCompletionOption, CancellationToken)
 at System.Net.HttpWebRequest.SendRequest(Boolean, HttpContent)
 at System.Net.HttpWebRequest.<HandleResponse>d__201.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.HttpWebRequest.GetResponse()
--SocketException
 at System.Net.Dns.GetHostEntryOrAddressesCore(String, Boolean, AddressFamily, Nullable`1)
 at System.Net.Dns.GetHostAddresses(String, AddressFamily)
 at System.Net.HttpWebRequest.<>c__DisplayClass224_0.<<CreateHttpClient>b__1>d.MoveNext()
--- End of stack trace from previous location ---
 at System.Net.Http.HttpConnectionPool.<ConnectToTcpHostAsync>d__54.MoveNext()
```

## Fix

Wrap the test body in a `try/catch` that catches `WebException` with `ConnectFailure`, `NameResolutionFailure`, or `Timeout` status and calls `Assert.Inconclusive()`.