### PR TITLE
Skip ILC LinkNative target for NativeAOT, remove llvm-ar dependency

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -33,13 +33,5 @@ This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
   <Import Project="Microsoft.Android.Sdk.RuntimeConfig.targets" />
   <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
   <Import Project="Microsoft.Android.Sdk.HotReload.targets" Condition=" '$(AndroidApplication)' == 'true' " />
-
-  <!--
-    Override ILC's LinkNative with a no-op.  With NativeLib=static, LinkNative only runs
-    llvm-ar to create a .a archive from the ILC-compiled .o file.  We never consume that
-    .a — _AndroidLinkNativeAotSharedLibrary links the .o directly into a .so.  This must
-    be defined here (in After.targets) because the ILC NuGet package targets are imported
-    after the workload SDK targets, and the last target definition wins in MSBuild.
-  -->
-  <Target Name="LinkNative" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
+  <Import Project="Microsoft.Android.Sdk.NativeAOT.After.targets" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.After.targets
@@ -33,4 +33,13 @@ This file is imported *after* the Microsoft.NET.Sdk/Sdk.targets.
   <Import Project="Microsoft.Android.Sdk.RuntimeConfig.targets" />
   <Import Project="Microsoft.Android.Sdk.Tooling.targets" />
   <Import Project="Microsoft.Android.Sdk.HotReload.targets" Condition=" '$(AndroidApplication)' == 'true' " />
+
+  <!--
+    Override ILC's LinkNative with a no-op.  With NativeLib=static, LinkNative only runs
+    llvm-ar to create a .a archive from the ILC-compiled .o file.  We never consume that
+    .a — _AndroidLinkNativeAotSharedLibrary links the .o directly into a .so.  This must
+    be defined here (in After.targets) because the ILC NuGet package targets are imported
+    after the workload SDK targets, and the last target definition wins in MSBuild.
+  -->
+  <Target Name="LinkNative" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.After.targets
@@ -10,12 +10,15 @@ Imported from Microsoft.Android.Sdk.After.targets.
 <Project>
 
   <!--
-    Override ILC's LinkNative with a no-op.  With NativeLib=static, LinkNative only runs
-    llvm-ar to create a .a archive from the ILC-compiled .o file.  We never consume that
-    .a — _AndroidLinkNativeAotSharedLibrary links the .o directly into a .so.  This must
-    be imported after the ILC NuGet package targets because the last target definition wins
-    in MSBuild.
+    Override ILC's LinkNative with a no-op for archive creation, while still preserving
+    the dependency that produces the ILC-compiled .o file. With NativeLib=static,
+    LinkNative normally runs llvm-ar to create a .a archive from the ILC-compiled .o
+    file. We never consume that .a — _AndroidLinkNativeAotSharedLibrary links the .o
+    directly into a .so. This must be imported after the ILC NuGet package targets
+    because the last target definition wins in MSBuild.
   -->
-  <Target Name="LinkNative" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
+  <Target Name="LinkNative"
+      Condition=" '$(_AndroidRuntime)' == 'NativeAOT' "
+      DependsOnTargets="IlcCompile" />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.After.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.After.targets
@@ -1,0 +1,21 @@
+<!--
+***********************************************************************************************
+Microsoft.Android.Sdk.NativeAOT.After.targets
+
+NativeAOT-specific targets that must be imported *after* the ILC NuGet package targets.
+Imported from Microsoft.Android.Sdk.After.targets.
+
+***********************************************************************************************
+-->
+<Project>
+
+  <!--
+    Override ILC's LinkNative with a no-op.  With NativeLib=static, LinkNative only runs
+    llvm-ar to create a .a archive from the ILC-compiled .o file.  We never consume that
+    .a — _AndroidLinkNativeAotSharedLibrary links the .o directly into a .so.  This must
+    be imported after the ILC NuGet package targets because the last target definition wins
+    in MSBuild.
+  -->
+  <Target Name="LinkNative" Condition=" '$(_AndroidRuntime)' == 'NativeAOT' " />
+
+</Project>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -126,18 +126,9 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <CppCompilerAndLinker>$(_NdkAbi)-linux-android$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppCompilerAndLinker>
       <CppLinker>$(_NdkAbi)-linux-android$(_NDKApiLevel)-clang$(_NdkWrapperScriptExt)</CppLinker>
       <ObjCopyName>llvm-objcopy</ObjCopyName>
-      <!-- Use the NDK's llvm-ar instead of the host 'ar' so that ELF objects are handled
-           correctly when cross-compiling. -->
-      <CppLibCreator>llvm-ar</CppLibCreator>
 
       <!-- We must ensure this is `false`, as it would interfere with statically linking libc++ -->
       <LinkStandardCPlusPlusLibrary>false</LinkStandardCPlusPlusLibrary>
-
-      <!-- Clear LinkerFlavor: the ILC targets set it to 'lld' for android/bionic, but with NativeLib=static
-           the _LinkerVersion detection is skipped, causing a numeric comparison error in LinkNative.
-           Since we handle native linking ourselves, LinkerFlavor is not needed.
-           Context: https://github.com/dotnet/runtime/issues/126978 -->
-      <LinkerFlavor />
     </PropertyGroup>
 
     <!-- ILLink-specific settings: only when ILLink runs before ILC (non-trimmable path) -->


### PR DESCRIPTION
## Summary

Override ILC's `LinkNative` target with a no-op for NativeAOT builds. With `NativeLib=static`, `LinkNative` only runs `llvm-ar` to create a `.a` archive from the ILC-compiled `.o` file. We never consume that `.a` — `_AndroidLinkNativeAotSharedLibrary` links the `.o` directly into a `.so`.

This eliminates the need for:
- `llvm-ar` (not shipped in the workload toolchain)
- The `CppLibCreator` property pointing to `llvm-ar`
- The `LinkerFlavor` workaround for dotnet/runtime#126978

## Changes

- **`Microsoft.Android.Sdk.NativeAOT.targets`**: Remove `CppLibCreator` and `LinkerFlavor` properties that were only needed for the `LinkNative` target we no longer run.
- **`Microsoft.Android.Sdk.NativeAOT.After.targets`** *(new)*: Define the `LinkNative` no-op override. This must be imported *after* the ILC NuGet package targets (last target definition wins in MSBuild).
- **`Microsoft.Android.Sdk.After.targets`**: Import the new file with a `_AndroidRuntime == 'NativeAOT'` condition, keeping this file as a pure import list.