### PR TITLE
[Export] Fix dynamic export array callbacks

### DIFF
--- a/src/Mono.Android.Export/CallbackCode.cs
+++ b/src/Mono.Android.Export/CallbackCode.cs
@@ -264,6 +264,8 @@ namespace Java.Interop
 					copyArrayMethod = typeof (JNIEnv).GetMethod ("CopyArray", new Type [] { type, typeof (IntPtr) });
 					break;
 				}
+				if (copyArrayMethod == null)
+					throw new NotSupportedException ($"JNIEnv.CopyArray does not support array type '{type}'.");
 				CodeBlock copyArrayBlock = new CodeBlock ();
 				copyArrayBlock.Add (new CodeMethodCall (copyArrayMethod, arg, orgArg));
 				return new CodeIf (CodeExpression.Not (arg.IsNull)) {

--- a/src/Mono.Android.Export/CallbackCode.cs
+++ b/src/Mono.Android.Export/CallbackCode.cs
@@ -167,7 +167,7 @@ namespace Java.Interop
 			return GetCallbackPrep (type, parameter_kind, arg);
 		}
 	
-		public CodeExpression CleanupCallback (CodeExpression arg, CodeExpression orgArg)
+		public CodeItem CleanupCallback (CodeExpression arg, CodeExpression orgArg)
 		{
 			return GetCallbackCleanup (type, arg, orgArg);
 		}
@@ -190,7 +190,7 @@ namespace Java.Interop
 			// ArraySymbol:
 			//	return new string[] { String.Format ("{0}[] {1} = ({0}[]) JNIEnv.GetArray ({2}, JniHandleOwnership.DoNotTransfer, typeof ({3}));", ElementType, var_name, SymbolTable.GetNativeName (var_name), sym.FullName) };
 			case SymbolKind.Array:
-				return new CodeMethodCall (jnienv_getarray, arg, do_not_transfer_literal, new CodeLiteral (type)).CastTo (type);
+				return new CodeMethodCall (jnienv_getarray.MakeGenericMethod (type.GetElementType ()), arg).CastTo (type);
 
 			// CharSequenceSymbol:
 			//	return new string[] { String.Format ("Java.Lang.ICharSequence {0} = Java.Lang.Object.GetObject<Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, SymbolTable.GetNativeName (var_name)) };
@@ -239,7 +239,7 @@ namespace Java.Interop
 			return arg;
 		}
 		
-		public static CodeExpression GetCallbackCleanup (Type type, CodeExpression arg, CodeExpression orgArg)
+		public static CodeItem GetCallbackCleanup (Type type, CodeExpression arg, CodeExpression orgArg)
 		{
 			switch (GetKind (type)) {
 			// ArraySymbol:
@@ -249,13 +249,14 @@ namespace Java.Interop
 			//	return result;
 			case SymbolKind.Array:
 				MethodInfo copyArrayMethod;
-				switch (Type.GetTypeCode (type)) {
+				Type elementType = type.GetElementType ();
+				switch (Type.GetTypeCode (elementType)) {
 				case TypeCode.Empty:
 				case TypeCode.DBNull:
 					throw new NotSupportedException ("Only primitive types and IJavaObject is supported in array type in callback method parameter or return value");
 				case TypeCode.Object:
-					if (typeof (IJavaObject).IsAssignableFrom (type))
-						copyArrayMethod = typeof (JNIEnv).GetMethod ("CopyArray", new Type [] { typeof (IJavaObject), typeof (IntPtr) });
+					if (typeof (IJavaObject).IsAssignableFrom (elementType))
+						copyArrayMethod = typeof (JNIEnv).GetMethod ("CopyArray", new Type [] { typeof (IJavaObject[]), typeof (IntPtr) });
 					else
 						goto case TypeCode.Empty;
 					break;
@@ -263,7 +264,11 @@ namespace Java.Interop
 					copyArrayMethod = typeof (JNIEnv).GetMethod ("CopyArray", new Type [] { type, typeof (IntPtr) });
 					break;
 				}
-				return new CodeWhen (arg.IsNull, arg, new CodeMethodCall (copyArrayMethod, arg, orgArg));
+				CodeBlock copyArrayBlock = new CodeBlock ();
+				copyArrayBlock.Add (new CodeMethodCall (copyArrayMethod, arg, orgArg));
+				return new CodeIf (CodeExpression.Not (arg.IsNull)) {
+					TrueBlock = copyArrayBlock,
+				};
 			
 			// CharSequenceSymbol:
 			// 	return new string[] { String.Format ("Java.Lang.ICharSequence {0} = Java.Lang.Object.GetObject<Java.Lang.ICharSequence> ({1}, JniHandleOwnership.DoNotTransfer);", var_name, SymbolTable.GetNativeName (var_name)) };
@@ -711,10 +716,12 @@ namespace Java.Interop
 			//		sw.WriteLine ("{0}\t{1} {2};", indent, Parameters.HasCleanup ? RetVal.NativeType + " __ret =" : "return", RetVal.ToNative (opt, call));
 			var callArgs = new List<CodeExpression> ();
 			for (int i = 0; i < parameter_type_infos.Count; i++) {
-				if (parameter_type_infos [i].NeedsPrep)
-					callArgs.Add (parameter_type_infos [i].PrepareCallback (mgen.GetArg (i + 2)));
-				else
+				if (parameter_type_infos [i].NeedsPrep) {
+					var preparedArg = parameter_type_infos [i].PrepareCallback (mgen.GetArg (i + 2));
+					callArgs.Add (builder.DeclareVariable (method.GetParameters () [i].ParameterType, preparedArg));
+				} else {
 					callArgs.Add (parameter_type_infos [i].FromNative (mgen.GetArg (i + 2)));
+				}
 			}
 			CodeMethodCall call;
 			if (method.IsStatic)
@@ -740,7 +747,7 @@ namespace Java.Interop
 			//	sw.WriteLine ("{0}\t{1}", indent, cleanup);
 			var callbackCleanup = new List<CodeStatement> ();
 			for (int i = 0; i < parameter_type_infos.Count; i++)
-				builder.CurrentBlock.Add (parameter_type_infos [i].CleanupCallback (callArgs [i], mgen.GetArg (i)));
+				builder.CurrentBlock.Add (parameter_type_infos [i].CleanupCallback (callArgs [i], mgen.GetArg (i + 2)));
 
 			//if (!IsVoid && Parameters.HasCleanup)
 			//	sw.WriteLine ("{0}\treturn __ret;", indent);

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ExportTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/ExportTests.cs
@@ -99,8 +99,6 @@ namespace Java.InteropTests
 		[Test, Category ("Export")]
 		public void Export_Method_IntArray_RoundTrip_AndCopyBack ()
 		{
-			AssumeTrimmableExportArrayMarshalling ();
-
 			using var e = new ExportIntArray ();
 			var m = JNIEnv.GetMethodID (e.Class.Handle, "DoubleArray", "([I)[I");
 			Assert.AreNotEqual (IntPtr.Zero, m, "JNI method id for DoubleArray not found");
@@ -135,8 +133,6 @@ namespace Java.InteropTests
 		[Test, Category ("Export")]
 		public void Export_Method_PeerArray_RoundTrip ()
 		{
-			AssumeTrimmableExportArrayMarshalling ();
-
 			using var e = new ExportPeerArray ();
 			using var a = new Java.Lang.Integer (1);
 			using var b = new Java.Lang.Integer (2);
@@ -260,13 +256,6 @@ namespace Java.InteropTests
 		{
 			if (!RuntimeFeature.TrimmableTypeMap) {
 				Assert.Ignore ("[Export] exception routing coverage is only relevant for the trimmable typemap path.");
-			}
-		}
-
-		static void AssumeTrimmableExportArrayMarshalling ()
-		{
-			if (!RuntimeFeature.TrimmableTypeMap) {
-				Assert.Ignore ("[Export] array marshalling coverage is enabled in the Mono.Android.Export stacked PR.");
 			}
 		}
 


### PR DESCRIPTION
Stacked on #11123
Closes #1259

This PR keeps the trimmable typemap export PR focused on the new trimmable path, and moves the unrelated legacy `Mono.Android.Export` dynamic callback fixes here. The end result is that the new array `[Export]` tests can run head-to-head on the legacy non-trimmable typemap paths too, instead of being disabled there.

## Where this broke

I traced the `JNIEnv.GetArray<T>` and `Mono.Android.Export` history. This was not a later `JNIEnv.GetArray<T>` signature change that regressed working code. The mismatch was present from the original `Mono.Android.Export` import in [`d92a49d56`](https://github.com/dotnet/android/commit/d92a49d56) (`[Mono.Android.Export] Import from monodroid/d393f359`, 2016-04-21):

- `CallbackCode.cs` cached `jnienv_getarray` from `JNIEnv.GetArray<int>`, whose signature was already `GetArray<T>(IntPtr array_ptr)`.
- The array callback prep path nevertheless emitted a call with three arguments: `(IntPtr, JniHandleOwnership.DoNotTransfer, Type)`.

So array-shaped dynamic `[Export]` callbacks appear to have been broken since that import. The new tests in #11123 are what exposed the bug because they exercise `[Export]` methods with array parameters/returns on the legacy dynamic-export path.

## What used to crash

A small app/test like this is enough to trigger the broken legacy dynamic callback generation:

```csharp
class ExportIntArray : Java.Lang.Object
{
    [Export]
    public int [] DoubleArray (int [] xs)
    {
        for (int i = 0; i < xs.Length; i++) {
            xs [i] *= 2;
        }
        return xs;
    }
}
```

When Java/JNI calls `DoubleArray(int[])`, `Mono.Android.Export` dynamically emits a native callback delegate that converts the incoming `jintArray` to `int[]`, calls the managed method, converts the return value back to JNI, and copies any managed array parameter mutations back to the original JNI array.

Before this fix, the generated callback was wrong in several ways. Simplified, it behaved like this:

```il
// Parameter prep: CallbackCode cached JNIEnv.GetArray<T>(IntPtr), but emitted three arguments.
ldarg.2                              // jintArray parameter
ldc.i4.0                             // JniHandleOwnership.DoNotTransfer
ldtoken int32[]
call Android.Runtime.JNIEnv::GetArray<int32>(native int, valuetype JniHandleOwnership, class System.Type)
castclass int32[]
call instance int32[] ExportIntArray::DoubleArray(int32[])
call native int Android.Runtime.JNIEnv::NewArray<int32>(int32[])

// Cleanup/copy-back: used the wrong JNI argument slot and was represented as an invalid ternary
// instead of an if statement.
ldarg.0                              // BUG: this is JNIEnv*, not the original jintArray parameter
call void Android.Runtime.JNIEnv::CopyArray(int32[], native int)
```

Depending on exactly how far callback generation got, this could fail while creating the dynamic method (for example invalid `GetArray`/`CopyArray` calls or an invalid ternary expression mixing `int[]` and `void`) or later abort under CheckJNI because registration left a pending managed exception.

With the fix, the generated shape is instead:

```il
// Parameter prep: call the one-argument JNIEnv.GetArray<T>(IntPtr) method and materialize the managed array.
ldarg.2                              // jintArray parameter
call int32[] Android.Runtime.JNIEnv::GetArray<int32>(native int)
stloc.s managedArray

// Call the user's exported method with the same managed array instance that cleanup will copy back.
ldloc.s managedArray
call instance int32[] ExportIntArray::DoubleArray(int32[])
call native int Android.Runtime.JNIEnv::NewArray<int32>(int32[])
stloc.s abiReturn

// Cleanup/copy-back: if (managedArray != null) JNIEnv.CopyArray(managedArray, originalJniArray);
ldloc.s managedArray
brfalse.s doneCopyBack
ldloc.s managedArray
ldarg.2                              // original jintArray parameter
call void Android.Runtime.JNIEnv::CopyArray(int32[], native int)
doneCopyBack:
ldloc.s abiReturn
ret
```

That fixes both the crash and the semantic bug: mutations to the managed `int[]` parameter are copied back to the original JNI array handle.

## Changes

- Fix array callback prep to call the one-argument `JNIEnv.GetArray<T>(IntPtr)` method that `CallbackCode` already cached.
- Materialize prepared array parameters so copy-back updates the managed instance passed to the exported method.
- Copy array parameters back to the correct JNI argument slot.
- Use the array element type when selecting `JNIEnv.CopyArray` overloads.
- Emit array cleanup as an `if` statement instead of an invalid ternary expression.
- Re-enable the int-array and peer-array export tests on non-trimmable typemap paths.

## Validation

Validation performed locally before splitting this out from #11123:

- CoreCLR `llvm-ir` `IncludeCategories=Export` passed with scalar/object/array tests enabled and exception-routing ignored.
- Mono `llvm-ir` `IncludeCategories=Export` passed with scalar/object/array tests enabled and exception-routing ignored.
- CoreCLR trimmable `IncludeCategories=Export` passed all export method tests.
