### PR TITLE
[ci] Apply MAUI Android 37 patch

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -164,6 +164,13 @@ extends:
             -androidVersion $(ANDROID_PACK_VERSION)
           displayName: Update MAUI's Android dependency
 
+        - task: CopyFiles@2
+          displayName: Override MAUI Android target framework version
+          inputs:
+            SourceFolder: $(Build.SourcesDirectory)/android/build-tools/automation/maui
+            Contents: Directory.Build.Override.props
+            TargetFolder: $(Build.SourcesDirectory)/maui
+
         - task: DotNetCoreCLI@2
           displayName: Update Android SDK band in Workloads.csproj
           inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -164,12 +164,10 @@ extends:
             -androidVersion $(ANDROID_PACK_VERSION)
           displayName: Update MAUI's Android dependency
 
-        - task: CopyFiles@2
-          displayName: Override MAUI Android target framework version
-          inputs:
-            SourceFolder: $(Build.SourcesDirectory)/android/build-tools/automation/maui
-            Contents: Directory.Build.Override.props
-            TargetFolder: $(Build.SourcesDirectory)/maui
+        - script: >-
+            git -C "$(Build.SourcesDirectory)/maui"
+            apply "$(Build.SourcesDirectory)/android/build-tools/automation/maui/android37-target-framework.diff"
+          displayName: Update MAUI Android target framework version
 
         - task: DotNetCoreCLI@2
           displayName: Update Android SDK band in Workloads.csproj

--- a/build-tools/automation/maui/Directory.Build.Override.props
+++ b/build-tools/automation/maui/Directory.Build.Override.props
@@ -1,6 +1,0 @@
-<Project>
-  <PropertyGroup>
-    <AndroidTargetFrameworkVersionSdkDefault>37.0</AndroidTargetFrameworkVersionSdkDefault>
-    <AndroidTargetFrameworkVersion>37.0</AndroidTargetFrameworkVersion>
-  </PropertyGroup>
-</Project>

--- a/build-tools/automation/maui/Directory.Build.Override.props
+++ b/build-tools/automation/maui/Directory.Build.Override.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <AndroidTargetFrameworkVersionSdkDefault>37.0</AndroidTargetFrameworkVersionSdkDefault>
+    <AndroidTargetFrameworkVersion>37.0</AndroidTargetFrameworkVersion>
+  </PropertyGroup>
+</Project>

--- a/build-tools/automation/maui/android37-target-framework.diff
+++ b/build-tools/automation/maui/android37-target-framework.diff
@@ -1,0 +1,35 @@
+diff --git a/Directory.Build.props b/Directory.Build.props
+index 35fb59d68a..338a393eb6 100644
+--- a/Directory.Build.props
++++ b/Directory.Build.props
+@@ -162,13 +162,13 @@
+     <TvosTargetFrameworkVersionSdkDefault>26.2</TvosTargetFrameworkVersionSdkDefault>
+     <MacCatalystTargetFrameworkVersionSdkDefault>26.2</MacCatalystTargetFrameworkVersionSdkDefault>
+     <MacosTargetFrameworkVersionSdkDefault>26.2</MacosTargetFrameworkVersionSdkDefault>
+-    <AndroidTargetFrameworkVersionSdkDefault>36.1</AndroidTargetFrameworkVersionSdkDefault>
++    <AndroidTargetFrameworkVersionSdkDefault>37.0</AndroidTargetFrameworkVersionSdkDefault>
+     <!-- Current .NET -->
+     <IosTargetFrameworkVersion>26.2</IosTargetFrameworkVersion>
+     <TvosTargetFrameworkVersion>26.2</TvosTargetFrameworkVersion>
+     <MacCatalystTargetFrameworkVersion>26.2</MacCatalystTargetFrameworkVersion>
+     <MacosTargetFrameworkVersion>26.2</MacosTargetFrameworkVersion>
+-    <AndroidTargetFrameworkVersion>36.1</AndroidTargetFrameworkVersion>
++    <AndroidTargetFrameworkVersion>37.0</AndroidTargetFrameworkVersion>
+     <WindowsTargetFrameworkVersion>10.0.19041.0</WindowsTargetFrameworkVersion>
+     <Windows2TargetFrameworkVersion>10.0.20348.0</Windows2TargetFrameworkVersion>
+     <TizenTargetFrameworkVersion>7.0</TizenTargetFrameworkVersion>
+diff --git a/eng/Versions.props b/eng/Versions.props
+index b8590e25520..057bb5018a 100644
+--- a/eng/Versions.props
++++ b/eng/Versions.props
+@@ -205,8 +205,8 @@
+     <AndroidSdkApiLevels Include="34" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+     <AndroidSdkApiLevels Include="35" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+     <AndroidSdkApiLevels Include="36" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
+-    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+-    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
++    <AndroidSdkApiLevels Include="36.1" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" />
++    <AndroidSdkApiLevels Include="37" SystemImageType="google_apis_playstore" DeviceType="$(AndroidSdkAvdDeviceType)" IsDefault="True" />
+   </ItemGroup>
+   <PropertyGroup>
+     <!-- arcade -->


### PR DESCRIPTION
## Description

Temporarily unblock the MAUI integration leg after dotnet/android#11254 made Android 37 the only .NET 11 Android target.

MAUI's `net11.0` branch currently still generates `net11.0-android36.1`, which fails during `Pack .NET Maui` when the tested Android packs only advertise `37.0` as a valid target platform version.

This applies a checked-in patch to the MAUI checkout before packing so MAUI computes `net11.0-android37.0`. The first version of this workaround copied `Directory.Build.Override.props`, but MAUI's Cake startup code deletes that file when no platform switch is passed, so the override was gone before `dotnet-pack` evaluated `MauiPlatforms`.

This is intended as a temporary workaround until dotnet/maui consumes the real fix: https://github.com/dotnet/maui/pull/35337.

## Validation

- Parsed `build-tools/automation/azure-pipelines.yaml` as YAML.
- Applied `build-tools/automation/maui/android37-target-framework.diff` to a clean MAUI `net11.0` checkout.
- Evaluated MAUI `MauiPlatforms` after applying the patch and confirmed it contains `net11.0-android37.0` and not `net11.0-android36.1`.
