### PR TITLE
Bump `7-Zip.CommandLine` from 18.1.0 to 25.1.0

### DIFF
--- a/build-tools/xaprepare/xaprepare/xaprepare.csproj
+++ b/build-tools/xaprepare/xaprepare/xaprepare.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="7-Zip.CommandLine" Version="18.1.0" GeneratePathProperty="true" />
+    <PackageReference Include="7-Zip.CommandLine" Version="25.1.0" GeneratePathProperty="true" />
     <PackageReference Include="Kajabity.Tools.Java" Version="0.2.6862.30334" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
     <PackageReference Include="Mono.Unix" Version="7.1.0-final.1.21458.1" />

--- a/src/binutils/binutils.csproj
+++ b/src/binutils/binutils.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="7-Zip.CommandLine" Version="18.1.0" GeneratePathProperty="true" ExcludeAssets="all" />
+    <PackageReference Include="7-Zip.CommandLine" Version="25.1.0" GeneratePathProperty="true" ExcludeAssets="all" />
   </ItemGroup>
 
   <Import Project="..\..\Configuration.props" />


### PR DESCRIPTION
Updates the `7-Zip.CommandLine` NuGet package from 18.1.0 (2018-era) to [25.1.0](https://www.nuget.org/packages/7-Zip.CommandLine/25.1.0) in both references:

- `src/binutils/binutils.csproj`
- `build-tools/xaprepare/xaprepare/xaprepare.csproj`

This package is used during the build to extract the binutils toolchain archive.
