### PR TITLE
[ci] Target NuGet Dependabot updates at release/10.0.1xx

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,35 @@
 # https://docs.github.com/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/
 version: 2
 updates:
-  # NuGet scanning is intentionally scoped to a curated allow-list of
-  # directories whose projects build against the previous-stable .NET
-  # SDK (currently net10.0) with no Android workload. `main` always
-  # targets the next .NET release, so Dependabot's container (which
-  # only has the stable SDK) cannot evaluate net*-android projects.
+  # Dependabot's NuGet updater runs in a container that only has the
+  # previous-stable .NET SDK installed. `main` targets the next .NET
+  # release, so restore fails on most projects with NETSDK1045 and
+  # discovery silently aborts -- meaning we only get PRs for things
+  # discoverable via text scanning (e.g. msbuild-sdks in global.json).
+  #
+  # Workaround: target a release branch whose projects build against
+  # the SDK Dependabot has. PRs land on release/10.0.1xx; forward-port
+  # them to `main` by cherry-picking onto a branch off `main`:
+  #
+  #     gh pr checkout <dependabot-pr-number>
+  #     $sha = git rev-parse HEAD
+  #     git fetch origin main
+  #     git checkout -b bump/<package>-<version> origin/main
+  #     git cherry-pick $sha
+  #     git push -u origin HEAD
+  #     gh pr create --base main `
+  #         --title "<copy from dependabot PR>" `
+  #         --body  "Forward-port of #<dependabot-pr-number>"
+  #
+  # Do NOT use GitHub's "Change base branch" button to retarget the
+  # Dependabot PR at `main` -- the branch is based on release/10.0.1xx,
+  # so the resulting diff would include every commit on the release
+  # branch that isn't on `main`.
+  #
+  # The directories list is also scoped to a curated allow-list of
+  # folders whose projects don't require the Android workload to
+  # restore (Dependabot's nuget container doesn't install workloads, so
+  # net*-android projects fail with NETSDK1139 regardless of branch).
   # Extend this list when a new non-android-workload project is added
   # in a different folder.
   - package-ecosystem: "nuget"
@@ -13,6 +37,7 @@ updates:
       - "/build-tools"
       - "/tools"
       - "/src/Xamarin.Android.Build.Tasks"
+    target-branch: "release/10.0.1xx"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gradle"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
   #
   # Workaround: target a release branch whose projects build against
   # the SDK Dependabot has. PRs land on release/10.0.1xx; forward-port
-  # them to `main` by cherry-picking onto a branch off `main`:
+  # them to `main` by cherry-picking onto a branch off `main` (PowerShell example):
   #
   #     gh pr checkout <dependabot-pr-number>
   #     $sha = git rev-parse HEAD


### PR DESCRIPTION
### Why

Dependabot's NuGet ecosystem is currently producing very few PRs against `main` -- in practice, only `global.json` MSBuild SDK bumps. Looking at a recent successful run ([26638010552](https://github.com/dotnet/android/actions/runs/26638010552/job/78503159365)) and a failing one ([26821676022](https://github.com/dotnet/android/actions/runs/26821676022)), the root cause is that Dependabot's `dependabot-updater-nuget` container only ships the previous-stable .NET SDK (currently `10.0.103`). `main` targets `net11.0`, so restore aborts with `NETSDK1045`:

```
error NETSDK1045: The current .NET SDK does not support targeting .NET 11.0.
```

Discovery silently fails for almost every project, leaving only dependencies that can be found via plain text scanning -- which is why we only see `global.json` PRs.

### Approach

Point the NuGet ecosystem at `release/10.0.1xx`, whose projects build against the SDK that Dependabot's container has. PRs from this entry will land on the release branch, and we forward-port them to `main` by cherry-picking. The `gradle` and `gitsubmodule` ecosystems are unaffected -- they continue to target `main`.

The functional change is one line (`target-branch: "release/10.0.1xx"`); the rest is documentation.

### What this does *not* fix

`net*-android` projects will still be skipped on the release branch. Dependabot's container does not run `dotnet workload install android`, so those projects fail with `NETSDK1139` ("android was not recognized") regardless of which branch is targeted. There is no supported config knob for this; it is an upstream Dependabot limitation. Our existing `directories:` allow-list already excludes those projects.

### Forward-porting PRs to main

The `dependabot.yml` comment and the commit message both spell this out, but for reviewers: PRs from this entry land on `release/10.0.1xx`. To bring an update to `main`, cherry-pick onto a branch off `main`:

```powershell
gh pr checkout <dependabot-pr-number>
$sha = git rev-parse HEAD
git fetch origin main
git checkout -b bump/<package>-<version> origin/main
git cherry-pick $sha
git push -u origin HEAD
gh pr create --base main `
    --title "<copy from dependabot PR>" `
    --body  "Forward-port of #<dependabot-pr-number>"
```

**Do NOT** use GitHub's "Change base branch" button to retarget the Dependabot PR at `main` -- the branch is based on `release/10.0.1xx`, so the resulting diff would include every commit on the release branch that isn't on `main`.