### PR TITLE
[Trimming] Update value managers for annotated peer activation

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -832,7 +832,11 @@ namespace Android.Runtime {
 			return null;
 		}
 
-		public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object? []? argumentValues)
+		public override void ActivatePeer (
+			JniObjectReference reference,
+			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type,
+			ConstructorInfo cinfo,
+			object?[]? argumentValues)		
 		{
 			Java.Interop.TypeManager.Activate (reference.Handle, cinfo, argumentValues);
 		}

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -836,7 +836,7 @@ namespace Android.Runtime {
 			JniObjectReference reference,
 			[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors)] Type type,
 			ConstructorInfo cinfo,
-			object?[]? argumentValues)		
+			object?[]? argumentValues)
 		{
 			Java.Interop.TypeManager.Activate (reference.Handle, cinfo, argumentValues);
 		}

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -252,7 +252,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 	public override void ActivatePeer (JniObjectReference reference, [DynamicallyAccessedMembers (Constructors)] Type type, ConstructorInfo cinfo, object?[]? argumentValues)
 	{
 		if (RuntimeFeature.TrimmableTypeMap)
-			throw new PlatformNotSupportedException ("Activating Java peers is not supported when trimming is enabled.");
+			throw new PlatformNotSupportedException ("Activating Java peers is not supported when TrimmableTypeMap is enabled.");
 
 		base.ActivatePeer (reference, type, cinfo, argumentValues);
 	}

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -249,39 +249,12 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 		value.Finalized ();
 	}
 
-	public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
+	public override void ActivatePeer (JniObjectReference reference, [DynamicallyAccessedMembers (Constructors)] Type type, ConstructorInfo cinfo, object?[]? argumentValues)
 	{
-		try {
-			ActivateViaReflection (reference, cinfo, argumentValues);
-		} catch (Exception e) {
-			var m = string.Format (
-					CultureInfo.InvariantCulture,
-					"Could not activate {{ PeerReference={0} IdentityHashCode=0x{1} Java.Type={2} }} for managed type '{3}'.",
-					reference,
-					GetJniIdentityHashCode (reference).ToString ("x", CultureInfo.InvariantCulture),
-					JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
-					cinfo.DeclaringType?.FullName);
-			Debug.WriteLine (m);
+		if (RuntimeFeature.TrimmableTypeMap)
+			throw new PlatformNotSupportedException ("Activating Java peers is not supported when trimming is enabled.");
 
-			throw new NotSupportedException (m, e);
-		}
-	}
-
-	void ActivateViaReflection (JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-	{
-		var declType  = GetDeclaringType (cinfo);
-
-#pragma warning disable IL2072
-		var self      = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (declType);
-#pragma warning restore IL2072
-		self.SetPeerReference (reference);
-
-		cinfo.Invoke (self, argumentValues);
-
-		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "🤷‍♂️")]
-		[return: DynamicallyAccessedMembers (Constructors)]
-		Type GetDeclaringType (ConstructorInfo cinfo) =>
-			cinfo.DeclaringType ?? throw new NotSupportedException ("Do not know the type to create!");
+		base.ActivatePeer (reference, type, cinfo, argumentValues);
 	}
 
 	public override List<JniSurfacedPeerInfo> GetSurfacedPeers ()

--- a/src/Mono.Android/Microsoft.Android.Runtime/SimpleValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/SimpleValueManager.cs
@@ -207,41 +207,6 @@ class SimpleValueManager : JniRuntime.JniValueManager
 		value.Finalized ();
 	}
 
-	public override void ActivatePeer (IJavaPeerable? self, JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-	{
-		try {
-			ActivateViaReflection (reference, cinfo, argumentValues);
-		} catch (Exception e) {
-			var m = string.Format (
-					CultureInfo.InvariantCulture,
-					"Could not activate {{ PeerReference={0} IdentityHashCode=0x{1} Java.Type={2} }} for managed type '{3}'.",
-					reference,
-					GetJniIdentityHashCode (reference).ToString ("x", CultureInfo.InvariantCulture),
-					JniEnvironment.Types.GetJniTypeNameFromInstance (reference),
-					cinfo.DeclaringType?.FullName);
-			Debug.WriteLine (m);
-
-			throw new NotSupportedException (m, e);
-		}
-	}
-
-	void ActivateViaReflection (JniObjectReference reference, ConstructorInfo cinfo, object?[]? argumentValues)
-	{
-		var declType  = GetDeclaringType (cinfo);
-
-#pragma warning disable IL2072
-		var self      = (IJavaPeerable) System.Runtime.CompilerServices.RuntimeHelpers.GetUninitializedObject (declType);
-#pragma warning restore IL2072
-		self.SetPeerReference (reference);
-
-		cinfo.Invoke (self, argumentValues);
-
-		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "🤷‍♂️")]
-		[return: DynamicallyAccessedMembers (Constructors)]
-		Type GetDeclaringType (ConstructorInfo cinfo) =>
-			cinfo.DeclaringType ?? throw new NotSupportedException ("Do not know the type to create!");
-	}
-
 	public override List<JniSurfacedPeerInfo> GetSurfacedPeers ()
 	{
 		if (RegisteredInstances == null)


### PR DESCRIPTION
## Summary
- update Android value manager overrides for the annotated `JniValueManager.ActivatePeer()` signature
- remove local reflection activation implementations that used trimming suppressions
- intentionally do **not** include a Java.Interop submodule bump in this PR

Part of #10794
Supersedes #11447 - includes the java.interop version bump to include https://github.com/dotnet/java-interop/pull/1429

## Validation
- Not currently expected to build against the current `external/Java.Interop` submodule revision because the required `JniValueManager.ActivatePeer()` API change has not flowed yet.
- Before removing the temporary Java.Interop bump, `./dotnet-local.sh build src/Mono.Android/Mono.Android.csproj -v:minimal -nr:false` succeeded and no IL/trimming warnings (`IL####`) were found in the build log.

