### PR TITLE
[Trimming] Use DiagnosticMethodInfo for AOT-safe stack frame information

### DIFF
--- a/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
+++ b/src/Mono.Android/Android.Runtime/JavaProxyThrowable.cs
@@ -39,7 +39,7 @@ namespace Android.Runtime {
 			return proxy;
 		}
 
-		(int lineNumber, string? methodName, string? className) GetFrameInfo (StackFrame? managedFrame, MethodBase? managedMethod)
+		(int lineNumber, string? methodName, string? className) GetFrameInfo (StackFrame? managedFrame, DiagnosticMethodInfo? managedMethod)
 		{
 			string? methodName = null;
 			string? className = null;
@@ -47,7 +47,7 @@ namespace Android.Runtime {
 			if (managedFrame == null) {
 				if (managedMethod != null) {
 					methodName = managedMethod.Name;
-					className = managedMethod.DeclaringType?.FullName;
+					className = managedMethod.DeclaringTypeName;
 				}
 
 				return (-1, methodName, className);
@@ -69,7 +69,7 @@ namespace Android.Runtime {
 					methodName = managedMethod.Name;
 				}
 
-				return (lineNumber, methodName, managedMethod.DeclaringType?.FullName);
+				return (lineNumber, methodName, managedMethod.DeclaringTypeName);
 			}
 
 			string frameString = managedFrame.ToString ();
@@ -116,14 +116,6 @@ namespace Android.Runtime {
 
 		void TranslateStackTrace ()
 		{
-			// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
-			// StackFrame.GetMethod() will return null under NativeAOT;
-			// However, you can still get useful information from StackFrame.ToString():
-			// MainActivity.OnCreate() + 0x37 at offset 55 in file:line:column <filename unknown>:0:0
-			[UnconditionalSuppressMessage ("Trimming", "IL2026", Justification = "StackFrame.GetMethod() is \"best attempt\", we handle null & exceptions")]
-			static MethodBase? StackFrameGetMethod (StackFrame frame) =>
-				frame.GetMethod ();
-
 			var trace = new StackTrace (InnerException, fNeedFileInfo: true);
 			if (trace.FrameCount <= 0) {
 				return;
@@ -145,10 +137,10 @@ namespace Android.Runtime {
 			const string Unknown = "Unknown";
 			for (int i = 0; i < frames.Length; i++) {
 				StackFrame managedFrame = frames[i];
-				MethodBase? managedMethod = StackFrameGetMethod (managedFrame);
+				DiagnosticMethodInfo? methodInfo = DiagnosticMethodInfo.Create (managedFrame);
 
 				// https://developer.android.com/reference/java/lang/StackTraceElement?hl=en#StackTraceElement(java.lang.String,%20java.lang.String,%20java.lang.String,%20int)
-				(int lineNumber, string? methodName, string? declaringClass) = GetFrameInfo (managedFrame, managedMethod);
+				(int lineNumber, string? methodName, string? declaringClass) = GetFrameInfo (managedFrame, methodInfo);
 				var throwableFrame = new StackTraceElement (
 					declaringClass: declaringClass ?? Unknown,
 					methodName: methodName ?? Unknown,


### PR DESCRIPTION
## Summary
- use `DiagnosticMethodInfo.Create(StackFrame)` in `JavaProxyThrowable.TranslateStackTrace()`
- avoid `StackFrame.GetMethod()` so stack frame translation remains AOT/trimming-safe
- remove the local `UnconditionalSuppressMessage` for `StackFrame.GetMethod()`

Part of #10794.

## Validation
- `./dotnet-local.sh build src/Mono.Android/Mono.Android.csproj -v:minimal -nr:false` succeeded
- no IL/trimming warnings (`IL####`) found in the build log

Note: this fresh worktree emitted existing generated/baseline warnings unrelated to this one-file change (CS0436/CA1422/RS0025/javac warnings).

