### PR TITLE
Define empty compressed assembly symbols

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -148,6 +148,14 @@ namespace Xamarin.Android.Build.Tests
 			using var peReader = new System.Reflection.PortableExecutable.PEReader (stream);
 			Assert.IsTrue (peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
 				$"ReadyToRun image not found in {assemblyName}.dll! ManagedNativeHeaderDirectory should not be empty!");
+
+			var compressedAssembliesSource = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", $"compressed_assemblies.{abi}.ll");
+			FileAssert.Exists (compressedAssembliesSource);
+			var compressedAssembliesSourceText = File.ReadAllText (compressedAssembliesSource);
+			StringAssert.Contains ("@compressed_assembly_count", compressedAssembliesSourceText);
+			StringAssert.Contains ("@compressed_assembly_descriptors", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_size", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_buffer", compressedAssembliesSourceText);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -149,13 +149,13 @@ namespace Xamarin.Android.Build.Tests
 			Assert.IsTrue (peReader.PEHeaders.CorHeader.ManagedNativeHeaderDirectory.Size > 0,
 				$"ReadyToRun image not found in {assemblyName}.dll! ManagedNativeHeaderDirectory should not be empty!");
 
-			var compressedAssembliesSource = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", $"compressed_assemblies.{abi}.ll");
+			var compressedAssembliesSource = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, rid, "android", $"compressed_assemblies.{abi}.ll");
 			FileAssert.Exists (compressedAssembliesSource);
 			var compressedAssembliesSourceText = File.ReadAllText (compressedAssembliesSource);
-			StringAssert.Contains ("@compressed_assembly_count", compressedAssembliesSourceText);
-			StringAssert.Contains ("@compressed_assembly_descriptors", compressedAssembliesSourceText);
-			StringAssert.Contains ("@uncompressed_assemblies_data_size", compressedAssembliesSourceText);
-			StringAssert.Contains ("@uncompressed_assemblies_data_buffer", compressedAssembliesSourceText);
+			StringAssert.Contains ("@compressed_assembly_count = dso_local local_unnamed_addr constant i32 0, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@compressed_assembly_descriptors = dso_local local_unnamed_addr global [0 x %struct.CompressedAssemblyDescriptor] zeroinitializer, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_size = dso_local local_unnamed_addr constant i32 0, align 4", compressedAssembliesSourceText);
+			StringAssert.Contains ("@uncompressed_assemblies_data_buffer = dso_local local_unnamed_addr global [0 x i8] zeroinitializer, align 1", compressedAssembliesSourceText);
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/CompressedAssembliesNativeAssemblyGenerator.cs
@@ -134,6 +134,24 @@ namespace Xamarin.Android.Tasks
 			);
 
 			if (archData.Count == 0) {
+				var emptyCountVar = new LlvmIrGlobalVariable (typeof(uint), CompressedAssemblyCountSymbolName) {
+					Options = LlvmIrVariableOptions.GlobalConstant,
+					Value = 0u,
+				};
+				module.Add (emptyCountVar);
+
+				var emptyDescriptorsVar = new LlvmIrGlobalVariable (typeof(List<StructureInstance<CompressedAssemblyDescriptor>>), DescriptorsArraySymbolName) {
+					Options = LlvmIrVariableOptions.GlobalWritable,
+					Value = new List<StructureInstance<CompressedAssemblyDescriptor>> (),
+				};
+				module.Add (emptyDescriptorsVar);
+
+				var emptyBufferSizeVar = new LlvmIrGlobalVariable (typeof(uint), UncompressedAssembliesBufferSizeSymbolName) {
+					Options = LlvmIrVariableOptions.GlobalConstant,
+					Value = 0u,
+				};
+				module.Add (emptyBufferSizeVar);
+
 				var emptyBufferVar = new LlvmIrGlobalVariable (typeof(List<byte>), UncompressedAssembliesBufferSymbolName, LlvmIrVariableOptions.GlobalWritable) {
 					ArrayItemCount = 0,
 					ZeroInitializeArray = true,


### PR DESCRIPTION
Follow-up to #11473.

When `AndroidEnableAssemblyCompression=false`, the compressed assemblies generator emitted only `uncompressed_assemblies_data_buffer`. CoreCLR still references the other compressed assembly metadata symbols, so publish output must define them even when there are no compressed assemblies.

This emits empty/default definitions for all expected symbols and extends `BasicApplicationPublishReadyToRun` to cover the no-compression case.

Validated with:

```
MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh test bin/TestDebug/net10.0/Xamarin.Android.Build.Tests.dll --filter Name=BasicApplicationPublishReadyToRun -v:minimal
```