### PR TITLE
Remove unnecessary Task.Run from androidtest template

### DIFF
--- a/src/Microsoft.Android.Templates/androidtest/TestInstrumentation.cs
+++ b/src/Microsoft.Android.Templates/androidtest/TestInstrumentation.cs
@@ -20,41 +20,38 @@ public class TestInstrumentation : Instrumentation
         Start();
     }
 
-    public override void OnStart()
+    public override async void OnStart()
     {
         base.OnStart();
 
-        Task.Run(async () =>
+        var consumer = new ResultConsumer(this);
+        var bundle = new Bundle();
+        try
         {
-            var consumer = new ResultConsumer(this);
-            var bundle = new Bundle();
-            try
-            {
-                var writeablePath = Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? Path.GetTempPath();
-                var resultsPath = Path.Combine(writeablePath, "TestResults");
-                var builder = await TestApplication.CreateBuilderAsync([
-                    "--results-directory", resultsPath,
-                    "--report-trx"
-                ]);
-                builder.AddMSTest(() => [GetType().Assembly]);
-                builder.AddTrxReportProvider();
-                builder.TestHost.AddDataConsumer(_ => consumer);
+            var writeablePath = Application.Context.GetExternalFilesDir(null)?.AbsolutePath ?? Path.GetTempPath();
+            var resultsPath = Path.Combine(writeablePath, "TestResults");
+            var builder = await TestApplication.CreateBuilderAsync([
+                "--results-directory", resultsPath,
+                "--report-trx"
+            ]);
+            builder.AddMSTest(() => [GetType().Assembly]);
+            builder.AddTrxReportProvider();
+            builder.TestHost.AddDataConsumer(_ => consumer);
 
-                using ITestApplication app = await builder.BuildAsync();
-                await app.RunAsync();
+            using ITestApplication app = await builder.BuildAsync();
+            await app.RunAsync();
 
-                bundle.PutInt("passed", consumer.Passed);
-                bundle.PutInt("failed", consumer.Failed);
-                bundle.PutInt("skipped", consumer.Skipped);
-                bundle.PutString("resultsPath", consumer.TrxReportPath);
-                Finish(Result.Ok, bundle);
-            }
-            catch (Exception ex)
-            {
-                bundle.PutString("error", ex.ToString());
-                Finish(Result.Canceled, bundle);
-            }
-        });
+            bundle.PutInt("passed", consumer.Passed);
+            bundle.PutInt("failed", consumer.Failed);
+            bundle.PutInt("skipped", consumer.Skipped);
+            bundle.PutString("resultsPath", consumer.TrxReportPath);
+            Finish(Result.Ok, bundle);
+        }
+        catch (Exception ex)
+        {
+            bundle.PutString("error", ex.ToString());
+            Finish(Result.Canceled, bundle);
+        }
     }
 
     class ResultConsumer(Instrumentation instrumentation) : IDataConsumer


### PR DESCRIPTION
## Description

`OnStart()` in the `androidtest` template wrapped all its async work in `Task.Run(async () => { ... })`. This is unnecessary because `OnStart()` is an instrumentation callback -- not a UI-thread method -- and the work inside is already async. The `Task.Run` just adds an extra thread pool hop and allocation for no benefit.

This change makes `OnStart` an `async void` method directly, which is the appropriate pattern for framework callbacks that have comprehensive try/catch error handling.

- [x] Useful description of *why the change is necessary*.
- N/A - Links to issues fixed
- N/A - Unit tests (template-only change, no runtime behavior difference)