### PR TITLE
[TrimmableTypeMap] Skip UCO constructor generation for abstract types

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -356,6 +356,13 @@ static class ModelBuilder
 			return;
 		}
 
+		// Abstract types are never directly instantiated from Java — the ACW
+		// constructor's getClass() guard prevents activation. Skip generating
+		// UCO constructor wrappers for them.
+		if (peer.IsAbstract) {
+			return;
+		}
+
 		foreach (var ctor in peer.JavaConstructors) {
 			if (ctor.SuperArgumentsString != null && !ctor.HasMatchingManagedCtor) {
 				throw new InvalidOperationException (

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -398,6 +398,10 @@ namespace UnnamedProject {
 		[Test]
 		public void Build_WithTrimmableTypeMap_AbstractTypeWithProtectedCtor_Succeeds ()
 		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.NativeAOT, release: true)) {
+				return;
+			}
+
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -394,5 +394,32 @@ namespace UnnamedProject {
 				"assembly or the user's [Export] source. Offending warning lines:\n  " +
 				string.Join ("\n  ", offending));
 		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_AbstractTypeWithProtectedCtor_Succeeds ()
+		{
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.NativeAOT);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+			proj.Sources.Add (new BuildItem.Source ("AbstractProvider.cs") {
+				TextContent = () => @"
+namespace UnnamedProject {
+	public abstract class AbstractProvider : Java.Lang.Object {
+		protected AbstractProvider (Android.Content.Context context) { }
+		public abstract string GetData ();
+	}
+
+	public class ConcreteProvider : AbstractProvider {
+		public ConcreteProvider (Android.Content.Context context) : base (context) { }
+		public override string GetData () => ""hello"";
+	}
+}"
+			});
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded — abstract types with protected ctors should not cause XAGTT7009.");
+		}
 	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1369,6 +1369,26 @@ public class ModelBuilderTests : FixtureTestBase
 			Assert.Contains ("no matching user-visible managed constructor", ex.Message);
 			Assert.Contains ("MyApp.MissingCtor", ex.Message);
 		}
+
+		[Fact]
+		public void Build_AbstractTypeWithProtectedCtor_NoUcoConstructors ()
+		{
+			var peer = MakeAcwPeer ("my/app/AbstractAdapter", "MyApp.AbstractAdapter", "App") with {
+				IsAbstract = true,
+				JavaConstructors = new List<JavaConstructorInfo> {
+					new JavaConstructorInfo {
+						ConstructorIndex = 0,
+						JniSignature = "(Landroid/content/Context;)V",
+						HasMatchingManagedCtor = false,
+						SuperArgumentsString = "p0",
+					},
+				},
+			};
+			var model = BuildModel (new [] { peer });
+			var proxy = model.ProxyTypes.FirstOrDefault (p => p.TypeName.Contains ("AbstractAdapter"));
+			Assert.NotNull (proxy);
+			Assert.Empty (proxy.UcoConstructors);
+		}
 	}
 
 	public class NativeRegistrations


### PR DESCRIPTION
> *This content was created with assistance from AI.*

## Summary

Abstract types are never directly instantiated from Java — the ACW constructor's `getClass() == ThisClass.class` guard prevents activation. Generating UCO (Unified Constructor Override) constructor wrappers for them is dead code that fails at build time when the managed constructor is protected, which is the standard pattern for abstract types.

## Problem

When using `_AndroidTypeMapImplementation=trimmable` with a type hierarchy where an abstract C# type extending a Java type has a protected constructor (e.g. MAUI's `CellAdapter`), the build fails with:

```
error XAGTT7009: Trimmable typemap cannot generate Java constructor wrapper
'(Landroid/content/Context;)V' for 'CellAdapter' because no matching
user-visible managed constructor was found.
```

## Root Cause

`BuildUcoConstructors` in `ModelBuilder.cs` throws when `SuperArgumentsString != null && !HasMatchingManagedCtor`. The scanner (`TryGetMatchingPublicConstructorParameterTypes`) only searches for **public** constructors, but abstract types legitimately have **protected** constructors. However, the real issue isn't visibility — abstract types should not get activation wrappers at all since they can never be activated from Java.

## Fix

Skip UCO constructor generation entirely for abstract types in `BuildUcoConstructors` by checking `peer.IsAbstract` early.

## Tests

- **Unit test** (`TypeMapModelBuilderTests.cs`): Asserts `BuildModel` produces no UCO constructors for an abstract peer with a protected constructor.
- **Integration test** (`TrimmableTypeMapBuildTests.cs`): Verifies a full build succeeds with an abstract type extending `Java.Lang.Object` with a protected `(Context)` constructor using trimmable type maps + NativeAOT.

References #11295
