### PR TITLE
Test NuGet MSI conversion template update

### DIFF
--- a/build-tools/automation/azure-pipelines-nightly.yaml
+++ b/build-tools/automation/azure-pipelines-nightly.yaml
@@ -14,7 +14,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/deps/update-nuget-msi-convert-wix
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
+    ref: refs/heads/deps/update-nuget-msi-convert-wix
   - repository: android-platform-support
     type: git
     name: DevDiv/android-platform-support


### PR DESCRIPTION
## Summary

Temporarily points the Android pipeline YAML template resource at the `Xamarin.yaml-templates` branch containing the NuGet MSI conversion template update.

This follows the existing release-test validation pattern so the appropriate Android checks can run before the template change is merged.
