### PR TITLE
[tests] Add TRX report support for dotnet test

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -75,8 +75,6 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.pdb" TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.runtimeconfig.json" TargetPath="tools" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Platform.dll" TargetPath="tools" />
-      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.dll" TargetPath="tools" />
-      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.Abstractions.dll" TargetPath="tools" />
       <FilesToPackage Include="@(VersionFiles)" TargetPath="tools" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" TargetPath="Sdk" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" TargetPath="PreserveLists" />

--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -75,6 +75,8 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.pdb" TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.runtimeconfig.json" TargetPath="tools" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Platform.dll" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.dll" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.Abstractions.dll" TargetPath="tools" />
       <FilesToPackage Include="@(VersionFiles)" TargetPath="tools" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" TargetPath="Sdk" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" TargetPath="PreserveLists" />

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2273,10 +2273,12 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				Assert.IsTrue (dotnet.Build (target: "Install", parameters: buildParameters.ToArray ()), "`dotnet build -t:Install` should succeed");
 
 			// Run based on mode
-			var runParameters = buildParameters.Select (p => $"/p:{p}").ToArray ();
+			var runParameters = buildParameters.Select (p => $"/p:{p}").ToList ();
+			if (mode == "test")
+				runParameters.Add ("--report-trx");
 			using var process = mode == "run"
-				? dotnet.StartRun (waitForExit: true, parameters: runParameters)
-				: dotnet.StartTest (parameters: runParameters);
+				? dotnet.StartRun (waitForExit: true, parameters: runParameters.ToArray ())
+				: dotnet.StartTest (parameters: runParameters.ToArray ());
 
 			var locker = new Lock ();
 			var output = new StringBuilder ();
@@ -2329,6 +2331,15 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				StringAssert.Contains ("succeeded: 1", outputText, $"Output should report 1 passed test. See {logPath} for details.");
 				StringAssert.Contains ("failed: 1", outputText, $"Output should report 1 failed test. See {logPath} for details.");
 				StringAssert.Contains ("skipped: 1", outputText, $"Output should report 1 skipped test. See {logPath} for details.");
+
+				// Verify TRX report was generated via --report-trx
+				var testResultsDir = Path.Combine (projectDirectory, "TestResults");
+				Assert.IsTrue (Directory.Exists (testResultsDir), $"TestResults directory should exist at {testResultsDir}");
+				var trxFiles = Directory.GetFiles (testResultsDir, "*.trx", SearchOption.AllDirectories);
+				Assert.IsTrue (trxFiles.Length > 0, $"At least one .trx file should exist in {testResultsDir}");
+				var trxContent = File.ReadAllText (trxFiles [0]);
+				TestContext.AddTestAttachment (trxFiles [0]);
+				StringAssert.Contains ("UnitTestResult", trxContent, $"TRX file should contain test results. See {trxFiles [0]}");
 			}
 		}
 


### PR DESCRIPTION
Add `--report-trx` to the `dotnet test` invocation in `DotNetNewAndroidTest` and assert the TRX file is generated with test results.

Include `Microsoft.Testing.Extensions.TrxReport` DLLs in the SDK package so the TRX report provider is available at runtime by adding them to `FilesToPackage` in `Microsoft.Android.Sdk.proj`.

Changes:
- **`InstallAndRunTests.cs`**: pass `--report-trx` to `dotnet test`, assert `TestResults/*.trx` exists and contains `UnitTestResult` elements
- **`Microsoft.Android.Sdk.proj`**: add `TrxReport.dll` and `TrxReport.Abstractions.dll` to `FilesToPackage`