### PR TITLE
Use AcesShared macOS pool for public dnceng pipelines

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -72,8 +72,9 @@ stages:
   - job: mac_build_create_installers
     displayName: macOS > Build
     pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      name: AcesShared
+      demands:
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
       os: macOS
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
@@ -276,8 +277,9 @@ stages:
       parallel: 10
     displayName: macOS > Tests > MSBuild
     pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImage)
+      name: AcesShared
+      demands:
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
       os: macOS
     timeoutInMinutes: 240
     cancelTimeoutInMinutes: 5
@@ -367,8 +369,9 @@ stages:
       parallel: 8
     displayName: "macOS > Tests > MSBuild+Emulator"
     pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImageWithEmulator)
+      name: AcesShared
+      demands:
+      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
       os: macOS
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5

--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -368,10 +368,10 @@ stages:
     strategy:
       parallel: 8
     displayName: "macOS > Tests > MSBuild+Emulator"
+    # NOTE: AcesShared pool cannot boot Android emulators, so these jobs must use hosted images
     pool:
-      name: AcesShared
-      demands:
-      - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      name: Azure Pipelines
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     cancelTimeoutInMinutes: 5

--- a/build-tools/automation/yaml-templates/build-macos-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-macos-steps.yaml
@@ -14,6 +14,12 @@ parameters:
 steps:
 - template: /build-tools/automation/yaml-templates/log-disk-space.yaml
 
+- ${{ if ne(parameters.use1ESTemplate, true) }}:
+  - bash: |
+      set -e
+      brew install p7zip
+    displayName: Install p7zip on macOS
+
 - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml
   parameters:
     useAgentJdkPath: false

--- a/build-tools/automation/yaml-templates/setup-test-environment-public.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment-public.yaml
@@ -5,7 +5,7 @@ parameters:
   configuration: $(XA.Build.Configuration)
   xaSourcePath: $(System.DefaultWorkingDirectory)
   jdkMajorVersion: $(DefaultJavaSdkMajorVersion)
-  useAgentJdkPath: true
+  useAgentJdkPath: false
   remove_dotnet: false
   dotnetVersion: $(DotNetSdkVersion)
   dotnetQuality: $(DotNetSdkQuality)

--- a/build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
@@ -35,7 +35,7 @@ steps:
     custom: build-server
     arguments: shutdown
 
-# Install p7zip on Linux for public agents
+# Install p7zip on Linux/macOS for public agents
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
   - bash: |
       set -e
@@ -43,6 +43,12 @@ steps:
       sudo apt-get install -y p7zip-full
     displayName: Install p7zip on Linux
     condition: and(succeeded(), eq(variables['agent.os'], 'Linux'))
+
+  - bash: |
+      set -e
+      brew install p7zip
+    displayName: Install p7zip on macOS
+    condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
 - template: /build-tools/automation/yaml-templates/run-xaprepare.yaml
   parameters:

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -10,16 +10,12 @@ stages:
   dependsOn: mac_build
   jobs:
 # Check - "Xamarin.Android (Package Tests macOS > Tests > APKs .NET)"
+  # NOTE: AcesShared pool cannot boot Android emulators, so APK test jobs must use hosted images
   - job: mac_apk_tests_net_1
     displayName: macOS > Tests > APKs 1
     pool:
-      ${{ if eq(parameters.use1ESTemplate, false) }}:
-        name: AcesShared
-        demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
-      ${{ else }}:
-        name: Azure Pipelines
-        vmImage: $(HostedMacImageWithEmulator)
+      name: Azure Pipelines
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:
@@ -28,7 +24,6 @@ stages:
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
-        useAgentJdkPath: ${{ eq(parameters.use1ESTemplate, true) }}
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2
@@ -116,16 +111,12 @@ stages:
 
     - template: /build-tools/automation/yaml-templates/fail-on-issue.yaml
 
+  # NOTE: AcesShared pool cannot boot Android emulators, so APK test jobs must use hosted images
   - job: mac_apk_tests_net_2
     displayName: macOS > Tests > APKs 2
     pool:
-      ${{ if eq(parameters.use1ESTemplate, false) }}:
-        name: AcesShared
-        demands:
-        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
-      ${{ else }}:
-        name: Azure Pipelines
-        vmImage: $(HostedMacImageWithEmulator)
+      name: Azure Pipelines
+      vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:
@@ -134,7 +125,6 @@ stages:
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
-        useAgentJdkPath: ${{ eq(parameters.use1ESTemplate, true) }}
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -13,8 +13,13 @@ stages:
   - job: mac_apk_tests_net_1
     displayName: macOS > Tests > APKs 1
     pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImageWithEmulator)
+      ${{ if eq(parameters.use1ESTemplate, false) }}:
+        name: AcesShared
+        demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      ${{ else }}:
+        name: Azure Pipelines
+        vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:
@@ -113,8 +118,13 @@ stages:
   - job: mac_apk_tests_net_2
     displayName: macOS > Tests > APKs 2
     pool:
-      name: Azure Pipelines
-      vmImage: $(HostedMacImageWithEmulator)
+      ${{ if eq(parameters.use1ESTemplate, false) }}:
+        name: AcesShared
+        demands:
+        - ImageOverride -equals ACES_VM_SharedPool_Tahoe
+      ${{ else }}:
+        name: Azure Pipelines
+        vmImage: $(HostedMacImageWithEmulator)
       os: macOS
     timeoutInMinutes: 180
     workspace:

--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -28,6 +28,7 @@ stages:
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
+        useAgentJdkPath: ${{ eq(parameters.use1ESTemplate, true) }}
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2
@@ -133,6 +134,7 @@ stages:
     - template: /build-tools/automation/yaml-templates/setup-test-environment.yaml
       parameters:
         xaprepareScenario: EmulatorTestDependencies
+        useAgentJdkPath: ${{ eq(parameters.use1ESTemplate, true) }}
         use1ESTemplate: ${{ parameters.use1ESTemplate }}
 
     - task: DownloadPipelineArtifact@2


### PR DESCRIPTION
## Description

Switch the public dnceng-public macOS pipeline jobs to use the `AcesShared` pool with `ACES_VM_SharedPool_Tahoe` image override, matching what dotnet/maui uses in their public CI.

### What changed

**Pool changes** (`azure-pipelines-public.yaml`):
- **macOS Build** → `AcesShared` pool
- **macOS MSBuild Tests** → `AcesShared` pool
- **macOS MSBuild+Emulator Tests** → kept on hosted `Azure Pipelines` (AcesShared cannot boot Android emulators)

**Template fixes for AcesShared compatibility:**
- `setup-test-environment-public.yaml` — default `useAgentJdkPath` to `false` (AcesShared agents don't have `JAVA_HOME_NN_arm64` env vars)
- `setup-test-environment-steps.yaml` — add `brew install p7zip` on macOS for public agents (AcesShared agents don't have `7za` pre-installed)
- `build-macos-steps.yaml` — add `brew install p7zip` before build for public agents
- `stage-package-tests.yaml` — keep APK test jobs on hosted images with a comment explaining why

### Not changed
- **APK test jobs** (`stage-package-tests.yaml`) — stay on hosted `Azure Pipelines` with `$(HostedMacImageWithEmulator)` because AcesShared cannot boot Android emulators
- **Internal pipeline** (`azure-pipelines.yaml`) — untouched

### Known issue
Some incremental build tests fail on public CI due to missing Fast Deployment (commercial-only feature). Tracked in #11419.
