### PR TITLE
[Trimming] Remove RegisterJniNatives suppression

### DIFF
--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -58,16 +58,11 @@ namespace Android.Runtime
 		}
 
 		[UnmanagedCallersOnly]
+		[RequiresUnreferendedCode ("Uses reflection to load types and register native methods, which may require access to members that could be trimmed. Ensure the necessary types and members are preserved.")]
 		static unsafe void RegisterJniNatives (IntPtr typeName_ptr, int typeName_len, IntPtr jniClass, IntPtr methods_ptr, int methods_len)
 		{
-			// FIXME: https://github.com/xamarin/xamarin-android/issues/8724
-			[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type should be preserved by the MarkJavaObjects trimmer step.")]
-			[return: DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods | DynamicallyAccessedMemberTypes.NonPublicNestedTypes)]
-			static Type TypeGetType (string typeName) =>
-				Type.GetType (typeName, throwOnError: false);
-
 			string typeName = new string ((char*) typeName_ptr, 0, typeName_len);
-			var type = TypeGetType (typeName);
+			var type = Type.GetType (typeName, throwOnError: false);
 			if (type == null) {
 				RuntimeNativeMethods.monodroid_log (LogLevel.Error,
 				               LogCategories.Default,

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -58,7 +58,7 @@ namespace Android.Runtime
 		}
 
 		[UnmanagedCallersOnly]
-		[RequiresUnreferendedCode ("Uses reflection to load types and register native methods, which may require access to members that could be trimmed. Ensure the necessary types and members are preserved.")]
+		[RequiresUnreferencedCode ("Uses reflection to load types and register native methods, which may require access to members that could be trimmed. Ensure the necessary types and members are preserved.")]
 		static unsafe void RegisterJniNatives (IntPtr typeName_ptr, int typeName_len, IntPtr jniClass, IntPtr methods_ptr, int methods_len)
 		{
 			string typeName = new string ((char*) typeName_ptr, 0, typeName_len);


### PR DESCRIPTION
## Summary
- remove the local `UnconditionalSuppressMessage` around `Type.GetType()` in `RegisterJniNatives()`
- mark the native callback with `RequiresUnreferencedCode` instead of hiding the reflection warning

Part of #10794.

## Validation
- `./dotnet-local.sh build src/Mono.Android/Mono.Android.csproj -v:minimal -nr:false` succeeded
- no IL/trimming warnings (`IL####`) found in the build log

Note: this fresh worktree emitted existing generated/baseline warnings unrelated to this one-file change (CS0436/CA1422/RS0025/javac warnings).

