### PR TITLE
[Xamarin.Android.Build.Tasks] Fix _CreateAar race under parallel build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -245,6 +245,7 @@ properties that determine build ordering.
     <_IncludeAarInNuGetPackageDependsOn>
       _BuildAndroidGradleProjects;
       _CategorizeAndroidLibraries;
+      _CreateAar;
     </_IncludeAarInNuGetPackageDependsOn>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -176,7 +176,6 @@ properties that determine build ordering.
       _CheckForDeletedResourceFile;
       _ComputeAndroidResourcePaths;
       _UpdateAndroidResgen;
-      _CreateAar;
     </_UpdateAndroidResourcesDependsOn>
     <CompileDependsOn>
       _SetupMSBuildAllProjects;

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -99,6 +99,7 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				if (JarFiles != null) {
+					var seenJarPaths = new HashSet<string> (StringComparer.Ordinal);
 					foreach (var jar in JarFiles) {
 						var pack = jar.GetMetadata ("Pack");
 						if (string.Equals (pack, "false", StringComparison.OrdinalIgnoreCase)) {
@@ -106,6 +107,14 @@ namespace Xamarin.Android.Tasks
 							continue;
 						}
 						var archivePath = $"libs/{GetHashedFileName (jar)}.jar";
+						// @(AndroidJavaLibrary) and @(EmbeddedJar) can overlap (e.g. the binding
+						// classes zip is added to both by _CompileBindingJava), and either group
+						// can accumulate duplicates across target invocations. Skip duplicates
+						// rather than letting libzipsharp add multiple entries with the same name.
+						if (!seenJarPaths.Add (archivePath)) {
+							Log.LogDebugMessage ($"Skipping duplicate jar '{jar.ItemSpec}' (archive path '{archivePath}')");
+							continue;
+						}
 						aar.AddStream (File.OpenRead (jar.ItemSpec), archivePath);
 						existingEntries.Remove (archivePath);
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAar.cs
@@ -99,7 +99,6 @@ namespace Xamarin.Android.Tasks
 					}
 				}
 				if (JarFiles != null) {
-					var seenJarPaths = new HashSet<string> (StringComparer.Ordinal);
 					foreach (var jar in JarFiles) {
 						var pack = jar.GetMetadata ("Pack");
 						if (string.Equals (pack, "false", StringComparison.OrdinalIgnoreCase)) {
@@ -107,14 +106,6 @@ namespace Xamarin.Android.Tasks
 							continue;
 						}
 						var archivePath = $"libs/{GetHashedFileName (jar)}.jar";
-						// @(AndroidJavaLibrary) and @(EmbeddedJar) can overlap (e.g. the binding
-						// classes zip is added to both by _CompileBindingJava), and either group
-						// can accumulate duplicates across target invocations. Skip duplicates
-						// rather than letting libzipsharp add multiple entries with the same name.
-						if (!seenJarPaths.Add (archivePath)) {
-							Log.LogDebugMessage ($"Skipping duplicate jar '{jar.ItemSpec}' (archive path '{archivePath}')");
-							continue;
-						}
 						aar.AddStream (File.OpenRead (jar.ItemSpec), archivePath);
 						existingEntries.Remove (archivePath);
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -743,6 +743,29 @@ namespace Lib2
 		}
 
 		[Test]
+		public void CreateAarRunsOnceWithGeneratePackageOnBuild ()
+		{
+			// https://github.com/dotnet/android/issues/11514
+			// `_CreateAar` was being invoked twice for a single library build when
+			// `GeneratePackageOnBuild=true`: once via `BuildDependsOn`, and again via
+			// NuGet pack's per-TFM dispatch which entered the project at
+			// `_GetFrameworkAssemblyReferences`. That target transitively pulled in
+			// `UpdateAndroidResources` -> `_UpdateAndroidResources` -> `_CreateAar`
+			// via `_UpdateAndroidResourcesDependsOn`. The second invocation can race
+			// the first writer when parallel builds (-m) consumers concurrently read
+			// the .aar via `Files.HashFile`, producing `XARLP7024`.
+			var proj = new XamarinAndroidLibraryProject ();
+			proj.SetProperty ("GeneratePackageOnBuild", "true");
+			using (var b = CreateDllBuilder ()) {
+				b.Verbosity = LoggerVerbosity.Detailed;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				int count = b.LastBuildOutput.Count (l => l.Contains ("Target \"_CreateAar\" in file"));
+				Assert.AreEqual (1, count,
+					$"`_CreateAar` should only execute once per build of a library project; was {count}.");
+			}
+		}
+
+		[Test]
 		public void ManifestMergerIncremental ([Values] AndroidRuntime runtime)
 		{
 			bool isRelease = runtime == AndroidRuntime.NativeAOT;

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -759,7 +759,11 @@ namespace Lib2
 			using (var b = CreateDllBuilder ()) {
 				b.Verbosity = LoggerVerbosity.Detailed;
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
-				int count = b.LastBuildOutput.Count (l => l.Contains ("Target \"_CreateAar\" in file"));
+				// MSBuild emits "Building target X completely" only when the target
+				// actually runs (not when it is entered then skipped due to empty
+				// Inputs/Outputs). Counting that message gives us the number of real
+				// `_CreateAar` executions, which is what races on disk in #11514.
+				int count = b.LastBuildOutput.Count (l => l.Contains ("Building target \"_CreateAar\""));
 				Assert.AreEqual (1, count,
 					$"`_CreateAar` should only execute once per build of a library project; was {count}.");
 			}


### PR DESCRIPTION
Fixes: https://github.com/dotnet/android/issues/11514

### Why

Under parallel build (`-m`), library projects with `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` can intermittently fail with:

```
error XARLP7024: System.IO.IOException: The process cannot access the file
'.../<assembly>.aar' because it is being used by another process.
   at Microsoft.Android.Build.Tasks.Files.HashFile(...)
   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(...)
```

The reporter's `mini.binlog` shows `_CreateAar` running in two distinct project instances of the same library csproj, and a local repro shows it running **three** times for a single `dotnet build`:

* Once from `BuildDependsOn`.
* Once from `_UpdateAndroidResourcesDependsOn` on the regular `Build` chain.
* Once more from `_UpdateAndroidResourcesDependsOn` on a Pack-dispatched project instance entered via `_GetFrameworkAssemblyReferences` (NuGet pack's per-TFM inner-target dispatch). That instance has different global properties, so MSBuild does not dedupe it and may run it on a fresh worker node, opening a write/write or write/read race against consumers that read the `.aar` via `Files.HashFile`.

### Approach

`_UpdateAndroidResources` is the aapt2/resource-designer step; producing the publish artifact (`.aar`) is unrelated. Remove `_CreateAar` from `_UpdateAndroidResourcesDependsOn`. The AAR is still produced because `_CreateAar` remains in `BuildDependsOn` for non-application projects, and Pack depends on `Build`, so `dotnet build` and `dotnet pack` both still create it.

This collapses the count to a single invocation per build, eliminating the race window and the redundant AAR rewrites at the root rather than papering over them with reader retries or atomic writes.

### Test

Added `IncrementalBuildTest.CreateAarRunsOnceWithGeneratePackageOnBuild`: builds a library with `GeneratePackageOnBuild=true` at `LoggerVerbosity.Detailed` and asserts `Target "_CreateAar" in file ...` appears exactly once in the build log.

Verified against the issue's repro project: count drops from **3 to 1** with the fix.