### PR TITLE
[tests] Set xamarin_manifest_needs_updating to false for API 37

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Android.Build.Tests
 
 			// Set to true when we are marking a new Android API level as stable, but it has not
 			// been added to the Xamarin manifest yet.
-			var xamarin_manifest_needs_updating = true;
+			var xamarin_manifest_needs_updating = false;
 
 			AssertCommercialBuild ();
 			var oldSdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_SDK_PATH");


### PR DESCRIPTION
The Xamarin manifest now includes API 37 entries, so `InstallAndroidDependenciesTest` should no longer expect failures when using the Xamarin manifest type.

All three runtimes (MonoVM, CoreCLR, NativeAOT) are currently failing on main with:
> *We didn't expect the Xamarin manifest to have the requested component. If the manifest has been updated, change 'InstallAndroidDependenciesTest.xamarin_manifest_needs_updating' to be 'false'.*

Example failing build: [Xamarin.Android #14101833](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_build/results?buildId=14101833)

*This content was created with assistance from AI.*