### PR TITLE
Docs: fix broken Wear OS link in XA4312 page

### DIFF
--- a/Documentation/docs-mobile/messages/xa4312.md
+++ b/Documentation/docs-mobile/messages/xa4312.md
@@ -11,6 +11,9 @@ f1_keywords:
 Referencing an [Android Wear][0] application project from an Android
 application project is deprecated.
 
+[Wear OS][0] apps should be distributed as [standalone][1] applications
+instead.
+
 From a `Foo.Android.csproj` in past versions of .NET for Android, you
 could reference a `Foo.Wear.csproj` such as:
 
@@ -26,7 +29,7 @@ This would embed `com.foo.wear.apk` *inside* `com.foo.android.apk` in
 ## Solution
 
 Distribute `Foo.Wear.csproj` in the above example as a [standalone][1]
-Android Wear application instead.
+Wear OS application instead.
 
-[0]: /xamarin/android/wear/get-started/intro-to-wear
+[0]: https://developer.android.com/training/wearables
 [1]: https://developer.android.com/training/wearables/apps/standalone-apps


### PR DESCRIPTION
Context: #4918

The [XA4312 docs page](https://github.com/dotnet/android/blob/main/Documentation/docs-mobile/messages/xa4312.md) linked to `/xamarin/android/wear/get-started/intro-to-wear`, which no longer exists — the old xamarin.com Android Wear documentation was never migrated to learn.microsoft.com when the docs moved.

This PR points both references at Google's current [Wear OS documentation](https://developer.android.com/training/wearables) instead.

Tiny fix; closes out the long-standing #4918.
