### PR TITLE
[ci] Scope Dependabot NuGet scanning to stable-SDK directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,18 @@
 # https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/
 version: 2
 updates:
+  # NuGet scanning is intentionally scoped to a curated allow-list of
+  # directories whose projects build against the previous-stable .NET
+  # SDK (currently net10.0) with no Android workload. `main` always
+  # targets the next .NET release, so Dependabot's container (which
+  # only has the stable SDK) cannot evaluate net*-android projects.
+  # Extend this list when a new non-android-workload project is added
+  # in a different folder.
   - package-ecosystem: "nuget"
-    directory: "/"
+    directories:
+      - "/build-tools"
+      - "/tools"
+      - "/src/Xamarin.Android.Build.Tasks"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gradle"


### PR DESCRIPTION
Dependabot's weekly NuGet job has been failing on `main` (e.g. [run 26533399988](https://github.com/dotnet/android/actions/runs/26533399988/job/78155773701)) with `dependency_file_not_found` / `MissingFileException`. The container Dependabot uses only ships the previous-stable .NET SDK (currently `10.0.103`) and has no Android workload, while `main` always targets the *next* .NET release. MSBuild evaluation aborts on every `net*-android` csproj and on classic-style binding test projects, killing the run.

This is a permanent condition: as long as `main` is one release ahead of stable, Dependabot will never be able to evaluate workload-dependent projects. The fix scopes Dependabot to a curated allow-list of folders that build cleanly against the stable SDK with no Android workload:

- `/build-tools` (10 projects — `xa-prep-tasks`, `BootstrapTasks`, `xaprepare`, `jnienv-gen`, ...)
- `/tools` (11 projects — `assembly-store-reader`, `decompress-assemblies`, `relnote-gen`, ...)
- `/src/Xamarin.Android.Build.Tasks` (4 projects — highest-value, holds most third-party `PackageReference`s)

Verified each candidate uses only `$(DotNetStableTargetFramework)` (= `net10.0`) or `netstandard2.0`, and none import workload-specific targets.

### Trade-off

Packages referenced only by `net*-android` projects (e.g. dependencies pulled in by `Mono.Android-Tests`) will not get Dependabot update PRs. We're accepting that to keep the weekly job green; partial coverage is better than total failure. The allow-list will need occasional extension when a new non-workload project shows up in a different folder, hence the comment in `dependabot.yml`.

The other Dependabot entries (`gradle`, `gitsubmodule`) are unchanged.