### PR TITLE
[ci] Stop using preview .NET SDK channel in two lanes

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -134,8 +134,8 @@ extends:
           parameters:
             xaSourcePath: $(Build.SourcesDirectory)/android
             androidSdkPlatforms: $(DefaultTestSdkPlatforms)
-            dotnetVersion: $(DotNetPreviewSdkVersion)
-            dotnetQuality: $(DotNetPreviewSdkQuality)
+            dotnetVersion: $(DotNetSdkVersion)
+            dotnetQuality: $(DotNetSdkQuality)
 
         - task: NuGetAuthenticate@1
           displayName: authenticate with azure artifacts
@@ -353,8 +353,8 @@ extends:
 
         - template: /build-tools/automation/yaml-templates/use-dot-net.yaml@self
           parameters:
-            version: $(DotNetPreviewSdkVersion)
-            quality: $(DotNetPreviewSdkQuality)
+            version: $(DotNetSdkVersion)
+            quality: $(DotNetSdkQuality)
 
         # Download symbols to be published to the symbols artifact drop declared above
         - task: DownloadPipelineArtifact@2

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -27,10 +27,6 @@ variables:
   value: 10.0
 - name: DotNetSdkQuality
   value: GA
-- name: DotNetPreviewSdkVersion
-  value: 10.0
-- name: DotNetPreviewSdkQuality
-  value: preview
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage


### PR DESCRIPTION
Component Governance is reporting a vulnerable .NET 10.0 SDK against two lanes in the `Xamarin.Android` pipeline -- `MAUI Integration` and `Publish symbols and Push to Maestro` -- while every other lane reports `Fix detected`.

Those two lanes were the only ones installing the SDK with `DotNetPreviewSdkVersion=10.0` + `DotNetPreviewSdkQuality=preview`. Now that 10.0 has shipped GA, the `preview` quality on that channel resolves to a stale pre-GA SDK that never received the security fix that landed in the 10.0 GA SDKs. Every other lane installs `DotNetSdkVersion=10.0` + `DotNetSdkQuality=GA`, which is why CG shows `Fix detected` for them.

This PR switches both lanes to `DotNetSdkVersion` / `DotNetSdkQuality` so they pick up the patched GA SDK like the rest of the pipeline, and removes the now-unused `DotNetPreviewSdk*` variables so the stale preview channel cannot be reintroduced.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests (N/A -- CI infrastructure only)