### PR TITLE
Add TRX report support to Microsoft.Android.Run

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -75,6 +75,8 @@ core workload SDK packs imported by WorkloadManifest.targets.
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.pdb" TargetPath="..\tools" IsSymbolFile="true" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Android.Run.runtimeconfig.json" TargetPath="tools" />
       <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Platform.dll" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.dll" TargetPath="tools" />
+      <FilesToPackage Include="$(MicrosoftAndroidSdkOutDir)Microsoft.Testing.Extensions.TrxReport.Abstractions.dll" TargetPath="tools" />
       <FilesToPackage Include="@(VersionFiles)" TargetPath="tools" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Xamarin.Android.Build.Tasks\Microsoft.Android.Sdk\Sdk\**" TargetPath="Sdk" />
       <FilesToPackage Include="$(XamarinAndroidSourcePath)src\Microsoft.Android.Sdk.ILLink\PreserveLists\**" TargetPath="PreserveLists" />

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -1,4 +1,5 @@
 using System.Xml.Linq;
+using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
 using Microsoft.Testing.Platform.Extensions;
 using Microsoft.Testing.Platform.Extensions.Messages;
@@ -83,10 +84,18 @@ class AndroidTestAdapter(
 				_ => new PassedTestNodeStateProperty (),
 			};
 
+			var properties = new List<IProperty> { stateProperty };
+
+			// Add TRX report properties required by ITrxReportCapability
+			if (!string.IsNullOrEmpty (result.ClassName))
+				properties.Add (new TrxFullyQualifiedTypeNameProperty (result.ClassName));
+			if (result.Outcome == TrxOutcome.Failed)
+				properties.Add (new TrxExceptionProperty (result.ErrorMessage, result.StackTrace));
+
 			var testNode = new TestNode {
 				Uid = new TestNodeUid (result.FullyQualifiedName),
 				DisplayName = result.TestName,
-				Properties = new PropertyBag (stateProperty),
+				Properties = new PropertyBag (properties.ToArray ()),
 			};
 
 			await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, testNode));
@@ -235,18 +244,14 @@ class AndroidTestAdapter(
 					? $"{className}.{testName}"
 					: testName;
 
-				// Extract error message if present
+				// Extract error message and stack trace if present
 				string? errorMessage = null;
+				string? stackTrace = null;
 				var outputElement = unitTestResult.Element (ns + "Output");
 				var errorInfo = outputElement?.Element (ns + "ErrorInfo");
 				if (errorInfo != null) {
-					var message = errorInfo.Element (ns + "Message")?.Value;
-					var stackTrace = errorInfo.Element (ns + "StackTrace")?.Value;
-					errorMessage = message;
-					if (!string.IsNullOrEmpty (stackTrace))
-						errorMessage = string.IsNullOrEmpty (errorMessage)
-							? stackTrace
-							: $"{errorMessage}\n{stackTrace}";
+					errorMessage = errorInfo.Element (ns + "Message")?.Value;
+					stackTrace = errorInfo.Element (ns + "StackTrace")?.Value;
 				}
 
 				var trxOutcome = outcome switch {
@@ -256,7 +261,7 @@ class AndroidTestAdapter(
 					_ => TrxOutcome.Passed,
 				};
 
-				results.Add (new TrxTestResult (fullyQualifiedName, testName, trxOutcome, errorMessage));
+				results.Add (new TrxTestResult (fullyQualifiedName, testName, className, trxOutcome, errorMessage, stackTrace));
 			}
 		}
 
@@ -284,10 +289,22 @@ enum TrxOutcome
 record TrxTestResult (
 	string FullyQualifiedName,
 	string TestName,
+	string? ClassName,
 	TrxOutcome Outcome,
-	string? ErrorMessage);
+	string? ErrorMessage,
+	string? StackTrace);
 
 class AndroidTestCapabilities : ITestFrameworkCapabilities
 {
-	public IReadOnlyCollection<ITestFrameworkCapability> Capabilities { get; } = [];
+	public IReadOnlyCollection<ITestFrameworkCapability> Capabilities { get; } = [new AndroidTrxReportCapability ()];
+}
+
+class AndroidTrxReportCapability : ITrxReportCapability
+{
+	public bool IsSupported => true;
+
+	public void Enable ()
+	{
+		// No-op: TRX properties are always added to test nodes.
+	}
 }

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -77,9 +77,14 @@ class AndroidTestAdapter(
 
 		var testResults = ParseTrxFile (localTrxPath);
 		foreach (var result in testResults) {
+			// Build the failure message including stack trace for non-TRX consumers
+			var failureMessage = result.ErrorMessage ?? "Test failed";
+			if (!string.IsNullOrEmpty (result.StackTrace))
+				failureMessage += "\n" + result.StackTrace;
+
 			var stateProperty = result.Outcome switch {
 				TrxOutcome.Passed => (IProperty) new PassedTestNodeStateProperty (),
-				TrxOutcome.Failed => new FailedTestNodeStateProperty (result.ErrorMessage ?? "Test failed"),
+				TrxOutcome.Failed => new FailedTestNodeStateProperty (failureMessage),
 				TrxOutcome.NotExecuted => new SkippedTestNodeStateProperty (result.ErrorMessage),
 				_ => new PassedTestNodeStateProperty (),
 			};
@@ -89,7 +94,7 @@ class AndroidTestAdapter(
 			// Add TRX report properties required by ITrxReportCapability
 			if (!string.IsNullOrEmpty (result.ClassName))
 				properties.Add (new TrxFullyQualifiedTypeNameProperty (result.ClassName));
-			if (result.Outcome == TrxOutcome.Failed)
+			if (result.Outcome == TrxOutcome.Failed && (!string.IsNullOrEmpty (result.ErrorMessage) || !string.IsNullOrEmpty (result.StackTrace)))
 				properties.Add (new TrxExceptionProperty (result.ErrorMessage, result.StackTrace));
 
 			var testNode = new TestNode {

--- a/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
+++ b/src/Microsoft.Android.Run/Microsoft.Android.Run.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageReference Include="Mono.Options" Version="$(MonoOptionsVersion)" />
   </ItemGroup>
 

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -318,6 +318,13 @@ async Task<int> RunDotnetTestAsync (List<string> mtpArgs)
 	// since MTP needs them to set up the test communication channel.
 	mtpArgs.AddRange (["--server", "dotnettestcli", "--dotnet-test-pipe", validatedDotnetTestPipe]);
 
+	// MTP defaults its working directory to the DLL location (SDK tools directory),
+	// not Environment.CurrentDirectory. Pass --results-directory explicitly so TRX
+	// reports are written to the project directory, matching dotnet test conventions.
+	if (!mtpArgs.Contains ("--results-directory")) {
+		mtpArgs.AddRange (["--results-directory", Path.Combine (Environment.CurrentDirectory, "TestResults")]);
+	}
+
 	var testApplicationBuilder = await Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync (mtpArgs.ToArray ());
 
 	var adapter = new AndroidTestAdapter (

--- a/src/Microsoft.Android.Run/Program.cs
+++ b/src/Microsoft.Android.Run/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using Microsoft.Testing.Extensions;
 using Mono.Options;
 using Xamarin.Android.Tools;
 
@@ -329,6 +330,8 @@ async Task<int> RunDotnetTestAsync (List<string> mtpArgs)
 	testApplicationBuilder.RegisterTestFramework (
 		_ => new AndroidTestCapabilities (),
 		(_, _) => adapter);
+
+	testApplicationBuilder.AddTrxReportProvider ();
 
 	using var testApplication = await testApplicationBuilder.BuildAsync ();
 	return await testApplication.RunAsync ();

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2405,6 +2405,8 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 		[TestCase ("run", AndroidRuntime.CoreCLR)]
 		[TestCase ("test", AndroidRuntime.MonoVM)]
 		[TestCase ("test", AndroidRuntime.CoreCLR)]
+		[TestCase ("test-trx", AndroidRuntime.MonoVM)]
+		[TestCase ("test-trx", AndroidRuntime.CoreCLR)]
 		public void DotNetNewAndroidTest (string mode, AndroidRuntime runtime)
 		{
 			var templateName = $"DotNetNewAndroidTest_{mode}_{runtime}";
@@ -2437,16 +2439,21 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			Assert.IsTrue (dotnet.Build (parameters: buildParameters.ToArray ()), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();
 
+			bool isTestMode = mode.StartsWith ("test", StringComparison.Ordinal);
+
 			// `dotnet test` doesn't go through the MSBuild Run target, so Install
 			// must be invoked explicitly to deploy the APK to the device.
-			if (mode == "test")
+			if (isTestMode)
 				Assert.IsTrue (dotnet.Build (target: "Install", parameters: buildParameters.ToArray ()), "`dotnet build -t:Install` should succeed");
 
 			// Run based on mode
-			var runParameters = buildParameters.Select (p => $"/p:{p}").ToArray ();
+			var runParameters = buildParameters.Select (p => $"/p:{p}").ToList ();
+			if (mode == "test-trx")
+				runParameters.Add ("--report-trx");
+
 			using var process = mode == "run"
-				? dotnet.StartRun (waitForExit: true, parameters: runParameters)
-				: dotnet.StartTest (parameters: runParameters);
+				? dotnet.StartRun (waitForExit: true, parameters: runParameters.ToArray ())
+				: dotnet.StartTest (parameters: runParameters.ToArray ());
 
 			var locker = new Lock ();
 			var output = new StringBuilder ();
@@ -2499,6 +2506,19 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				StringAssert.Contains ("succeeded: 1", outputText, $"Output should report 1 passed test. See {logPath} for details.");
 				StringAssert.Contains ("failed: 1", outputText, $"Output should report 1 failed test. See {logPath} for details.");
 				StringAssert.Contains ("skipped: 1", outputText, $"Output should report 1 skipped test. See {logPath} for details.");
+
+				if (mode == "test-trx") {
+					// Verify that a TRX file was produced
+					var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
+					Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
+
+					var trxDoc = XDocument.Load (trxFiles [0]);
+					var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
+					var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
+					Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
+
+					TestContext.AddTestAttachment (trxFiles [0]);
+				}
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2504,15 +2504,21 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				StringAssert.Contains ("skipped: 1", outputText, $"Output should report 1 skipped test. See {logPath} for details.");
 
 				// Verify that a TRX file was produced by --report-trx
-				var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
-				Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
+				// The TRX path is reported in stdout, e.g.:
+				//   In process file artifacts produced:
+				//     - /path/to/TestResults/file.trx
+				var trxPathMatch = System.Text.RegularExpressions.Regex.Match (outputText, @"^\s+-\s+(.+\.trx)\s*$", System.Text.RegularExpressions.RegexOptions.Multiline);
+				Assert.IsTrue (trxPathMatch.Success, $"Expected TRX file path in output. See {logPath} for details.");
 
-				TestContext.AddTestAttachment (trxFiles [0]);
+				var trxPath = trxPathMatch.Groups [1].Value.Trim ();
+				Assert.IsTrue (File.Exists (trxPath), $"TRX file should exist at: {trxPath}. See {logPath} for details.");
 
-				var trxDoc = XDocument.Load (trxFiles [0]);
+				TestContext.AddTestAttachment (trxPath);
+
+				var trxDoc = XDocument.Load (trxPath);
 				var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
 				var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
-				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
+				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxPath}");
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2504,21 +2504,15 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				StringAssert.Contains ("skipped: 1", outputText, $"Output should report 1 skipped test. See {logPath} for details.");
 
 				// Verify that a TRX file was produced by --report-trx
-				// The TRX path is reported in stdout, e.g.:
-				//   In process file artifacts produced:
-				//     - /path/to/TestResults/file.trx
-				var trxPathMatch = System.Text.RegularExpressions.Regex.Match (outputText, @"^\s+-\s+(.+\.trx)\s*$", System.Text.RegularExpressions.RegexOptions.Multiline);
-				Assert.IsTrue (trxPathMatch.Success, $"Expected TRX file path in output. See {logPath} for details.");
+				var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
+				Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
 
-				var trxPath = trxPathMatch.Groups [1].Value.Trim ();
-				Assert.IsTrue (File.Exists (trxPath), $"TRX file should exist at: {trxPath}. See {logPath} for details.");
+				TestContext.AddTestAttachment (trxFiles [0]);
 
-				TestContext.AddTestAttachment (trxPath);
-
-				var trxDoc = XDocument.Load (trxPath);
+				var trxDoc = XDocument.Load (trxFiles [0]);
 				var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
 				var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
-				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxPath}");
+				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2507,12 +2507,12 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
 				Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
 
+				TestContext.AddTestAttachment (trxFiles [0]);
+
 				var trxDoc = XDocument.Load (trxFiles [0]);
 				var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
 				var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
 				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
-
-				TestContext.AddTestAttachment (trxFiles [0]);
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2405,8 +2405,6 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 		[TestCase ("run", AndroidRuntime.CoreCLR)]
 		[TestCase ("test", AndroidRuntime.MonoVM)]
 		[TestCase ("test", AndroidRuntime.CoreCLR)]
-		[TestCase ("test-trx", AndroidRuntime.MonoVM)]
-		[TestCase ("test-trx", AndroidRuntime.CoreCLR)]
 		public void DotNetNewAndroidTest (string mode, AndroidRuntime runtime)
 		{
 			var templateName = $"DotNetNewAndroidTest_{mode}_{runtime}";
@@ -2439,7 +2437,7 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			Assert.IsTrue (dotnet.Build (parameters: buildParameters.ToArray ()), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();
 
-			bool isTestMode = mode.StartsWith ("test", StringComparison.Ordinal);
+			bool isTestMode = mode == "test";
 
 			// `dotnet test` doesn't go through the MSBuild Run target, so Install
 			// must be invoked explicitly to deploy the APK to the device.
@@ -2448,7 +2446,7 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 
 			// Run based on mode
 			var runParameters = buildParameters.Select (p => $"/p:{p}").ToList ();
-			if (mode == "test-trx")
+			if (isTestMode)
 				runParameters.Add ("--report-trx");
 
 			using var process = mode == "run"
@@ -2507,18 +2505,16 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 				StringAssert.Contains ("failed: 1", outputText, $"Output should report 1 failed test. See {logPath} for details.");
 				StringAssert.Contains ("skipped: 1", outputText, $"Output should report 1 skipped test. See {logPath} for details.");
 
-				if (mode == "test-trx") {
-					// Verify that a TRX file was produced
-					var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
-					Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
+				// Verify that a TRX file was produced by --report-trx
+				var trxFiles = Directory.GetFiles (projectDirectory, "*.trx", SearchOption.AllDirectories);
+				Assert.IsTrue (trxFiles.Length > 0, $"Expected at least one .trx file in {projectDirectory}. See {logPath} for details.");
 
-					var trxDoc = XDocument.Load (trxFiles [0]);
-					var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
-					var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
-					Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
+				var trxDoc = XDocument.Load (trxFiles [0]);
+				var trxNs = trxDoc.Root?.Name.Namespace ?? XNamespace.None;
+				var resultSummary = trxDoc.Root?.Element (trxNs + "ResultSummary");
+				Assert.IsNotNull (resultSummary, $"TRX file should contain a ResultSummary element. File: {trxFiles [0]}");
 
-					TestContext.AddTestAttachment (trxFiles [0]);
-				}
+				TestContext.AddTestAttachment (trxFiles [0]);
 			}
 		}
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -2437,16 +2437,14 @@ Facebook.FacebookSdk.LogEvent(""TestFacebook"");
 			Assert.IsTrue (dotnet.Build (parameters: buildParameters.ToArray ()), "`dotnet build` should succeed");
 			dotnet.AssertHasNoWarnings ();
 
-			bool isTestMode = mode == "test";
-
 			// `dotnet test` doesn't go through the MSBuild Run target, so Install
 			// must be invoked explicitly to deploy the APK to the device.
-			if (isTestMode)
+			if (mode == "test")
 				Assert.IsTrue (dotnet.Build (target: "Install", parameters: buildParameters.ToArray ()), "`dotnet build -t:Install` should succeed");
 
 			// Run based on mode
 			var runParameters = buildParameters.Select (p => $"/p:{p}").ToList ();
-			if (isTestMode)
+			if (mode == "test")
 				runParameters.Add ("--report-trx");
 
 			using var process = mode == "run"


### PR DESCRIPTION
## Description

Add TRX report support to `Microsoft.Android.Run`, the host-side MTP test adapter for Android `dotnet test`. This enables `--report-trx` to produce standard TRX result files.

## Changes

- **`Microsoft.Android.Run.csproj`**: Add `Microsoft.Testing.Extensions.TrxReport` package reference
- **`Program.cs`**: Register TRX report provider via `AddTrxReportProvider()` in the MTP builder pipeline
- **`AndroidTestAdapter.cs`**:
  - Add `TrxFullyQualifiedTypeNameProperty` and `TrxExceptionProperty` to test nodes for TRX report generation
  - Parse `ClassName` and `StackTrace` as separate fields from the TRX XML (previously concatenated into `ErrorMessage`)
  - Add `AndroidTrxReportCapability` implementing `ITrxReportCapability`
  - Register the capability in `AndroidTestCapabilities`
- **`Microsoft.Android.Sdk.proj`**: Ship `Microsoft.Testing.Extensions.TrxReport.dll` and `Microsoft.Testing.Extensions.TrxReport.Abstractions.dll` in the SDK workload pack
