### PR TITLE
[tests] Add AssertCommercialBuild() to incremental build tests

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
@@ -214,6 +214,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var gradleProject = AndroidGradleProject.CreateDefault (GradleTestProjectDir);
 			var gradleModule = gradleProject.Modules.First ();

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -277,6 +277,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var proj = new XamarinAndroidApplicationProject  {
 				IsRelease = isRelease,
@@ -386,6 +387,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			// TODO: NativeAOT fails with: 'classlibrary1.CustomTextView should have been replaced with an $(Hash).CustomTextView'
 			if (runtime == AndroidRuntime.NativeAOT) {
@@ -1145,6 +1147,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var path = Path.Combine ("temp", TestName);
 			var appProj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
@@ -1436,6 +1439,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -1501,6 +1505,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			BuildItem CreateItem (string include) =>
 				new AndroidItem.AndroidResource (include) {
 					TextContent = () => "",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -388,7 +388,7 @@ namespace Xamarin.Android.Build.Tests
 				return;
 			}
 
-			// TODO:NativeAOT fails with: 'classlibrary1.CustomTextView should have been replaced with an $(Hash).CustomTextView'
+			// TODO: NativeAOT fails with: 'classlibrary1.CustomTextView should have been replaced with an $(Hash).CustomTextView'
 			if (runtime == AndroidRuntime.NativeAOT) {
 				Assert.Ignore ("NativeAOT fails here atm");
 			}
@@ -1032,7 +1032,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var path= Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName);
 			var target = "_CreateAar";
 			var foo = new BuildItem.Source ("Foo.cs") {
 				TextContent = () => @"using System;
@@ -1151,7 +1151,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var path= Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName);
 			var appProj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				ProjectName = "App1",
@@ -1446,7 +1446,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var proj= new XamarinAndroidApplicationProject {
+			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
@@ -1513,7 +1513,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			BuildItem CreateItem(string include) =>
+			BuildItem CreateItem (string include) =>
 				new AndroidItem.AndroidResource (include) {
 					TextContent = () => "",
 				};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -387,9 +387,8 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
-			// TODO: NativeAOT fails with: 'classlibrary1.CustomTextView should have been replaced with an $(Hash).CustomTextView'
+			// TODO:NativeAOT fails with: 'classlibrary1.CustomTextView should have been replaced with an $(Hash).CustomTextView'
 			if (runtime == AndroidRuntime.NativeAOT) {
 				Assert.Ignore ("NativeAOT fails here atm");
 			}
@@ -545,7 +544,9 @@ namespace UnnamedProject
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");
-				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
+				}
 
 				lib.Touch ("CustomTextView.cs");
 
@@ -1031,8 +1032,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var path = Path.Combine ("temp", TestName);
+			var path= Path.Combine ("temp", TestName);
 			var target = "_CreateAar";
 			var foo = new BuildItem.Source ("Foo.cs") {
 				TextContent = () => @"using System;
@@ -1087,10 +1087,14 @@ namespace Lib1 {
 					appBuilder.Output.AssertTargetIsNotSkipped ("_UpdateAndroidResgen");
 					foo.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
-					libBuilder.Output.AssertTargetIsSkipped (target);
+					if (TestEnvironment.CommercialBuildAvailable) {
+						libBuilder.Output.AssertTargetIsSkipped (target);
+					}
 					appBuilder.BuildLogFile = "build1.log";
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
-					appBuilder.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
+					if (TestEnvironment.CommercialBuildAvailable) {
+						appBuilder.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
+					}
 					// Check Contents of the file in the apk are correct.
 					string apk = Path.Combine (Root, appBuilder.ProjectDirectory, appProj.OutputPath, appProj.PackageName + "-Signed.apk");
 					byte[] rawContentBuildOne = ZipHelper.ReadFileFromZip (apk,
@@ -1147,8 +1151,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var path = Path.Combine ("temp", TestName);
+			var path= Path.Combine ("temp", TestName);
 			var appProj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				ProjectName = "App1",
@@ -1173,12 +1176,16 @@ namespace Lib1 {
 				appBuilder.BuildLogFile = "build.log";
 				Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true),
 					"Normal Application Build should have succeeded.");
-				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
-					"Target '_ManagedUpdateAndroidResgen' should not have run.");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
+						"Target '_ManagedUpdateAndroidResgen' should not have run.");
+				}
 				appBuilder.BuildLogFile = "designtimebuild.log";
 				Assert.IsTrue (appBuilder.DesignTimeBuild (appProj, doNotCleanupOnUpdate: true), "DesignTime Application Build should have succeeded.");
-				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
-					"Target '_ManagedUpdateAndroidResgen' should not have run.");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
+						"Target '_ManagedUpdateAndroidResgen' should not have run.");
+				}
 
 				Assert.IsTrue (appBuilder.Clean (appProj), "Clean should have succeeded");
 				Assert.IsTrue (File.Exists (designerFile), $"'{designerFile}' should not have been cleaned.");
@@ -1439,8 +1446,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var proj = new XamarinAndroidApplicationProject {
+			var proj= new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
@@ -1456,12 +1462,14 @@ namespace UnnamedProject
 				proj.Touch (@"Resources\layout\Main.axml");
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded");
-				Assert.IsTrue (
-					b.Output.IsTargetPartiallyBuilt ("_CompileResources"),
-					"The target _CompileResources should have been partially built");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_FixupCustomViewsForAapt2", defaultIfNotUsed: true),
-					"The target _FixupCustomViewsForAapt2 should have been skipped");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (
+						b.Output.IsTargetPartiallyBuilt ("_CompileResources"),
+						"The target _CompileResources should have been partially built");
+					Assert.IsTrue (
+						b.Output.IsTargetSkipped ("_FixupCustomViewsForAapt2", defaultIfNotUsed: true),
+						"The target _FixupCustomViewsForAapt2 should have been skipped");
+				}
 
 				var r_java = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", proj.PackageNameJavaIntermediatePath, "R.java");
 				FileAssert.Exists (r_java);
@@ -1505,8 +1513,7 @@ namespace UnnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			BuildItem CreateItem (string include) =>
+			BuildItem CreateItem(string include) =>
 				new AndroidItem.AndroidResource (include) {
 					TextContent = () => "",
 				};
@@ -1522,7 +1529,9 @@ namespace UnnamedProject
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
-				b.Output.AssertTargetIsSkipped ("_CompileResources");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					b.Output.AssertTargetIsSkipped ("_CompileResources");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -1029,6 +1029,7 @@ namespace Lib1 {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var path = Path.Combine ("temp", TestName);
 			var target = "_CreateAar";
 			var foo = new BuildItem.Source ("Foo.cs") {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -195,6 +195,7 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var abisSanitized = supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
 			var path = Path.Combine ("temp", string.Format ("BuildAotNdk AndÜmläüts_{0}_{1}_{2}", abisSanitized, enableLLVM, usesAssemblyBlobs));

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -254,8 +254,9 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
-			var abisSanitized = supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
+			var abisSanitized= supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
 			var path = Path.Combine ("temp", string.Format ("BuildAot AndÜmläüts_{0}_{1}_{2}", abisSanitized, enableLLVM, usesAssemblyBlobs));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -252,12 +252,12 @@ namespace Xamarin.Android.Build.Tests
 
 		[Test]
 		[TestCaseSource (nameof (AotChecks))]
-		public void BuildAotApplicationAndÜmläüts(string supportedAbis, bool enableLLVM, bool usesAssemblyBlobs)
+		public void BuildAotApplicationAndÜmläüts (string supportedAbis, bool enableLLVM, bool usesAssemblyBlobs)
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");
 
-			var abisSanitized= supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
+			var abisSanitized = supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
 			var path = Path.Combine ("temp", string.Format ("BuildAot AndÜmläüts_{0}_{1}_{2}", abisSanitized, enableLLVM, usesAssemblyBlobs));
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -239,18 +239,20 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 				Assert.IsTrue (b.Build (proj), "Second Build should have succeeded.");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CompileJava"),
-					"the _CompileJava target should be skipped");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
-					"the _BuildApkEmbed target should be skipped");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (
+						b.Output.IsTargetSkipped ("_CompileJava"),
+						"the _CompileJava target should be skipped");
+					Assert.IsTrue (
+						b.Output.IsTargetSkipped ("_BuildApkEmbed"),
+						"the _BuildApkEmbed target should be skipped");
+				}
 			}
 		}
 
 		[Test]
 		[TestCaseSource (nameof (AotChecks))]
-		public void BuildAotApplicationAndÜmläüts (string supportedAbis, bool enableLLVM, bool usesAssemblyBlobs)
+		public void BuildAotApplicationAndÜmläüts(string supportedAbis, bool enableLLVM, bool usesAssemblyBlobs)
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -195,7 +195,6 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var abisSanitized = supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
 			var path = Path.Combine ("temp", string.Format ("BuildAotNdk AndÜmläüts_{0}_{1}_{2}", abisSanitized, enableLLVM, usesAssemblyBlobs));
@@ -255,7 +254,6 @@ namespace Xamarin.Android.Build.Tests
 		{
 			if (IsWindows)
 				Assert.Ignore ("https://github.com/dotnet/runtime/issues/88625");
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var abisSanitized= supportedAbis.Replace (";", "").Replace ("-", "").Replace ("_", "");
 			var path = Path.Combine ("temp", string.Format ("BuildAot AndÜmläüts_{0}_{1}_{2}", abisSanitized, enableLLVM, usesAssemblyBlobs));
@@ -289,12 +287,14 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 				Assert.IsTrue (b.Build (proj), "Second Build should have succeeded.");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_CompileJava"),
-					"the _CompileJava target should be skipped");
-				Assert.IsTrue (
-					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
-					"the _BuildApkEmbed target should be skipped");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (
+						b.Output.IsTargetSkipped ("_CompileJava"),
+						"the _CompileJava target should be skipped");
+					Assert.IsTrue (
+						b.Output.IsTargetSkipped ("_BuildApkEmbed"),
+						"the _BuildApkEmbed target should be skipped");
+				}
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -165,8 +165,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var path = Path.Combine ("temp", TestName);
+			var path= Path.Combine ("temp", TestName);
 			var asset3 = new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 				TextContent = () => "Asset3",
 				Encoding = Encoding.ASCII,
@@ -220,9 +219,11 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
 				}
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), $"{app.ProjectName} should succeed");
-				appBuilder.Output.AssertTargetIsSkipped ("_CreateAssetPackManifests");
-				appBuilder.Output.AssertTargetIsSkipped ("_BuildAssetPacks");
-				appBuilder.Output.AssertTargetIsSkipped ("_GenerateAndroidAssetsDir");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					appBuilder.Output.AssertTargetIsSkipped ("_CreateAssetPackManifests");
+					appBuilder.Output.AssertTargetIsSkipped ("_BuildAssetPacks");
+					appBuilder.Output.AssertTargetIsSkipped ("_GenerateAndroidAssetsDir");
+				}
 				FileAssert.Exists (asset3File, $"file {asset3File} should exist.");
 				asset3.TextContent = () => "Asset3 Updated";
 				asset3.Timestamp = DateTime.UtcNow.AddSeconds(1);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var path= Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName);
 			var asset3 = new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 				TextContent = () => "Asset3",
 				Encoding = Encoding.ASCII,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -165,6 +165,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var path = Path.Combine ("temp", TestName);
 			var asset3 = new AndroidItem.AndroidAsset ("Assets\\asset3.txt") {
 				TextContent = () => "Asset3",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -835,8 +835,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var path = Path.Combine ("temp", TestName);
+			var path= Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidBindingProject () {
 				IsRelease = isRelease,
 				ProjectName = "BindingsProject",
@@ -885,8 +884,10 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 					"generated", "src", "Com.Xamarin.Android.Test.Msbuildtest.IJavaSourceTestInterface.cs");
 				StringAssertEx.ContainsText (File.ReadAllLines (generatedIface), "string GreetWithQuestion (string name, global::Java.Util.Date date, string question);");
 				Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
-				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava", defaultIfNotUsed: true), $"`_CompileBindingJava` should be skipped on second build!");
-				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava", defaultIfNotUsed: true), $"`_CompileBindingJava` should be skipped on second build!");
+					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
+				}
 				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on second build.");
 				Assert.IsTrue (libBuilder.DesignTimeBuild (lib, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
 				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on DTB build.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -835,7 +835,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var path= Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidBindingProject () {
 				IsRelease = isRelease,
 				ProjectName = "BindingsProject",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -97,6 +97,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var targets = new List<string> {
 				"_ExportJarToXml",
@@ -834,6 +835,7 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidBindingProject () {
 				IsRelease = isRelease,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1143,8 +1143,7 @@ namespace Xamarin.Android.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-			var proj = new XamarinAndroidApplicationProject () {
+			var proj= new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
@@ -1199,17 +1198,19 @@ namespace UnamedProject
 				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after the second `Build`.");
 
 				//NOTE: none of these targets should run, since we have not actually changed anything!
-				var targetsToBeSkipped = new [] {
-					//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
-					//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
-					//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
-					//"_LinkAssembliesNoShrink",
-					"_UpdateAndroidResgen",
-					"_BuildLibraryImportsCache",
-					"_CompileJava",
-				};
-				foreach (var targetName in targetsToBeSkipped) {
-					Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					var targetsToBeSkipped = new [] {
+						//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
+						//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
+						//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
+						//"_LinkAssembliesNoShrink",
+						"_UpdateAndroidResgen",
+						"_BuildLibraryImportsCache",
+						"_CompileJava",
+					};
+					foreach (var targetName in targetsToBeSkipped) {
+						Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
+					}
 				}
 
 				b.Target = "Clean";
@@ -1301,9 +1302,8 @@ namespace UnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
-			var start = DateTime.UtcNow.AddSeconds (-1);
+			var start= DateTime.UtcNow.AddSeconds (-1);
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 
@@ -1350,13 +1350,15 @@ namespace UnamedProject
 				//One last build with no changes
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
 
-				// NativeAOT always runs the linking step
-				if (runtime != AndroidRuntime.NativeAOT) {
-					b.Output.AssertTargetIsSkipped (isRelease ? KnownTargets.LinkAssembliesShrink : KnownTargets.LinkAssembliesNoShrink);
+				if (TestEnvironment.CommercialBuildAvailable) {
+					// NativeAOT always runs the linking step
+					if (runtime != AndroidRuntime.NativeAOT) {
+						b.Output.AssertTargetIsSkipped (isRelease ? KnownTargets.LinkAssembliesShrink : KnownTargets.LinkAssembliesNoShrink);
+					}
+					b.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
+					b.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
+					b.Output.AssertTargetIsSkipped ("_CompileJava");
 				}
-				b.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
-				b.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
-				b.Output.AssertTargetIsSkipped ("_CompileJava");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -896,6 +896,7 @@ class MemTest {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var proj = new XamarinFormsMapsApplicationProject {
 				IsRelease = isRelease,
@@ -1142,6 +1143,7 @@ namespace Xamarin.Android.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
@@ -1299,6 +1301,7 @@ namespace UnamedProject
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var start = DateTime.UtcNow.AddSeconds (-1);
 			var proj = new XamarinFormsAndroidApplicationProject {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -1143,7 +1143,7 @@ namespace Xamarin.Android.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			var proj= new XamarinAndroidApplicationProject () {
+			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
@@ -1303,7 +1303,7 @@ namespace UnamedProject
 				return;
 			}
 
-			var start= DateTime.UtcNow.AddSeconds (-1);
+			var start = DateTime.UtcNow.AddSeconds (-1);
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -703,7 +703,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			if (runtime == AndroidRuntime.NativeAOT) {
 				// Fails on NativeAOT with:
@@ -752,16 +751,18 @@ namespace Lib2
 				Assert.IsTrue (libBuilder.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
-				appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
-				appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
-				appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
-				appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
+					appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
+					appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
+					appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
 
-				appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
+					appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
 
-				appBuilder.Output.AssertTargetIsNotSkipped ("_BuildApkEmbed");
-				appBuilder.Output.AssertTargetIsNotSkipped ("_CopyPackage");
-				appBuilder.Output.AssertTargetIsNotSkipped ("_Sign");
+					appBuilder.Output.AssertTargetIsNotSkipped ("_BuildApkEmbed");
+					appBuilder.Output.AssertTargetIsNotSkipped ("_CopyPackage");
+					appBuilder.Output.AssertTargetIsNotSkipped ("_Sign");
+				}
 			}
 		}
 
@@ -923,9 +924,8 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
-			var path = Path.Combine ("temp", TestName);
+			var path= Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 				ProjectName = "MyApp",
@@ -998,13 +998,15 @@ namespace Lib2
 				appBuilder.BuildLogFile = "build2.log";
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
-				var targetsShouldSkip = new [] {
-					"_BuildLibraryImportsCache",
-					"_ResolveLibraryProjectImports",
-					"_ConvertCustomView",
-				};
-				foreach (var target in targetsShouldSkip) {
-					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					var targetsShouldSkip = new [] {
+						"_BuildLibraryImportsCache",
+						"_ResolveLibraryProjectImports",
+						"_ConvertCustomView",
+					};
+					foreach (var target in targetsShouldSkip) {
+						Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+					}
 				}
 
 				var targetsShouldRun = new [] {
@@ -1015,16 +1017,18 @@ namespace Lib2
 					"_CopyPackage",
 					"_Sign",
 				};
-				foreach (var target in targetsShouldRun) {
-					Assert.IsFalse (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
-				}
+				if (TestEnvironment.CommercialBuildAvailable) {
+					foreach (var target in targetsShouldRun) {
+						Assert.IsFalse (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
+					}
 
-				var aapt2TargetsShouldBeSkipped = new [] {
-					"_FixupCustomViewsForAapt2",
-					"_CompileResources"
-				};
-				foreach (var target in aapt2TargetsShouldBeSkipped) {
-					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"{target} should be skipped!");
+					var aapt2TargetsShouldBeSkipped = new [] {
+						"_FixupCustomViewsForAapt2",
+						"_CompileResources"
+					};
+					foreach (var target in aapt2TargetsShouldBeSkipped) {
+						Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"{target} should be skipped!");
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -68,6 +69,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			if (runtime != AndroidRuntime.MonoVM) { // temporarily
 				Assert.Ignore ("Runtimes other than MonoVM are currently broken here.");
@@ -352,6 +354,7 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var app = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
@@ -532,6 +535,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var targets = new List<(string target, bool ignoreOnNAOT)> {
 				("_GeneratePackageManagerJava", true), // TODO: NativeAOT doesn't skip this target on 3rd attempt, check if that's ok?
@@ -699,6 +703,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			if (runtime == AndroidRuntime.NativeAOT) {
 				// Fails on NativeAOT with:
@@ -849,6 +854,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -917,6 +923,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
@@ -1235,6 +1242,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			// TODO: NativeAOT build doesn't add android/environment.arm64-v8a.o to file writes
 			if (runtime == AndroidRuntime.NativeAOT) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -670,6 +670,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
@@ -1028,6 +1029,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
@@ -1669,6 +1671,7 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -925,7 +925,7 @@ namespace Lib2
 				return;
 			}
 
-			var path= Path.Combine ("temp", TestName);
+			var path = Path.Combine ("temp", TestName);
 			var app = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 				ProjectName = "MyApp",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -220,6 +220,7 @@ namespace Bug12935
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				ManifestMerger = "manifestmerger.jar",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -593,6 +593,7 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -593,7 +593,6 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
@@ -614,8 +613,10 @@ string.Join ("\n", packages.Select (x => metaDataTemplate.Replace ("%", x.Id))) 
 
 				// Build with no changes
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
-				foreach (var target in new [] { "_Sign", "_BuildApkEmbed" }) {
-					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+				if (TestEnvironment.CommercialBuildAvailable) {
+					foreach (var target in new [] { "_Sign", "_BuildApkEmbed" }) {
+						Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
+					}
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Android.Build.Tests {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
+			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,


### PR DESCRIPTION
These tests verify MSBuild targets are skipped on incremental builds, which only holds true when Fast Deployment is available (commercial builds). Without it, additional targets run and the assertions fail.

Fixes: https://github.com/dotnet/android/issues/11419
