### PR TITLE
[TrimmableTypeMap] Reuse base UCO wrappers for inherited overrides

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ExportMethodDispatchEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ExportMethodDispatchEmitter.cs
@@ -43,7 +43,7 @@ sealed class ExportMethodDispatchEmitter
 		var callbackRef = AddExportMethodDispatchRef (uco, callbackTypeHandle);
 
 		// Wrap the dispatch in the standard BeginMarshalMethod/try/catch/finally pattern so
-		// managed exceptions thrown from the [Export] body are routed through
+		// managed exceptions thrown from the method body are routed through
 		// JniRuntime.OnUserUnhandledException — matching the legacy LLVM-IR contract
 		// (Mono.Android.Export/CallbackCode.cs) and the trimmable UCO ctor wrapper.
 		var handle = _pe.EmitBody (uco.WrapperName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -165,7 +165,7 @@ sealed class JavaPeerProxyData
 	public List<UcoConstructorData> UcoConstructors { get; } = new ();
 
 	/// <summary>
-	/// RegisterNatives registrations (method name, JNI signature, wrapper name).
+	/// RegisterNatives registrations (method name, JNI signature, wrapper target).
 	/// </summary>
 	public List<NativeRegistrationData> NativeRegistrations { get; } = new ();
 }
@@ -230,6 +230,24 @@ sealed record UcoMethodData
 	/// True when this wrapper performs the static [Export] direct-dispatch path.
 	/// </summary>
 	public bool UsesExportMethodDispatch => ExportMethodDispatch != null;
+}
+
+sealed record UcoWrapperTargetData
+{
+	/// <summary>
+	/// Namespace of the generated proxy type containing the wrapper method.
+	/// </summary>
+	public required string TypeNamespace { get; init; }
+
+	/// <summary>
+	/// Name of the generated proxy type containing the wrapper method.
+	/// </summary>
+	public required string TypeName { get; init; }
+
+	/// <summary>
+	/// Name of the UCO wrapper method whose function pointer to register.
+	/// </summary>
+	public required string MethodName { get; init; }
 }
 
 sealed record ExportMethodDispatchData
@@ -329,6 +347,13 @@ sealed record NativeRegistrationData
 	/// Name of the UCO wrapper method whose function pointer to register.
 	/// </summary>
 	public required string WrapperMethodName { get; init; }
+
+	/// <summary>
+	/// Generated proxy wrapper target to register. This may point at a wrapper
+	/// emitted for a different proxy when inherited virtual overrides share the
+	/// same base callback.
+	/// </summary>
+	public required UcoWrapperTargetData WrapperTarget { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -236,6 +236,15 @@ sealed record UcoMethodData
 
 sealed record UcoWrapperTargetData
 {
+	public static UcoWrapperTargetData From (JavaPeerProxyData proxy, string methodName)
+	{
+		return new UcoWrapperTargetData {
+			TypeNamespace = proxy.Namespace,
+			TypeName = proxy.TypeName,
+			MethodName = methodName,
+		};
+	}
+
 	/// <summary>
 	/// Namespace of the generated proxy type containing the wrapper method.
 	/// </summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -196,7 +196,9 @@ sealed record TypeRefData
 /// <summary>
 /// An [UnmanagedCallersOnly] static wrapper for a marshal method.
 /// Body: either forward to an existing n_* callback or dispatch directly to the
-/// managed export target when the trimmable path can avoid dynamic callback generation.
+/// managed target. Direct dispatch avoids inherited n_* callbacks that can route
+/// through the wrong managed virtual slot for hidden/new-slot members sharing the
+/// same JNI method.
 /// </summary>
 sealed record UcoMethodData
 {
@@ -221,13 +223,13 @@ sealed record UcoMethodData
 	public required string JniSignature { get; init; }
 
 	/// <summary>
-	/// Optional [Export]-only metadata for wrappers that dispatch directly to the
-	/// managed export target instead of forwarding to a generated n_* callback.
+	/// Optional metadata for wrappers that dispatch directly to the managed target
+	/// instead of forwarding to a generated n_* callback.
 	/// </summary>
 	public ExportMethodDispatchData? ExportMethodDispatch { get; init; }
 
 	/// <summary>
-	/// True when this wrapper performs the static [Export] direct-dispatch path.
+	/// True when this wrapper performs the managed direct-dispatch path.
 	/// </summary>
 	public bool UsesExportMethodDispatch => ExportMethodDispatch != null;
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -338,7 +338,7 @@ static class ModelBuilder
 					AssemblyName = !mm.DeclaringAssemblyName.IsNullOrEmpty () ? mm.DeclaringAssemblyName : peer.AssemblyName,
 				},
 				JniSignature = mm.JniSignature,
-				ExportMethodDispatch = mm.IsExport ? new ExportMethodDispatchData {
+				ExportMethodDispatch = (mm.IsExport || mm.CallManagedMethodDirectly) ? new ExportMethodDispatchData {
 					ManagedMethodName = mm.ManagedMethodName,
 					ParameterTypes = mm.ManagedParameterTypes,
 					ParameterKinds = mm.ManagedParameterExportKinds,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -99,6 +99,8 @@ static class ModelBuilder
 			}
 		}
 
+		BuildNativeRegistrations (model);
+
 		// Compute IgnoresAccessChecksTo from cross-assembly references
 		var referencedAssemblies = new SortedSet<string> (StringComparer.Ordinal);
 		foreach (var proxy in model.ProxyTypes) {
@@ -314,7 +316,6 @@ static class ModelBuilder
 		if (isAcw) {
 			BuildUcoMethods (peer, proxy);
 			BuildUcoConstructors (peer, proxy);
-			BuildNativeRegistrations (proxy);
 		}
 
 		return proxy;
@@ -374,30 +375,103 @@ static class ModelBuilder
 		}
 	}
 
-	static void BuildNativeRegistrations (JavaPeerProxyData proxy)
+	static void BuildNativeRegistrations (TypeMapAssemblyData model)
 	{
-		foreach (var uco in proxy.UcoMethods) {
-			proxy.NativeRegistrations.Add (new NativeRegistrationData {
-				JniMethodName = uco.CallbackMethodName,
-				JniSignature = uco.JniSignature,
-				WrapperMethodName = uco.WrapperName,
-			});
+		var sharedWrapperTargets = new Dictionary<UcoWrapperReuseKey, UcoWrapperTargetData> ();
+		foreach (var proxy in model.ProxyTypes) {
+			foreach (var uco in proxy.UcoMethods) {
+				if (!CanShareUcoWrapper (proxy, uco)) {
+					continue;
+				}
+
+				var reuseKey = CreateUcoWrapperReuseKey (uco);
+				if (!sharedWrapperTargets.ContainsKey (reuseKey)) {
+					sharedWrapperTargets.Add (reuseKey, CreateWrapperTarget (proxy, uco.WrapperName));
+				}
+			}
 		}
 
-		foreach (var uco in proxy.UcoConstructors) {
-			string jniName = uco.WrapperName;
-			int ucoSuffix = jniName.LastIndexOf ("_uco", StringComparison.Ordinal);
-			if (ucoSuffix >= 0) {
-				jniName = jniName.Substring (0, ucoSuffix);
+		foreach (var proxy in model.ProxyTypes) {
+			var reusedUcoMethods = new HashSet<UcoMethodData> ();
+
+			foreach (var uco in proxy.UcoMethods) {
+				var wrapperTarget = CreateWrapperTarget (proxy, uco.WrapperName);
+				if (CanReuseUcoWrapper (proxy, uco) &&
+				    sharedWrapperTargets.TryGetValue (CreateUcoWrapperReuseKey (uco), out var sharedWrapperTarget)) {
+					wrapperTarget = sharedWrapperTarget;
+					reusedUcoMethods.Add (uco);
+				}
+				proxy.NativeRegistrations.Add (new NativeRegistrationData {
+					JniMethodName = uco.CallbackMethodName,
+					JniSignature = uco.JniSignature,
+					WrapperMethodName = wrapperTarget.MethodName,
+					WrapperTarget = wrapperTarget,
+				});
 			}
 
-			proxy.NativeRegistrations.Add (new NativeRegistrationData {
-				JniMethodName = jniName,
-				JniSignature = uco.JniSignature,
-				WrapperMethodName = uco.WrapperName,
-			});
+			if (reusedUcoMethods.Count > 0) {
+				proxy.UcoMethods.RemoveAll (uco => reusedUcoMethods.Contains (uco));
+			}
+
+			foreach (var uco in proxy.UcoConstructors) {
+				string jniName = uco.WrapperName;
+				int ucoSuffix = jniName.LastIndexOf ("_uco", StringComparison.Ordinal);
+				if (ucoSuffix >= 0) {
+					jniName = jniName.Substring (0, ucoSuffix);
+				}
+
+				var wrapperTarget = CreateWrapperTarget (proxy, uco.WrapperName);
+				proxy.NativeRegistrations.Add (new NativeRegistrationData {
+					JniMethodName = jniName,
+					JniSignature = uco.JniSignature,
+					WrapperMethodName = wrapperTarget.MethodName,
+					WrapperTarget = wrapperTarget,
+				});
+			}
 		}
 	}
+
+	static bool CanShareUcoWrapper (JavaPeerProxyData proxy, UcoMethodData uco)
+	{
+		return !uco.UsesExportMethodDispatch &&
+			!proxy.IsGenericDefinition &&
+			!uco.CallbackType.ManagedTypeName.Contains ('`') &&
+			string.Equals (uco.CallbackType.ManagedTypeName, proxy.TargetType.ManagedTypeName, StringComparison.Ordinal) &&
+			string.Equals (uco.CallbackType.AssemblyName, proxy.TargetType.AssemblyName, StringComparison.Ordinal);
+	}
+
+	static bool CanReuseUcoWrapper (JavaPeerProxyData proxy, UcoMethodData uco)
+	{
+		return !uco.UsesExportMethodDispatch &&
+			!proxy.IsGenericDefinition &&
+			!uco.CallbackType.ManagedTypeName.Contains ('`') &&
+			(!string.Equals (uco.CallbackType.ManagedTypeName, proxy.TargetType.ManagedTypeName, StringComparison.Ordinal) ||
+			 !string.Equals (uco.CallbackType.AssemblyName, proxy.TargetType.AssemblyName, StringComparison.Ordinal));
+	}
+
+	static UcoWrapperTargetData CreateWrapperTarget (JavaPeerProxyData proxy, string methodName)
+	{
+		return new UcoWrapperTargetData {
+			TypeNamespace = proxy.Namespace,
+			TypeName = proxy.TypeName,
+			MethodName = methodName,
+		};
+	}
+
+	static UcoWrapperReuseKey CreateUcoWrapperReuseKey (UcoMethodData uco)
+	{
+		return new UcoWrapperReuseKey (
+			uco.CallbackType.ManagedTypeName,
+			uco.CallbackType.AssemblyName,
+			uco.CallbackMethodName,
+			uco.JniSignature);
+	}
+
+	readonly record struct UcoWrapperReuseKey (
+		string CallbackTypeName,
+		string CallbackAssemblyName,
+		string CallbackMethodName,
+		string JniSignature);
 
 	static TypeMapAttributeData BuildEntry (JavaPeerInfo peer, JavaPeerProxyData? proxy,
 		string outputAssemblyName, string jniName)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -386,7 +386,7 @@ static class ModelBuilder
 
 				var reuseKey = CreateUcoWrapperReuseKey (uco);
 				if (!sharedWrapperTargets.ContainsKey (reuseKey)) {
-					sharedWrapperTargets.Add (reuseKey, CreateWrapperTarget (proxy, uco.WrapperName));
+					sharedWrapperTargets.Add (reuseKey, UcoWrapperTargetData.From (proxy, uco.WrapperName));
 				}
 			}
 		}
@@ -395,7 +395,7 @@ static class ModelBuilder
 			var reusedUcoMethods = new HashSet<UcoMethodData> ();
 
 			foreach (var uco in proxy.UcoMethods) {
-				var wrapperTarget = CreateWrapperTarget (proxy, uco.WrapperName);
+				var wrapperTarget = UcoWrapperTargetData.From (proxy, uco.WrapperName);
 				if (CanReuseUcoWrapper (proxy, uco) &&
 				    sharedWrapperTargets.TryGetValue (CreateUcoWrapperReuseKey (uco), out var sharedWrapperTarget)) {
 					wrapperTarget = sharedWrapperTarget;
@@ -420,7 +420,7 @@ static class ModelBuilder
 					jniName = jniName.Substring (0, ucoSuffix);
 				}
 
-				var wrapperTarget = CreateWrapperTarget (proxy, uco.WrapperName);
+				var wrapperTarget = UcoWrapperTargetData.From (proxy, uco.WrapperName);
 				proxy.NativeRegistrations.Add (new NativeRegistrationData {
 					JniMethodName = jniName,
 					JniSignature = uco.JniSignature,
@@ -433,29 +433,25 @@ static class ModelBuilder
 
 	static bool CanShareUcoWrapper (JavaPeerProxyData proxy, UcoMethodData uco)
 	{
-		return !uco.UsesExportMethodDispatch &&
-			!proxy.IsGenericDefinition &&
-			!uco.CallbackType.ManagedTypeName.Contains ('`') &&
-			string.Equals (uco.CallbackType.ManagedTypeName, proxy.TargetType.ManagedTypeName, StringComparison.Ordinal) &&
-			string.Equals (uco.CallbackType.AssemblyName, proxy.TargetType.AssemblyName, StringComparison.Ordinal);
+		return IsUcoWrapperReuseCandidate (proxy, uco) && IsCallbackOwnedByProxy (proxy, uco);
 	}
 
 	static bool CanReuseUcoWrapper (JavaPeerProxyData proxy, UcoMethodData uco)
 	{
-		return !uco.UsesExportMethodDispatch &&
-			!proxy.IsGenericDefinition &&
-			!uco.CallbackType.ManagedTypeName.Contains ('`') &&
-			(!string.Equals (uco.CallbackType.ManagedTypeName, proxy.TargetType.ManagedTypeName, StringComparison.Ordinal) ||
-			 !string.Equals (uco.CallbackType.AssemblyName, proxy.TargetType.AssemblyName, StringComparison.Ordinal));
+		return IsUcoWrapperReuseCandidate (proxy, uco) && !IsCallbackOwnedByProxy (proxy, uco);
 	}
 
-	static UcoWrapperTargetData CreateWrapperTarget (JavaPeerProxyData proxy, string methodName)
+	static bool IsUcoWrapperReuseCandidate (JavaPeerProxyData proxy, UcoMethodData uco)
 	{
-		return new UcoWrapperTargetData {
-			TypeNamespace = proxy.Namespace,
-			TypeName = proxy.TypeName,
-			MethodName = methodName,
-		};
+		return !uco.UsesExportMethodDispatch &&
+			!proxy.IsGenericDefinition &&
+			!uco.CallbackType.ManagedTypeName.Contains ('`');
+	}
+
+	static bool IsCallbackOwnedByProxy (JavaPeerProxyData proxy, UcoMethodData uco)
+	{
+		return string.Equals (uco.CallbackType.ManagedTypeName, proxy.TargetType.ManagedTypeName, StringComparison.Ordinal) &&
+			string.Equals (uco.CallbackType.AssemblyName, proxy.TargetType.AssemblyName, StringComparison.Ordinal);
 	}
 
 	static UcoWrapperReuseKey CreateUcoWrapperReuseKey (UcoMethodData uco)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -739,12 +739,12 @@ sealed class TypeMapAssemblyEmitter
 			var handle = uco.UsesExportMethodDispatch
 				? GetExportMethodDispatchEmitter ().EmitUcoMethod (uco)
 				: EmitUcoMethod (uco, proxy);
-			wrapperHandles [CreateWrapperTarget (proxy, uco.WrapperName)] = handle;
+			wrapperHandles [UcoWrapperTargetData.From (proxy, uco.WrapperName)] = handle;
 		}
 
 		foreach (var uco in proxy.UcoConstructors) {
 			var handle = EmitUcoConstructor (uco, proxy);
-			wrapperHandles [CreateWrapperTarget (proxy, uco.WrapperName)] = handle;
+			wrapperHandles [UcoWrapperTargetData.From (proxy, uco.WrapperName)] = handle;
 		}
 
 		// RegisterNatives
@@ -1609,15 +1609,6 @@ sealed class TypeMapAssemblyEmitter
 		// local 4: target type (class)
 		blob.WriteByte (0x12); // ELEMENT_TYPE_CLASS
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (targetTypeRef));
-	}
-
-	static UcoWrapperTargetData CreateWrapperTarget (JavaPeerProxyData proxy, string methodName)
-	{
-		return new UcoWrapperTargetData {
-			TypeNamespace = proxy.Namespace,
-			TypeName = proxy.TypeName,
-			MethodName = methodName,
-		};
 	}
 
 	void EmitRegisterNatives (JavaPeerProxyData proxy,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -206,7 +206,7 @@ sealed class TypeMapAssemblyEmitter
 		// Track wrapper targets → handles for RegisterNatives.
 		var wrapperHandles = new Dictionary<UcoWrapperTargetData, MethodDefinitionHandle> ();
 
-		foreach (var proxy in model.ProxyTypes) {
+		foreach (var proxy in OrderProxiesForWrapperTargets (model.ProxyTypes)) {
 			EmitProxyType (proxy, wrapperHandles);
 		}
 
@@ -223,6 +223,52 @@ sealed class TypeMapAssemblyEmitter
 		}
 
 		_pe.EmitIgnoresAccessChecksToAttribute (model.IgnoresAccessChecksTo);
+	}
+
+	static List<JavaPeerProxyData> OrderProxiesForWrapperTargets (IReadOnlyList<JavaPeerProxyData> proxies)
+	{
+		var proxyByType = new Dictionary<(string Namespace, string TypeName), JavaPeerProxyData> ();
+		foreach (var proxy in proxies) {
+			proxyByType [(proxy.Namespace, proxy.TypeName)] = proxy;
+		}
+
+		var ordered = new List<JavaPeerProxyData> (proxies.Count);
+		var states = new Dictionary<JavaPeerProxyData, int> ();
+
+		foreach (var proxy in proxies) {
+			Visit (proxy);
+		}
+
+		return ordered;
+
+		void Visit (JavaPeerProxyData proxy)
+		{
+			if (states.TryGetValue (proxy, out int state)) {
+				if (state == 2) {
+					return;
+				}
+
+				// A cycle would indicate invalid wrapper-target data. Avoid recursing
+				// forever and keep the original relative order for the cyclic edge.
+				return;
+			}
+
+			states [proxy] = 1;
+
+			foreach (var registration in proxy.NativeRegistrations) {
+				var target = registration.WrapperTarget;
+				if (target.TypeNamespace == proxy.Namespace && target.TypeName == proxy.TypeName) {
+					continue;
+				}
+
+				if (proxyByType.TryGetValue ((target.TypeNamespace, target.TypeName), out var targetProxy)) {
+					Visit (targetProxy);
+				}
+			}
+
+			states [proxy] = 2;
+			ordered.Add (proxy);
+		}
 	}
 
 	void EmitTypeReferences ()

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -203,8 +203,8 @@ sealed class TypeMapAssemblyEmitter
 		EmitRankSentinels (model);
 		EmitMemberReferences ();
 
-		// Track wrapper method names → handles for RegisterNatives
-		var wrapperHandles = new Dictionary<string, MethodDefinitionHandle> ();
+		// Track wrapper targets → handles for RegisterNatives.
+		var wrapperHandles = new Dictionary<UcoWrapperTargetData, MethodDefinitionHandle> ();
 
 		foreach (var proxy in model.ProxyTypes) {
 			EmitProxyType (proxy, wrapperHandles);
@@ -598,7 +598,7 @@ sealed class TypeMapAssemblyEmitter
 		return _exportMethodDispatchEmitter;
 	}
 
-	void EmitProxyType (JavaPeerProxyData proxy, Dictionary<string, MethodDefinitionHandle> wrapperHandles)
+	void EmitProxyType (JavaPeerProxyData proxy, Dictionary<UcoWrapperTargetData, MethodDefinitionHandle> wrapperHandles)
 	{
 		if (proxy.IsAcw) {
 			// RegisterNatives uses RVA-backed UTF-8 fields under <PrivateImplementationDetails>.
@@ -693,12 +693,12 @@ sealed class TypeMapAssemblyEmitter
 			var handle = uco.UsesExportMethodDispatch
 				? GetExportMethodDispatchEmitter ().EmitUcoMethod (uco)
 				: EmitUcoMethod (uco, proxy);
-			wrapperHandles [uco.WrapperName] = handle;
+			wrapperHandles [CreateWrapperTarget (proxy, uco.WrapperName)] = handle;
 		}
 
 		foreach (var uco in proxy.UcoConstructors) {
 			var handle = EmitUcoConstructor (uco, proxy);
-			wrapperHandles [uco.WrapperName] = handle;
+			wrapperHandles [CreateWrapperTarget (proxy, uco.WrapperName)] = handle;
 		}
 
 		// RegisterNatives
@@ -1565,14 +1565,23 @@ sealed class TypeMapAssemblyEmitter
 		blob.WriteCompressedInteger (CodedIndex.TypeDefOrRefOrSpec (targetTypeRef));
 	}
 
+	static UcoWrapperTargetData CreateWrapperTarget (JavaPeerProxyData proxy, string methodName)
+	{
+		return new UcoWrapperTargetData {
+			TypeNamespace = proxy.Namespace,
+			TypeName = proxy.TypeName,
+			MethodName = methodName,
+		};
+	}
+
 	void EmitRegisterNatives (JavaPeerProxyData proxy,
-		Dictionary<string, MethodDefinitionHandle> wrapperHandles)
+		Dictionary<UcoWrapperTargetData, MethodDefinitionHandle> wrapperHandles)
 	{
 		// Filter to only registrations that have corresponding wrapper methods
 		var registrations = proxy.NativeRegistrations;
 		var validRegs = new List<(NativeRegistrationData Reg, MethodDefinitionHandle Wrapper)> (registrations.Count);
 		foreach (var reg in registrations) {
-			if (wrapperHandles.TryGetValue (reg.WrapperMethodName, out var wrapperHandle)) {
+			if (wrapperHandles.TryGetValue (reg.WrapperTarget, out var wrapperHandle)) {
 				validRegs.Add ((reg, wrapperHandle));
 			}
 		}

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerInfo.cs
@@ -267,6 +267,15 @@ public sealed record MarshalMethodInfo
 	/// (Pass 4: CollectInterfaceMethodImplementations), not from the type itself.
 	/// </summary>
 	public bool IsInterfaceImplementation { get; init; }
+
+	/// <summary>
+	/// True when the generated UCO wrapper should dispatch directly to the managed method
+	/// instead of forwarding to an existing static n_* callback. This is needed for
+	/// direct registered methods because an inherited callback can dispatch through a
+	/// different managed virtual slot when a derived type hides a base member with
+	/// <c>new virtual</c> while reusing the same JNI name and signature.
+	/// </summary>
+	public bool CallManagedMethodDirectly { get; init; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Scanner/JavaPeerScanner.cs
@@ -1112,19 +1112,22 @@ public sealed class JavaPeerScanner : IDisposable
 		var managedSig = methodDef.DecodeSignature (SignatureTypeProvider.Instance, genericContext: default);
 		string jniSignature = registerInfo.Signature ?? "()V";
 
-		// Only decode TypeRefData signatures for [Export] methods — they need precise
-		// managed type + assembly metadata for direct dispatch IL generation.
-		var managedTypeSig = isExport
-			? methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index)
-			: default;
-		var parameterKinds = exportInfo?.ParameterKinds ?? CreateDefaultExportKinds (managedSig.ParameterTypes.Length);
-
 		string declaringTypeName = "";
 		string declaringAssemblyName = "";
 		ParseConnectorDeclaringType (registerInfo.Connector, out declaringTypeName, out declaringAssemblyName);
 
+		bool mayCallManagedMethodDirectly = ShouldCallManagedMethodDirectly (isConstructor, isExport, declaringTypeName);
+
+		// Only decode TypeRefData signatures for methods that need direct dispatch IL
+		// generation; static n_* callback forwarders already encode from the JNI signature.
+		var managedTypeSig = mayCallManagedMethodDirectly
+			? methodDef.DecodeSignature (TypeRefSignatureTypeProvider.Instance, index)
+			: default;
+		bool callManagedMethodDirectly = isExport || (mayCallManagedMethodDirectly && SupportsDirectManagedMethodCall (managedTypeSig));
+		var parameterKinds = exportInfo?.ParameterKinds ?? CreateDefaultExportKinds (managedSig.ParameterTypes.Length);
+
 		var managedParameterTypes = new List<TypeRefData> ();
-		if (isExport) {
+		if (callManagedMethodDirectly) {
 			foreach (var parameterType in managedTypeSig.ParameterTypes) {
 				managedParameterTypes.Add (EnrichTypeRefWithEnumInfo (parameterType));
 			}
@@ -1140,7 +1143,7 @@ public sealed class JavaPeerScanner : IDisposable
 			NativeCallbackName = GetNativeCallbackName (registerInfo.Connector, managedName, isConstructor),
 			ManagedParameterTypes = managedParameterTypes,
 			ManagedParameterExportKinds = parameterKinds,
-			ManagedReturnType = isExport ? EnrichTypeRefWithEnumInfo (managedTypeSig.ReturnType) : new TypeRefData {
+			ManagedReturnType = callManagedMethodDirectly ? EnrichTypeRefWithEnumInfo (managedTypeSig.ReturnType) : new TypeRefData {
 				ManagedTypeName = managedSig.ReturnType,
 				AssemblyName = "System.Runtime",
 			},
@@ -1152,7 +1155,55 @@ public sealed class JavaPeerScanner : IDisposable
 			JavaAccess = isExport ? GetJavaAccess (methodDef.Attributes & MethodAttributes.MemberAccessMask) : null,
 			ThrownNames = exportInfo?.ThrownNames,
 			SuperArgumentsString = exportInfo?.SuperArgumentsString,
+			CallManagedMethodDirectly = callManagedMethodDirectly,
 		});
+	}
+
+	static bool ShouldCallManagedMethodDirectly (bool isConstructor, bool isExport, string declaringTypeName)
+	{
+		if (isExport) {
+			return true;
+		}
+
+		if (isConstructor) {
+			return false;
+		}
+
+		// Direct [Register] methods have no connector-declared callback owner, so forwarding
+		// through n_* may bind to an inherited callback. If the type hides a base virtual
+		// member with "new virtual" but keeps the same JNI method, that inherited callback
+		// dispatches through the base slot instead of the scanned method. Calling the managed
+		// method body directly keeps the wrapper tied to this managed method.
+		return declaringTypeName.IsNullOrEmpty ();
+	}
+
+	static bool SupportsDirectManagedMethodCall (MethodSignature<TypeRefData> managedTypeSig)
+	{
+		if (!SupportsDirectManagedMethodCall (managedTypeSig.ReturnType)) {
+			return false;
+		}
+
+		foreach (var parameterType in managedTypeSig.ParameterTypes) {
+			if (!SupportsDirectManagedMethodCall (parameterType)) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	static bool SupportsDirectManagedMethodCall (TypeRefData type)
+	{
+		var typeName = type.ManagedTypeName;
+		if (typeName.EndsWith ("&", StringComparison.Ordinal) || typeName.EndsWith ("*", StringComparison.Ordinal)) {
+			return false;
+		}
+
+		while (typeName.EndsWith ("[]", StringComparison.Ordinal)) {
+			typeName = typeName.Substring (0, typeName.Length - 2);
+		}
+
+		return !typeName.StartsWith ("!", StringComparison.Ordinal) && typeName.IndexOf ('<') < 0;
 	}
 
 	static string GetJavaAccess (MethodAttributes access)

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -107,9 +107,9 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void TrimmableTypeMapInheritedVirtualOverrideUsesBaseUco ([Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
+		public void TrimmableTypeMapInheritedVirtualOverrideUsesCorrectUco ([Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
 		{
-			const string expectedLogcatOutput = "UCO_OVERRIDE_REUSE_RESULTS 107:211:1:1";
+			const string expectedLogcatOutput = "UCO_OVERRIDE_REUSE_RESULTS 107:211:1:1:405:1:0";
 
 			if (IgnoreUnsupportedConfiguration (runtime, release: true)) {
 				return;
@@ -178,6 +178,59 @@ namespace UnnamedProject
 			return value + 200;
 		}
 	}
+
+	[Register (""my/app/UcoOverrideHiddenBase"")]
+	public class UcoOverrideHiddenBase : Java.Lang.Object
+	{
+		public static int Calls;
+
+		public UcoOverrideHiddenBase () { }
+
+		protected UcoOverrideHiddenBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register (""doHiddenWork"", ""()I"", """")]
+		public virtual int DoHiddenWork ()
+		{
+			Calls++;
+			return 300;
+		}
+	}
+
+	[Register (""my/app/UcoOverrideHiddenIntermediate"")]
+	public class UcoOverrideHiddenIntermediate : UcoOverrideHiddenBase
+	{
+		public UcoOverrideHiddenIntermediate () { }
+
+		protected UcoOverrideHiddenIntermediate (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		// Deliberately hide the base virtual slot while reusing the same JNI signature.
+		[Register (""doHiddenWork"", ""()I"", """")]
+		public new virtual int DoHiddenWork ()
+		{
+			return 400;
+		}
+	}
+
+	[Register (""my/app/UcoOverrideHiddenLeaf"")]
+	public class UcoOverrideHiddenLeaf : UcoOverrideHiddenIntermediate
+	{
+		readonly int value;
+		public static new int Calls;
+
+		public UcoOverrideHiddenLeaf (int value)
+		{
+			this.value = value;
+		}
+
+		protected UcoOverrideHiddenLeaf (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register (""doHiddenWork"", ""()I"", """")]
+		public override int DoHiddenWork ()
+		{
+			Calls++;
+			return value + 400;
+		}
+	}
 }
 ",
 			});
@@ -187,15 +240,28 @@ namespace UnnamedProject
 var two = new UcoOverrideTwo (11);
 int oneResult = InvokeDoWork (one);
 int twoResult = InvokeDoWork (two);
-Console.WriteLine ($""# UCO_OVERRIDE_REUSE_RESULTS {oneResult}:{twoResult}:{UcoOverrideOne.Calls}:{UcoOverrideTwo.Calls}"");
-if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOverrideTwo.Calls != 1) {
+var leaf = new UcoOverrideHiddenLeaf (5);
+int leafResult = InvokeDoHiddenWork (leaf);
+Console.WriteLine ($""# UCO_OVERRIDE_REUSE_RESULTS {oneResult}:{twoResult}:{UcoOverrideOne.Calls}:{UcoOverrideTwo.Calls}:{leafResult}:{UcoOverrideHiddenLeaf.Calls}:{UcoOverrideHiddenBase.Calls}"");
+if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOverrideTwo.Calls != 1 ||
+		leafResult != 405 || UcoOverrideHiddenLeaf.Calls != 1 || UcoOverrideHiddenBase.Calls != 0) {
 	throw new InvalidOperationException (""Unexpected UCO override dispatch result."");
 }
 
 static int InvokeDoWork (Java.Lang.Object instance)
 {
+	return InvokeIntMethod (instance, ""doWork"");
+}
+
+static int InvokeDoHiddenWork (Java.Lang.Object instance)
+{
+	return InvokeIntMethod (instance, ""doHiddenWork"");
+}
+
+static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
+{
 	IntPtr klass = global::Android.Runtime.JNIEnv.GetObjectClass (instance.Handle);
-	IntPtr method = global::Android.Runtime.JNIEnv.GetMethodID (klass, ""doWork"", ""()I"");
+	IntPtr method = global::Android.Runtime.JNIEnv.GetMethodID (klass, methodName, ""()I"");
 	try {
 		return global::Android.Runtime.JNIEnv.CallIntMethod (instance.Handle, method);
 	} finally {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -107,6 +107,112 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
+		public void TrimmableTypeMapInheritedVirtualOverrideUsesBaseUco ([Values (AndroidRuntime.CoreCLR)] AndroidRuntime runtime)
+		{
+			const string expectedLogcatOutput = "UCO_OVERRIDE_REUSE_RESULTS 107:211:1:1";
+
+			if (IgnoreUnsupportedConfiguration (runtime, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime, "ucoverride")) {
+				IsRelease = true,
+			};
+			proj.SetRuntime (runtime);
+			proj.SetRuntimeIdentifiers (new [] { DeviceAbi });
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+			proj.SetDefaultTargetDevice ();
+			proj.Sources.Add (new BuildItem.Source ("UcoOverrideTypes.cs") {
+				TextContent = () => @"using System;
+using Android.Runtime;
+
+namespace UnnamedProject
+{
+	[Register (""my/app/UcoOverrideBase"")]
+	public abstract class UcoOverrideBase : Java.Lang.Object
+	{
+		public UcoOverrideBase () { }
+
+		protected UcoOverrideBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		[Register (""doWork"", ""()I"", """")]
+		public abstract int DoWork ();
+	}
+
+	[Register (""my/app/UcoOverrideOne"")]
+	public class UcoOverrideOne : UcoOverrideBase
+	{
+		readonly int value;
+		public static int Calls;
+
+		public UcoOverrideOne (int value)
+		{
+			this.value = value;
+		}
+
+		protected UcoOverrideOne (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public override int DoWork ()
+		{
+			Calls++;
+			return value + 100;
+		}
+	}
+
+	[Register (""my/app/UcoOverrideTwo"")]
+	public class UcoOverrideTwo : UcoOverrideBase
+	{
+		readonly int value;
+		public static int Calls;
+
+		public UcoOverrideTwo (int value)
+		{
+			this.value = value;
+		}
+
+		protected UcoOverrideTwo (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
+
+		public override int DoWork ()
+		{
+			Calls++;
+			return value + 200;
+		}
+	}
+}
+",
+			});
+			proj.MainActivity = proj.DefaultMainActivity.Replace (
+				"//${AFTER_ONCREATE}",
+				@"var one = new UcoOverrideOne (7);
+var two = new UcoOverrideTwo (11);
+int oneResult = InvokeDoWork (one);
+int twoResult = InvokeDoWork (two);
+Console.WriteLine ($""# UCO_OVERRIDE_REUSE_RESULTS {oneResult}:{twoResult}:{UcoOverrideOne.Calls}:{UcoOverrideTwo.Calls}"");
+if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOverrideTwo.Calls != 1) {
+	throw new InvalidOperationException (""Unexpected UCO override dispatch result."");
+}
+
+static int InvokeDoWork (Java.Lang.Object instance)
+{
+	IntPtr klass = global::Android.Runtime.JNIEnv.GetObjectClass (instance.Handle);
+	IntPtr method = global::Android.Runtime.JNIEnv.GetMethodID (klass, ""doWork"", ""()I"");
+	try {
+		return global::Android.Runtime.JNIEnv.CallIntMethod (instance.Handle, method);
+	} finally {
+		global::Android.Runtime.JNIEnv.DeleteLocalRef (klass);
+	}
+}");
+			using var builder = CreateApkBuilder ();
+			Assert.True (builder.Install (proj), "Project should have installed.");
+			RunProjectAndAssert (proj, builder, doNotCleanupOnUpdate: true);
+			Assert.True (WaitForActivityToStart (proj.PackageName, "MainActivity",
+				Path.Combine (Root, builder.ProjectDirectory, "logcat.log"), ActivityStartTimeoutInSeconds), "Activity should have started.");
+			Assert.IsTrue (MonitorAdbLogcat ((line) => line.Contains (expectedLogcatOutput),
+				Path.Combine (Root, builder.ProjectDirectory, "startup-logcat.log"), 45), $"Output did not contain {expectedLogcatOutput}!");
+			Assert.True (builder.Uninstall (proj), "Project should have uninstalled.");
+		}
+
+		[Test]
 		public void DotNetRunWaitForExit ()
 		{
 			AssertCommercialBuild (); //FIXME: https://github.com/dotnet/android/issues/10832

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -124,19 +124,21 @@ namespace Xamarin.Android.Build.Tests
 			proj.SetDefaultTargetDevice ();
 			proj.Sources.Add (new BuildItem.Source ("UcoOverrideTypes.cs") {
 				TextContent = () => @"using System;
+using Android.Content;
 using Android.Runtime;
+using Android.Views;
 
 namespace UnnamedProject
 {
 	[Register (""my/app/UcoOverrideBase"")]
-	public abstract class UcoOverrideBase : Java.Lang.Object
+	public abstract class UcoOverrideBase : View
 	{
-		public UcoOverrideBase () { }
+		public UcoOverrideBase (Context context) : base (context) { }
 
 		protected UcoOverrideBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""hashCode"", ""()I"", """")]
-		public abstract override int GetHashCode ();
+		[Register (""getSolidColor"", ""()I"", ""GetGetSolidColorHandler"")]
+		public abstract override int SolidColor { get; }
 	}
 
 	[Register (""my/app/UcoOverrideOne"")]
@@ -145,17 +147,18 @@ namespace UnnamedProject
 		readonly int value;
 		public static int Calls;
 
-		public UcoOverrideOne (int value)
+		public UcoOverrideOne (Context context, int value) : base (context)
 		{
 			this.value = value;
 		}
 
 		protected UcoOverrideOne (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		public override int GetHashCode ()
-		{
-			Calls++;
-			return value + 100;
+		public override int SolidColor {
+			get {
+				Calls++;
+				return value + 100;
+			}
 		}
 	}
 
@@ -165,49 +168,52 @@ namespace UnnamedProject
 		readonly int value;
 		public static int Calls;
 
-		public UcoOverrideTwo (int value)
+		public UcoOverrideTwo (Context context, int value) : base (context)
 		{
 			this.value = value;
 		}
 
 		protected UcoOverrideTwo (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		public override int GetHashCode ()
-		{
-			Calls++;
-			return value + 200;
+		public override int SolidColor {
+			get {
+				Calls++;
+				return value + 200;
+			}
 		}
 	}
 
 	[Register (""my/app/UcoOverrideHiddenBase"")]
-	public class UcoOverrideHiddenBase : Java.Lang.Object
+	public class UcoOverrideHiddenBase : View
 	{
 		public static int Calls;
 
-		public UcoOverrideHiddenBase () { }
+		public UcoOverrideHiddenBase (Context context) : base (context) { }
 
 		protected UcoOverrideHiddenBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""hashCode"", ""()I"", """")]
-		public override int GetHashCode ()
-		{
-			Calls++;
-			return 300;
+		[Register (""getSolidColor"", ""()I"", ""GetGetSolidColorHandler"")]
+		public override int SolidColor {
+			get {
+				Calls++;
+				return 300;
+			}
 		}
 	}
 
 	[Register (""my/app/UcoOverrideHiddenIntermediate"")]
 	public class UcoOverrideHiddenIntermediate : UcoOverrideHiddenBase
 	{
-		public UcoOverrideHiddenIntermediate () { }
+		public UcoOverrideHiddenIntermediate (Context context) : base (context) { }
 
 		protected UcoOverrideHiddenIntermediate (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		// Deliberately hide the base virtual slot while reusing the same JNI signature.
-		[Register (""hashCode"", ""()I"", """")]
-		public new virtual int GetHashCode ()
-		{
-			return 400;
+		[Register (""getSolidColor"", ""()I"", ""GetGetSolidColorHandler"")]
+		public new virtual int SolidColor {
+			get {
+				return 400;
+			}
 		}
 	}
 
@@ -217,18 +223,19 @@ namespace UnnamedProject
 		readonly int value;
 		public static new int Calls;
 
-		public UcoOverrideHiddenLeaf (int value)
+		public UcoOverrideHiddenLeaf (Context context, int value) : base (context)
 		{
 			this.value = value;
 		}
 
 		protected UcoOverrideHiddenLeaf (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""hashCode"", ""()I"", """")]
-		public override int GetHashCode ()
-		{
-			Calls++;
-			return value + 400;
+		[Register (""getSolidColor"", ""()I"", ""GetGetSolidColorHandler"")]
+		public override int SolidColor {
+			get {
+				Calls++;
+				return value + 400;
+			}
 		}
 	}
 }
@@ -236,11 +243,11 @@ namespace UnnamedProject
 			});
 			proj.MainActivity = proj.DefaultMainActivity.Replace (
 				"//${AFTER_ONCREATE}",
-				@"var one = new UcoOverrideOne (7);
-var two = new UcoOverrideTwo (11);
+				@"var one = new UcoOverrideOne (this, 7);
+var two = new UcoOverrideTwo (this, 11);
 int oneResult = InvokeDoWork (one);
 int twoResult = InvokeDoWork (two);
-var leaf = new UcoOverrideHiddenLeaf (5);
+var leaf = new UcoOverrideHiddenLeaf (this, 5);
 int leafResult = InvokeDoHiddenWork (leaf);
 Console.WriteLine ($""# UCO_OVERRIDE_REUSE_RESULTS {oneResult}:{twoResult}:{UcoOverrideOne.Calls}:{UcoOverrideTwo.Calls}:{leafResult}:{UcoOverrideHiddenLeaf.Calls}:{UcoOverrideHiddenBase.Calls}"");
 if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOverrideTwo.Calls != 1 ||
@@ -250,12 +257,12 @@ if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOver
 
 static int InvokeDoWork (Java.Lang.Object instance)
 {
-	return InvokeIntMethod (instance, ""hashCode"");
+	return InvokeIntMethod (instance, ""getSolidColor"");
 }
 
 static int InvokeDoHiddenWork (Java.Lang.Object instance)
 {
-	return InvokeIntMethod (instance, ""hashCode"");
+	return InvokeIntMethod (instance, ""getSolidColor"");
 }
 
 static int InvokeIntMethod (Java.Lang.Object instance, string methodName)

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -135,8 +135,8 @@ namespace UnnamedProject
 
 		protected UcoOverrideBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""doWork"", ""()I"", """")]
-		public abstract int DoWork ();
+		[Register (""hashCode"", ""()I"", """")]
+		public abstract override int GetHashCode ();
 	}
 
 	[Register (""my/app/UcoOverrideOne"")]
@@ -152,7 +152,7 @@ namespace UnnamedProject
 
 		protected UcoOverrideOne (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		public override int DoWork ()
+		public override int GetHashCode ()
 		{
 			Calls++;
 			return value + 100;
@@ -172,7 +172,7 @@ namespace UnnamedProject
 
 		protected UcoOverrideTwo (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		public override int DoWork ()
+		public override int GetHashCode ()
 		{
 			Calls++;
 			return value + 200;
@@ -188,8 +188,8 @@ namespace UnnamedProject
 
 		protected UcoOverrideHiddenBase (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""doHiddenWork"", ""()I"", """")]
-		public virtual int DoHiddenWork ()
+		[Register (""hashCode"", ""()I"", """")]
+		public override int GetHashCode ()
 		{
 			Calls++;
 			return 300;
@@ -204,8 +204,8 @@ namespace UnnamedProject
 		protected UcoOverrideHiddenIntermediate (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
 		// Deliberately hide the base virtual slot while reusing the same JNI signature.
-		[Register (""doHiddenWork"", ""()I"", """")]
-		public new virtual int DoHiddenWork ()
+		[Register (""hashCode"", ""()I"", """")]
+		public new virtual int GetHashCode ()
 		{
 			return 400;
 		}
@@ -224,8 +224,8 @@ namespace UnnamedProject
 
 		protected UcoOverrideHiddenLeaf (IntPtr handle, JniHandleOwnership transfer) : base (handle, transfer) { }
 
-		[Register (""doHiddenWork"", ""()I"", """")]
-		public override int DoHiddenWork ()
+		[Register (""hashCode"", ""()I"", """")]
+		public override int GetHashCode ()
 		{
 			Calls++;
 			return value + 400;
@@ -250,12 +250,12 @@ if (oneResult != 107 || twoResult != 211 || UcoOverrideOne.Calls != 1 || UcoOver
 
 static int InvokeDoWork (Java.Lang.Object instance)
 {
-	return InvokeIntMethod (instance, ""doWork"");
+	return InvokeIntMethod (instance, ""hashCode"");
 }
 
 static int InvokeDoHiddenWork (Java.Lang.Object instance)
 {
-	return InvokeIntMethod (instance, ""doHiddenWork"");
+	return InvokeIntMethod (instance, ""hashCode"");
 }
 
 static int InvokeIntMethod (Java.Lang.Object instance, string methodName)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -873,7 +873,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		// Regression test: the UCO wrapper must use byte (unsigned, JNI ABI) for boolean,
 		// but the callback MemberRef must use sbyte (signed, MCW convention).
 		// A mismatch caused ILLink to fail resolving the member reference and trim n_* methods.
-		var peer = FindFixtureByJavaName ("my/app/TouchHandler");
+		var peer = MakeTouchHandlerCallbackDispatchPeer ();
 		using var stream = GenerateAssembly (new [] { peer }, "BoolReturnTest");
 		using var pe = new PEReader (stream);
 		var reader = pe.GetMetadataReader ();
@@ -896,7 +896,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 	public void Generate_UcoMethod_BooleanParam_WrapperUsesByte_CallbackUsesSByte ()
 	{
 		// Regression test: boolean parameters must also use the correct encoding.
-		var peer = FindFixtureByJavaName ("my/app/TouchHandler");
+		var peer = MakeTouchHandlerCallbackDispatchPeer ();
 		using var stream = GenerateAssembly (new [] { peer }, "BoolParamTest");
 		using var pe = new PEReader (stream);
 		var reader = pe.GetMetadataReader ();
@@ -1166,6 +1166,18 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var ldftnTokens = ReadLdftnTokens (registerBytes);
 		Assert.DoesNotContain (MetadataTokens.GetToken (rootBaseUcoHandle), ldftnTokens);
 		Assert.Contains (MetadataTokens.GetToken (leafUcoHandle), ldftnTokens);
+	}
+
+	JavaPeerInfo MakeTouchHandlerCallbackDispatchPeer ()
+	{
+		var peer = FindFixtureByJavaName ("my/app/TouchHandler");
+		return peer with {
+			MarshalMethods = peer.MarshalMethods.Select (m => m with {
+				DeclaringTypeName = m.IsConstructor ? "" : "MyApp.TouchHandler",
+				DeclaringAssemblyName = m.IsConstructor ? "" : "TestFixtures",
+				CallManagedMethodDirectly = false,
+			}).ToList (),
+		};
 	}
 
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1122,6 +1122,52 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Contains (MetadataTokens.GetToken (intermediateUcoHandle), ldftnTokens);
 	}
 
+	[Fact]
+	public void Generate_InheritedVirtualOverride_MissingIntermediateProxy_LocalUcoMethodCallsIntermediateCallback ()
+	{
+		var rootBasePeer = MakeAcwPeer ("my/app/RootBase", "MyApp.RootBase", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+		var leafPeer = MakeInheritedOverridePeer ("my/app/Leaf", "MyApp.Leaf", declaringTypeName: "MyApp.HiddenIntermediate");
+
+		using var stream = GenerateAssembly ([leafPeer, rootBasePeer], "InheritedOverrideMissingIntermediate");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var rootBaseProxy = FindProxyType (reader, "MyApp_RootBase_Proxy");
+		var leafProxy = FindProxyType (reader, "MyApp_Leaf_Proxy");
+		var rootBaseUcoHandle = FindMethodDefinition (reader, rootBaseProxy, "n_doWork_uco_0");
+		var leafUcoHandle = FindMethodDefinition (reader, leafProxy, "n_doWork_uco_0");
+		var rootBaseCallback = FindCallbackMemberRef (reader, "n_DoWork", "MyApp", "RootBase");
+		var intermediateCallback = FindCallbackMemberRef (reader, "n_DoWork", "MyApp", "HiddenIntermediate");
+
+		var leafUco = reader.GetMethodDefinition (leafUcoHandle);
+		var leafUcoBody = pe.GetMethodBody (leafUco.RelativeVirtualAddress);
+		var leafUcoBytes = leafUcoBody.GetILBytes ();
+		Assert.NotNull (leafUcoBytes);
+		var leafUcoCallTokens = ReadCallTokens (leafUcoBytes);
+		Assert.DoesNotContain (MetadataTokens.GetToken (rootBaseCallback), leafUcoCallTokens);
+		Assert.Contains (MetadataTokens.GetToken (intermediateCallback), leafUcoCallTokens);
+
+		var leafRegisterNatives = reader.GetMethodDefinition (FindMethodDefinition (reader, leafProxy, "RegisterNatives"));
+		var registerBody = pe.GetMethodBody (leafRegisterNatives.RelativeVirtualAddress);
+		var registerBytes = registerBody.GetILBytes ();
+		Assert.NotNull (registerBytes);
+		var ldftnTokens = ReadLdftnTokens (registerBytes);
+		Assert.DoesNotContain (MetadataTokens.GetToken (rootBaseUcoHandle), ldftnTokens);
+		Assert.Contains (MetadataTokens.GetToken (leafUcoHandle), ldftnTokens);
+	}
+
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
@@ -1130,6 +1176,23 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			.ToList ();
 		Assert.Single (refs);
 		return refs [0];
+	}
+
+	static MemberReferenceHandle FindCallbackMemberRef (MetadataReader reader, string methodName, string parentNamespace, string parentName)
+	{
+		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
+			.Select (MetadataTokens.MemberReferenceHandle)
+			.Where (h => {
+				var member = reader.GetMemberReference (h);
+				if (reader.GetString (member.Name) != methodName || member.Parent.Kind != HandleKind.TypeReference)
+					return false;
+
+				var parent = reader.GetTypeReference ((TypeReferenceHandle) member.Parent);
+				return reader.GetString (parent.Namespace) == parentNamespace &&
+					reader.GetString (parent.Name) == parentName;
+			})
+			.ToList ();
+		return Assert.Single (refs);
 	}
 
 	static TypeDefinition FindProxyType (MetadataReader reader, string typeName)
@@ -1165,6 +1228,22 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 				(ilBytes [i + 3] << 8) |
 				(ilBytes [i + 4] << 16) |
 				(ilBytes [i + 5] << 24));
+		}
+		return tokens;
+	}
+
+	static List<int> ReadCallTokens (byte [] ilBytes)
+	{
+		var tokens = new List<int> ();
+		for (int i = 0; i < ilBytes.Length - 4; i++) {
+			if (ilBytes [i] != 0x28) {
+				continue;
+			}
+
+			tokens.Add (ilBytes [i + 1] |
+				(ilBytes [i + 2] << 8) |
+				(ilBytes [i + 3] << 16) |
+				(ilBytes [i + 4] << 24));
 		}
 		return tokens;
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1034,6 +1034,43 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Contains (MetadataTokens.GetToken (baseUcoHandle), ReadLdftnTokens (ilBytes));
 	}
 
+	[Fact]
+	public void Generate_InheritedVirtualOverride_ThroughIntermediate_RegisterNativesUsesRootBaseUcoMethod ()
+	{
+		var rootBasePeer = MakeAcwPeer ("my/app/C", "MyApp.C", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+		var intermediatePeer = MakeAcwPeer ("my/app/B", "MyApp.B", "App");
+		var leafPeer = MakeInheritedOverridePeer ("my/app/A", "MyApp.A", declaringTypeName: "MyApp.C");
+
+		using var stream = GenerateAssembly ([leafPeer, intermediatePeer, rootBasePeer], "InheritedOverrideUcoIntermediate");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var rootBaseProxy = FindProxyType (reader, "MyApp_C_Proxy");
+		var intermediateProxy = FindProxyType (reader, "MyApp_B_Proxy");
+		var leafProxy = FindProxyType (reader, "MyApp_A_Proxy");
+		var rootBaseUcoHandle = FindMethodDefinition (reader, rootBaseProxy, "n_doWork_uco_0");
+		Assert.Empty (FindMethodDefinitions (reader, intermediateProxy, "n_doWork_uco_0"));
+		Assert.Empty (FindMethodDefinitions (reader, leafProxy, "n_doWork_uco_0"));
+
+		var leafRegisterNatives = reader.GetMethodDefinition (FindMethodDefinition (reader, leafProxy, "RegisterNatives"));
+		var body = pe.GetMethodBody (leafRegisterNatives.RelativeVirtualAddress);
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+		Assert.Contains (MetadataTokens.GetToken (rootBaseUcoHandle), ReadLdftnTokens (ilBytes));
+	}
+
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
@@ -1081,7 +1118,8 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		return tokens;
 	}
 
-	static JavaPeerInfo MakeInheritedOverridePeer (string jniName, string managedName)
+	static JavaPeerInfo MakeInheritedOverridePeer (string jniName, string managedName,
+		string declaringTypeName = "MyApp.AbstractBase")
 	{
 		return MakeAcwPeer (jniName, managedName, "App") with {
 			MarshalMethods = [
@@ -1093,7 +1131,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 				new MarshalMethodInfo {
 					JniName = "doWork", NativeCallbackName = "n_DoWork",
 					JniSignature = "()V", ManagedMethodName = "DoWork",
-					DeclaringTypeName = "MyApp.AbstractBase",
+					DeclaringTypeName = declaringTypeName,
 					DeclaringAssemblyName = "App",
 				},
 			],

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -966,6 +966,40 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Equal (new byte [] { 0x01, 0x00, 0x00, 0x00 }, reader.GetBlobBytes (ucoAttr.Value));
 	}
 
+	[Fact]
+	public void Generate_InheritedVirtualOverride_RegisterNativesUsesBaseUcoMethod ()
+	{
+		var basePeer = MakeAcwPeer ("my/app/AbstractBase", "MyApp.AbstractBase", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+		var derivedPeer = MakeInheritedOverridePeer ("my/app/Concrete", "MyApp.Concrete");
+
+		using var stream = GenerateAssembly ([basePeer, derivedPeer], "InheritedOverrideUco");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var baseProxy = FindProxyType (reader, "MyApp_AbstractBase_Proxy");
+		var derivedProxy = FindProxyType (reader, "MyApp_Concrete_Proxy");
+		var baseUcoHandle = FindMethodDefinition (reader, baseProxy, "n_doWork_uco_0");
+		Assert.Empty (FindMethodDefinitions (reader, derivedProxy, "n_doWork_uco_0"));
+
+		var derivedRegisterNatives = reader.GetMethodDefinition (FindMethodDefinition (reader, derivedProxy, "RegisterNatives"));
+		var body = pe.GetMethodBody (derivedRegisterNatives.RelativeVirtualAddress);
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+		Assert.Contains (MetadataTokens.GetToken (baseUcoHandle), ReadLdftnTokens (ilBytes));
+	}
+
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
@@ -974,6 +1008,62 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 			.ToList ();
 		Assert.Single (refs);
 		return refs [0];
+	}
+
+	static TypeDefinition FindProxyType (MetadataReader reader, string typeName)
+	{
+		return reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Single (t =>
+				reader.GetString (t.Namespace) == "_TypeMap.Proxies" &&
+				reader.GetString (t.Name) == typeName);
+	}
+
+	static MethodDefinitionHandle FindMethodDefinition (MetadataReader reader, TypeDefinition type, string methodName)
+	{
+		return FindMethodDefinitions (reader, type, methodName).Single ();
+	}
+
+	static List<MethodDefinitionHandle> FindMethodDefinitions (MetadataReader reader, TypeDefinition type, string methodName)
+	{
+		return type.GetMethods ()
+			.Where (h => reader.GetString (reader.GetMethodDefinition (h).Name) == methodName)
+			.ToList ();
+	}
+
+	static List<int> ReadLdftnTokens (byte [] ilBytes)
+	{
+		var tokens = new List<int> ();
+		for (int i = 0; i < ilBytes.Length - 5; i++) {
+			if (ilBytes [i] != 0xFE || ilBytes [i + 1] != 0x06) {
+				continue;
+			}
+
+			tokens.Add (ilBytes [i + 2] |
+				(ilBytes [i + 3] << 8) |
+				(ilBytes [i + 4] << 16) |
+				(ilBytes [i + 5] << 24));
+		}
+		return tokens;
+	}
+
+	static JavaPeerInfo MakeInheritedOverridePeer (string jniName, string managedName)
+	{
+		return MakeAcwPeer (jniName, managedName, "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+					DeclaringTypeName = "MyApp.AbstractBase",
+					DeclaringAssemblyName = "App",
+				},
+			],
+		};
 	}
 
 	[Theory]

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1071,6 +1071,57 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Contains (MetadataTokens.GetToken (rootBaseUcoHandle), ReadLdftnTokens (ilBytes));
 	}
 
+	[Fact]
+	public void Generate_InheritedVirtualOverride_IntermediateCallbackOwner_RegisterNativesUsesIntermediateUcoMethod ()
+	{
+		var rootBasePeer = MakeAcwPeer ("my/app/C", "MyApp.C", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+		var intermediatePeer = MakeAcwPeer ("my/app/B", "MyApp.B", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+		var leafPeer = MakeInheritedOverridePeer ("my/app/A", "MyApp.A", declaringTypeName: "MyApp.B");
+
+		using var stream = GenerateAssembly ([leafPeer, rootBasePeer, intermediatePeer], "InheritedOverrideUcoIntermediateOwner");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var rootBaseProxy = FindProxyType (reader, "MyApp_C_Proxy");
+		var intermediateProxy = FindProxyType (reader, "MyApp_B_Proxy");
+		var leafProxy = FindProxyType (reader, "MyApp_A_Proxy");
+		var rootBaseUcoHandle = FindMethodDefinition (reader, rootBaseProxy, "n_doWork_uco_0");
+		var intermediateUcoHandle = FindMethodDefinition (reader, intermediateProxy, "n_doWork_uco_0");
+		Assert.Empty (FindMethodDefinitions (reader, leafProxy, "n_doWork_uco_0"));
+
+		var leafRegisterNatives = reader.GetMethodDefinition (FindMethodDefinition (reader, leafProxy, "RegisterNatives"));
+		var body = pe.GetMethodBody (leafRegisterNatives.RelativeVirtualAddress);
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+		var ldftnTokens = ReadLdftnTokens (ilBytes);
+		Assert.DoesNotContain (MetadataTokens.GetToken (rootBaseUcoHandle), ldftnTokens);
+		Assert.Contains (MetadataTokens.GetToken (intermediateUcoHandle), ldftnTokens);
+	}
+
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1148,8 +1148,8 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var leafProxy = FindProxyType (reader, "MyApp_Leaf_Proxy");
 		var rootBaseUcoHandle = FindMethodDefinition (reader, rootBaseProxy, "n_doWork_uco_0");
 		var leafUcoHandle = FindMethodDefinition (reader, leafProxy, "n_doWork_uco_0");
-		var rootBaseCallback = FindCallbackMemberRef (reader, "n_DoWork", "MyApp", "RootBase");
-		var intermediateCallback = FindCallbackMemberRef (reader, "n_DoWork", "MyApp", "HiddenIntermediate");
+		var rootBaseCallback = FindCallbackMemberRefHandle (reader, "n_DoWork", "MyApp", "RootBase");
+		var intermediateCallback = FindCallbackMemberRefHandle (reader, "n_DoWork", "MyApp", "HiddenIntermediate");
 
 		var leafUco = reader.GetMethodDefinition (leafUcoHandle);
 		var leafUcoBody = pe.GetMethodBody (leafUco.RelativeVirtualAddress);
@@ -1178,7 +1178,7 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		return refs [0];
 	}
 
-	static MemberReferenceHandle FindCallbackMemberRef (MetadataReader reader, string methodName, string parentNamespace, string parentName)
+	static MemberReferenceHandle FindCallbackMemberRefHandle (MetadataReader reader, string methodName, string parentNamespace, string parentName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))
 			.Select (MetadataTokens.MemberReferenceHandle)
@@ -1218,25 +1218,19 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 
 	static List<int> ReadLdftnTokens (byte [] ilBytes)
 	{
-		var tokens = new List<int> ();
-		for (int i = 0; i < ilBytes.Length - 5; i++) {
-			if (ilBytes [i] != 0xFE || ilBytes [i + 1] != 0x06) {
-				continue;
-			}
-
-			tokens.Add (ilBytes [i + 2] |
-				(ilBytes [i + 3] << 8) |
-				(ilBytes [i + 4] << 16) |
-				(ilBytes [i + 5] << 24));
-		}
-		return tokens;
+		return ReadInlineMethodTokens (ilBytes, 0xFE, 0x06);
 	}
 
 	static List<int> ReadCallTokens (byte [] ilBytes)
 	{
+		return ReadInlineMethodTokens (ilBytes, 0x28);
+	}
+
+	static List<int> ReadInlineMethodTokens (byte [] ilBytes, byte opcode)
+	{
 		var tokens = new List<int> ();
 		for (int i = 0; i < ilBytes.Length - 4; i++) {
-			if (ilBytes [i] != 0x28) {
+			if (ilBytes [i] != opcode) {
 				continue;
 			}
 
@@ -1244,6 +1238,22 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 				(ilBytes [i + 2] << 8) |
 				(ilBytes [i + 3] << 16) |
 				(ilBytes [i + 4] << 24));
+		}
+		return tokens;
+	}
+
+	static List<int> ReadInlineMethodTokens (byte [] ilBytes, byte opcodePrefix, byte opcode)
+	{
+		var tokens = new List<int> ();
+		for (int i = 0; i < ilBytes.Length - 5; i++) {
+			if (ilBytes [i] != opcodePrefix || ilBytes [i + 1] != opcode) {
+				continue;
+			}
+
+			tokens.Add (ilBytes [i + 2] |
+				(ilBytes [i + 3] << 8) |
+				(ilBytes [i + 4] << 16) |
+				(ilBytes [i + 5] << 24));
 		}
 		return tokens;
 	}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -1000,6 +1000,40 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Contains (MetadataTokens.GetToken (baseUcoHandle), ReadLdftnTokens (ilBytes));
 	}
 
+	[Fact]
+	public void Generate_InheritedVirtualOverride_BaseProxyLater_RegisterNativesUsesBaseUcoMethod ()
+	{
+		var derivedPeer = MakeInheritedOverridePeer ("aaa/app/Concrete", "MyApp.Concrete");
+		var basePeer = MakeAcwPeer ("zzz/app/AbstractBase", "MyApp.AbstractBase", "App") with {
+			MarshalMethods = [
+				new MarshalMethodInfo {
+					JniName = "<init>", NativeCallbackName = "n_ctor",
+					JniSignature = "()V", ManagedMethodName = ".ctor",
+					IsConstructor = true,
+				},
+				new MarshalMethodInfo {
+					JniName = "doWork", NativeCallbackName = "n_DoWork",
+					JniSignature = "()V", ManagedMethodName = "DoWork",
+				},
+			],
+		};
+
+		using var stream = GenerateAssembly ([derivedPeer, basePeer], "InheritedOverrideUcoBaseLater");
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var baseProxy = FindProxyType (reader, "MyApp_AbstractBase_Proxy");
+		var derivedProxy = FindProxyType (reader, "MyApp_Concrete_Proxy");
+		var baseUcoHandle = FindMethodDefinition (reader, baseProxy, "n_doWork_uco_0");
+		Assert.Empty (FindMethodDefinitions (reader, derivedProxy, "n_doWork_uco_0"));
+
+		var derivedRegisterNatives = reader.GetMethodDefinition (FindMethodDefinition (reader, derivedProxy, "RegisterNatives"));
+		var body = pe.GetMethodBody (derivedRegisterNatives.RelativeVirtualAddress);
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+		Assert.Contains (MetadataTokens.GetToken (baseUcoHandle), ReadLdftnTokens (ilBytes));
+	}
+
 	static MemberReference FindCallbackMemberRef (MetadataReader reader, string methodName)
 	{
 		var refs = Enumerable.Range (1, reader.GetTableRowCount (TableIndex.MemberRef))

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1390,6 +1390,39 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Build_InheritedVirtualOverride_ThroughIntermediate_ReuseRootBaseUcoMethod ()
+		{
+			var rootBase = MakeAcwPeer ("my/app/C", "MyApp.C", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+			var intermediate = MakeAcwPeer ("my/app/B", "MyApp.B", "App");
+			var leaf = MakeInheritedOverridePeer ("my/app/A", "MyApp.A", declaringTypeName: "MyApp.C");
+
+			var model = BuildModel ([leaf, intermediate, rootBase]);
+			var rootBaseProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.C");
+			var intermediateProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.B");
+			var leafProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.A");
+
+			Assert.Single (rootBaseProxy.UcoMethods);
+			Assert.Empty (intermediateProxy.UcoMethods);
+			Assert.Empty (leafProxy.UcoMethods);
+
+			var rootBaseRegistration = rootBaseProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			var leafRegistration = leafProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			Assert.Equal (rootBaseRegistration.WrapperTarget, leafRegistration.WrapperTarget);
+		}
+
+		[Fact]
 		public void Build_InheritedVirtualOverride_TargetUnavailable_FallsBackToLocalUcoMethod ()
 		{
 			var derived = MakeInheritedOverridePeer ("my/app/Concrete", "MyApp.Concrete");
@@ -1437,7 +1470,8 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		static JavaPeerInfo MakeInheritedOverridePeer (string jniName, string managedName,
-			string jniSignature = "()V", bool isExport = false, bool isGeneric = false)
+			string jniSignature = "()V", bool isExport = false, bool isGeneric = false,
+			string declaringTypeName = "MyApp.AbstractBase")
 		{
 			return MakeAcwPeer (jniName, managedName, "App") with {
 				IsGenericDefinition = isGeneric,
@@ -1450,7 +1484,7 @@ public class ModelBuilderTests : FixtureTestBase
 					new MarshalMethodInfo {
 						JniName = "doWork", NativeCallbackName = "n_DoWork",
 						JniSignature = jniSignature, ManagedMethodName = "DoWork",
-						DeclaringTypeName = "MyApp.AbstractBase",
+						DeclaringTypeName = declaringTypeName,
 						DeclaringAssemblyName = "App",
 						IsExport = isExport,
 					},

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1323,6 +1323,140 @@ public class ModelBuilderTests : FixtureTestBase
 			Assert.Single (model.ProxyTypes);
 			Assert.False (model.ProxyTypes [0].IsAcw);
 		}
+
+		[Fact]
+		public void Build_InheritedVirtualOverrides_ReuseBaseUcoMethod ()
+		{
+			var basePeer = MakeAcwPeer ("my/app/AbstractBase", "MyApp.AbstractBase", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+			var derivedOne = MakeInheritedOverridePeer ("my/app/ConcreteOne", "MyApp.ConcreteOne");
+			var derivedTwo = MakeInheritedOverridePeer ("my/app/ConcreteTwo", "MyApp.ConcreteTwo");
+
+			var model = BuildModel ([basePeer, derivedOne, derivedTwo]);
+			var baseProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.AbstractBase");
+			var concreteOneProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.ConcreteOne");
+			var concreteTwoProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.ConcreteTwo");
+
+			Assert.Single (baseProxy.UcoMethods);
+			Assert.Empty (concreteOneProxy.UcoMethods);
+			Assert.Empty (concreteTwoProxy.UcoMethods);
+
+			var baseWrapperTarget = baseProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork").WrapperTarget;
+			Assert.Equal (baseProxy.Namespace, baseWrapperTarget.TypeNamespace);
+			Assert.Equal (baseProxy.TypeName, baseWrapperTarget.TypeName);
+			Assert.Equal (baseProxy.UcoMethods [0].WrapperName, baseWrapperTarget.MethodName);
+
+			Assert.Equal (baseWrapperTarget, concreteOneProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork").WrapperTarget);
+			Assert.Equal (baseWrapperTarget, concreteTwoProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork").WrapperTarget);
+		}
+
+		[Fact]
+		public void Build_InheritedVirtualOverride_BaseProxyLater_ReuseBaseUcoMethod ()
+		{
+			var derived = MakeInheritedOverridePeer ("aaa/app/Concrete", "MyApp.Concrete");
+			var basePeer = MakeAcwPeer ("zzz/app/AbstractBase", "MyApp.AbstractBase", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+
+			var model = BuildModel ([derived, basePeer]);
+			var baseProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.AbstractBase");
+			var derivedProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.Concrete");
+
+			Assert.Empty (derivedProxy.UcoMethods);
+			var baseRegistration = baseProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			var registration = derivedProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			Assert.Equal (baseRegistration.WrapperTarget, registration.WrapperTarget);
+		}
+
+		[Fact]
+		public void Build_InheritedVirtualOverride_TargetUnavailable_FallsBackToLocalUcoMethod ()
+		{
+			var derived = MakeInheritedOverridePeer ("my/app/Concrete", "MyApp.Concrete");
+
+			var model = BuildModel ([derived]);
+			var derivedProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.Concrete");
+
+			Assert.Single (derivedProxy.UcoMethods);
+			var registration = derivedProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			Assert.Equal (derivedProxy.Namespace, registration.WrapperTarget.TypeNamespace);
+			Assert.Equal (derivedProxy.TypeName, registration.WrapperTarget.TypeName);
+			Assert.Equal (derivedProxy.UcoMethods [0].WrapperName, registration.WrapperTarget.MethodName);
+		}
+
+		[Theory]
+		[InlineData ("(I)V", false, false)]
+		[InlineData ("()V", true, false)]
+		[InlineData ("()V", false, true)]
+		public void Build_UnsafeInheritedVirtualOverride_FallsBackToLocalUcoMethod (string jniSignature, bool isExport, bool isGeneric)
+		{
+			var basePeer = MakeAcwPeer ("my/app/AbstractBase", "MyApp.AbstractBase", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+			var derived = MakeInheritedOverridePeer ("my/app/Concrete", isGeneric ? "MyApp.Concrete`1" : "MyApp.Concrete",
+				jniSignature, isExport, isGeneric);
+
+			var model = BuildModel ([basePeer, derived]);
+			var derivedProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == derived.ManagedTypeName);
+
+			Assert.Single (derivedProxy.UcoMethods);
+			var registration = derivedProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			Assert.Equal (derivedProxy.Namespace, registration.WrapperTarget.TypeNamespace);
+			Assert.Equal (derivedProxy.TypeName, registration.WrapperTarget.TypeName);
+			Assert.Equal (derivedProxy.UcoMethods [0].WrapperName, registration.WrapperTarget.MethodName);
+		}
+
+		static JavaPeerInfo MakeInheritedOverridePeer (string jniName, string managedName,
+			string jniSignature = "()V", bool isExport = false, bool isGeneric = false)
+		{
+			return MakeAcwPeer (jniName, managedName, "App") with {
+				IsGenericDefinition = isGeneric,
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = jniSignature, ManagedMethodName = "DoWork",
+						DeclaringTypeName = "MyApp.AbstractBase",
+						DeclaringAssemblyName = "App",
+						IsExport = isExport,
+					},
+				],
+			};
+		}
 	}
 
 	public class UcoConstructors

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1423,6 +1423,53 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Build_InheritedVirtualOverride_IntermediateCallbackOwner_ReuseIntermediateUcoMethod ()
+		{
+			var rootBase = MakeAcwPeer ("my/app/C", "MyApp.C", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+			var intermediate = MakeAcwPeer ("my/app/B", "MyApp.B", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "doWork", NativeCallbackName = "n_DoWork",
+						JniSignature = "()V", ManagedMethodName = "DoWork",
+					},
+				],
+			};
+			var leaf = MakeInheritedOverridePeer ("my/app/A", "MyApp.A", declaringTypeName: "MyApp.B");
+
+			var model = BuildModel ([leaf, rootBase, intermediate]);
+			var rootBaseProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.C");
+			var intermediateProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.B");
+			var leafProxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.A");
+
+			Assert.Single (rootBaseProxy.UcoMethods);
+			Assert.Single (intermediateProxy.UcoMethods);
+			Assert.Empty (leafProxy.UcoMethods);
+
+			var rootBaseRegistration = rootBaseProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			var intermediateRegistration = intermediateProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			var leafRegistration = leafProxy.NativeRegistrations.Single (r => r.JniMethodName == "n_DoWork");
+			Assert.NotEqual (rootBaseRegistration.WrapperTarget, leafRegistration.WrapperTarget);
+			Assert.Equal (intermediateRegistration.WrapperTarget, leafRegistration.WrapperTarget);
+		}
+
+		[Fact]
 		public void Build_InheritedVirtualOverride_TargetUnavailable_FallsBackToLocalUcoMethod ()
 		{
 			var derived = MakeInheritedOverridePeer ("my/app/Concrete", "MyApp.Concrete");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1470,6 +1470,40 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
+		public void Build_DirectRegisteredMethod_UsesLocalManagedDispatchWrapper ()
+		{
+			var peer = MakeAcwPeer ("my/app/DirectRegister", "MyApp.DirectRegister", "App") with {
+				MarshalMethods = [
+					new MarshalMethodInfo {
+						JniName = "<init>", NativeCallbackName = "n_ctor",
+						JniSignature = "()V", ManagedMethodName = ".ctor",
+						IsConstructor = true,
+					},
+					new MarshalMethodInfo {
+						JniName = "getValue", NativeCallbackName = "n_GetValue",
+						JniSignature = "()I", ManagedMethodName = "get_Value",
+						CallManagedMethodDirectly = true,
+						ManagedReturnType = new TypeRefData {
+							ManagedTypeName = "System.Int32",
+							AssemblyName = "System.Runtime",
+						},
+					},
+				],
+			};
+
+			var model = BuildModel ([peer]);
+			var proxy = model.ProxyTypes.Single (p => p.TargetType.ManagedTypeName == "MyApp.DirectRegister");
+			var uco = Assert.Single (proxy.UcoMethods);
+			Assert.True (uco.UsesExportMethodDispatch);
+			Assert.Equal ("get_Value", uco.ExportMethodDispatch?.ManagedMethodName);
+
+			var registration = proxy.NativeRegistrations.Single (r => r.JniMethodName == "n_GetValue");
+			Assert.Equal (proxy.Namespace, registration.WrapperTarget.TypeNamespace);
+			Assert.Equal (proxy.TypeName, registration.WrapperTarget.TypeName);
+			Assert.Equal (uco.WrapperName, registration.WrapperTarget.MethodName);
+		}
+
+		[Fact]
 		public void Build_InheritedVirtualOverride_TargetUnavailable_FallsBackToLocalUcoMethod ()
 		{
 			var derived = MakeInheritedOverridePeer ("my/app/Concrete", "MyApp.Concrete");

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Scanner/OverrideDetectionTests.cs
@@ -47,6 +47,12 @@ public class OverrideDetectionTests : FixtureTestBase
 		Assert.Contains ("customMethod", marshalNames);
 		var marshalKeys = peer.MarshalMethods.Select (m => $"{m.JniName}:{m.JniSignature}").ToList ();
 		Assert.Equal (marshalKeys.Count, marshalKeys.Distinct ().Count ());
+
+		var customMethod = Assert.Single (peer.MarshalMethods, m => m.JniName == "customMethod");
+		Assert.True (customMethod.CallManagedMethodDirectly);
+
+		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
+		Assert.False (onCreate.CallManagedMethodDirectly);
 	}
 
 	[Fact]
@@ -68,7 +74,8 @@ public class OverrideDetectionTests : FixtureTestBase
 	public void DirectRegister_StillWorksForMainActivity ()
 	{
 		var peer = FindFixtureByJavaName ("my/app/MainActivity");
-		Assert.Contains (peer.MarshalMethods, m => m.JniName == "onCreate");
+		var onCreate = Assert.Single (peer.MarshalMethods, m => m.JniName == "onCreate");
+		Assert.True (onCreate.CallManagedMethodDirectly);
 	}
 
 	[Fact]


### PR DESCRIPTION
## Summary

Avoid generating duplicate `[UnmanagedCallersOnly]` wrappers for inherited virtual override marshal methods in the trimmable typemap assembly.

For compatible inherited overrides, derived `RegisterNatives` entries now point at the base proxy UCO wrapper target. The base callback still does `Object.GetObject<BaseType> (...)` and calls the managed virtual method, so managed virtual dispatch reaches the derived override without an extra generated UCO wrapper per derived type.

The reuse envelope is intentionally conservative:

- exact callback type/method/JNI signature match
- no constructors
- no `[Export]` direct-dispatch methods
- no generic proxy or generic callback targets
- fallback to the existing local wrapper when no compatible base wrapper target is emitted in the current typemap assembly

The emitter now also orders generated proxy types by wrapper-target dependency before emitting method bodies. This keeps derived `RegisterNatives` emission order-independent: a derived proxy can safely reference a base proxy UCO wrapper even when the derived proxy appears earlier in the input model.

## Generated shape

The Java surface still has one native method per generated Java type. The change is only the function pointer each generated proxy passes to `RegisterNatives`:

```java
abstract class UcoOverrideBase extends android.view.View {
    private native void n_doWork0();
}

final class UcoOverrideDerived0 extends UcoOverrideBase {
    private native void n_doWork0();
}
```

Before this change, the derived proxy registered `UcoOverrideDerived0.n_doWork0()` against its own duplicate UCO wrapper:

```csharp
// Decompiled shape from _TypeMap.Proxies.MyApp_UcoOverrideDerived0_Proxy
public unsafe void RegisterNatives (JniType nativeClass)
{
    JniNativeMethod* methods = stackalloc JniNativeMethod [2];
    methods [0] = new JniNativeMethod (
        "n_doWork0",
        "()V",
        (IntPtr)(delegate*<IntPtr, IntPtr, void>)(&n_doWork0_uco_0));
    methods [1] = new JniNativeMethod (
        "<init>",
        "()V",
        (IntPtr)(delegate*<IntPtr, IntPtr, void>)(&nctor_0_uco));

    Types.RegisterNatives (nativeClass.PeerReference, new ReadOnlySpan<JniNativeMethod> (methods, 2));
}
```

After this change, the derived proxy keeps the same Java native registration, but the method callback points at the base proxy's UCO wrapper:

```csharp
// Decompiled shape from _TypeMap.Proxies.MyApp_UcoOverrideDerived0_Proxy
public unsafe void RegisterNatives (JniType nativeClass)
{
    JniNativeMethod* methods = stackalloc JniNativeMethod [2];
    methods [0] = new JniNativeMethod (
        "n_doWork0",
        "()V",
        (IntPtr)(delegate*<IntPtr, IntPtr, void>)(&MyApp_UcoOverrideBase_Proxy.n_doWork0_uco_0));
    methods [1] = new JniNativeMethod (
        "<init>",
        "()V",
        (IntPtr)(delegate*<IntPtr, IntPtr, void>)(&nctor_0_uco));

    Types.RegisterNatives (nativeClass.PeerReference, new ReadOnlySpan<JniNativeMethod> (methods, 2));
}
```

The shared base wrapper still calls the base registered callback; that callback performs `Object.GetObject<BaseType> (...)`, then the managed virtual call dispatches to the derived override:

```csharp
public static void n_doWork0_uco_0 (IntPtr jnienv, IntPtr self)
{
    AndroidRuntimeInternal.WaitForBridgeProcessing ();
    try {
        UcoOverrideBase.n_DoWork0 (jnienv, self);
    } catch (Exception ex) {
        AndroidEnvironmentInternal.UnhandledException (ex);
    }
}
```

## Measurements

In a synthetic app-shaped typemap with one registered abstract base and 20 registered derived types overriding 12 virtual methods:

- Method UCO wrappers: 252 -> 12
- Typemap DLL: 51,712 B -> 30,720 B (-20,992 B, -40.6%)
- Stripped `osx-arm64` NativeAOT proxy executable: 1,136,000 B -> 1,102,752 B (-33,248 B, -2.93%)

That works out to roughly 87 B saved in the CoreCLR typemap DLL and 139 B in the stripped NativeAOT proxy executable per removed derived-method UCO wrapper. These are directional estimates; actual app savings depend on metadata/native layout and alignment.

## Tests

- `dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj --no-restore` (556 passed, run with .NET SDK 10.0.101 from a session-local global.json)

Added model/emitted-IL coverage for inherited override reuse, including the derived-before-base input-order case and intermediate callback-owner case, plus a focused CoreCLR/trimmable `MSBuildDeviceIntegration` test for Java-to-native dispatch through the shared base UCO path. I could not run the device test locally because this worktree's repo-prep/device-test build is blocked by local tooling/generated-artifact issues (`make prepare` fails under the local .NET 11 preview SDK; the device-test build then hits missing `javac`, `XABuildConfig.cs`, `Xamarin.Android.Tools.BootstrapTasks.dll`, and manifestmerger Gradle failures).



References #10795
References #10958
