### PR TITLE
[NativeAOT] Make workload linker the default for NativeAOT builds

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -15,6 +15,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
   <!-- Default property values for NativeAOT -->
   <PropertyGroup>
     <_AndroidRuntimePackRuntime>NativeAOT</_AndroidRuntimePackRuntime>
+    <_AndroidUseWorkloadNativeLinker Condition=" '$(_AndroidUseWorkloadNativeLinker)' == '' ">true</_AndroidUseWorkloadNativeLinker>
     <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' ">JavaInterop1</_AndroidJcwCodegenTarget>
     <_AndroidTypeMapImplementation Condition=" '$(_AndroidTypeMapImplementation)' == '' ">managed</_AndroidTypeMapImplementation>
     <!-- .NET SDK gives: error NETSDK1191: A runtime identifier for the property 'PublishAot' couldn't be inferred. Specify a rid explicitly. -->
@@ -299,7 +300,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       Outputs="$(NativeOutputPath)$(NativeBinaryPrefix)$(TargetName).so">
     <PropertyGroup>
       <_AndroidNativeAotSharedLibrary>$(NativeOutputPath)$(NativeBinaryPrefix)$(TargetName).so</_AndroidNativeAotSharedLibrary>
-      <_AndroidUseWorkloadNativeLinker Condition=" '$(_AndroidUseWorkloadNativeLinker)' == '' ">true</_AndroidUseWorkloadNativeLinker>
     </PropertyGroup>
 
     <!-- Resolve the runtime pack native directory for workload-provided linker dependencies.

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -299,7 +299,7 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       Outputs="$(NativeOutputPath)$(NativeBinaryPrefix)$(TargetName).so">
     <PropertyGroup>
       <_AndroidNativeAotSharedLibrary>$(NativeOutputPath)$(NativeBinaryPrefix)$(TargetName).so</_AndroidNativeAotSharedLibrary>
-      <_AndroidUseWorkloadNativeLinker Condition=" '$(_AndroidUseWorkloadNativeLinker)' == '' ">false</_AndroidUseWorkloadNativeLinker>
+      <_AndroidUseWorkloadNativeLinker Condition=" '$(_AndroidUseWorkloadNativeLinker)' == '' ">true</_AndroidUseWorkloadNativeLinker>
     </PropertyGroup>
 
     <!-- Resolve the runtime pack native directory for workload-provided linker dependencies.

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -167,14 +167,13 @@ namespace Xamarin.Android.Build.Tests
 				Assert.Ignore ("CoreCLR doesn't support AOT, it doesn't ever require the NDK");
 			}
 
-			// NativeAOT doesn't support profiled AOT
+			// NativeAOT doesn't support profiled AOT or EnableLLVM (Mono concepts)
 			if (runtime == AndroidRuntime.NativeAOT && property == "AndroidEnableProfiledAot") {
 				Assert.Ignore ("NativeAOT doesn't support profiled AOT");
 			}
 
-			// NativeAOT always requires the NDK (PublishAot=true), so ndkRequired=false cases don't apply
-			if (runtime == AndroidRuntime.NativeAOT && !ndkRequired) {
-				Assert.Ignore ("NativeAOT always requires NDK via PublishAot=true");
+			if (runtime == AndroidRuntime.NativeAOT && property == "EnableLLVM") {
+				Assert.Ignore ("EnableLLVM is not applicable to NativeAOT");
 			}
 
 			var proj = new XamarinAndroidApplicationProject {
@@ -200,13 +199,14 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void NativeAotRequiresNdk ()
+		public void NativeAotRequiresNdk_WhenWorkloadLinkerDisabled ()
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};
 			proj.SetRuntime (AndroidRuntime.NativeAOT);
 			proj.SetProperty ("_AndroidUseWorkloadNativeLinker", "false");
+			proj.SetProperty ("_SkipNdkResolution", "false");
 			using (var builder = CreateApkBuilder ()) {
 				builder.Verbosity = LoggerVerbosity.Detailed;
 				builder.Target = "GetAndroidDependencies";

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -206,6 +206,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = true,
 			};
 			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetProperty ("_AndroidUseWorkloadNativeLinker", "false");
 			using (var builder = CreateApkBuilder ()) {
 				builder.Verbosity = LoggerVerbosity.Detailed;
 				builder.Target = "GetAndroidDependencies";
@@ -215,7 +216,7 @@ namespace Xamarin.Android.Build.Tests
 					.SkipWhile (x => !x.StartsWith ("Task \"CalculateProjectDependencies\"", StringComparison.Ordinal))
 					.SkipWhile (x => !x.StartsWith ("Output Item(s):", StringComparison.Ordinal))
 					.TakeWhile (x => !x.StartsWith ("Done executing task \"CalculateProjectDependencies\"", StringComparison.Ordinal));
-				StringAssertEx.Contains ("ndk-bundle", taskOutput, "ndk-bundle should be a dependency for NativeAOT.");
+				StringAssertEx.Contains ("ndk-bundle", taskOutput, "ndk-bundle should be a dependency for NativeAOT without workload linker.");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -12,7 +12,40 @@ namespace Xamarin.Android.Build.Tests
 	public class NativeAotBuildTests : BaseTest
 	{
 		[Test]
-		public void BuildNativeAot_WithoutNdk_Fails ()
+		public void BuildNativeAot_WithoutNdk ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.Build (proj),
+				"Build should succeed without NDK (workload linker is the default)."
+			);
+		}
+
+		[Test]
+		public void BuildNativeAot_WithNdkLinker ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetProperty ("_SkipNdkResolution", "false");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (
+				builder.Build (proj, parameters: new [] {
+					"_AndroidUseWorkloadNativeLinker=false",
+				}),
+				"Build should succeed with NDK linker."
+			);
+		}
+
+		[Test]
+		public void BuildNativeAot_WithoutNdk_WorkloadLinkerDisabled_Fails ()
 		{
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
@@ -22,26 +55,10 @@ namespace Xamarin.Android.Build.Tests
 			using var builder = CreateApkBuilder ();
 			builder.ThrowOnBuildFailure = false;
 			Assert.IsFalse (
-				builder.Build (proj, parameters: new [] { "_SkipNdkResolution=true" }),
-				"Build should have failed without NDK."
-			);
-		}
-
-		[Test]
-		public void BuildNativeAot_WithWorkloadLinker_WithoutNdk ()
-		{
-			var proj = new XamarinAndroidApplicationProject {
-				IsRelease = true,
-			};
-			proj.SetRuntime (AndroidRuntime.NativeAOT);
-
-			using var builder = CreateApkBuilder ();
-			Assert.IsTrue (
 				builder.Build (proj, parameters: new [] {
-					"_SkipNdkResolution=true",
-					"_AndroidUseWorkloadNativeLinker=true",
+					"_AndroidUseWorkloadNativeLinker=false",
 				}),
-				"Build should succeed with workload linker and no NDK."
+				"Build should fail without NDK when workload linker is disabled."
 			);
 		}
 	}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/ProjectExtensions.cs
@@ -24,6 +24,7 @@ public static class ProjectExtensions
 			return;
 		}
 		project.SetPublishAot (true);
+		project.SetProperty ("_SkipNdkResolution", "true");
 		EnablePreviewFeaturesIfNeeded (project, runtime);
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2860,7 +2860,7 @@ because xbuild doesn't support framework reference assemblies.
   <PropertyGroup>
     <_ProjectAndroidManifest>$(ProjectDir)$(AndroidManifest)</_ProjectAndroidManifest>
     <_NdkRequired Condition="'$(EnableLLVM)' == 'True'">true</_NdkRequired>
-    <_NdkRequired Condition="'$(PublishAot)' == 'true'">true</_NdkRequired>
+    <_NdkRequired Condition="'$(PublishAot)' == 'true' and '$(_AndroidUseWorkloadNativeLinker)' != 'true'">true</_NdkRequired>
     <_NdkRequired Condition="'$(_NdkRequired)' == ''">false</_NdkRequired>
   </PropertyGroup>
   <Error Text="AndroidManifest file does not exist" Condition="'$(_ProjectAndroidManifest)'!='' And !Exists ('$(_ProjectAndroidManifest)')"/>


### PR DESCRIPTION
Change _AndroidUseWorkloadNativeLinker default from false to true so NativeAOT builds use the workload-provided linker and sysroot by default, removing the NDK requirement.

Update SetRuntime(NativeAOT) to set _SkipNdkResolution=true so all existing NativeAOT tests exercise the NDK-free workload linker path.

Update NativeAotBuildTests with three tests covering the full matrix:
- BuildNativeAot_WithoutNdk: workload linker (default), no NDK -> succeeds
- BuildNativeAot_WithNdkLinker: opt-out to NDK linker, with NDK -> succeeds
- BuildNativeAot_WithoutNdk_WorkloadLinkerDisabled_Fails: opt-out, no NDK -> fails
