### PR TITLE
[tests] Fix ApplicationRunsWithDebuggerAndBreaks flakiness

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -644,6 +644,7 @@ namespace ${ROOT_NAMESPACE} {
 					ClearAdbLogcat ();
 					ClearBlockingDialogs ();
 					Assert.True (ClickButton (app.PackageName, "myXFButton", "CLICK ME"), "Button should have been clicked!");
+					timeout = TimeSpan.FromSeconds (60);
 					while (session.IsConnected && breakcountHitCount < 1 && timeout >= TimeSpan.Zero) {
 						Thread.Sleep (10);
 						timeout = timeout.Subtract (TimeSpan.FromMilliseconds (10));


### PR DESCRIPTION
The `timeout` `TimeSpan` variable in `ApplicationRunsWithDebuggerAndBreaks` is shared between two consecutive wait loops. The first loop (wait for initial breakpoints to be hit) decrements it; the second loop (wait for the post-button-click breakpoint) then starts with whatever time is left, which on a slow CI machine can be near zero — causing a spurious assertion failure.

Reset `timeout` to 60 seconds before the second loop so each phase has a full budget.

Addresses #11320.