### PR TITLE
[tests] Reduce ApplicationRunsWithDebuggerAndBreaks flakiness

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -470,6 +470,19 @@ namespace ${ROOT_NAMESPACE} {
 				return;
 			}
 
+			// Fast Deployment (EmbedAssembliesIntoApk=False) is not supported when targeting a
+			// secondary Android user: `pm install --user N` does not create the per-user data
+			// directory until the app is first launched, so the `run-as` queries performed by
+			// the FastDeploy task fail with XA0137 (see
+			// https://github.com/dotnet/android/issues/7821). The recommended workaround
+			// documented for XA0137 is to set EmbedAssembliesIntoApk=True, which is exactly
+			// what the (embedAssemblies=True, username=guest) parametrizations of this test
+			// already exercise. Skip the unsupported combination explicitly rather than
+			// letting it flake CI.
+			if (!embedAssemblies && !string.IsNullOrEmpty (username)) {
+				Assert.Ignore ("Fast Deployment is not supported on secondary Android users; see https://github.com/dotnet/android/issues/7821.");
+			}
+
 			AssertCommercialBuild ();
 			SwitchUser ();
 			WaitFor (5000);
@@ -644,6 +657,10 @@ namespace ${ROOT_NAMESPACE} {
 					ClearAdbLogcat ();
 					ClearBlockingDialogs ();
 					Assert.True (ClickButton (app.PackageName, "myXFButton", "CLICK ME"), "Button should have been clicked!");
+					// Reset the timeout budget for the post-click wait — the previous loop
+					// decremented `timeout`, leaving little or no time for the button-click
+					// breakpoint on slow machines.
+					timeout = TimeSpan.FromSeconds (60);
 					while (session.IsConnected && breakcountHitCount < 1 && timeout >= TimeSpan.Zero) {
 						Thread.Sleep (10);
 						timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));


### PR DESCRIPTION
Investigation of the recurring `ApplicationRunsWithDebuggerAndBreaks` CI failures (see #11322, follow-up to #11320 / #11203) identified two test-side issues, on top of the underlying product limitation tracked by #7821.

## 1. Fast Deployment + secondary Android user (XA0137)

Every red-CI hit on this test in the last 14 days was an `embedAssemblies=False` parametrization, and the build logs all show the same failure:

```
error XA0137: The 'run-as' command failed with 'run-as: couldn't stat
    /data/user/11/com.xamarin.applicationrunswithdebuggerandbreaks: No such file or directory'
... Fast Deployment is not currently supported on this device.
```

Root cause: `pm install --user N <apk>` does **not** create `/data/user/N/<pkg>` until the app is first launched, so the `run-as` queries performed by the `FastDeploy` task fail. There is no clean way to fix this from the test side; the documented workaround for XA0137 is to set `EmbedAssembliesIntoApk=True`, which is exactly what the `(embedAssemblies=True, username="guest1", ...)` parametrizations of this test already exercise.

Skip the unsupported `(embedAssemblies=False, username!=null)` combinations up front with `Assert.Ignore` and a link to #7821, rather than letting them flake CI on a known-unsupported product combination.

## 2. Shared `timeout` between two consecutive wait loops

```csharp
TimeSpan timeout = TimeSpan.FromSeconds (60);
// ... wait-for-3-breakpoints loop decrements `timeout` ...
while (session.IsConnected && breakcountHitCount < 1 && timeout >= TimeSpan.Zero) {
    // wait for the post-button-click breakpoint, with whatever's left of `timeout`
}
```

The second loop reuses whatever time is left after the first finishes. On a slow shard the first loop can consume most or all of the 60 seconds, leaving the second loop with near-zero budget and producing a misleading `Should have hit 1 breakpoints. Only hit 0` failure.

Reset `timeout` to 60 seconds before the second loop so each phase has a full budget.

## Why this is a test-side fix only

The underlying product limitation (Fast Deployment + secondary user) is tracked separately by #7821 and would need a product change (e.g. a brief `am start` before `run-as` queries, or detecting the missing data directory and creating it). That is out of scope for a flaky-test fix.

## Test impact

- `(embedAssemblies=True, ...)` parametrizations — unchanged, full coverage retained.
- `(embedAssemblies=False, username=null, ...)` parametrizations — unchanged, full coverage retained.
- `(embedAssemblies=False, username="guest1", ...)` parametrizations — now `Assert.Ignore`'d as a known-unsupported combination.

## Precedent

Follows the pattern used for other known environment-sensitive failures:
- #11249 — `Assert.Inconclusive` for `PerformanceTest` on slow CI machines.
- #11110 — `Assert.Inconclusive` for emulator-acquisition failures.
- #11202 — `[Ignore]` for `InflateCustomView_ShouldNotLeakGlobalRefs` until the underlying leak is fixed.

## Related issues

- #11322 — root-cause analysis for this test
- #11320 — broader flaky-test analysis (last 14 days)
- #11203 — prior flaky-test analysis
- #7821 — underlying "`run-as` command failed" product issue
