### PR TITLE
[TrimmableTypeMap] Add trimmable typemap runtime coverage tests

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapRuntimeCoverageTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/TrimmableTypeMapRuntimeCoverageTests.cs
@@ -1,0 +1,254 @@
+using System;
+
+using Android.Text;
+using Android.Runtime;
+using Android.Views;
+
+using Java.Interop;
+
+using Microsoft.Android.Runtime;
+
+using NUnit.Framework;
+
+namespace Java.InteropTests
+{
+	[TestFixture]
+	[Category ("TrimmableTypeMapRuntimeCoverage")]
+	public class TrimmableTypeMapRuntimeCoverageTests
+	{
+		[Test]
+		public void JavaToManagedTextWatcherCallback_MarshalsStringAndPrimitiveParameters ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+			TrimmableRuntimeTextWatcher.Reset ();
+
+			using var watcher = new TrimmableRuntimeTextWatcher ();
+			using var text = new Java.Lang.String ("managed");
+
+			var method = JNIEnv.GetMethodID (watcher.Class.Handle, "onTextChanged", "(Ljava/lang/CharSequence;III)V");
+			JNIEnv.CallVoidMethod (
+				watcher.Handle,
+				method,
+				new JValue (text.Handle),
+				new JValue (2),
+				new JValue (3),
+				new JValue (4));
+
+			Assert.AreEqual (1, TrimmableRuntimeTextWatcher.OnTextChangedInvocations);
+			Assert.AreEqual ("managed", watcher.TextValue);
+			Assert.AreEqual (2, watcher.StartValue);
+			Assert.AreEqual (3, watcher.BeforeValue);
+			Assert.AreEqual (4, watcher.CountValue);
+		}
+
+		[Test]
+		public void JavaToManagedClickCallback_MarshalsObjectParameter ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+			TrimmableRuntimeClickListener.Reset ();
+
+			using var listener = new TrimmableRuntimeClickListener ();
+			using var view = new View (Android.App.Application.Context);
+
+			var method = JNIEnv.GetMethodID (listener.Class.Handle, "onClick", "(Landroid/view/View;)V");
+			JNIEnv.CallVoidMethod (listener.Handle, method, new JValue (view.Handle));
+
+			Assert.AreEqual (1, TrimmableRuntimeClickListener.OnClickInvocations);
+			Assert.AreEqual (view.Handle, listener.ViewHandle);
+		}
+
+		[Test]
+		public void JavaToManagedInvocationHandlerCallback_MarshalsObjectArrayParameter ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+			TrimmableRuntimeInvocationHandler.Reset ();
+
+			using var handler = new TrimmableRuntimeInvocationHandler ();
+			using var first = new Java.Lang.String ("first");
+			using var second = new Java.Lang.String ("second");
+			var args = JNIEnv.NewArray (new Java.Lang.Object [] { first, second });
+
+			try {
+				var method = JNIEnv.GetMethodID (handler.Class.Handle, "invoke", "(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;");
+				var result = JNIEnv.CallObjectMethod (handler.Handle, method, JValue.Zero, JValue.Zero, new JValue (args));
+				JNIEnv.DeleteLocalRef (result);
+
+				Assert.AreEqual (1, TrimmableRuntimeInvocationHandler.InvokeInvocations);
+				Assert.AreEqual (2, handler.ArgumentCount);
+				Assert.AreEqual ("first", handler.FirstArgument);
+				Assert.AreEqual ("second", handler.SecondArgument);
+			} finally {
+				JNIEnv.DeleteLocalRef (args);
+			}
+		}
+
+		[Test]
+		public void JavaActivatedPeer_DisposeCanAccessThisAndInvokeVirtualMember ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+			TrimmableRuntimeDisposePeer.Reset ();
+
+			using (var peer = CreateFromJava<TrimmableRuntimeDisposePeer> ()) {
+				Assert.AreEqual (1, TrimmableRuntimeDisposePeer.ConstructorInvocations);
+				peer.Dispose ();
+			}
+
+			Assert.AreEqual (1, TrimmableRuntimeDisposePeer.DisposeInvocations);
+			Assert.AreEqual (1, TrimmableRuntimeDisposePeer.VirtualInvocationsDuringDispose);
+			Assert.AreNotEqual (0, TrimmableRuntimeDisposePeer.DisposeIdentityHashCode);
+		}
+
+		[Test]
+		public void ClosedGenericJavaList_CanWrapJavaCreatedArrayListHandle ()
+		{
+			AssumeTrimmableTypeMapEnabled ();
+
+			var arrayListClass = JniEnvironment.Types.FindClass ("java/util/ArrayList");
+			try {
+				var constructor = JNIEnv.GetMethodID (arrayListClass.Handle, "<init>", "()V");
+				var handle = JNIEnv.NewObject (arrayListClass.Handle, constructor);
+				using (var list = Java.Lang.Object.GetObject<JavaList<string>> (handle, JniHandleOwnership.TransferLocalRef)) {
+					Assert.IsNotNull (list);
+					Assert.AreEqual (typeof (JavaList<string>), list.GetType ());
+
+					list.Add ("alpha");
+					list.Add ("beta");
+
+					Assert.AreEqual (2, list.Count);
+					Assert.AreEqual ("alpha", list [0]);
+					Assert.AreEqual ("beta", list [1]);
+				}
+			} finally {
+				JniObjectReference.Dispose (ref arrayListClass);
+			}
+		}
+
+		static T CreateFromJava<T> ()
+			where T : Java.Lang.Object
+		{
+			var instance = JNIEnv.StartCreateInstance (typeof (T), "()V");
+			JNIEnv.FinishCreateInstance (instance, "()V");
+			var result = Java.Lang.Object.GetObject<T> (instance, JniHandleOwnership.TransferLocalRef);
+			Assert.IsNotNull (result);
+			return result;
+		}
+
+		static void AssumeTrimmableTypeMapEnabled ()
+		{
+			if (!RuntimeFeature.TrimmableTypeMap) {
+				Assert.Ignore ("TrimmableTypeMap feature switch is off; test only relevant for the trimmable typemap path.");
+			}
+		}
+	}
+
+	class TrimmableRuntimeTextWatcher : Java.Lang.Object, ITextWatcher
+	{
+		public static int OnTextChangedInvocations;
+
+		public string TextValue;
+		public int StartValue;
+		public int BeforeValue;
+		public int CountValue;
+
+		public void AfterTextChanged (IEditable s)
+		{
+		}
+
+		public void BeforeTextChanged (Java.Lang.ICharSequence s, int start, int count, int after)
+		{
+		}
+
+		public void OnTextChanged (Java.Lang.ICharSequence s, int start, int before, int count)
+		{
+			OnTextChangedInvocations++;
+			TextValue = s?.ToString ();
+			StartValue = start;
+			BeforeValue = before;
+			CountValue = count;
+		}
+
+		public static void Reset ()
+		{
+			OnTextChangedInvocations = 0;
+		}
+	}
+
+	class TrimmableRuntimeClickListener : Java.Lang.Object, View.IOnClickListener
+	{
+		public static int OnClickInvocations;
+
+		public IntPtr ViewHandle;
+
+		public void OnClick (View v)
+		{
+			OnClickInvocations++;
+			ViewHandle = v.Handle;
+		}
+
+		public static void Reset ()
+		{
+			OnClickInvocations = 0;
+		}
+	}
+
+	class TrimmableRuntimeInvocationHandler : Java.Lang.Object, Java.Lang.Reflect.IInvocationHandler
+	{
+		public static int InvokeInvocations;
+
+		public int ArgumentCount;
+		public string FirstArgument;
+		public string SecondArgument;
+
+		public Java.Lang.Object Invoke (Java.Lang.Object proxy, Java.Lang.Reflect.Method method, Java.Lang.Object [] args)
+		{
+			InvokeInvocations++;
+			ArgumentCount = args.Length;
+			FirstArgument = args [0].ToString ();
+			SecondArgument = args [1].ToString ();
+			return null;
+		}
+
+		public static void Reset ()
+		{
+			InvokeInvocations = 0;
+		}
+	}
+
+	[Register ("net/dot/android/test/TrimmableRuntimeDisposePeer")]
+	class TrimmableRuntimeDisposePeer : Java.Lang.Object
+	{
+		public static int ConstructorInvocations;
+		public static int DisposeInvocations;
+		public static int VirtualInvocationsDuringDispose;
+		public static int DisposeIdentityHashCode;
+
+		public TrimmableRuntimeDisposePeer ()
+		{
+			ConstructorInvocations++;
+		}
+
+		protected virtual int GetDisposeIdentityHashCodeCore ()
+		{
+			VirtualInvocationsDuringDispose++;
+			return Java.Lang.JavaSystem.IdentityHashCode (this);
+		}
+
+		protected override void Dispose (bool disposing)
+		{
+			if (disposing && Handle != IntPtr.Zero) {
+				DisposeInvocations++;
+				DisposeIdentityHashCode = GetDisposeIdentityHashCodeCore ();
+			}
+
+			base.Dispose (disposing);
+		}
+
+		public static void Reset ()
+		{
+			ConstructorInvocations = 0;
+			DisposeInvocations = 0;
+			VirtualInvocationsDuringDispose = 0;
+			DisposeIdentityHashCode = 0;
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Java.Interop\JavaListTest.cs" />
     <Compile Include="Java.Interop\JavaObjectExtensionsTests.cs" />
     <Compile Include="Java.Interop\JnienvTest.cs" />
+    <Compile Include="Java.Interop\TrimmableTypeMapRuntimeCoverageTests.cs" />
     <Compile Include="Java.Interop\TrimmableTypeMapTypeManagerTests.cs" />
     <Compile Include="Java.Lang\ObjectArrayMarshaling.cs" />
     <Compile Include="Java.Lang\ObjectTest.cs" />


### PR DESCRIPTION
## Summary

Adds focused Mono.Android.NET-Tests coverage for trimmable typemap runtime behavior beyond constructor activation.

## Test coverage

### `JavaToManagedTextWatcherCallback_MarshalsStringAndPrimitiveParameters`

Java calls managed `ITextWatcher.OnTextChanged(ICharSequence, int, int, int)` through the generated interface invoker. This covers callback marshalling with a Java string-like object plus primitive parameters. It is a common Android callback shape and verifies trimmable typemap metadata keeps the managed implementation discoverable.

### `JavaToManagedClickCallback_MarshalsObjectParameter`

Java calls managed `View.IOnClickListener.OnClick(View)`. This covers callback marshalling where the parameter is a framework object that must be materialized as the correct managed peer, protecting a very common listener/event path.

### `JavaToManagedInvocationHandlerCallback_MarshalsObjectArrayParameter`

Java calls managed `IInvocationHandler.Invoke(Object, Method, Object[])`. This covers object-array marshalling across the Java-to-managed boundary. Arrays are a distinct typemap/marshalling shape from scalar objects and primitives, so this closes a separate runtime gap.

### `JavaActivatedPeer_DisposeCanAccessThisAndInvokeVirtualMember`

A registered managed peer is created through the Java activation path, then disposed while accessing `this` and invoking a virtual member. This extends coverage beyond constructor activation into lifetime behavior and verifies the trimmable typemap path still supports peer identity, handle use, and virtual dispatch during disposal.

### `ClosedGenericJavaList_CanWrapJavaCreatedArrayListHandle`

A Java-created `java.util.ArrayList` handle is wrapped as `JavaList<string>` and used from managed code. This covers closed generic Java collection wrappers under trimmable typemap lookup and protects generic wrapper activation and typed collection operations, which differ from simple non-generic peer activation.

## Validation

```bash
MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj \
    -t:RunTestApp -c Release \
    -p:_AndroidTypeMapImplementation=trimmable \
    -p:UseMonoRuntime=false \
    -p:IncludeCategories=TrimmableTypeMapRuntimeCoverage \
    -nr:false
```

Result: 5 total, 5 passed.

Full trimmable lane also runs these new tests successfully, but the overall lane remains red due to existing `Java.InteropTests.JniPeerMembersTests` remap failures unrelated to this fixture.