### PR TITLE
Fix AndroidMessageHandler response body cancellation

### DIFF
--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -104,6 +104,133 @@ namespace Xamarin.Android.Net
 			}
 		}
 
+		sealed class CancellationAwareResponseStream : Stream
+		{
+			readonly Stream stream;
+			readonly HttpURLConnection httpConnection;
+
+			public CancellationAwareResponseStream (Stream stream, HttpURLConnection httpConnection)
+			{
+				this.stream = stream ?? throw new ArgumentNullException (nameof (stream));
+				this.httpConnection = httpConnection ?? throw new ArgumentNullException (nameof (httpConnection));
+			}
+
+			public override bool CanRead => stream.CanRead;
+			public override bool CanSeek => stream.CanSeek;
+			public override bool CanWrite => stream.CanWrite;
+			public override long Length => stream.Length;
+
+			public override long Position {
+				get => stream.Position;
+				set => stream.Position = value;
+			}
+
+			protected override void Dispose (bool disposing)
+			{
+				if (disposing) {
+					stream.Dispose ();
+					httpConnection.Dispose ();
+				}
+
+				base.Dispose (disposing);
+			}
+
+			public override void Flush ()
+			{
+				stream.Flush ();
+			}
+
+			public override async Task CopyToAsync (Stream destination, int bufferSize, CancellationToken cancellationToken)
+			{
+				cancellationToken.ThrowIfCancellationRequested ();
+
+				using (cancellationToken.Register (QueueAbortRead, useSynchronizationContext: false)) {
+					try {
+						await stream.CopyToAsync (destination, bufferSize, cancellationToken).ConfigureAwait (false);
+					} catch (global::System.OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+						throw;
+					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
+						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
+					}
+				}
+			}
+
+			public override int Read (byte[] buffer, int offset, int count)
+			{
+				return stream.Read (buffer, offset, count);
+			}
+
+			public override Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+			{
+				return ReadAsync (buffer.AsMemory (offset, count), cancellationToken).AsTask ();
+			}
+
+			// StreamContent uses this overload on modern runtimes, so the wrapper must handle its ValueTask-based contract.
+			public override async ValueTask<int> ReadAsync (Memory<byte> buffer, CancellationToken cancellationToken = default)
+			{
+				cancellationToken.ThrowIfCancellationRequested ();
+
+				using (cancellationToken.Register (QueueAbortRead, useSynchronizationContext: false)) {
+					try {
+						return await stream.ReadAsync (buffer, cancellationToken).ConfigureAwait (false);
+					} catch (global::System.OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+						throw;
+					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
+						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
+					}
+				}
+			}
+
+			public override long Seek (long offset, SeekOrigin origin)
+			{
+				return stream.Seek (offset, origin);
+			}
+
+			public override void SetLength (long value)
+			{
+				stream.SetLength (value);
+			}
+
+			public override void Write (byte[] buffer, int offset, int count)
+			{
+				stream.Write (buffer, offset, count);
+			}
+
+			void QueueAbortRead ()
+			{
+				Task.Run (AbortRead).ContinueWith (t => {
+					if (t.Exception != null)
+						Logger.Log (LogLevel.Info, LOG_APP, $"Response body cancellation exception: {t.Exception}");
+				}, TaskScheduler.Default);
+			}
+
+			void AbortRead ()
+			{
+				try {
+					httpConnection.Disconnect ();
+				} catch (Exception ex) {
+					Logger.Log (LogLevel.Info, LOG_APP, $"Disconnection exception: {ex}");
+				}
+
+				try {
+					stream.Dispose ();
+				} catch (Exception ex) {
+					Logger.Log (LogLevel.Info, LOG_APP, $"Response stream close exception: {ex}");
+				}
+			}
+
+			static bool ShouldMapToCancellation (Exception ex, CancellationToken cancellationToken)
+			{
+				return cancellationToken.IsCancellationRequested && (
+					ex is global::System.IO.IOException ||
+					ex is Java.IO.IOException ||
+					ex is InvalidDataException ||
+					ex is ObjectDisposedException ||
+					ex is WebException
+				);
+			}
+		}
+
 		internal const string LOG_APP = "monodroid-net";
 
 		const string GZIP_ENCODING = "gzip";
@@ -903,10 +1030,10 @@ namespace Xamarin.Android.Net
 			return ret ?? inputStream;
 		}
 
-		HttpContent GetContent (URLConnection httpConnection, Stream contentStream, ContentState contentState)
+		HttpContent GetContent (HttpURLConnection httpConnection, Stream contentStream, ContentState contentState)
 		{
 			Stream inputStream = GetDecompressionWrapper (httpConnection, new BufferedStream (contentStream), contentState);
-			return new StreamContent (inputStream);
+			return new StreamContent (new CancellationAwareResponseStream (inputStream, httpConnection));
 		}
 
 		bool HandleRedirect (HttpStatusCode redirectCode, HttpURLConnection httpConnection, RequestRedirectionState redirectState, out bool disposeRet)

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -224,6 +224,14 @@ namespace Xamarin.Android.Net
 
 			static bool ShouldMapToCancellation (Exception ex, CancellationToken cancellationToken)
 			{
+				return cancellationToken.IsCancellationRequested &&
+					ex is global::System.IO.IOException
+						or Java.IO.IOException
+						or InvalidDataException
+						or ObjectDisposedException
+						or WebException;
+			}
+			{
 				return cancellationToken.IsCancellationRequested && (
 					ex is global::System.IO.IOException ||
 					ex is Java.IO.IOException ||

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -147,8 +147,6 @@ namespace Xamarin.Android.Net
 				using (cancellationToken.Register (QueueAbortRead, useSynchronizationContext: false)) {
 					try {
 						await stream.CopyToAsync (destination, bufferSize, cancellationToken).ConfigureAwait (false);
-					} catch (global::System.OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
-						throw;
 					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
 						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
 					}
@@ -173,8 +171,6 @@ namespace Xamarin.Android.Net
 				using (cancellationToken.Register (QueueAbortRead, useSynchronizationContext: false)) {
 					try {
 						return await stream.ReadAsync (buffer, cancellationToken).ConfigureAwait (false);
-					} catch (global::System.OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
-						throw;
 					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
 						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
 					}
@@ -198,10 +194,11 @@ namespace Xamarin.Android.Net
 
 			void QueueAbortRead ()
 			{
-				Task.Run (AbortRead).ContinueWith (t => {
-					if (t.Exception != null)
-						Logger.Log (LogLevel.Info, LOG_APP, $"Response body cancellation exception: {t.Exception}");
-				}, TaskScheduler.Default);
+				Task.Run (AbortRead).ContinueWith (
+					LogAbortReadException,
+					CancellationToken.None,
+					TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+					TaskScheduler.Default);
 			}
 
 			void AbortRead ()
@@ -228,6 +225,11 @@ namespace Xamarin.Android.Net
 					ex is ObjectDisposedException ||
 					ex is WebException
 				);
+			}
+
+			static void LogAbortReadException (Task task)
+			{
+				Logger.Log (LogLevel.Info, LOG_APP, $"Response body cancellation exception: {task.Exception}");
 			}
 		}
 

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Android.Net
 		{
 			readonly Stream stream;
 			readonly HttpURLConnection httpConnection;
+			int streamDisposed;
 
 			public CancellationAwareResponseStream (Stream stream, HttpURLConnection httpConnection)
 			{
@@ -128,8 +129,7 @@ namespace Xamarin.Android.Net
 			protected override void Dispose (bool disposing)
 			{
 				if (disposing) {
-					stream.Dispose ();
-					httpConnection.Dispose ();
+					DisposeStream ();
 				}
 
 				base.Dispose (disposing);
@@ -210,10 +210,16 @@ namespace Xamarin.Android.Net
 				}
 
 				try {
-					stream.Dispose ();
+					DisposeStream ();
 				} catch (Exception ex) {
 					Logger.Log (LogLevel.Info, LOG_APP, $"Response stream close exception: {ex}");
 				}
+			}
+
+			void DisposeStream ()
+			{
+				if (Interlocked.Exchange (ref streamDisposed, 1) == 0)
+					stream.Dispose ();
 			}
 
 			static bool ShouldMapToCancellation (Exception ex, CancellationToken cancellationToken)

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -231,15 +231,6 @@ namespace Xamarin.Android.Net
 						or ObjectDisposedException
 						or WebException;
 			}
-			{
-				return cancellationToken.IsCancellationRequested && (
-					ex is global::System.IO.IOException ||
-					ex is Java.IO.IOException ||
-					ex is InvalidDataException ||
-					ex is ObjectDisposedException ||
-					ex is WebException
-				);
-			}
 
 			static void LogAbortReadException (Task task)
 			{

--- a/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
+++ b/src/Mono.Android/Xamarin.Android.Net/AndroidMessageHandler.cs
@@ -135,10 +135,7 @@ namespace Xamarin.Android.Net
 				base.Dispose (disposing);
 			}
 
-			public override void Flush ()
-			{
-				stream.Flush ();
-			}
+			public override void Flush () => stream.Flush ();
 
 			public override async Task CopyToAsync (Stream destination, int bufferSize, CancellationToken cancellationToken)
 			{
@@ -148,20 +145,14 @@ namespace Xamarin.Android.Net
 					try {
 						await stream.CopyToAsync (destination, bufferSize, cancellationToken).ConfigureAwait (false);
 					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
-						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
+						throw new System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
 					}
 				}
 			}
 
-			public override int Read (byte[] buffer, int offset, int count)
-			{
-				return stream.Read (buffer, offset, count);
-			}
+			public override int Read (byte[] buffer, int offset, int count) => stream.Read (buffer, offset, count);
 
-			public override Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-			{
-				return ReadAsync (buffer.AsMemory (offset, count), cancellationToken).AsTask ();
-			}
+			public override Task<int> ReadAsync (byte[] buffer, int offset, int count, CancellationToken cancellationToken) => ReadAsync (buffer.AsMemory (offset, count), cancellationToken).AsTask ();
 
 			// StreamContent uses this overload on modern runtimes, so the wrapper must handle its ValueTask-based contract.
 			public override async ValueTask<int> ReadAsync (Memory<byte> buffer, CancellationToken cancellationToken = default)
@@ -172,34 +163,23 @@ namespace Xamarin.Android.Net
 					try {
 						return await stream.ReadAsync (buffer, cancellationToken).ConfigureAwait (false);
 					} catch (Exception ex) when (ShouldMapToCancellation (ex, cancellationToken)) {
-						throw new global::System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
+						throw new System.OperationCanceledException ("Response body read was canceled.", ex, cancellationToken);
 					}
 				}
 			}
 
-			public override long Seek (long offset, SeekOrigin origin)
-			{
-				return stream.Seek (offset, origin);
-			}
+			public override long Seek (long offset, SeekOrigin origin) => stream.Seek (offset, origin);
 
-			public override void SetLength (long value)
-			{
-				stream.SetLength (value);
-			}
+			public override void SetLength (long value) => stream.SetLength (value);
 
-			public override void Write (byte[] buffer, int offset, int count)
-			{
-				stream.Write (buffer, offset, count);
-			}
+			public override void Write (byte[] buffer, int offset, int count) => stream.Write (buffer, offset, count);
 
-			void QueueAbortRead ()
-			{
+			void QueueAbortRead () =>
 				Task.Run (AbortRead).ContinueWith (
-					LogAbortReadException,
+					task => Logger.Log (LogLevel.Info, LOG_APP, $"Response body cancellation exception: {task.Exception}"),
 					CancellationToken.None,
 					TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
 					TaskScheduler.Default);
-			}
 
 			void AbortRead ()
 			{
@@ -232,10 +212,6 @@ namespace Xamarin.Android.Net
 						or WebException;
 			}
 
-			static void LogAbortReadException (Task task)
-			{
-				Logger.Log (LogLevel.Info, LOG_APP, $"Response body cancellation exception: {task.Exception}");
-			}
 		}
 
 		internal const string LOG_APP = "monodroid-net";

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
@@ -136,6 +136,7 @@
     <Compile Include="System.Threading\InterlockedTest.cs" />
     <Compile Include="System.Xml\XmlSerializer.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidHandlerTestBase.cs" />
+    <Compile Include="Xamarin.Android.Net\AndroidMessageHandlerCancellationTests.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidMessageHandlerTests.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidMessageHandlerNegotiateAuthenticationTests.cs" />
     <Compile Include="Xamarin.Android.Net\AndroidMessageHandlerIntegrationTests.cs" />

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -55,7 +55,7 @@ namespace Xamarin.Android.NetTests
 
 			await WaitForBodyReadToBlock (server.BodyStartedTask).ConfigureAwait (false);
 			cts.Cancel ();
-			await AssertCanceledPromptly (readTask, server.ReleaseBody).ConfigureAwait (false);
+			await AssertCanceledPromptly (readTask, server.ReleaseResponseBody).ConfigureAwait (false);
 		}
 
 		[Test]
@@ -72,7 +72,7 @@ namespace Xamarin.Android.NetTests
 
 			await WaitForBodyReadToBlock (server.BodyStartedTask).ConfigureAwait (false);
 			readCts.Cancel ();
-			await AssertCanceledPromptly (readContentTask, server.ReleaseBody).ConfigureAwait (false);
+			await AssertCanceledPromptly (readContentTask, server.ReleaseResponseBody).ConfigureAwait (false);
 		}
 
 		static int GetAvailablePort ()
@@ -82,17 +82,6 @@ namespace Xamarin.Android.NetTests
 			int port = ((IPEndPoint) tcpListener.LocalEndpoint).Port;
 			tcpListener.Stop ();
 			return port;
-		}
-
-		static async Task WriteRemainingResponseBody (HttpListenerResponse response)
-		{
-			var buffer = new byte [4096];
-			int remainingBytes = StalledResponseContentLength - InitialResponseChunk.Length;
-			while (remainingBytes > 0) {
-				int bytesToWrite = Math.Min (remainingBytes, buffer.Length);
-				await response.OutputStream.WriteAsync (buffer, 0, bytesToWrite).ConfigureAwait (false);
-				remainingBytes -= bytesToWrite;
-			}
 		}
 
 		static async Task WaitForBodyReadToBlock (Task bodyStarted)
@@ -105,11 +94,11 @@ namespace Xamarin.Android.NetTests
 			await Task.Delay (BodyReadBlockDelayMilliseconds).ConfigureAwait (false);
 		}
 
-		static async Task AssertCanceledPromptly (Task readTask, TaskCompletionSource<bool> releaseBody)
+		static async Task AssertCanceledPromptly (Task readTask, Action releaseBody)
 		{
 			var completed = await Task.WhenAny (readTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
 			if (completed != readTask) {
-				releaseBody.TrySetResult (true);
+				releaseBody ();
 				await ObserveReadTaskAfterRelease (readTask).ConfigureAwait (false);
 				Assert.Fail ($"Response body read did not observe cancellation within {PromptCancellationTimeoutMilliseconds}ms.");
 			}
@@ -118,6 +107,7 @@ namespace Xamarin.Android.NetTests
 				await readTask.ConfigureAwait (false);
 				Assert.Fail ("Response body read completed successfully after cancellation.");
 			} catch (OperationCanceledException) {
+				return;
 			}
 		}
 
@@ -134,19 +124,11 @@ namespace Xamarin.Android.NetTests
 			}
 		}
 
-		static async Task ObserveServerTask (Task serverTask)
-		{
-			var completed = await Task.WhenAny (serverTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
-			if (completed != serverTask)
-				return;
-
-			await serverTask.ConfigureAwait (false);
-		}
-
 		sealed class StalledResponseServer
 		{
 			readonly HttpListener listener;
 			readonly TaskCompletionSource<bool> bodyStarted = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
+			readonly TaskCompletionSource<bool> releaseBody = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
 			readonly Task serverTask;
 
 			public StalledResponseServer ()
@@ -163,13 +145,16 @@ namespace Xamarin.Android.NetTests
 
 			public Task BodyStartedTask => bodyStarted.Task;
 
-			public TaskCompletionSource<bool> ReleaseBody { get; } = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
-
 			public async Task StopAsync ()
 			{
-				ReleaseBody.TrySetResult (true);
+				ReleaseResponseBody ();
 				listener.Close ();
-				await ObserveServerTask (serverTask).ConfigureAwait (false);
+				await ObserveServerTask ().ConfigureAwait (false);
+			}
+
+			public void ReleaseResponseBody ()
+			{
+				releaseBody.TrySetResult (true);
 			}
 
 			async Task ServeStalledResponseBody ()
@@ -183,7 +168,7 @@ namespace Xamarin.Android.NetTests
 					await response.OutputStream.FlushAsync ().ConfigureAwait (false);
 					bodyStarted.TrySetResult (true);
 
-					await ReleaseBody.Task.ConfigureAwait (false);
+					await releaseBody.Task.ConfigureAwait (false);
 					await WriteRemainingResponseBody (response).ConfigureAwait (false);
 				} catch (Exception ex) {
 					if (!BodyStartedTask.IsCompleted) {
@@ -192,6 +177,26 @@ namespace Xamarin.Android.NetTests
 					}
 					Console.WriteLine ($"Exception while serving stalled response body: {ex}");
 				}
+			}
+
+			async Task WriteRemainingResponseBody (HttpListenerResponse response)
+			{
+				var buffer = new byte [4096];
+				int remainingBytes = StalledResponseContentLength - InitialResponseChunk.Length;
+				while (remainingBytes > 0) {
+					int bytesToWrite = Math.Min (remainingBytes, buffer.Length);
+					await response.OutputStream.WriteAsync (buffer, 0, bytesToWrite).ConfigureAwait (false);
+					remainingBytes -= bytesToWrite;
+				}
+			}
+
+			async Task ObserveServerTask ()
+			{
+				var completed = await Task.WhenAny (serverTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
+				if (completed != serverTask)
+					return;
+
+				await serverTask.ConfigureAwait (false);
 			}
 		}
 	}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -24,8 +24,6 @@ namespace Xamarin.Android.NetTests
 
 		static readonly byte[] InitialResponseChunk = new byte[] { 42 };
 
-		static readonly byte[] InitialResponseChunk = [42];
-
 		[SetUp]
 		public void SetUp ()
 		{

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -1,0 +1,198 @@
+#nullable enable
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Xamarin.Android.Net;
+
+using NUnit.Framework;
+
+namespace Xamarin.Android.NetTests
+{
+	[TestFixture]
+	[Category ("AndroidMessageHandlerCancellation")]
+	[Category ("InetAccess")]
+	public class AndroidMessageHandlerCancellationTests
+	{
+		const int StalledResponseContentLength = 1024 * 1024;
+		const int BodyReadBlockDelayMilliseconds = 250;
+		const int PromptCancellationTimeoutMilliseconds = 3000;
+
+		static readonly byte[] InitialResponseChunk = new byte[] { 42 };
+
+		StalledResponseServer? stalledResponseServer;
+
+		[SetUp]
+		public void SetUp ()
+		{
+			stalledResponseServer = new StalledResponseServer ();
+		}
+
+		[TearDown]
+		public void TearDown ()
+		{
+			var server = stalledResponseServer;
+			stalledResponseServer = null;
+
+			if (server != null)
+				server.StopAsync ().GetAwaiter ().GetResult ();
+		}
+
+		[Test]
+		public async Task ResponseContentReadBodyReadCancellationIsPrompt ()
+		{
+			var server = stalledResponseServer ?? throw new InvalidOperationException ("The stalled response server was not initialized.");
+			using var handler = new AndroidMessageHandler ();
+			using var client = new HttpClient (handler);
+			using var cts = new CancellationTokenSource ();
+			using var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{server.Port}/");
+
+			Task readTask = client.SendAsync (request, HttpCompletionOption.ResponseContentRead, cts.Token);
+
+			await WaitForBodyReadToBlock (server.BodyStartedTask).ConfigureAwait (false);
+			cts.Cancel ();
+			await AssertCanceledPromptly (readTask, server.ReleaseBody).ConfigureAwait (false);
+		}
+
+		[Test]
+		public async Task ResponseHeadersReadBodyReadCancellationIsPrompt ()
+		{
+			var server = stalledResponseServer ?? throw new InvalidOperationException ("The stalled response server was not initialized.");
+			using var handler = new AndroidMessageHandler ();
+			using var client = new HttpClient (handler);
+			using var request = new HttpRequestMessage (HttpMethod.Get, $"http://localhost:{server.Port}/");
+			using var response = await client.SendAsync (request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait (false);
+			using var readCts = new CancellationTokenSource ();
+
+			Task readContentTask = response.Content.ReadAsByteArrayAsync (readCts.Token);
+
+			await WaitForBodyReadToBlock (server.BodyStartedTask).ConfigureAwait (false);
+			readCts.Cancel ();
+			await AssertCanceledPromptly (readContentTask, server.ReleaseBody).ConfigureAwait (false);
+		}
+
+		static int GetAvailablePort ()
+		{
+			using var tcpListener = new TcpListener (IPAddress.Any, 0);
+			tcpListener.Start ();
+			int port = ((IPEndPoint) tcpListener.LocalEndpoint).Port;
+			tcpListener.Stop ();
+			return port;
+		}
+
+		static async Task WriteRemainingResponseBody (HttpListenerResponse response)
+		{
+			var buffer = new byte [4096];
+			int remainingBytes = StalledResponseContentLength - InitialResponseChunk.Length;
+			while (remainingBytes > 0) {
+				int bytesToWrite = Math.Min (remainingBytes, buffer.Length);
+				await response.OutputStream.WriteAsync (buffer, 0, bytesToWrite).ConfigureAwait (false);
+				remainingBytes -= bytesToWrite;
+			}
+		}
+
+		static async Task WaitForBodyReadToBlock (Task bodyStarted)
+		{
+			var completed = await Task.WhenAny (bodyStarted, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
+			if (completed != bodyStarted)
+				Assert.Fail ($"The test server did not start sending a response body within {PromptCancellationTimeoutMilliseconds}ms.");
+
+			await bodyStarted.ConfigureAwait (false);
+			await Task.Delay (BodyReadBlockDelayMilliseconds).ConfigureAwait (false);
+		}
+
+		static async Task AssertCanceledPromptly (Task readTask, TaskCompletionSource<bool> releaseBody)
+		{
+			var completed = await Task.WhenAny (readTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
+			if (completed != readTask) {
+				releaseBody.TrySetResult (true);
+				await ObserveReadTaskAfterRelease (readTask).ConfigureAwait (false);
+				Assert.Fail ($"Response body read did not observe cancellation within {PromptCancellationTimeoutMilliseconds}ms.");
+			}
+
+			try {
+				await readTask.ConfigureAwait (false);
+				Assert.Fail ("Response body read completed successfully after cancellation.");
+			} catch (OperationCanceledException) {
+			}
+		}
+
+		static async Task ObserveReadTaskAfterRelease (Task readTask)
+		{
+			var completed = await Task.WhenAny (readTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
+			if (completed != readTask)
+				return;
+
+			try {
+				await readTask.ConfigureAwait (false);
+			} catch (Exception ex) {
+				Console.WriteLine ($"Exception after releasing stalled response body: {ex}");
+			}
+		}
+
+		static async Task ObserveServerTask (Task serverTask)
+		{
+			var completed = await Task.WhenAny (serverTask, Task.Delay (PromptCancellationTimeoutMilliseconds)).ConfigureAwait (false);
+			if (completed != serverTask)
+				return;
+
+			await serverTask.ConfigureAwait (false);
+		}
+
+		sealed class StalledResponseServer
+		{
+			readonly HttpListener listener;
+			readonly TaskCompletionSource<bool> bodyStarted = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
+			readonly Task serverTask;
+
+			public StalledResponseServer ()
+			{
+				Port = GetAvailablePort ();
+				listener = new HttpListener ();
+				listener.Prefixes.Add ($"http://+:{Port}/");
+				listener.Start ();
+
+				serverTask = ServeStalledResponseBody ();
+			}
+
+			public int Port { get; }
+
+			public Task BodyStartedTask => bodyStarted.Task;
+
+			public TaskCompletionSource<bool> ReleaseBody { get; } = new TaskCompletionSource<bool> (TaskCreationOptions.RunContinuationsAsynchronously);
+
+			public async Task StopAsync ()
+			{
+				ReleaseBody.TrySetResult (true);
+				listener.Close ();
+				await ObserveServerTask (serverTask).ConfigureAwait (false);
+			}
+
+			async Task ServeStalledResponseBody ()
+			{
+				try {
+					var context = await listener.GetContextAsync ().ConfigureAwait (false);
+					using var response = context.Response;
+					response.StatusCode = 200;
+					response.ContentLength64 = StalledResponseContentLength;
+					await response.OutputStream.WriteAsync (InitialResponseChunk, 0, InitialResponseChunk.Length).ConfigureAwait (false);
+					await response.OutputStream.FlushAsync ().ConfigureAwait (false);
+					bodyStarted.TrySetResult (true);
+
+					await ReleaseBody.Task.ConfigureAwait (false);
+					await WriteRemainingResponseBody (response).ConfigureAwait (false);
+				} catch (Exception ex) {
+					if (!BodyStartedTask.IsCompleted) {
+						bodyStarted.TrySetException (ex);
+						return;
+					}
+					Console.WriteLine ($"Exception while serving stalled response body: {ex}");
+				}
+			}
+		}
+	}
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Android.NetTests
 		const int PromptCancellationTimeoutMilliseconds = 3000;
 
 		static readonly byte[] InitialResponseChunk = [42];
+		StalledResponseServer? stalledResponseServer;
 
 		[SetUp]
 		public void SetUp ()

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -38,8 +38,9 @@ namespace Xamarin.Android.NetTests
 			var server = stalledResponseServer;
 			stalledResponseServer = null;
 
+			// NUnitLite used by the on-device tests does not support async TearDown methods.
 			if (server != null)
-				server.StopAsync ().GetAwaiter ().GetResult ();
+				server.Stop ();
 		}
 
 		[Test]
@@ -77,7 +78,7 @@ namespace Xamarin.Android.NetTests
 
 		static int GetAvailablePort ()
 		{
-			using var tcpListener = new TcpListener (IPAddress.Any, 0);
+			using var tcpListener = new TcpListener (IPAddress.Loopback, 0);
 			tcpListener.Start ();
 			int port = ((IPEndPoint) tcpListener.LocalEndpoint).Port;
 			tcpListener.Stop ();
@@ -135,7 +136,7 @@ namespace Xamarin.Android.NetTests
 			{
 				Port = GetAvailablePort ();
 				listener = new HttpListener ();
-				listener.Prefixes.Add ($"http://+:{Port}/");
+				listener.Prefixes.Add ($"http://localhost:{Port}/");
 				listener.Start ();
 
 				serverTask = ServeStalledResponseBody ();
@@ -145,11 +146,11 @@ namespace Xamarin.Android.NetTests
 
 			public Task BodyStartedTask => bodyStarted.Task;
 
-			public async Task StopAsync ()
+			public void Stop ()
 			{
 				ReleaseResponseBody ();
 				listener.Close ();
-				await ObserveServerTask ().ConfigureAwait (false);
+				ObserveServerTask ().GetAwaiter ().GetResult ();
 			}
 
 			public void ReleaseResponseBody ()

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Android.NetTests
 
 		static readonly byte[] InitialResponseChunk = new byte[] { 42 };
 
-		StalledResponseServer? stalledResponseServer;
+		static readonly byte[] InitialResponseChunk = [42];
 
 		[SetUp]
 		public void SetUp ()

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerCancellationTests.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Android.NetTests
 		const int BodyReadBlockDelayMilliseconds = 250;
 		const int PromptCancellationTimeoutMilliseconds = 3000;
 
-		static readonly byte[] InitialResponseChunk = new byte[] { 42 };
+		static readonly byte[] InitialResponseChunk = [42];
 
 		[SetUp]
 		public void SetUp ()


### PR DESCRIPTION
Fixes #11548

## Summary
- make response-content reads cancellation-aware in `AndroidMessageHandler`
- abort stalled body reads by disconnecting the `HttpURLConnection` and disposing the response stream when the read token is canceled
- add dedicated `HttpListener`-based coverage for `ResponseContentRead` and `ResponseHeadersRead` body cancellation

## Testing
- `make all`
- `ANDROID_SERIAL=R58Y30HZ65V ./dotnet-local.sh build -t:RunTestApp tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -p:IncludeCategories=AndroidMessageHandlerCancellation`
