### PR TITLE
Use x64 shared Macs for macOS build jobs

### DIFF
--- a/build-tools/automation/azure-pipelines-apidocs.yaml
+++ b/build-tools/automation/azure-pipelines-apidocs.yaml
@@ -81,7 +81,7 @@ extends:
           name: $(SharedMacPool)
           demands:
           - macOS.Name -equals $(SharedMacName)
-          - Agent.OSArchitecture -equals $(SharedMacArch)
+          - macOS.Architecture -equals $(SharedMacArch)
           os: macOS
         timeoutInMinutes: 120
         workspace:

--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -44,7 +44,7 @@ stages:
       name: $(SharedMacPool)
       demands:
       - macOS.Name -equals $(SharedMacName)
-      - Agent.OSArchitecture -equals $(SharedMacArch)
+      - macOS.Architecture -equals $(SharedMacArch)
     timeoutInMinutes: 420
     workspace:
       clean: all

--- a/build-tools/automation/yaml-templates/build-macos.yaml
+++ b/build-tools/automation/yaml-templates/build-macos.yaml
@@ -32,7 +32,7 @@ stages:
         name: $(SharedMacPool)
         demands:
         - macOS.Name -equals $(SharedMacName)
-        - Agent.OSArchitecture -equals $(SharedMacArch)
+        - macOS.Architecture -equals $(SharedMacArch)
       ${{ else }}:
         name: Azure Pipelines
         vmImage: $(HostedMacImage)

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -42,7 +42,7 @@ variables:
 - name: SharedMacName
   value: Sequoia
 - name: SharedMacArch
-  value: arm64
+  value: x64
 - name: HostedWinImage
   value: windows-2022
 - name: WindowsPoolImage1ESPT


### PR DESCRIPTION
The macOS build failures are caused by running the Android NDK darwin-x86_64 host toolchain on ARM64 shared Macs without Rosetta. CMake fails compiler detection with `posix_spawn failed: Exec format error` when it tries to execute `/Users/builder/android-toolchain/ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/clang`.

https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14187608&view=ms.vss-build-web.run-extensions-tab:
<img width="879" height="927" alt="image" src="https://github.com/user-attachments/assets/86f921e0-11e4-40ed-91cd-b40c9f78c162" />

The repo currently selects ARM64 shared Macs via `SharedMacArch: arm64`, but xaprepare still generates `Configuration.OperatingSystem.props` with `NdkLlvmTag=darwin-x86_64`, and the generated native build uses that NDK clang path.

This changes shared Mac jobs back to x64 and uses the existing `macOS.Architecture` pool capability consistently. Existing emulator jobs already use `macOS.Architecture -equals x64`, so this matches the known working pool capability instead of depending on Rosetta on ARM64 machines.

Validation:
- `git diff --check`