### PR TITLE
[Build] Block insecure HTTP Maven repository URLs for defense in depth

### DIFF
--- a/Documentation/docs-mobile/binding-libs/msbuild-reference/build-items.md
+++ b/Documentation/docs-mobile/binding-libs/msbuild-reference/build-items.md
@@ -173,6 +173,7 @@ hosted in Maven.
 | - | - |
 | Version | Required string. The version of the Java library that should be downloaded from Maven. Defaults to `true`. |
 | Repository | Optional string. Specifies Maven repository to use. Supported values are `Central`, `Google`, or an `https` URL to a Maven repository. Defaults to `Central`. |
+| AllowInsecureHttp | Optional boolean. When `Repository` is an `http://` URL, this must be set to `true` to allow the insecure connection. Defaults to `false`. Using HTTPS is strongly recommended for supply-chain security. |
 | Bind | Optional boolean. Specifies whether the Java library should have a C# binding generated for it. Defaults to `true`. |
 | Pack | Optional boolean. Specifies whether the Java library should be included in the project output. Defaults to `true`. |
 

--- a/Documentation/docs-mobile/building-apps/build-items.md
+++ b/Documentation/docs-mobile/building-apps/build-items.md
@@ -296,6 +296,9 @@ The following MSBuild metadata are supported:
 - `%(Version)`: Required version of the Java library referenced by `%(Include)`.
 - `%(Repository)`: Optional Maven repository to use. Supported values are `Central` (default),
    `Google`, or an `https` URL to a Maven repository.
+- `%(AllowInsecureHttp)`: Optional boolean. When `%(Repository)` is an `http://` URL, this must be
+   set to `true` to allow the insecure connection. Defaults to `false`. Using HTTPS is strongly
+   recommended for supply-chain security.
 
 The `<AndroidMavenLibrary>` item is translated to
 [`AndroidLibrary`](#androidlibrary), so any metadata supported by

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -208,6 +208,7 @@ Either change the value in the AndroidManifest.xml to match the $(SupportedOSPla
 + [XA4248](xa4248.md): Could not find NuGet package '{nugetId}' version '{version}' in lock file. Ensure NuGet Restore has run since this `<PackageReference>` was added.
 + [XA4235](xa4249.md): Maven artifact specification '{artifact}' is invalid. The correct format is 'group_id:artifact_id:version'.
 + [XA4250](xa4250.md): Manifest-referenced type '{type}' was not found in any scanned assembly. It may be a framework type.
++ [XA4252](xa4252.md): Insecure HTTP Maven repository URL '{url}' is not allowed. Use an HTTPS URL, or set AllowInsecureHttp="true" metadata on the item to override this check.
 + XA4300: Native library '{library}' will not be bundled because it has an unsupported ABI.
 + [XA4301](xa4301.md): Apk already contains the item `xxx`.
 + [XA4302](xa4302.md): Unhandled exception merging \`AndroidManifest.xml\`: {ex}

--- a/Documentation/docs-mobile/messages/xa4252.md
+++ b/Documentation/docs-mobile/messages/xa4252.md
@@ -1,0 +1,43 @@
+---
+title: .NET for Android error XA4252
+description: XA4252 error code
+ms.date: 05/15/2026
+f1_keywords:
+  - "XA4252"
+---
+
+# .NET for Android error XA4252
+
+## Example message
+
+```
+error XA4252: Insecure HTTP Maven repository URL 'http://repo.example.com/maven2/' is not allowed. Use an HTTPS URL, or set AllowInsecureHttp="true" metadata on the item to override this check.
+```
+
+## Issue
+
+An `<AndroidMavenLibrary>` item specifies a Maven repository URL using `http://` instead of `https://`.
+Downloading artifacts over plain HTTP is a security risk because the connection is not encrypted and is
+vulnerable to man-in-the-middle attacks and supply-chain compromise.
+
+This check aligns with default behavior in Gradle (`allowInsecureProtocol`) and Maven (`<blocked>http://*</blocked>`)
+for defense in depth and supply-chain hardening.
+
+## Solution
+
+Use an HTTPS URL for the Maven repository whenever possible:
+
+```xml
+<ItemGroup>
+  <AndroidMavenLibrary Include="com.example:mylib" Version="1.0.0" Repository="https://repo.example.com/maven2/" />
+</ItemGroup>
+```
+
+If the repository does not support HTTPS and you understand the security implications,
+set `AllowInsecureHttp="true"` to explicitly opt in to insecure HTTP:
+
+```xml
+<ItemGroup>
+  <AndroidMavenLibrary Include="com.example:mylib" Version="1.0.0" Repository="http://repo.example.com/maven2/" AllowInsecureHttp="true" />
+</ItemGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -1462,6 +1462,15 @@ namespace Xamarin.Android.Tasks.Properties {
                 return ResourceManager.GetString("XA4250", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Insecure HTTP Maven repository URL &apos;{0}&apos; is not allowed. Use an HTTPS URL, or set AllowInsecureHttp=&quot;true&quot; metadata on the item to override this check..
+        /// </summary>
+        public static string XA4251 {
+            get {
+                return ResourceManager.GetString("XA4251", resourceCulture);
+            }
+        }
 
         /// <summary>
         ///   Looks up a localized string similar to Native library &apos;{0}&apos; will not be bundled because it has an unsupported ABI. Move this file to a directory with a valid Android ABI name such as &apos;libs/armeabi-v7a/&apos;..

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1080,6 +1080,11 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
     <comment>The following are literal names and should not be translated: Manifest, framework.
 {0} - Java type name from AndroidManifest.xml</comment>
   </data>
+  <data name="XA4251" xml:space="preserve">
+    <value>Insecure HTTP Maven repository URL '{0}' is not allowed. Use an HTTPS URL, or set AllowInsecureHttp="true" metadata on the item to override this check.</value>
+    <comment>The following are literal names and should not be translated: HTTP, HTTPS, Maven, AllowInsecureHttp
+{0} - The insecure HTTP URL</comment>
+  </data>
   <data name="XA0142" xml:space="preserve">
     <value>Command '{0}' failed.\n{1}</value>
     <comment>'{0}' is a failed command name (potentially with path) followed by all the arguments passed to it. {1} is the combined output on the standard error and standard output streams.</comment>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -146,8 +146,9 @@ public class MavenDownload : AsyncTask
 			_ => null
 		};
 
-		if (repo is null && type.StartsWith ("http", StringComparison.OrdinalIgnoreCase)) {
-			if (type.StartsWith ("http://", StringComparison.OrdinalIgnoreCase) &&
+		if (repo is null && Uri.TryCreate (type, UriKind.Absolute, out var uri) &&
+			(uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps)) {
+			if (uri.Scheme == Uri.UriSchemeHttp &&
 				!string.Equals (item.GetMetadataOrDefault ("AllowInsecureHttp", "false"), "true", StringComparison.OrdinalIgnoreCase)) {
 				Log.LogCodedError ("XA4252", Properties.Resources.XA4252, type);
 				return null;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/MavenDownload.cs
@@ -147,6 +147,12 @@ public class MavenDownload : AsyncTask
 		};
 
 		if (repo is null && type.StartsWith ("http", StringComparison.OrdinalIgnoreCase)) {
+			if (type.StartsWith ("http://", StringComparison.OrdinalIgnoreCase) &&
+				!string.Equals (item.GetMetadataOrDefault ("AllowInsecureHttp", "false"), "true", StringComparison.OrdinalIgnoreCase)) {
+				Log.LogCodedError ("XA4251", Properties.Resources.XA4251, type);
+				return null;
+			}
+
 			using var hasher = SHA256.Create ();
 			var hash = hasher.ComputeHash (Encoding.UTF8.GetBytes (type));
 			var cache_name = Convert.ToBase64String (hash);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
@@ -3,7 +3,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -103,8 +102,9 @@ public class MavenDownloadTests
 
 		await task.RunTaskAsync ();
 
-		// Should not have the XA4252 insecure HTTP error; it will fail with a download error instead
-		Assert.IsFalse (engine.Errors.Any (e => e.Code == "XA4252"), "Should not have XA4252 error when AllowInsecureHttp is set");
+		// Should bypass the XA4252 insecure HTTP check and attempt the download, which fails with XA4236
+		Assert.AreEqual (1, engine.Errors.Count);
+		Assert.AreEqual ("XA4236", engine.Errors [0].Code, "Expected a download error (XA4236), not a security error (XA4252)");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/MavenDownloadTests.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using NUnit.Framework;
@@ -70,6 +71,40 @@ public class MavenDownloadTests
 
 		Assert.AreEqual (1, engine.Errors.Count);
 		Assert.AreEqual ("Unknown Maven repository: 'bad-repo'.", engine.Errors [0].Message);
+	}
+
+	[Test]
+	public async Task InsecureHttpRepository_Blocked ()
+	{
+		var engine = new MockBuildEngine (TestContext.Out, new List<BuildErrorEventArgs> ());
+		var task = new MavenDownload {
+			BuildEngine = engine,
+			AndroidMavenLibraries = [CreateMavenTaskItem ("com.google.android.material:material", "1.0.0", "http://repo.example.com/maven2/")],
+		};
+
+		await task.RunTaskAsync ();
+
+		Assert.AreEqual (1, engine.Errors.Count);
+		Assert.AreEqual ("Insecure HTTP Maven repository URL 'http://repo.example.com/maven2/' is not allowed. Use an HTTPS URL, or set AllowInsecureHttp=\"true\" metadata on the item to override this check.", engine.Errors [0].Message);
+	}
+
+	[Test]
+	public async Task InsecureHttpRepository_AllowedWithOptIn ()
+	{
+		var engine = new MockBuildEngine (TestContext.Out, new List<BuildErrorEventArgs> ());
+		var item = CreateMavenTaskItem ("com.example:dummy", "1.0.0", "http://repo.example.com/maven2/");
+		item.SetMetadata ("AllowInsecureHttp", "true");
+
+		var task = new MavenDownload {
+			BuildEngine = engine,
+			MavenCacheDirectory = Path.GetTempPath (),
+			AndroidMavenLibraries = [item],
+		};
+
+		await task.RunTaskAsync ();
+
+		// Should not have the XA4251 insecure HTTP error; it will fail with a download error instead
+		Assert.IsFalse (engine.Errors.Any (e => e.Code == "XA4251"), "Should not have XA4251 error when AllowInsecureHttp is set");
 	}
 
 	[Test]


### PR DESCRIPTION
## Summary

Aligning with Gradle & Maven behavior for **defense in depth** and **supply-chain hardening**.

When a customer specifies an `http://` Maven repository URL, the build now fails with error **XA4252** unless `AllowInsecureHttp="true"` metadata is explicitly set on the item. HTTPS URLs are unaffected.

### Problem

A customer could write an insecure `http://` Maven repository URL and the product would use it.

### Solution

Require explicit opt-in via `AllowInsecureHttp="true"` metadata:

```xml
<!-- This will now fail with XA4252 -->
<AndroidMavenLibrary Include="com.example:library" Version="1.0.0" Repository="http://repo.example.com/maven2/" />

<!-- Explicit opt-in to insecure HTTP -->
<AndroidMavenLibrary Include="com.example:library" Version="1.0.0" Repository="http://repo.example.com/maven2/" AllowInsecureHttp="true" />
```

This mirrors what Gradle (`allowInsecureProtocol`) and Maven (`<blocked>http://*</blocked>`) already enforce by default.

### Changes

- **`MavenDownload.cs`** — Added HTTP check in `GetRepository()` that logs error XA4252 when `http://` is used without `AllowInsecureHttp="true"`
- **`Resources.resx` / `Resources.Designer.cs`** — Added XA4252 error message
- **`MavenDownloadTests.cs`** — Two new tests:
  - `InsecureHttpRepository_Blocked` — verifies `http://` URL without opt-in produces XA4252
  - `InsecureHttpRepository_AllowedWithOptIn` — verifies `AllowInsecureHttp="true"` bypasses the check