### PR TITLE
[build] Drop always-true _HasCommercialFiles / _AndroidFastDeploymentSupported gates

### DIFF
--- a/build-tools/installers/create-installers.targets
+++ b/build-tools/installers/create-installers.targets
@@ -18,7 +18,6 @@
     <LibExtension Condition=" '$(HostOS)' == 'Linux' ">so</LibExtension>
     <LibExtension Condition=" '$(HostOS)' == 'Windows' ">dll</LibExtension>
     <UseCommercialInstallerName Condition="'$(UseCommercialInstallerName)' == ''">False</UseCommercialInstallerName>
-    <_HasCommercialFiles Condition="Exists('$(MicrosoftAndroidSdkOutDir)Xamarin.Android.Common.Debugging.targets')">True</_HasCommercialFiles>
   </PropertyGroup>
   <Target Name="_FindFrameworkDirs">
     <ItemGroup>
@@ -246,9 +245,8 @@
   </ItemGroup>
   <!-- monodroid: in-tree installer/debugging projects under src/Xamarin.Installer.*,
        src/Mono.AndroidTools, src/Xamarin.AndroidTools,
-       src/Xamarin.Android.Build.Debugging.Tasks, and tools/fastdev.
-       Only included for commercial builds (see _HasCommercialFiles above). -->
-  <ItemGroup Condition=" '$(_HasCommercialFiles)' == 'True' ">
+       src/Xamarin.Android.Build.Debugging.Tasks, and tools/fastdev. -->
+  <ItemGroup>
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ICSharpCode.SharpZipLib.dll" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)ICSharpCode.SharpZipLib.pdb" />
     <_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)INIFileParser.dll" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.Application.targets
@@ -15,14 +15,9 @@ This file contains targets specific for Android application projects.
   <UsingTask TaskName="Xamarin.Android.BuildTools.PrepTasks.XASleepInternal" AssemblyFile="$(_XamarinAndroidBuildTasksAssembly)" />
 
   <PropertyGroup>
-    <!-- If Xamarin.Android.Common.Debugging.targets exists, we can rely on _Run for debugging. -->
-    <_RunDependsOn Condition=" '$(_AndroidFastDeploymentSupported)' == 'true' ">
+    <_RunDependsOn>
       Install;
       _Run;
-    </_RunDependsOn>
-    <_RunDependsOn Condition=" '$(_AndroidFastDeploymentSupported)' != 'true' ">
-      Install;
-      StartAndroidActivity;
     </_RunDependsOn>
     <_AndroidComputeRunArgumentsDependsOn Condition=" '$(_AndroidComputeRunArgumentsDependsOn)' == '' ">
       _ResolveMonoAndroidSdks;

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.BuildOrder.targets
@@ -126,19 +126,11 @@ properties that determine build ordering.
       $(_MinimalSignAndroidPackageDependsOn);
     </SignAndroidPackageDependsOn>
     <!-- This should function similar to SignAndroidPackage inside VS plus also deploy -->
-    <DeployToDeviceDependsOnTargets Condition=" '$(_AndroidFastDeploymentSupported)' == 'true' ">
+    <DeployToDeviceDependsOnTargets>
       $(_MinimalSignAndroidPackageDependsOn);
       _GenerateEnvironmentFiles;
       _EnsureDeviceBooted;
       _Upload;
-      _AndroidConfigureAdbReverse;
-    </DeployToDeviceDependsOnTargets>
-    <DeployToDeviceDependsOnTargets Condition=" '$(_AndroidFastDeploymentSupported)' != 'true' ">
-      $(_MinimalSignAndroidPackageDependsOn);
-      _GenerateEnvironmentFiles;
-      _EnsureDeviceBooted;
-      _DeployApk;
-      _DeployAppBundle;
       _AndroidConfigureAdbReverse;
     </DeployToDeviceDependsOnTargets>
   </PropertyGroup>

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -17,8 +17,6 @@
     <GenerateDependencyFile Condition=" '$(GenerateDependencyFile)' == '' ">false</GenerateDependencyFile>
     <CopyLocalLockFileAssemblies Condition=" '$(CopyLocalLockFileAssemblies)' == '' ">false</CopyLocalLockFileAssemblies>
     <ComputeNETCoreBuildOutputFiles Condition=" '$(ComputeNETCoreBuildOutputFiles)' == '' ">false</ComputeNETCoreBuildOutputFiles>
-    <_AndroidFastDeploymentSupported Condition=" Exists ('$(MSBuildThisFileDirectory)../tools/Xamarin.Android.Common.Debugging.targets') ">true</_AndroidFastDeploymentSupported>
-    <_AndroidFastDeploymentSupported Condition=" '$(_AndroidFastDeploymentSupported)' == '' ">False</_AndroidFastDeploymentSupported>
 
     <!--
       Disable @(Content) from referenced projects

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.targets
@@ -32,7 +32,7 @@
   <Import Project="Microsoft.Android.Sdk.BundledVersions.targets" />
   <Import Project="Microsoft.Android.Sdk.DefaultProperties.targets" />
   <Import Project="$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props"
-      Condition="Exists('$(MSBuildThisFileDirectory)..\tools\Xamarin.Android.Common.Debugging.props') And '$(DesignTimeBuild)' != 'true' "/>
+      Condition=" '$(DesignTimeBuild)' != 'true' "/>
   <Import Project="Microsoft.Android.Sdk.$(_AndroidRuntime).targets" Condition=" '$(_AndroidRuntime)' != '' " />
 
 </Project>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1272,9 +1272,7 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 				EmbedAssembliesIntoApk = false,
 			};
 			proj.SetRuntime (runtime);
-			proj.SetProperty ("_AndroidFastDeploymentSupported", "true");
 			using (var b = CreateApkBuilder ()) {
-				//NOTE: build will fail, due to $(_AndroidFastDeploymentSupported)
 				b.ThrowOnBuildFailure = false;
 				b.Build (proj);
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
@@ -79,7 +79,6 @@ namespace Xamarin.Android.Build.Tests
 			AssertCommercialBuild ();
 
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("_AndroidFastDeploymentSupported", "true");
 			proj.SetProperty (proj.DebugProperties, "AndroidLinkMode", "Full");
 			using (var b = CreateApkBuilder ()) {
 				b.Target = "Build"; // SignAndroidPackage would fail for OSS builds
@@ -94,7 +93,6 @@ namespace Xamarin.Android.Build.Tests
 			AssertCommercialBuild ();
 
 			var proj = new XamarinAndroidApplicationProject ();
-			proj.SetProperty ("_AndroidFastDeploymentSupported", "true");
 			proj.SetProperty ("AndroidPackageFormat", "aab");
 			using (var builder = CreateApkBuilder ()) {
 				builder.ThrowOnBuildFailure = false;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -157,8 +157,7 @@ Copyright (C) 2011-2012 Xamarin. All rights reserved.
 	<TargetFrameworkIdentifier Condition="'$(TargetFrameworkIdentifier)' == ''">MonoAndroid</TargetFrameworkIdentifier>
 	<MonoAndroidVersion>v$(_XAMajorVersionNumber).0</MonoAndroidVersion>
 	<AndroidUpdateResourceReferences Condition="'$(AndroidUpdateResourceReferences)' == ''">True</AndroidUpdateResourceReferences>
-	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(Optimize)' != 'True' And '$(_AndroidFastDeploymentSupported)' == 'True' ">False</EmbedAssembliesIntoApk>
-	<EmbedAssembliesIntoApk Condition=" '$(_AndroidFastDeploymentSupported)' == 'False' ">True</EmbedAssembliesIntoApk>
+	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' And '$(Optimize)' != 'True' ">False</EmbedAssembliesIntoApk>
 	<EmbedAssembliesIntoApk Condition=" '$(EmbedAssembliesIntoApk)' == '' ">True</EmbedAssembliesIntoApk>
   <AndroidPreferNativeLibrariesWithDebugSymbols Condition=" '$(AndroidPreferNativeLibrariesWithDebugSymbols)' == '' ">False</AndroidPreferNativeLibrariesWithDebugSymbols>
 	<AndroidSkipJavacVersionCheck Condition="'$(AndroidSkipJavacVersionCheck)' == ''">False</AndroidSkipJavacVersionCheck>
@@ -2881,7 +2880,7 @@ because xbuild doesn't support framework reference assemblies.
 </Target>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets"
-        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Android.Common.Debugging.targets') And '$(DesignTimeBuild)' != 'true' "/>
+        Condition=" '$(DesignTimeBuild)' != 'true' "/>
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Application.targets"
         Condition=" '$(AndroidApplication)' == 'True' "/>

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2887,7 +2887,7 @@ because xbuild doesn't support framework reference assemblies.
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Android.Designer.targets" />
 
 <Import Project="$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets"
-        Condition="Exists('$(MSBuildThisFileDirectory)Xamarin.Installer.Common.targets') And '$(DesignTimeBuild)' != 'true' "/>
+        Condition=" '$(DesignTimeBuild)' != 'true' "/>
   <Target Name="_ValidateAndroidTypeMapImplementation"
       BeforeTargets="_CheckForInvalidConfigurationAndPlatform">
     <Error Condition=" '$(_AndroidTypeMapImplementation)' != '' and '$(_AndroidTypeMapImplementation)' != 'llvm-ir' and '$(_AndroidTypeMapImplementation)' != 'managed' and '$(_AndroidTypeMapImplementation)' != 'trimmable' "


### PR DESCRIPTION
Follow-up to #11529, which inlined the `external/android-platform-support` repo into dotnet/android. The Debugging.targets/props files and supporting assemblies (`Mono.AndroidTools`, `Xamarin.AndroidTools`, `Xamarin.Installer.*`, `Xamarin.Android.Build.Debugging.Tasks`, `fastdevtools`) are now always built in-tree by `Xamarin.Android.sln`, so several `Exists(...)` MSBuild gates are always true.

This PR removes those dead gates and their dead branches:

- **`build-tools/installers/create-installers.targets`** – drop `_HasCommercialFiles` and make the commercial `_MSBuildFiles` `ItemGroup` unconditional.
- **`Microsoft.Android.Sdk.DefaultProperties.targets`** – drop `_AndroidFastDeploymentSupported`.
- **`Microsoft.Android.Sdk.BuildOrder.targets`** – drop the `'$(_AndroidFastDeploymentSupported)' == 'true'` condition on `DeployToDeviceDependsOnTargets`; delete the dead `!= 'true'` branch.
- **`Microsoft.Android.Sdk.Application.targets`** – same treatment for `_RunDependsOn`; remove the now-stale comment.
- **`Xamarin.Android.Common.targets`** – drop `Exists(...)` from the `Xamarin.Android.Common.Debugging.targets` and `Xamarin.Installer.Common.targets` imports (keep the `'$(DesignTimeBuild)' != 'true'` guards); simplify the two dead `_AndroidFastDeploymentSupported` conditions on `EmbedAssembliesIntoApk`.
- **`Microsoft.Android.Sdk.targets`** – drop `Exists(...)` from the `Xamarin.Android.Common.Debugging.props` import (keep DTB guard).
- **Tests** – drop the now-defensive `proj.SetProperty ("_AndroidFastDeploymentSupported", "true")` calls (and the stale `//NOTE` comment) from `BuildTest.cs` and `InvalidConfigTests.cs`.

`TestEnvironment.CommercialBuildAvailable` / `BaseTest.AssertCommercialBuild()` are intentionally left for a follow-up PR.

After this change `git grep _HasCommercialFiles` and `git grep _AndroidFastDeploymentSupported` both return zero hits.