### PR TITLE
Update Microsoft.Build package references

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -51,6 +51,7 @@
     <NuGetApiPackageVersion>5.4.0</NuGetApiPackageVersion>
     <LZ4PackageVersion>1.3.6</LZ4PackageVersion>
     <MicrosoftTestingPlatformVersion>2.2.1</MicrosoftTestingPlatformVersion>
+    <MSBuildPackageReferenceVersion>18.6.3</MSBuildPackageReferenceVersion>
     <MonoOptionsVersion>6.12.0.148</MonoOptionsVersion>
     <SystemCollectionsImmutableVersion>8.0.0</SystemCollectionsImmutableVersion>
     <SystemRuntimeCompilerServicesUnsafeVersion>6.0.0</SystemRuntimeCompilerServicesUnsafeVersion>
@@ -78,5 +79,9 @@
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.ProjectTools.csproj' ">true</_AllowProjectWarnings>
     <TreatWarningsAsErrors Condition=" ('$(RunningOnCI)' == 'true' OR '$(_AndroidTreatWarningsAsErrors)' == 'true') AND '$(_AllowProjectWarnings)' != 'true' ">true</TreatWarningsAsErrors>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(MSBuildProjectName)' == 'Microsoft.Android.Build.BaseTasks' ">
+    <PackageReference Include="System.Reflection.Metadata" Version="$(SystemReflectionMetadataPackageVersion)" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Update Microsoft.Build package references from 17.14.28 to 18.6.3
- Add a direct System.Reflection.Metadata package reference for the shared base tasks project

## Validation
- dotnet restore tests/MSBuildDeviceIntegration/MSBuildDeviceIntegration.csproj --configfile nuget.config --disable-parallel --verbosity minimal
- dotnet restore src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests.csproj --configfile nuget.config --disable-parallel --verbosity minimal
- dotnet restore build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj --configfile nuget.config --disable-parallel --verbosity minimal
- dotnet build external/xamarin-android-tools/src/Microsoft.Android.Build.BaseTasks/Microsoft.Android.Build.BaseTasks.csproj --no-restore --verbosity minimal
- dotnet build build-tools/xa-prep-tasks/xa-prep-tasks.csproj --no-restore --verbosity minimal
- dotnet build build-tools/Xamarin.Android.Tools.BootstrapTasks/Xamarin.Android.Tools.BootstrapTasks.csproj --no-restore --verbosity minimal
