### PR TITLE
[build] provision OpenJDK before Java.Interop Prepare

### DIFF
--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -16,7 +16,18 @@
     />
   </Target>
 
-  <Target Name="PrepareJavaInterop">
+  <Target Name="PrepareOpenJDK">
+    <!-- Ensure the Microsoft OpenJDK is downloaded and extracted into $(JavaSdkDirectory)
+         before Java.Interop's Prepare target scans for a JDK. Otherwise its JdkInfo task
+         falls back to a system-installed JDK (e.g. the JDK 25 preinstalled on hosted
+         macOS images), which can be incompatible with our Gradle version. -->
+    <Exec
+        Command="&quot;$(DotNetPreviewTool)&quot; build $(_Root)src\openjdk\openjdk.csproj -c $(Configuration) -bl:$(_BinlogPathPrefix)-prepare-openjdk.binlog"
+    />
+  </Target>
+
+  <Target Name="PrepareJavaInterop"
+      DependsOnTargets="PrepareOpenJDK">
     <Exec
         Command="&quot;$(DotNetPreviewTool)&quot; build -t:Prepare Java.Interop.sln -c $(Configuration) -p:JdksRoot=$(JavaSdkDirectory) -p:DotnetToolPath=$(DotNetPreviewTool) -bl:$(_BinlogPathPrefix)-prepare-java-interop.binlog"
         WorkingDirectory="$(_Root)external\Java.Interop"

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -21,7 +21,7 @@
          before Java.Interop's Prepare target scans for a JDK. Otherwise its JdkInfo task
          falls back to a system-installed JDK (e.g. the JDK 25 preinstalled on hosted
          macOS images), which can be incompatible with our Gradle version. -->
-    <MSBuild Projects="$(_Root)src\openjdk\openjdk.csproj" Properties="Configuration=$(Configuration)" />
+    <MSBuild Projects="$(_Root)src\openjdk\openjdk.csproj" Properties="Configuration=$(Configuration)" Targets="Restore;Build" />
   </Target>
 
   <Target Name="PrepareJavaInterop"

--- a/build-tools/scripts/DotNet.targets
+++ b/build-tools/scripts/DotNet.targets
@@ -21,9 +21,7 @@
          before Java.Interop's Prepare target scans for a JDK. Otherwise its JdkInfo task
          falls back to a system-installed JDK (e.g. the JDK 25 preinstalled on hosted
          macOS images), which can be incompatible with our Gradle version. -->
-    <Exec
-        Command="&quot;$(DotNetPreviewTool)&quot; build $(_Root)src\openjdk\openjdk.csproj -c $(Configuration) -bl:$(_BinlogPathPrefix)-prepare-openjdk.binlog"
-    />
+    <MSBuild Projects="$(_Root)src\openjdk\openjdk.csproj" Properties="Configuration=$(Configuration)" />
   </Target>
 
   <Target Name="PrepareJavaInterop"


### PR DESCRIPTION
### Context

PR #11348 moved the JDK download/install out of `xaprepare` (which used to run during `make prepare`) and into the new `src/openjdk/openjdk.csproj` `NoTargets` project. That project is only pulled in by `src/manifestmerger`, `src/r8`, `src/bundletool`, and `src/java-runtime` during `make all`, so the JDK is no longer present on disk when `PrepareJavaInterop` runs.

### Symptom

On a fresh macOS hosted agent (today's `main` CI build `14159635`):

```
warning : Could not get information about JdksRoot path
`/Users/runner/android-toolchain/jdk-21`: Not a directory
```

`JdkInfo` then silently falls back to scanning system-installed JDKs and writes the highest-version match (Temurin **JDK 25**, newly preinstalled on the Microsoft-hosted macOS image) into `JdkInfo.props` as `$(JavaSdkDirectory)`. Later, `gradlew` is invoked with `JAVA_HOME=$(JavaSdkDirectory)`, so Gradle 8.12 starts its daemon on JDK 25 and crashes:

```
FAILURE: Build failed with an exception.
> Could not create task ':test'.
> Could not create an instance of type
  org.gradle.api.reporting.internal.DefaultReportContainer.
> Type T not present
BUILD FAILED
```

PR #11348's CI did not catch this because it ran on a persistent agent (`/Users/builder/...`) where `/Users/builder/android-toolchain/jdk-21` was already populated from a prior build, so the `JdksRoot` directory happened to exist and JDK 21 was selected correctly.

### Fix

Add a `PrepareOpenJDK` target in `build-tools/scripts/DotNet.targets` that builds `src/openjdk/openjdk.csproj`, and make `PrepareJavaInterop` depend on it. This ensures the Microsoft OpenJDK is downloaded and extracted into `$(JavaSdkDirectory)` before Java.Interop's `Prepare` target scans for a JDK, so we always use the JDK we ship rather than whatever the host image happens to preinstall.

The download/extract is incremental via the existing `Inputs`/`Outputs` on `_DownloadOpenJDK` and `_InstallOpenJDK`, so the later `make all` build of `Xamarin.Android.sln` will not redo the work.