### PR TITLE
[native] Track archive DSO stub output

### DIFF
--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -85,6 +85,7 @@
       <_ArchiveDSOInput Include="common\archive-dso-stub\CMakeLists.txt" />
 
       <_ArchiveDSOOutput Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-archive-dso-stub\CMakeCache.txt')" />
+      <_ArchiveDSOOutput Include="@(AndroidSupportedTargetJitAbi->'$(OutputPath)\%(AndroidRID)\libarchive-dso-stub.so')" />
 
       <_ArchiveOutputDirToCreate Include="$(FlavorIntermediateOutputPath)\%(AndroidSupportedTargetJitAbi.AndroidRID)-archive-dso-stub" />
     </ItemGroup>


### PR DESCRIPTION
The `_ConfigureAndBuildArchiveDSOStub` target configures and builds `libarchive-dso-stub.so`, but its incremental `Outputs` list only included the generated `CMakeCache.txt`. That means MSBuild can consider the target up-to-date when the CMake cache exists even if the actual `libarchive-dso-stub.so` output is missing.

Add the generated `libarchive-dso-stub.so` path to `_ArchiveDSOOutput` so the target's up-to-date check tracks the native artifact it produces. This keeps the PR intentionally focused to a single incremental-build correctness fix.

Validation:
- `git diff --check`