### PR TITLE
[release/10.0.1xx] [Xamarin.Android.Build.Tasks] Fix _CreateAar race under parallel build

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -174,7 +174,6 @@ properties that determine build ordering.
       _CheckForDeletedResourceFile;
       _ComputeAndroidResourcePaths;
       _UpdateAndroidResgen;
-      _CreateAar;
     </_UpdateAndroidResourcesDependsOn>
     <CompileDependsOn>
       _SetupMSBuildAllProjects;
@@ -244,6 +243,7 @@ properties that determine build ordering.
     <_IncludeAarInNuGetPackageDependsOn>
       _BuildAndroidGradleProjects;
       _CategorizeAndroidLibraries;
+      _CreateAar;
     </_IncludeAarInNuGetPackageDependsOn>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -523,6 +523,33 @@ namespace Lib2
 		}
 
 		[Test]
+		public void CreateAarRunsOnceWithGeneratePackageOnBuild ()
+		{
+			// https://github.com/dotnet/android/issues/11514
+			// `_CreateAar` was being invoked twice for a single library build when
+			// `GeneratePackageOnBuild=true`: once via `BuildDependsOn`, and again via
+			// NuGet pack's per-TFM dispatch which entered the project at
+			// `_GetFrameworkAssemblyReferences`. That target transitively pulled in
+			// `UpdateAndroidResources` -> `_UpdateAndroidResources` -> `_CreateAar`
+			// via `_UpdateAndroidResourcesDependsOn`. The second invocation can race
+			// the first writer when parallel builds (-m) consumers concurrently read
+			// the .aar via `Files.HashFile`, producing `XARLP7024`.
+			var proj = new XamarinAndroidLibraryProject ();
+			proj.SetProperty ("GeneratePackageOnBuild", "true");
+			using (var b = CreateDllBuilder ()) {
+				b.Verbosity = LoggerVerbosity.Detailed;
+				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
+				// MSBuild emits "Building target X completely" only when the target
+				// actually runs (not when it is entered then skipped due to empty
+				// Inputs/Outputs). Counting that message gives us the number of real
+				// `_CreateAar` executions, which is what races on disk in #11514.
+				int count = b.LastBuildOutput.Count (l => l.Contains ("Building target \"_CreateAar\""));
+				Assert.AreEqual (1, count,
+					$"`_CreateAar` should only execute once per build of a library project; was {count}.");
+			}
+		}
+
+		[Test]
 		public void ManifestMergerIncremental ()
 		{
 			var proj = new XamarinAndroidApplicationProject {


### PR DESCRIPTION
Backport of #11527 to `release/10.0.1xx`.

Fixes: https://github.com/dotnet/android/issues/11514

### Why

Under parallel build (`-m`), library projects with `<GeneratePackageOnBuild>true</GeneratePackageOnBuild>` can intermittently fail with:

```
error XARLP7024: System.IO.IOException: The process cannot access the file
'.../<assembly>.aar' because it is being used by another process.
   at Microsoft.Android.Build.Tasks.Files.HashFile(...)
   at Xamarin.Android.Tasks.ResolveLibraryProjectImports.Extract(...)
```

`_CreateAar` was running multiple times for a single `dotnet build`:

* Once from `BuildDependsOn`.
* Once from `_UpdateAndroidResourcesDependsOn` on the regular `Build` chain.
* Once more from `_UpdateAndroidResourcesDependsOn` on a Pack-dispatched project instance entered via `_GetFrameworkAssemblyReferences` (NuGet pack's per-TFM inner-target dispatch). That instance has different global properties, so MSBuild does not dedupe it and may run it on a fresh worker node, opening a write/write or write/read race against consumers that read the `.aar` via `Files.HashFile`.

### Approach

`_UpdateAndroidResources` is the aapt2/resource-designer step; producing the publish artifact (`.aar`) is unrelated. Remove `_CreateAar` from `_UpdateAndroidResourcesDependsOn`. The AAR is still produced because `_CreateAar` remains in `BuildDependsOn` for non-application projects, and Pack depends on `Build`, so `dotnet build` and `dotnet pack` both still create it.

### Conflicts

Minor merge conflict in `IncrementalBuildTest.cs` because `ManifestMergerIncremental` on `release/10.0.1xx` doesn't take the `[Values] AndroidRuntime runtime` parameter that exists on `main`. Resolved by adding the new test before the existing `ManifestMergerIncremental ()` signature.