### PR TITLE
[tests] Remove Xamarin.Forms usage to fix NU1703 warnings

### DIFF
--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,20 +1,20 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.5.26266.103">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.5.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="11.0.0-preview.5.26266.103">
+    <Dependency Name="Microsoft.NET.ILLink" Version="11.0.0-preview.5.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.5.26266.103">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.5.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-preview.26266.103">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-preview.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest-11.0.100-preview.4" Version="11.0.100-preview.4.26215.121">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -36,13 +36,13 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26266.103">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Authoring.Tasks" Version="11.0.100-preview.5.26266.103">
+    <Dependency Name="Microsoft.TemplateEngine.Authoring.Tasks" Version="11.0.100-preview.5.26268.112">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
+      <Sha>c5d1f734662eb718e7431a4e679a29e47c380f04</Sha>
     </Dependency>
     <Dependency Name="MSTest" Version="4.3.0-preview.26265.5">
       <Uri>https://github.com/microsoft/testfx</Uri>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,20 +1,20 @@
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.5.26258.110">
+    <Dependency Name="Microsoft.NET.Sdk" Version="11.0.100-preview.5.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="11.0.0-preview.5.26258.110">
+    <Dependency Name="Microsoft.NET.ILLink" Version="11.0.0-preview.5.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.5.26258.110">
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="11.0.0-preview.5.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-preview.26258.110">
+    <Dependency Name="Microsoft.DotNet.Cecil" Version="0.11.5-preview.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
     <Dependency Name="Microsoft.NET.Workload.Mono.Toolchain.Current.Manifest-11.0.100-preview.4" Version="11.0.100-preview.4.26215.121">
       <Uri>https://github.com/dotnet/dotnet</Uri>
@@ -36,13 +36,13 @@
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26258.110">
+    <Dependency Name="Microsoft.DotNet.Build.Tasks.Feed" Version="11.0.0-beta.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.TemplateEngine.Authoring.Tasks" Version="11.0.100-preview.5.26258.110">
+    <Dependency Name="Microsoft.TemplateEngine.Authoring.Tasks" Version="11.0.100-preview.5.26266.103">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2c9bec4ec0be4c22ce27ece0c2ca0a8a4d481168</Sha>
+      <Sha>3a62cc842c76761d4742f1d103892f19fd06dd3a</Sha>
     </Dependency>
     <Dependency Name="MSTest" Version="4.3.0-preview.26257.2">
       <Uri>https://github.com/microsoft/testfx</Uri>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,20 +1,20 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.5.26266.103</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.5.26268.112</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26266.103</MicrosoftNETILLinkPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.5.26266.103</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26268.112</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.5.26268.112</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <!-- Last version built for net10.0, needed for CI steps that only have the .NET 10 SDK installed (e.g., BAR manifest publishing) -->
     <MicrosoftDotNetBuildTasksFeedPackageVersionNet10>11.0.0-beta.26060.102</MicrosoftDotNetBuildTasksFeedPackageVersionNet10>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26266.103</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26268.112</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadMonoToolchainCurrentManifest110100preview4PackageVersion>11.0.100-preview.4.26215.121</MicrosoftNETWorkloadMonoToolchainCurrentManifest110100preview4PackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion>11.0.100-preview.4.26215.121</MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion>
     <MicrosoftNETWorkloadMonoToolChainPackageVersion>$(MicrosoftNETWorkloadMonoToolChainCurrentManifest110100preview4PackageVersion)</MicrosoftNETWorkloadMonoToolChainPackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
-    <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.5.26266.103</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26266.103</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.5.26268.112</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26268.112</MicrosoftDotNetCecilPackageVersion>
     <MSTestPackageVersion>4.3.0-preview.26265.5</MSTestPackageVersion>
     <SystemIOHashingPackageVersion>10.0.7</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataPackageVersion>11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -1,20 +1,20 @@
 <Project>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETSdkPackageVersion>11.0.100-preview.5.26258.110</MicrosoftNETSdkPackageVersion>
+    <MicrosoftNETSdkPackageVersion>11.0.100-preview.5.26266.103</MicrosoftNETSdkPackageVersion>
     <MicrosoftDotnetSdkInternalPackageVersion>$(MicrosoftNETSdkPackageVersion)</MicrosoftDotnetSdkInternalPackageVersion>
-    <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26258.110</MicrosoftNETILLinkPackageVersion>
-    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.5.26258.110</MicrosoftNETCoreAppRefPackageVersion>
+    <MicrosoftNETILLinkPackageVersion>11.0.0-preview.5.26266.103</MicrosoftNETILLinkPackageVersion>
+    <MicrosoftNETCoreAppRefPackageVersion>11.0.0-preview.5.26266.103</MicrosoftNETCoreAppRefPackageVersion>
     <MicrosoftDotNetApiCompatPackageVersion>7.0.0-beta.22103.1</MicrosoftDotNetApiCompatPackageVersion>
     <!-- Last version built for net10.0, needed for CI steps that only have the .NET 10 SDK installed (e.g., BAR manifest publishing) -->
     <MicrosoftDotNetBuildTasksFeedPackageVersionNet10>11.0.0-beta.26060.102</MicrosoftDotNetBuildTasksFeedPackageVersionNet10>
-    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26258.110</MicrosoftDotNetBuildTasksFeedPackageVersion>
+    <MicrosoftDotNetBuildTasksFeedPackageVersion>11.0.0-beta.26266.103</MicrosoftDotNetBuildTasksFeedPackageVersion>
     <MicrosoftNETWorkloadMonoToolchainCurrentManifest110100preview4PackageVersion>11.0.100-preview.4.26215.121</MicrosoftNETWorkloadMonoToolchainCurrentManifest110100preview4PackageVersion>
     <MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion>11.0.100-preview.4.26215.121</MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion>
     <MicrosoftNETWorkloadMonoToolChainPackageVersion>$(MicrosoftNETWorkloadMonoToolChainCurrentManifest110100preview4PackageVersion)</MicrosoftNETWorkloadMonoToolChainPackageVersion>
     <MicrosoftNETWorkloadEmscriptenPackageVersion>$(MicrosoftNETWorkloadEmscriptenCurrentManifest110100preview4PackageVersion)</MicrosoftNETWorkloadEmscriptenPackageVersion>
-    <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.5.26258.110</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
-    <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26258.110</MicrosoftDotNetCecilPackageVersion>
+    <MicrosoftTemplateEngineAuthoringTasksPackageVersion>11.0.100-preview.5.26266.103</MicrosoftTemplateEngineAuthoringTasksPackageVersion>
+    <MicrosoftDotNetCecilPackageVersion>0.11.5-preview.26266.103</MicrosoftDotNetCecilPackageVersion>
     <MSTestPackageVersion>4.3.0-preview.26257.2</MSTestPackageVersion>
     <SystemIOHashingPackageVersion>10.0.7</SystemIOHashingPackageVersion>
     <SystemReflectionMetadataPackageVersion>11.0.0-preview.1.26104.118</SystemReflectionMetadataPackageVersion>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 					"https://api.nuget.org/v3/index.json",
 				},
 				PackageReferences = {
-					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.3.1.1" },
+					new Package { Id = "Xamarin.AndroidX.AppCompat", Version = "1.7.1.3" },
 					// Using * here, so we explicitly get newer packages
 					new Package { Id = "Microsoft.AspNetCore.Components.WebView", Version = "8.0.*" },
 					new Package { Id = "Microsoft.Extensions.FileProviders.Embedded", Version = "8.0.*" },
@@ -244,7 +244,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (MonoComponentMaskChecks))]
 		public void CheckMonoComponentsMask (bool enableProfiler, bool useInterpreter, bool debugBuild, uint expectedMask)
 		{
-			var proj = new XamarinFormsAndroidApplicationProject () {
+			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = !debugBuild,
 			};
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -374,7 +374,6 @@ namespace Xamarin.Android.Build.Tests
 			foreach (AndroidRuntime runtime in Enum.GetValues (typeof (AndroidRuntime))) {
 				AddTestData (
 					isRelease: false,
-					xamarinForms: false,
 					multidex: false,
 					packageFormat: "apk",
 					runtime
@@ -382,15 +381,6 @@ namespace Xamarin.Android.Build.Tests
 
 				AddTestData (
 					isRelease: false,
-					xamarinForms: true,
-					multidex: false,
-					packageFormat: "apk",
-					runtime
-				);
-
-				AddTestData (
-					isRelease: false,
-					xamarinForms: true,
 					multidex: true,
 					packageFormat: "apk",
 					runtime
@@ -398,15 +388,6 @@ namespace Xamarin.Android.Build.Tests
 
 				AddTestData (
 					isRelease: true,
-					xamarinForms: false,
-					multidex: false,
-					packageFormat: "apk",
-					runtime
-				);
-
-				AddTestData (
-					isRelease: true,
-					xamarinForms: true,
 					multidex: false,
 					packageFormat: "apk",
 					runtime
@@ -414,7 +395,6 @@ namespace Xamarin.Android.Build.Tests
 
 				AddTestData (
 					isRelease: false,
-					xamarinForms: false,
 					multidex: false,
 					packageFormat: "aab",
 					runtime
@@ -422,7 +402,6 @@ namespace Xamarin.Android.Build.Tests
 
 				AddTestData (
 					isRelease: true,
-					xamarinForms: false,
 					multidex: false,
 					packageFormat: "aab",
 					runtime
@@ -431,11 +410,10 @@ namespace Xamarin.Android.Build.Tests
 
 			return ret;
 
-			void AddTestData (bool isRelease, bool xamarinForms, bool multidex, string packageFormat, AndroidRuntime runtime)
+			void AddTestData (bool isRelease, bool multidex, string packageFormat, AndroidRuntime runtime)
 			{
 				ret.Add (new object[] {
 					isRelease,
-					xamarinForms,
 					multidex,
 					packageFormat,
 					runtime
@@ -445,19 +423,17 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (Get_BuildHasNoWarningsData))]
-		public void BuildHasNoWarnings (bool isRelease, bool xamarinForms, bool multidex, string packageFormat, AndroidRuntime runtime)
+		public void BuildHasNoWarnings (bool isRelease, bool multidex, string packageFormat, AndroidRuntime runtime)
 		{
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
 
-			var proj = xamarinForms ?
-				new XamarinFormsAndroidApplicationProject () :
-				new XamarinAndroidApplicationProject ();
+			var proj = new XamarinAndroidApplicationProject ();
 			proj.IsRelease = isRelease;
 			proj.SetRuntime (runtime);
 			// Enable full trimming
-			if (!xamarinForms && isRelease) {
+			if (isRelease) {
 				proj.TrimModeRelease = TrimMode.Full;
 			}
 			if (multidex) {
@@ -478,20 +454,11 @@ namespace Xamarin.Android.Build.Tests
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 
 				if (runtime == AndroidRuntime.NativeAOT) {
-					int numberOfExpectedWarnings;
-					bool validateWarnings;
-					if (xamarinForms && !multidex && packageFormat == "apk") {
-						// NativeAOT goes nuts here (Nov 2025) with 120 different ILC warnings, too many to verify them here in a way that makes sense
-						numberOfExpectedWarnings = 120;
-						validateWarnings = false;
-					} else {
-						// NativeAOT currently (Nov 2025) produces 6 `ILC : AOT analysis warning IL3050` warnings for various
-						// bits of code. Even though this test expects no warnings and the above likely make the app not work
-						// correctly at run time, it is still worth running this test under NativeAOT to test for the absence
-						// of other warnings.
-						numberOfExpectedWarnings = 6;
-						validateWarnings = true;
-					}
+					// NativeAOT currently (Nov 2025) produces 6 `ILC : AOT analysis warning IL3050` warnings for various
+					// bits of code. Even though this test expects no warnings and the above likely make the app not work
+					// correctly at run time, it is still worth running this test under NativeAOT to test for the absence
+					// of other warnings.
+					int numberOfExpectedWarnings = 6;
 
 					Assert.IsTrue (
 						StringAssertEx.ContainsText (
@@ -501,12 +468,9 @@ namespace Xamarin.Android.Build.Tests
 						$"{b.BuildLogFile} should have exactly {numberOfExpectedWarnings} MSBuild warnings for NativeAOT."
 					);
 
-					if (validateWarnings) {
-						const string expectedWarningIL3050 = "ILC : AOT analysis warning IL3050:";
-						var warnings = b.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build succeeded.", StringComparison.Ordinal)).Where (x => x.Contains (expectedWarningIL3050, StringComparison.Ordinal));
-						Assert.IsTrue (warnings.Count () == numberOfExpectedWarnings, $"Expected {numberOfExpectedWarnings} 'IL3050' warnings, found {warnings.Count ()}");
-					}
-
+					const string expectedWarningIL3050 = "ILC : AOT analysis warning IL3050:";
+					var warnings = b.LastBuildOutput.SkipWhile (x => !x.StartsWith ("Build succeeded.", StringComparison.Ordinal)).Where (x => x.Contains (expectedWarningIL3050, StringComparison.Ordinal));
+					Assert.IsTrue (warnings.Count () == numberOfExpectedWarnings, $"Expected {numberOfExpectedWarnings} 'IL3050' warnings, found {warnings.Count ()}");
 				} else {
 					b.AssertHasNoWarnings ();
 				}


### PR DESCRIPTION
Remove `XamarinFormsAndroidApplicationProject` usage from tests that don't need Xamarin.Forms, fixing NU1703 warnings about the deprecated `MonoAndroid` framework.

## Changes
- **`CheckMonoComponentsMask`**: Use `XamarinAndroidApplicationProject` instead of `XamarinFormsAndroidApplicationProject`
- **`BuildHasNoWarnings`**: Remove `xamarinForms` parameter and all Xamarin.Forms test cases
- **`DotNetBuild`**: Update `Xamarin.AndroidX.AppCompat` from 1.3.1.1 to 1.7.1.3
