### PR TITLE
Bump to DevDiv/android-platform-support/main@120fcc4a

### DIFF
--- a/.external
+++ b/.external
@@ -1,1 +1,1 @@
-DevDiv/android-platform-support:main@21730a73e34c7dafbb2db46995e12a1dbc245805
+DevDiv/android-platform-support:main@120fcc4a8b3fc87ab29ca69dea7dec15f788c37e


### PR DESCRIPTION
Changes: https://devdiv.visualstudio.com/DevDiv/_git/android-platform-support/branchCompare?baseVersion=GC21730a73e34c7dafbb2db46995e12a1dbc245805&targetVersion=GC120fcc4a8b3fc87ab29ca69dea7dec15f788c37e

* Merged PR 737449: Update AndroidManifestFeed_d18.0.xml

* Merged PR 737433: Add --skip-jdk option and support in generator

* Merged PR 737398: Bump to dotnet/android-tools/main@482a9bbe

* Merged PR 737412: [FastDeploy] Start the target user before run-as queries (fixes XA0137 on secondary users)

* Merged PR 737401: Updated owners.txt

* Merged PR 735232: inventorySchemaUpdate-1.0.0

* Merged PR 706179: [Xamarin.Installer.Build.Tasks] allow `$(JavaSdkDirectory)` to be blank

* Merged PR 704100: [Debugging.Tasks] prevent `devices.cache` from growing on incremental builds