### PR TITLE
[TrimmableTypeMap] Use separate trimmable Java.Interop test jar

### DIFF
--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.targets
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.Interop-Tests.targets
@@ -1,12 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <_JavaInteropTestsJarFile>Jars\Mono.Android-Test-classes.jar</_JavaInteropTestsJarFile>
+    <_JavaInteropTestsJarFile Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' ">Jars\Mono.Android-Test-classes-trimmable.jar</_JavaInteropTestsJarFile>
+  </PropertyGroup>
   <ItemGroup>
-    <AndroidJavaLibrary Include="Jars\Mono.Android-Test-classes.jar" />
+    <AndroidJavaLibrary Include="$(_JavaInteropTestsJarFile)" />
   </ItemGroup>
   <Import Project="..\..\..\build-tools\scripts\Jar.targets" />
   <ItemDefinitionGroup>
     <TestJarEntry>
-      <OutputFile>Jars\Mono.Android-Test-classes.jar</OutputFile>
+      <OutputFile>$(_JavaInteropTestsJarFile)</OutputFile>
     </TestJarEntry>
   </ItemDefinitionGroup>
   <ItemGroup>
@@ -34,8 +38,8 @@
     -->
     <!--
       Both branches below are mutually exclusive on $(_AndroidTypeMapImplementation).
-      Switching between trimmable and non-trimmable requires a clean rebuild because
-      MSBuild's up-to-date check doesn't track the conditional swap automatically.
+      The trimmable variant uses a distinct output jar so MSBuild up-to-date
+      checks cannot reuse a non-trimmable jar with the desktop GetThis class.
     -->
     <TestJarEntry Include="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\**\*.java"
                   Exclude="$(MSBuildThisFileDirectory)..\..\..\external\Java.Interop\tests\Java.Interop-Tests\java\net\dot\jni\test\GetThis.java"


### PR DESCRIPTION
### Description

Use a distinct Java.Interop test jar for the trimmable typemap device-test lane.

The trimmable lane swaps in an Android-specific `GetThis.java` fixture that omits the desktop JVM `ManagedPeer.registerNativeMembers()` static initializer. Because both trimmable and non-trimmable builds previously wrote `Jars/Mono.Android-Test-classes.jar`, MSBuild could reuse a stale non-trimmable jar and package the desktop `GetThis` class, causing `JavaObjectTest.DisposeAccessesThis` to hit legacy native-member registration under the trimmable typemap.

### Testing

- `make prepare && make all`
- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj -v minimal`
- `./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter "FullyQualifiedName~TrimmableTypeMapBuildTests"`
- `./dotnet-local.sh test tests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests/Microsoft.Android.Sdk.TrimmableTypeMap.IntegrationTests.csproj -v minimal --no-build`
- `./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -t:RunTestApp -p:_AndroidTypeMapImplementation=llvm-ir -nr:false`
- `./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -t:RunTestApp -p:_AndroidTypeMapImplementation=trimmable -nr:false`

Also attempted `-p:_AndroidTypeMapImplementation=managed`; it failed during build with existing `XAGTM7009: Internal error: set of unique assemblies must be provided.`
