### PR TITLE
[TrimmableTypeMap] Refactor NativeTypeMap tests for trimmable typemap

### DIFF
--- a/tests/Mono.Android-Tests/Java.Interop-Tests/Java.InteropTests/AndroidValueManagerContractTests.cs
+++ b/tests/Mono.Android-Tests/Java.Interop-Tests/Java.InteropTests/AndroidValueManagerContractTests.cs
@@ -12,7 +12,7 @@ using Java.Interop;
 using NUnit.Framework;
 
 namespace Java.InteropTests {
-	[TestFixture, Category ("NativeTypeMap")]
+	[TestFixture]
 	public class AndroidValueManagerContractTests : JniRuntimeJniValueManagerContract {
 
 		[DynamicallyAccessedMembers (DynamicallyAccessedMemberTypes.PublicParameterlessConstructor)]

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -478,24 +478,24 @@ namespace Java.InteropTests
 			Assert.IsNull (ignore_t2, string.Format ("No exception should be thrown [t2]! Got: {0}", ignore_t2));
 		}
 
-		[Test, Category ("NativeTypeMap")]
+		[Test]
 		public void JavaToManagedTypeMapping ()
 		{
-			Type m = Java.Interop.TypeManager.GetJavaToManagedType ("android/content/res/Resources");
+			Type m = JniRuntime.CurrentRuntime.TypeManager.GetType (new JniTypeSignature ("android/content/res/Resources"));
 			Assert.AreNotEqual (null, m);
-			m = Java.Interop.TypeManager.GetJavaToManagedType ("this/type/does/not/exist");
+			m = JniRuntime.CurrentRuntime.TypeManager.GetType (new JniTypeSignature ("this/type/does/not/exist"));
 			Assert.AreEqual (null, m);
 		}
 
-		[Test, Category ("NativeTypeMap")]
+		[Test]
 		public void ManagedToJavaTypeMapping ()
 		{
 			Type type = typeof(Activity);
-			string m = JNIEnv.TypemapManagedToJava (type);
+			string m = JniRuntime.CurrentRuntime.TypeManager.GetTypeSignature (type).SimpleReference;
 			Assert.AreNotEqual (null, m, "`Activity` subclasses Java.Lang.Object, it should be in the typemap!");
 
 			type = typeof (JnienvTest);
-			m = JNIEnv.TypemapManagedToJava (type);
+			m = JniRuntime.CurrentRuntime.TypeManager.GetTypeSignature (type).SimpleReference;
 			Assert.AreEqual (null, m, "`JnienvTest` does *not* subclass Java.Lang.Object, it should *not* be in the typemap!");
 		}
 

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -31,7 +31,7 @@
     <!-- TODO: https://github.com/dotnet/android/issues/10069 -->
     <ExcludeCategories Condition=" '$(UseMonoRuntime)' != 'true' and '$(_AndroidTypeMapImplementation)' != 'trimmable' ">$(ExcludeCategories):CoreCLRIgnore:NTLM</ExcludeCategories>
     <!-- TODO: https://github.com/dotnet/android/issues/10079 -->
-    <ExcludeCategories Condition=" '$(PublishAot)' == 'true' ">$(ExcludeCategories):NativeAOTIgnore:SSL:NTLM:Export:NativeTypeMap</ExcludeCategories>
+    <ExcludeCategories Condition=" '$(PublishAot)' == 'true' ">$(ExcludeCategories):NativeAOTIgnore:SSL:NTLM:Export</ExcludeCategories>
     <!-- FIXME: LLVMIgnore https://github.com/dotnet/runtime/issues/89190 -->
     <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):LLVMIgnore</ExcludeCategories>
     <ExcludeCategories Condition=" '$(EnableLLVM)' == 'true' ">$(ExcludeCategories):InetAccess:NetworkInterfaces</ExcludeCategories>
@@ -40,7 +40,6 @@
   <PropertyGroup>
     <UseMonoRuntime Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishAot)' != 'true' ">false</UseMonoRuntime>
     <TestsFlavor Condition=" '$(TestsFlavor)' == '' and '$(_AndroidTypeMapImplementation)' == 'trimmable' ">CoreCLRTrimmable</TestsFlavor>
-    <ExcludeCategories Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' ">$(ExcludeCategories):NativeTypeMap</ExcludeCategories>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- route NativeTypeMap test lookups through `JniRuntime.CurrentRuntime.TypeManager`
- remove `NativeTypeMap` categories from refactored tests and AndroidValueManager contract tests
- drop stale `NativeTypeMap` test exclusions now that no tests use the category

## Testing
- Not run locally; relying on CI per machine-load constraint

Fixes #11018