### PR TITLE
[TrimmableTypeMap] Package ReadyToRun trimmable typemap assemblies

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -25,66 +25,39 @@
     </PropertyGroup>
   </Target>
 
-  <!-- Add TypeMap DLLs to assembly store with per-ABI metadata.
-       TypeMap DLLs are ABI-agnostic (pure IL), so the same DLLs are added for every ABI.
-       This target batches over @(_BuildTargetAbis) to add items per-ABI. -->
-  <Target Name="_AddTrimmableTypeMapAssembliesToStore"
-      BeforeTargets="_BuildApkEmbed"
-      DependsOnTargets="_PrepareTrimmableTypeMapAssemblies;_DefineBuildTargetAbis">
+  <!-- Add linked TypeMap DLLs to the normal publish assembly pipeline.  The SDK R2R
+       target only compiles ResolvedFileToPublish items with PostprocessAssembly=true. -->
+  <Target Name="_AddTrimmableTypeMapToResolvedFileToPublish"
+      Condition=" '$(RuntimeIdentifier)' != '' "
+      AfterTargets="ILLink"
+      BeforeTargets="CreateReadyToRunImages"
+      DependsOnTargets="_ReadGeneratedTrimmableTypeMapAssemblies">
     <ItemGroup>
-      <_TrimmableTypeMapAbi Include="@(_BuildTargetAbis)" />
-      <_TrimmableTypeMapAbi Update="@(_TrimmableTypeMapAbi)" Condition=" '%(_TrimmableTypeMapAbi.Identity)' == 'arm64-v8a' ">
-        <RuntimeIdentifier>android-arm64</RuntimeIdentifier>
-      </_TrimmableTypeMapAbi>
-      <_TrimmableTypeMapAbi Update="@(_TrimmableTypeMapAbi)" Condition=" '%(_TrimmableTypeMapAbi.Identity)' == 'armeabi-v7a' ">
-        <RuntimeIdentifier>android-arm</RuntimeIdentifier>
-      </_TrimmableTypeMapAbi>
-      <_TrimmableTypeMapAbi Update="@(_TrimmableTypeMapAbi)" Condition=" '%(_TrimmableTypeMapAbi.Identity)' == 'x86_64' ">
-        <RuntimeIdentifier>android-x64</RuntimeIdentifier>
-      </_TrimmableTypeMapAbi>
-      <_TrimmableTypeMapAbi Update="@(_TrimmableTypeMapAbi)" Condition=" '%(_TrimmableTypeMapAbi.Identity)' == 'x86' ">
-        <RuntimeIdentifier>android-x86</RuntimeIdentifier>
-      </_TrimmableTypeMapAbi>
+      <_TrimmableTypeMapLinkedAssemblies Include="$(IntermediateOutputPath)linked\_*.TypeMap.dll;$(IntermediateOutputPath)linked\_Microsoft.Android.TypeMap*.dll" />
+      <_TrimmableTypeMapAssembliesToPublish Include="@(_TrimmableTypeMapLinkedAssemblies)" />
+      <_TrimmableTypeMapAssembliesToPublish Include="@(_GeneratedTypeMapAssembliesFromList)" Condition=" '@(_TrimmableTypeMapLinkedAssemblies->Count())' == '0' " />
+      <ResolvedFileToPublish Include="@(_TrimmableTypeMapAssembliesToPublish)">
+        <RelativePath>%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <PostprocessAssembly>true</PostprocessAssembly>
+        <RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+      </ResolvedFileToPublish>
     </ItemGroup>
+  </Target>
 
-    <!-- Try linked/ first (trimmed by ILLink in inner builds) -->
+  <Target Name="_UseReadyToRunTrimmableTypeMapAssembliesForPublish"
+      Condition=" '$(RuntimeIdentifier)' != '' and '$(PublishReadyToRun)' == 'true' "
+      AfterTargets="CreateReadyToRunImages">
     <ItemGroup>
-      <_LinkedTypeMapDlls Include="$(IntermediateOutputPath)%(_TrimmableTypeMapAbi.RuntimeIdentifier)/linked/_*.TypeMap.dll;$(IntermediateOutputPath)%(_TrimmableTypeMapAbi.RuntimeIdentifier)/linked/_Microsoft.Android.TypeMap*.dll">
-        <Abi>%(_TrimmableTypeMapAbi.Identity)</Abi>
-        <RuntimeIdentifier>%(_TrimmableTypeMapAbi.RuntimeIdentifier)</RuntimeIdentifier>
-        <DestinationSubPath>%(_TrimmableTypeMapAbi.Identity)/%(_LinkedTypeMapDlls.Filename)%(_LinkedTypeMapDlls.Extension)</DestinationSubPath>
-        <DestinationSubDirectory>%(_TrimmableTypeMapAbi.Identity)/</DestinationSubDirectory>
-      </_LinkedTypeMapDlls>
-    </ItemGroup>
-    <ItemGroup Condition=" '@(_LinkedTypeMapDlls->Count())' != '0' ">
-      <_BuildApkResolvedUserAssemblies Include="@(_LinkedTypeMapDlls)">
-        <Abi>%(_LinkedTypeMapDlls.Abi)</Abi>
-        <RuntimeIdentifier>%(_LinkedTypeMapDlls.RuntimeIdentifier)</RuntimeIdentifier>
-        <DestinationSubPath>%(_LinkedTypeMapDlls.DestinationSubPath)</DestinationSubPath>
-        <DestinationSubDirectory>%(_LinkedTypeMapDlls.DestinationSubDirectory)</DestinationSubDirectory>
-      </_BuildApkResolvedUserAssemblies>
-    </ItemGroup>
-    <!-- Fallback: use untrimmed TypeMap DLLs when linked/ is empty (Debug builds without ILLink). -->
-    <ItemGroup Condition=" '@(_LinkedTypeMapDlls->Count())' == '0' and '@(_TrimmableTypeMapAbi)' != '' ">
-      <_TypeMapDlls Include="$(_TypeMapOutputDirectory)*.dll">
-        <Abi>%(_TrimmableTypeMapAbi.Identity)</Abi>
-        <RuntimeIdentifier>%(_TrimmableTypeMapAbi.RuntimeIdentifier)</RuntimeIdentifier>
-        <DestinationSubPath>%(_TrimmableTypeMapAbi.Identity)/%(_TypeMapDlls.Filename)%(_TypeMapDlls.Extension)</DestinationSubPath>
-        <DestinationSubDirectory>%(_TrimmableTypeMapAbi.Identity)/</DestinationSubDirectory>
-      </_TypeMapDlls>
-    </ItemGroup>
-    <ItemGroup Condition=" '@(_LinkedTypeMapDlls->Count())' == '0' ">
-      <_BuildApkResolvedUserAssemblies Include="@(_TypeMapDlls)">
-        <Abi>%(_TypeMapDlls.Abi)</Abi>
-        <RuntimeIdentifier>%(_TypeMapDlls.RuntimeIdentifier)</RuntimeIdentifier>
-        <DestinationSubPath>%(_TypeMapDlls.DestinationSubPath)</DestinationSubPath>
-        <DestinationSubDirectory>%(_TypeMapDlls.DestinationSubDirectory)</DestinationSubDirectory>
-      </_BuildApkResolvedUserAssemblies>
-    </ItemGroup>
-    <ItemGroup>
-      <_LinkedTypeMapDlls Remove="@(_LinkedTypeMapDlls)" />
-      <_TypeMapDlls Remove="@(_TypeMapDlls)" />
-      <_TrimmableTypeMapAbi Remove="@(_TrimmableTypeMapAbi)" />
+      <_TrimmableTypeMapLinkedAssemblies Include="$(IntermediateOutputPath)linked\_*.TypeMap.dll;$(IntermediateOutputPath)linked\_Microsoft.Android.TypeMap*.dll" />
+      <_TrimmableTypeMapReadyToRunAssemblies Include="$(IntermediateOutputPath)R2R\_*.TypeMap.dll;$(IntermediateOutputPath)R2R\_Microsoft.Android.TypeMap*.dll" />
+      <ResolvedFileToPublish Remove="@(_TrimmableTypeMapLinkedAssemblies)" />
+      <ResolvedFileToPublish Remove="@(_TrimmableTypeMapReadyToRunAssemblies)" />
+      <ResolvedFileToPublish Include="@(_TrimmableTypeMapReadyToRunAssemblies)">
+        <RelativePath>%(Filename)%(Extension)</RelativePath>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <RuntimeIdentifier>$(RuntimeIdentifier)</RuntimeIdentifier>
+      </ResolvedFileToPublish>
     </ItemGroup>
   </Target>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -148,6 +148,14 @@ namespace Xamarin.Android.Build.Tests
 			using var peReader = new System.Reflection.PortableExecutable.PEReader (stream);
 			Assert.IsTrue (peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
 				$"ReadyToRun image not found in {assemblyName}.dll! ManagedNativeHeaderDirectory should not be empty!");
+
+			var compressedAssembliesSource = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, rid, "android", $"compressed_assemblies.{abi}.ll");
+			FileAssert.Exists (compressedAssembliesSource);
+			var compressedAssembliesSourceText = File.ReadAllText (compressedAssembliesSource);
+			StringAssert.Contains ("@compressed_assembly_count = dso_local local_unnamed_addr constant i32 0, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@compressed_assembly_descriptors = dso_local local_unnamed_addr global [0 x %struct.CompressedAssemblyDescriptor] zeroinitializer, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_size = dso_local local_unnamed_addr constant i32 0, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_buffer = dso_local local_unnamed_addr global [0 x i8] zeroinitializer, align 1", compressedAssembliesSourceText);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text.RegularExpressions;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
+using Xamarin.Android.Tools;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests {
@@ -195,6 +196,62 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.IsTrue (
 				DexUtils.ContainsClassWithMethod ("Landroid/runtime/JavaProxyThrowable;", "<init>", "(Ljava/lang/String;)V", dexFile, AndroidSdkPath),
 				$"`{dexFile}` should include `android.runtime.JavaProxyThrowable`.");
+		}
+
+		[Test]
+		public void CoreClrTrimmableTypeMap_PackagesReadyToRunTypeMap ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+			proj.SetProperty ("RuntimeIdentifier", "android-arm64");
+			proj.SetProperty ("AndroidEnableAssemblyCompression", "false");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
+
+			var r2rTypeMap = builder.Output.GetIntermediaryPath (Path.Combine ("android-arm64", "R2R", "_Microsoft.Android.TypeMaps.dll"));
+			FileAssert.Exists (r2rTypeMap, "ReadyToRun should compile the generated TypeMap entry assembly.");
+			using (var r2rStream = File.OpenRead (r2rTypeMap)) {
+				using var r2rReader = new System.Reflection.PortableExecutable.PEReader (r2rStream);
+				Assert.IsTrue (
+					r2rReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
+					"ReadyToRun output for _Microsoft.Android.TypeMaps.dll should have a managed native header.");
+			}
+
+			var apk = Path.Combine (Root, builder.ProjectDirectory, proj.OutputPath, "android-arm64", $"{proj.PackageName}-Signed.apk");
+			FileAssert.Exists (apk);
+
+			var helper = new ArchiveAssemblyHelper (apk, useAssemblyStores: true);
+			var packagedTypeMapEntries = helper.ListArchiveContents ("lib/", arch: AndroidTargetArch.Arm64)
+				.Where (entry => entry.StartsWith ("lib/arm64-v8a/lib__", StringComparison.Ordinal) &&
+					entry.EndsWith (".dll.so", StringComparison.Ordinal) &&
+					!entry.EndsWith (".ni.dll.so", StringComparison.Ordinal) &&
+					entry.Contains ("TypeMap", StringComparison.Ordinal))
+				.ToArray ();
+			Assert.AreEqual (
+				packagedTypeMapEntries.Distinct ().Count (),
+				packagedTypeMapEntries.Length,
+				"TypeMap assemblies should be packaged only once; do not include both linked IL and ReadyToRun copies.");
+			Assert.AreEqual (
+				1,
+				packagedTypeMapEntries.Count (entry => entry == "lib/arm64-v8a/lib__Microsoft.Android.TypeMaps.dll.so"),
+				"_Microsoft.Android.TypeMaps.dll should be packaged only once.");
+
+			Assert.IsTrue (helper.Exists ("assemblies/arm64-v8a/_Microsoft.Android.TypeMaps.dll"), "_Microsoft.Android.TypeMaps.dll should exist in the APK.");
+			using (var packagedTypeMap = helper.ReadEntry ("assemblies/arm64-v8a/_Microsoft.Android.TypeMaps.dll", AndroidTargetArch.Arm64)) {
+				Assert.IsNotNull (packagedTypeMap, "_Microsoft.Android.TypeMaps.dll should be readable from the APK.");
+				using var packagedReader = new System.Reflection.PortableExecutable.PEReader (packagedTypeMap);
+				Assert.IsTrue (
+					packagedReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
+					"Packaged _Microsoft.Android.TypeMaps.dll should be the ReadyToRun image, not the linked IL image.");
+			}
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
@@ -134,6 +134,24 @@ namespace Xamarin.Android.Tasks
 			);
 
 			if (archData.Count == 0) {
+				var emptyCountVar = new LlvmIrGlobalVariable (typeof(uint), CompressedAssemblyCountSymbolName) {
+					Options = LlvmIrVariableOptions.GlobalConstant,
+					Value = 0u,
+				};
+				module.Add (emptyCountVar);
+
+				var emptyDescriptorsVar = new LlvmIrGlobalVariable (typeof(List<StructureInstance<CompressedAssemblyDescriptor>>), DescriptorsArraySymbolName) {
+					Options = LlvmIrVariableOptions.GlobalWritable,
+					Value = new List<StructureInstance<CompressedAssemblyDescriptor>> (),
+				};
+				module.Add (emptyDescriptorsVar);
+
+				var emptyBufferSizeVar = new LlvmIrGlobalVariable (typeof(uint), UncompressedAssembliesBufferSizeSymbolName) {
+					Options = LlvmIrVariableOptions.GlobalConstant,
+					Value = 0u,
+				};
+				module.Add (emptyBufferSizeVar);
+
 				var emptyBufferVar = new LlvmIrGlobalVariable (typeof(List<byte>), UncompressedAssembliesBufferSymbolName, LlvmIrVariableOptions.GlobalWritable) {
 					ArrayItemCount = 0,
 					ZeroInitializeArray = true,


### PR DESCRIPTION
## Summary
- flow generated trimmable TypeMap assemblies through ResolvedFileToPublish so crossgen2 processes them
- replace linked TypeMap publish items with the R2R outputs before Android packaging
- extend the CoreCLR trimmable TypeMap packaging test to prove the packaged entry assembly is ReadyToRun and TypeMap payloads are unique

## Validation
- MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter Name=CoreClrTrimmableTypeMap_PackagesReadyToRunTypeMap -v:minimal
- git diff --check

## Notes
- Samsung smoke measurements showed only a small startup improvement, so follow-up startup optimization work will stay separate from this packaging fix.

References #10792
