### PR TITLE
Fix dotnet restore hang in Step_InstallDotNetPreview

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -76,5 +76,7 @@ variables:
   value: true
 - name: DOTNET_CLI_TELEMETRY_OPTOUT
   value: true
-- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+- name: DOTNET_NOLOGO
   value: true
+- name: DOTNET_GENERATE_ASPNET_CERTIFICATE
+  value: false

--- a/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
+++ b/build-tools/xaprepare/xaprepare/Application/ProcessRunner.cs
@@ -290,7 +290,7 @@ namespace Xamarin.Android.Prepare
 			if (!exited) {
 				Log.ErrorLine ($"Process '{FullCommandLine}' timed out after {ProcessTimeout}");
 				ErrorReason = ErrorReasonCode.ExecutionTimedOut;
-				process.Kill ();
+				process.Kill (entireProcessTree: true);
 			}
 
 			// See: https://docs.microsoft.com/en-us/dotnet/api/system.diagnostics.process.waitforexit?view=netframework-4.7.2#System_Diagnostics_Process_WaitForExit)

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Android.Prepare
 				) {
 					EchoStandardOutput = true,
 					EchoStandardError = true,
+					ProcessTimeout = TimeSpan.FromMinutes (30),
 				};
 				if (runner.Run ()) {
 					restoreSucceeded = true;

--- a/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_InstallDotNetPreview.cs
@@ -62,7 +62,6 @@ namespace Xamarin.Android.Prepare
 				) {
 					EchoStandardOutput = true,
 					EchoStandardError = true,
-					ProcessTimeout = TimeSpan.FromMinutes (30),
 				};
 				if (runner.Run ()) {
 					restoreSucceeded = true;


### PR DESCRIPTION
## Summary

Follow-up to #11282. The `dotnet restore` of `package-download.proj` is still intermittently hanging on macOS CI machines with zero stdout output, causing all 3 retry attempts to time out after 10 minutes each.

Example failure from [build 14049272](https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build/results?buildId=14049272):

```
stderr | Welcome to .NET 11.0!
stderr | SDK Version: 11.0.100-preview.5.26251.112
Error: Process 'dotnet restore package-download.proj ...' timed out after 00:10:00
```

## Root Cause

Two issues identified:

1. **`process.Kill()` doesn't kill child processes.** When the restore times out, only the top-level `dotnet` process is killed — MSBuild worker nodes survive and can hold file locks that block subsequent retry attempts.

2. **`DOTNET_SKIP_FIRST_TIME_EXPERIENCE` is ignored since .NET 5.** The variable doesn't exist in dotnet/sdk source at all. The first-run experience still runs on fresh SDK installations, including ASP.NET cert generation (macOS keychain ops) which can hang on CI agents.

## Fix

1. Use `process.Kill(entireProcessTree: true)` in `ProcessRunner` to kill the full process tree on timeout.
2. Replace `DOTNET_SKIP_FIRST_TIME_EXPERIENCE` with:
   - `DOTNET_NOLOGO=true` — suppresses the first-run banner
   - `DOTNET_GENERATE_ASPNET_CERTIFICATE=false` — skips ASP.NET HTTPS cert generation (not needed on CI, and involves macOS keychain operations that can hang)
