### PR TITLE
Fix LayoutInflater.From for remapped inflater types

### DIFF
--- a/src/Mono.Android/Android.Views/LayoutInflater.cs
+++ b/src/Mono.Android/Android.Views/LayoutInflater.cs
@@ -1,16 +1,31 @@
 using System;
 
 using Android.Content;
+using Android.Runtime;
 
 namespace Android.Views {
 
 	public partial class LayoutInflater {
 
+		[Register ("from", "(Landroid/content/Context;)Landroid/view/LayoutInflater;", "")]
+		public static LayoutInflater? From (Context? context)
+		{
+			ArgumentNullException.ThrowIfNull (context);
+
+			return FromContext (context);
+		}
+
 		public static LayoutInflater? FromContext (Context context)
 		{
-			return context.GetSystemService (Context.LayoutInflaterService!) as LayoutInflater;
+			var service = context.GetSystemService (Context.LayoutInflaterService!);
+
+			if (service is LayoutInflater inflater)
+				return inflater;
+
+			if (service?.Handle != IntPtr.Zero)
+				return Java.Lang.Object.GetObject<LayoutInflater> (service.Handle, JniHandleOwnership.DoNotTransfer);
+
+			return null;
 		}
 	}
 }
-
-

--- a/src/Mono.Android/metadata
+++ b/src/Mono.Android/metadata
@@ -18,6 +18,7 @@
 
   <!-- FIXME: hack to workaround api-merge bug that brings two identical methods (it doesn't care generic type params) -->
   <remove-node path="/api/package[@name='android.animation']/interface[@name='TypeEvaluator']/method[@name='evaluate' and @merge.SourceFile]" />
+  <remove-node path="/api/package[@name='android.view']/class[@name='LayoutInflater']/method[@name='from' and parameter[1][@type='android.content.Context']]" />
 
   <!-- FIXME: this should NOT be exposed as public, but needs to exist. -->
   <attr api-since="5" api-until="8" path="/api/package[@name='java.util.concurrent.locks']/class[@name='AbstractOwnableSynchronizer']" name="visibility">public</attr>

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Views/LayoutInflaterTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Views/LayoutInflaterTest.cs
@@ -19,5 +19,8 @@ public class LayoutInflaterTest
 		// Remapped to "net/dot/android/test/MyLayoutInflater"
 		var from = LayoutInflater.From (Application.Context);
 		Assert.IsNotNull (from);
+
+		var fromContext = LayoutInflater.FromContext (Application.Context);
+		Assert.IsNotNull (fromContext);
 	}
 }


### PR DESCRIPTION
## Summary

`LayoutInflater.From(Context)` can return `null` when Android remapping redirects `android.view.LayoutInflater` to a Java subclass/proxy type, even though the Java object is a valid layout inflater. This breaks callers such as MAUI that use `LayoutInflater.From(activity)` during startup.

This replaces the generated `LayoutInflater.from(Context)` binding with a handwritten implementation that delegates to `FromContext(Context)`. `FromContext` now obtains the `layout_inflater` system service and, if the managed object is not directly typed as `LayoutInflater`, wraps the live Java handle as `LayoutInflater`.

## Changes

- Suppress the generated `android.view.LayoutInflater.from(Context)` binding via metadata.
- Add a handwritten registered `LayoutInflater.From(Context)` method.
- Make `FromContext(Context)` handle remapped/proxy inflater instances by wrapping the service handle.
- Extend the existing remap test to cover both `From(...)` and `FromContext(...)`.

## Validation

- Rebuilt `src/Mono.Android/Mono.Android.csproj` locally.
- Decompiled the rebuilt `Mono.Android.dll` and confirmed `LayoutInflater.From(Context)` delegates to `FromContext(Context)`.
- Built and launched a focused Android remap test app using the local workload on `emulator-5554`; the app showed `PASS` with `android/view/LayoutInflater` remapped to a Java subclass.

Note: the full `Mono.Android.NET-Tests` APK packaging path is currently blocked in this checkout by an unrelated duplicate Java class from the Java.Interop test artifact (`net.dot.jni.test.AndroidInterface`).
