### PR TITLE
[tests] Remove custom widget trimmable exclusion

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.RuntimeTests/NUnitInstrumentation.cs
@@ -31,17 +31,15 @@ namespace Xamarin.Android.RuntimeTests
                 // trimmable typemap. We don't control that assembly, so they must be
                 // excluded by name here.
                 ExcludedTestNames = new [] {
-                    // [JniAddNativeMethodRegistrationAttribute] is not supported by design under
-                    // the trimmable typemap. This Java.Interop-Tests fixture uses that attribute
+                    // Known limitation: [JniAddNativeMethodRegistrationAttribute] is not
+                    // supported by design under the trimmable typemap. This Java.Interop-Tests
+                    // fixture uses that attribute
                     // to register native callbacks on a hand-written Java peer (an obsolete code
                     // path whose primary consumer, jnimarshalmethod-gen, was removed in
                     // dotnet/java-interop#1405). The trimmable typemap generator emits XA4251
                     // when it encounters the attribute and instructs users to either avoid it or
                     // switch off the trimmable typemap. See https://github.com/dotnet/android/issues/11170.
                     "Java.InteropTests.InvokeVirtualFromConstructorTests",
-
-                    // Global ref leak when inflating custom views
-                    "Xamarin.Android.RuntimeTests.CustomWidgetTests.InflateCustomView_ShouldNotLeakGlobalRefs",
                 };
             }
         }


### PR DESCRIPTION
## Summary

- removes `Xamarin.Android.RuntimeTests.CustomWidgetTests.InflateCustomView_ShouldNotLeakGlobalRefs` from the CoreCLRTrimmable exact-name exclusion list
- keeps `Java.InteropTests.InvokeVirtualFromConstructorTests` excluded as a known trimmable typemap limitation
- documents that remaining Java.Interop exclusion as a known limitation in the instrumentation comment

`InflateCustomView_ShouldNotLeakGlobalRefs` is not a trimmable typemap-specific issue; it should follow its normal test-level disposition instead of being hidden by the trimmable runner.

## Validation

- `git diff --check`
- verified the custom-widget exact-name exclusion no longer appears in `NUnitInstrumentation.cs`

Closes #11099.
