### PR TITLE
[release/10.0.1xx] Emit NETSDK1202 EOL warning for net9.0-android projects

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.NET.Sdk.Android/WorkloadManifest.in.targets
@@ -19,6 +19,7 @@
         LatestRuntimeFrameworkVersion="@NET_PREVIOUS_VERSION@"
         TargetingPackVersion="@NET_PREVIOUS_VERSION@"
     />
+    <EolWorkload Include="net9.0-android" Url="https://aka.ms/maui-support-policy" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' == '.NETCoreApp' and $([MSBuild]::VersionGreaterThanOrEquals($(TargetFrameworkVersion), '9.0')) ">

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/XASdkTests.cs
@@ -340,6 +340,12 @@ public abstract class Foo<TVirtualView, TNativeView> : ViewHandler<TVirtualView,
 }",
 			});
 
+			// net9.0-android is EOL and emits NETSDK1202
+			bool isEol = targetFramework.StartsWith ("net9.0-", StringComparison.Ordinal);
+			if (isEol) {
+				library.SetProperty ("CheckEolWorkloads", "false");
+			}
+
 			var builder = CreateDllBuilder ();
 			Assert.IsTrue (builder.Build (library), $"{library.ProjectName} should succeed");
 			// NOTE: Preview API levels emit XA4211


### PR DESCRIPTION
Adds an `EolWorkload` item for `net9.0-android` so the .NET SDK emits the **NETSDK1202 warning** when building projects targeting `net9.0-android`, which has reached end-of-life.

```xml
<EolWorkload Include="net9.0-android" Url="https://aka.ms/maui-support-policy" />
```

This leverages the mechanism introduced in https://github.com/dotnet/sdk/pull/32426.

> [!NOTE]
> This change is only needed on `release/10.0.1xx`. On `main` (net11), `net9.0-android` projects already receive a hard **error** via `Eol.targets` (which imports for TFV ≤ 8.0 — and net9 will be added to that gate in a future release). On `release/10.0.1xx`, the net9 SDK is still functional, so we emit a **warning** rather than an error to give developers time to migrate.