### PR TITLE
ci: declare least-privilege workflow-level contents: read

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,6 +2,10 @@ name: "Copilot Setup Steps"
 
 on: workflow_dispatch
 
+
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds a workflow-level `permissions: contents: read` to 1 workflow(s) that currently have no `permissions:` block (and therefore get the default broad read-write token). Each affected workflow was inspected and only reads repository contents; no publish/release/push/comment paths, so the change is non-functional in steady state and just shrinks the blast radius.

GitHub's documented Actions security recommendation. Happy to split per-file or adjust naming if preferred.