### PR TITLE
$(AndroidPackVersionSuffix)=preview.6; main is .NET 11 preview 6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,7 +37,7 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>36.99.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.5</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>
   </PropertyGroup>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview5

We branched for .NET 11 Preview 5 from f0db4c6c4 into `release/11.0.1xx-preview5`; the `main` branch is now .NET 11 Preview 6.

Bumps `$(AndroidPackVersionSuffix)` in `Directory.Build.props` from `preview.5` to `preview.6`.