### PR TITLE
[tests] Remove always-true AssertCommercialBuild() / CommercialBuildAvailable

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -36,7 +36,6 @@ namespace Xamarin.Android.Build.Tests
 			// been added to the Xamarin manifest yet.
 			var xamarin_manifest_needs_updating = false;
 
-			AssertCommercialBuild ();
 			var oldSdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_SDK_PATH");
 			var oldJdkPath = Environment.GetEnvironmentVariable ("TEST_ANDROID_JDK_PATH");
 			try {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
@@ -214,8 +214,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var gradleProject = AndroidGradleProject.CreateDefault (GradleTestProjectDir);
 			var gradleModule = gradleProject.Modules.First ();
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidUpdateResourcesTest.cs
@@ -277,8 +277,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var proj = new XamarinAndroidApplicationProject  {
 				IsRelease = isRelease,
 			};
@@ -544,9 +542,7 @@ namespace UnnamedProject
 				Assert.IsFalse (StringAssertEx.ContainsText (b.LastBuildOutput, "AndroidResgen: Warning while updating Resource XML"),
 					"Warning while processing resources should not have been raised.");
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "Build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
-				}
+				Assert.IsTrue (b.Output.IsTargetSkipped ("_GenerateJavaStubs"), "Target _GenerateJavaStubs should have been skipped");
 
 				lib.Touch ("CustomTextView.cs");
 
@@ -1087,14 +1083,10 @@ namespace Lib1 {
 					appBuilder.Output.AssertTargetIsNotSkipped ("_UpdateAndroidResgen");
 					foo.Timestamp = DateTimeOffset.UtcNow;
 					Assert.IsTrue (libBuilder.Build (libProj, doNotCleanupOnUpdate: true, saveProject: false), "Library project should have built");
-					if (TestEnvironment.CommercialBuildAvailable) {
-						libBuilder.Output.AssertTargetIsSkipped (target);
-					}
+					libBuilder.Output.AssertTargetIsSkipped (target);
 					appBuilder.BuildLogFile = "build1.log";
 					Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true, saveProject: false), "Application Build should have succeeded.");
-					if (TestEnvironment.CommercialBuildAvailable) {
-						appBuilder.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
-					}
+					appBuilder.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
 					// Check Contents of the file in the apk are correct.
 					string apk = Path.Combine (Root, appBuilder.ProjectDirectory, appProj.OutputPath, appProj.PackageName + "-Signed.apk");
 					byte[] rawContentBuildOne = ZipHelper.ReadFileFromZip (apk,
@@ -1176,16 +1168,12 @@ namespace Lib1 {
 				appBuilder.BuildLogFile = "build.log";
 				Assert.IsTrue (appBuilder.Build (appProj, doNotCleanupOnUpdate: true),
 					"Normal Application Build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
-						"Target '_ManagedUpdateAndroidResgen' should not have run.");
-				}
+				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
+					"Target '_ManagedUpdateAndroidResgen' should not have run.");
 				appBuilder.BuildLogFile = "designtimebuild.log";
 				Assert.IsTrue (appBuilder.DesignTimeBuild (appProj, doNotCleanupOnUpdate: true), "DesignTime Application Build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
-						"Target '_ManagedUpdateAndroidResgen' should not have run.");
-				}
+				Assert.IsTrue (appProj.CreateBuildOutput (appBuilder).IsTargetSkipped ("_ManagedUpdateAndroidResgen", defaultIfNotUsed: true),
+					"Target '_ManagedUpdateAndroidResgen' should not have run.");
 
 				Assert.IsTrue (appBuilder.Clean (appProj), "Clean should have succeeded");
 				Assert.IsTrue (File.Exists (designerFile), $"'{designerFile}' should not have been cleaned.");
@@ -1462,14 +1450,12 @@ namespace UnnamedProject
 				proj.Touch (@"Resources\layout\Main.axml");
 
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true), "second build should have succeeded");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (
-						b.Output.IsTargetPartiallyBuilt ("_CompileResources"),
-						"The target _CompileResources should have been partially built");
-					Assert.IsTrue (
-						b.Output.IsTargetSkipped ("_FixupCustomViewsForAapt2", defaultIfNotUsed: true),
-						"The target _FixupCustomViewsForAapt2 should have been skipped");
-				}
+				Assert.IsTrue (
+					b.Output.IsTargetPartiallyBuilt ("_CompileResources"),
+					"The target _CompileResources should have been partially built");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_FixupCustomViewsForAapt2", defaultIfNotUsed: true),
+					"The target _FixupCustomViewsForAapt2 should have been skipped");
 
 				var r_java = Path.Combine (Root, b.ProjectDirectory, proj.IntermediateOutputPath, "android", "src", proj.PackageNameJavaIntermediatePath, "R.java");
 				FileAssert.Exists (r_java);
@@ -1529,9 +1515,7 @@ namespace UnnamedProject
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "first build should have succeeded.");
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					b.Output.AssertTargetIsSkipped ("_CompileResources");
-				}
+				b.Output.AssertTargetIsSkipped ("_CompileResources");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AotTests.cs
@@ -239,14 +239,12 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 				Assert.IsTrue (b.Build (proj), "Second Build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (
-						b.Output.IsTargetSkipped ("_CompileJava"),
-						"the _CompileJava target should be skipped");
-					Assert.IsTrue (
-						b.Output.IsTargetSkipped ("_BuildApkEmbed"),
-						"the _BuildApkEmbed target should be skipped");
-				}
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_CompileJava"),
+					"the _CompileJava target should be skipped");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
+					"the _BuildApkEmbed target should be skipped");
 			}
 		}
 
@@ -289,14 +287,12 @@ namespace Xamarin.Android.Build.Tests
 					}
 				}
 				Assert.IsTrue (b.Build (proj), "Second Build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (
-						b.Output.IsTargetSkipped ("_CompileJava"),
-						"the _CompileJava target should be skipped");
-					Assert.IsTrue (
-						b.Output.IsTargetSkipped ("_BuildApkEmbed"),
-						"the _BuildApkEmbed target should be skipped");
-				}
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_CompileJava"),
+					"the _CompileJava target should be skipped");
+				Assert.IsTrue (
+					b.Output.IsTargetSkipped ("_BuildApkEmbed"),
+					"the _BuildApkEmbed target should be skipped");
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AssetPackTests.cs
@@ -219,11 +219,9 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsFalse (zip.ContainsEntry ("assetpack1/resources.pb"), "aab should not contain assetpack1/resources.pb");
 				}
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), $"{app.ProjectName} should succeed");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					appBuilder.Output.AssertTargetIsSkipped ("_CreateAssetPackManifests");
-					appBuilder.Output.AssertTargetIsSkipped ("_BuildAssetPacks");
-					appBuilder.Output.AssertTargetIsSkipped ("_GenerateAndroidAssetsDir");
-				}
+				appBuilder.Output.AssertTargetIsSkipped ("_CreateAssetPackManifests");
+				appBuilder.Output.AssertTargetIsSkipped ("_BuildAssetPacks");
+				appBuilder.Output.AssertTargetIsSkipped ("_GenerateAndroidAssetsDir");
 				FileAssert.Exists (asset3File, $"file {asset3File} should exist.");
 				asset3.TextContent = () => "Asset3 Updated";
 				asset3.Timestamp = DateTime.UtcNow.AddSeconds(1);

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -97,8 +97,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var targets = new List<string> {
 				"_ExportJarToXml",
 				"GenerateBindings",
@@ -884,10 +882,8 @@ VNZXRob2RzLmphdmFQSwUGAAAAAAcABwDOAQAAVgMAAAAA
 					"generated", "src", "Com.Xamarin.Android.Test.Msbuildtest.IJavaSourceTestInterface.cs");
 				StringAssertEx.ContainsText (File.ReadAllLines (generatedIface), "string GreetWithQuestion (string name, global::Java.Util.Date date, string question);");
 				Assert.IsTrue (libBuilder.Build (lib), "Library build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava", defaultIfNotUsed: true), $"`_CompileBindingJava` should be skipped on second build!");
-					Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
-				}
+				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_CompileBindingJava", defaultIfNotUsed: true), $"`_CompileBindingJava` should be skipped on second build!");
+				Assert.IsTrue (libBuilder.Output.IsTargetSkipped ("_ClearGeneratedManagedBindings", defaultIfNotUsed: true), $"`_ClearGeneratedManagedBindings` should be skipped on second build!");
 				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on second build.");
 				Assert.IsTrue (libBuilder.DesignTimeBuild (lib, target: "UpdateGeneratedFiles"), "DTB should have succeeded.");
 				FileAssert.Exists (generatedCode, $"'{generatedCode}' should have not be deleted on DTB build.");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.TestCaseSource.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Android.Build.Tests
 				/* debugSymbols */     true ,
 				/* optimize */         true ,
 				/* embedassebmlies */  false ,
-				/* expectedResult */   TestEnvironment.CommercialBuildAvailable ? "debug" : "release",
+				/* expectedResult */   "debug",
 			},
 			new object[] {
 				/* supportedAbi */     "armeabi-v7a",
@@ -183,7 +183,7 @@ namespace Xamarin.Android.Build.Tests
 				/* debugSymbols */     false ,
 				/* optimize */         null ,
 				/* embedassebmlies */  null ,
-				/* expectedResult */   TestEnvironment.CommercialBuildAvailable ? "debug" : "release",
+				/* expectedResult */   "debug",
 			},
 		};
 #pragma warning restore 414

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -169,13 +169,13 @@ namespace Xamarin.Android.Build.Tests
 			Assert.AreEqual (XABuildConfig.AndroidDefaultTargetDotnetApiLevel.Major.ToString (),
 				uses_sdk.Attribute (ns + "targetSdkVersion").Value);
 
-			bool expectEmbeddedAssembies = !(TestEnvironment.CommercialBuildAvailable && !isRelease);
+			bool expectEmbeddedAssembies = isRelease;
 			var apkPath = Path.Combine (outputPath, $"{proj.PackageName}-Signed.apk");
 			FileAssert.Exists (apkPath);
 			var helper = new ArchiveAssemblyHelper (apkPath, usesAssemblyStore, rids);
 			if (runtime != AndroidRuntime.NativeAOT) {
 				helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.dll", shouldContainEntry: expectEmbeddedAssembies);
-				helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: !TestEnvironment.CommercialBuildAvailable && !isRelease);
+				helper.AssertContainsEntry ($"assemblies/{proj.ProjectName}.pdb", shouldContainEntry: false);
 				helper.AssertContainsEntry ($"assemblies/Mono.Android.dll",        shouldContainEntry: expectEmbeddedAssembies);
 				helper.AssertContainsEntry ($"assemblies/es/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
 				helper.AssertContainsEntry ($"assemblies/de-DE/{proj.ProjectName}.resources.dll", shouldContainEntry: expectEmbeddedAssembies);
@@ -1265,8 +1265,6 @@ AAAAAAAAAAAAPQAAAE1FVEEtSU5GL01BTklGRVNULk1GUEsBAhQAFAAICAgAJZFnS7uHtAn+AQAA
 			if (IgnoreUnsupportedConfiguration (runtime)) {
 				return;
 			}
-
-			AssertCommercialBuild ();
 
 			var proj = new XamarinAndroidApplicationProject {
 				EmbedAssembliesIntoApk = false,

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -867,8 +867,6 @@ class MemTest {
 			if (IgnoreUnsupportedConfiguration (runtime, release: false)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var proj = new XamarinFormsMapsApplicationProject ();
 			proj.SetRuntime (runtime);
 
@@ -1167,19 +1165,17 @@ namespace UnamedProject
 				FileAssert.Exists (designtime_build_props, "designtime/build.props should exist after the second `Build`.");
 
 				//NOTE: none of these targets should run, since we have not actually changed anything!
-				if (TestEnvironment.CommercialBuildAvailable) {
-					var targetsToBeSkipped = new [] {
-						//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
-						//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
-						//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
-						//"_LinkAssembliesNoShrink",
-						"_UpdateAndroidResgen",
-						"_BuildLibraryImportsCache",
-						"_CompileJava",
-					};
-					foreach (var targetName in targetsToBeSkipped) {
-						Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
-					}
+				var targetsToBeSkipped = new [] {
+					//TODO: We would like for this assertion to work, but the <Compile /> item group changes between DTB and regular builds
+					//      $(IntermediateOutputPath)designtime\Resource.designer.cs -> Resources\Resource.designer.cs
+					//      And so the built assembly changes between DTB and regular build, triggering `_LinkAssembliesNoShrink`
+					//"_LinkAssembliesNoShrink",
+					"_UpdateAndroidResgen",
+					"_BuildLibraryImportsCache",
+					"_CompileJava",
+				};
+				foreach (var targetName in targetsToBeSkipped) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (targetName), $"`{targetName}` should be skipped!");
 				}
 
 				b.Target = "Clean";
@@ -1319,15 +1315,13 @@ namespace UnamedProject
 				//One last build with no changes
 				Assert.IsTrue (b.Build (proj), "third build should have succeeded.");
 
-				if (TestEnvironment.CommercialBuildAvailable) {
-					// NativeAOT always runs the linking step
-					if (runtime != AndroidRuntime.NativeAOT) {
-						b.Output.AssertTargetIsSkipped (isRelease ? KnownTargets.LinkAssembliesShrink : KnownTargets.LinkAssembliesNoShrink);
-					}
-					b.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
-					b.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
-					b.Output.AssertTargetIsSkipped ("_CompileJava");
+				// NativeAOT always runs the linking step
+				if (runtime != AndroidRuntime.NativeAOT) {
+					b.Output.AssertTargetIsSkipped (isRelease ? KnownTargets.LinkAssembliesShrink : KnownTargets.LinkAssembliesNoShrink);
 				}
+				b.Output.AssertTargetIsSkipped ("_UpdateAndroidResgen");
+				b.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
+				b.Output.AssertTargetIsSkipped ("_CompileJava");
 			}
 		}
 
@@ -1887,8 +1881,6 @@ GVuZHNDbGFzc1ZhbHVlLmNsYXNzUEsFBgAAAAADAAMAwgAAAMYBAAAAAA==
 			if (IgnoreUnsupportedConfiguration (runtime)) {
 				return;
 			}
-
-			AssertCommercialBuild (); // FIXME: when Fast Deployment isn't available, we would need to use `llvm-objcopy` to extract the debug symbols
 
 			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidLibraryProject () {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildWithLibraryTests.cs
@@ -742,8 +742,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild ();
-
 			const string target = "_GetPrimaryCpuAbi";
 			var proj = new XamarinAndroidLibraryProject ();
 			using (var b = CreateDllBuilder ()) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/DebuggingTasksTests.cs
@@ -17,7 +17,6 @@ namespace Xamarin.Android.Build.Tests
 		[OneTimeSetUp]
 		public void SetUp ()
 		{
-			AssertCommercialBuild ();
 		}
 
 		// https://github.com/xamarin/monodroid/blob/63bbeb076d809c74811a8001d38bf2e9e8672627/tests/msbuild/nunit/Xamarin.Android.Build.Tests/Xamarin.Android.Build.Tests/ResolveXamarinAndroidToolsTests.cs

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/IncrementalBuildTest.cs
@@ -22,7 +22,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -69,8 +68,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			if (runtime != AndroidRuntime.MonoVM) { // temporarily
 				Assert.Ignore ("Runtimes other than MonoVM are currently broken here.");
 			}
@@ -429,8 +426,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var app = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				ProjectName = "App",
@@ -610,8 +605,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var targets = new List<(string target, bool ignoreOnNAOT)> {
 				("_GeneratePackageManagerJava", true), // TODO: NativeAOT doesn't skip this target on 3rd attempt, check if that's ok?
 				("_ResolveLibraryProjectImports", false),
@@ -776,8 +769,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 				ManifestMerger = "manifestmerger.jar"
@@ -853,18 +844,16 @@ namespace Lib2
 				Assert.IsTrue (libBuilder.Build (lib, doNotCleanupOnUpdate: true, saveProject: false), "second library build should have succeeded.");
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
-				if (TestEnvironment.CommercialBuildAvailable) {
-					appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
-					appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
-					appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
-					appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+				appBuilder.Output.AssertTargetIsSkipped ("CoreCompile");
+				appBuilder.Output.AssertTargetIsSkipped ("_BuildLibraryImportsCache");
+				appBuilder.Output.AssertTargetIsSkipped ("_ResolveLibraryProjectImports");
+				appBuilder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
 
-					appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
+				appBuilder.Output.AssertTargetIsPartiallyBuilt (KnownTargets.LinkAssembliesNoShrink);
 
-					appBuilder.Output.AssertTargetIsNotSkipped ("_BuildApkEmbed");
-					appBuilder.Output.AssertTargetIsNotSkipped ("_CopyPackage");
-					appBuilder.Output.AssertTargetIsNotSkipped ("_Sign");
-				}
+				appBuilder.Output.AssertTargetIsNotSkipped ("_BuildApkEmbed");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_CopyPackage");
+				appBuilder.Output.AssertTargetIsNotSkipped ("_Sign");
 			}
 		}
 
@@ -957,7 +946,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -993,8 +981,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -1100,15 +1086,13 @@ namespace Lib2
 				appBuilder.BuildLogFile = "build2.log";
 				Assert.IsTrue (appBuilder.Build (app, doNotCleanupOnUpdate: true, saveProject: false), "second app build should have succeeded.");
 
-				if (TestEnvironment.CommercialBuildAvailable) {
-					var targetsShouldSkip = new [] {
-						"_BuildLibraryImportsCache",
-						"_ResolveLibraryProjectImports",
-						"_ConvertCustomView",
-					};
-					foreach (var target in targetsShouldSkip) {
-						Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
-					}
+				var targetsShouldSkip = new [] {
+					"_BuildLibraryImportsCache",
+					"_ResolveLibraryProjectImports",
+					"_ConvertCustomView",
+				};
+				foreach (var target in targetsShouldSkip) {
+					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
 
 				var targetsShouldRun = new [] {
@@ -1119,18 +1103,16 @@ namespace Lib2
 					"_CopyPackage",
 					"_Sign",
 				};
-				if (TestEnvironment.CommercialBuildAvailable) {
-					foreach (var target in targetsShouldRun) {
-						Assert.IsFalse (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
-					}
+				foreach (var target in targetsShouldRun) {
+					Assert.IsFalse (appBuilder.Output.IsTargetSkipped (target), $"`{target}` should *not* be skipped!");
+				}
 
-					var aapt2TargetsShouldBeSkipped = new [] {
-						"_FixupCustomViewsForAapt2",
-						"_CompileResources"
-					};
-					foreach (var target in aapt2TargetsShouldBeSkipped) {
-						Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"{target} should be skipped!");
-					}
+				var aapt2TargetsShouldBeSkipped = new [] {
+					"_FixupCustomViewsForAapt2",
+					"_CompileResources"
+				};
+				foreach (var target in aapt2TargetsShouldBeSkipped) {
+					Assert.IsTrue (appBuilder.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"{target} should be skipped!");
 				}
 			}
 		}
@@ -1142,8 +1124,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var proj = new XamarinFormsAndroidApplicationProject {
 				IsRelease = isRelease,
 			};
@@ -1348,8 +1328,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			// TODO: NativeAOT build doesn't add android/environment.arm64-v8a.o to file writes
 			if (runtime == AndroidRuntime.NativeAOT) {
 				Assert.Ignore ("NativeAOT doesn't currently add android/environment.arm64-v8a.o to file writes");
@@ -1785,7 +1763,6 @@ namespace Lib2
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/InvalidConfigTests.cs
@@ -76,8 +76,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void XA0119 ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("_AndroidFastDeploymentSupported", "true");
 			proj.SetProperty (proj.DebugProperties, "AndroidLinkMode", "Full");
@@ -91,8 +89,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void XA0119AAB ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject ();
 			proj.SetProperty ("_AndroidFastDeploymentSupported", "true");
 			proj.SetProperty ("AndroidPackageFormat", "aab");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/ManifestTest.cs
@@ -220,7 +220,6 @@ namespace Bug12935
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 				ManifestMerger = "manifestmerger.jar",

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/PackagingTest.cs
@@ -652,10 +652,8 @@ namespace UnnamedProject {
 
 				// Build with no changes
 				Assert.IsTrue (b.Build (proj), "second build should have succeeded.");
-				if (TestEnvironment.CommercialBuildAvailable) {
-					foreach (var target in new [] { "_Sign", "_BuildApkEmbed" }) {
-						Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
-					}
+				foreach (var target in new [] { "_Sign", "_BuildApkEmbed" }) {
+					Assert.IsTrue (b.Output.IsTargetSkipped (target), $"`{target}` should be skipped!");
 				}
 			}
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -43,8 +43,6 @@ namespace Xamarin.Android.Build.Tests {
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild (); // Incremental build assertions require Fast Deployment
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = isRelease,
 			};

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -43,18 +43,6 @@ namespace Xamarin.Android.Build.Tests
 			return value;
 		}
 
-		/// <summary>
-		/// Checks if a commercial .NET for Android is available
-		/// * Defaults to Assert.Ignore ()
-		/// </summary>
-		public void AssertCommercialBuild ()
-		{
-			if (!TestEnvironment.CommercialBuildAvailable) {
-				var message = $"'{TestName}' requires a commercial build of .NET for Android.";
-				Assert.Inconclusive (message);
-			}
-		}
-
 		char [] invalidChars = { '{', '}', '(', ')', '$', ':', ';', '\"', '\'', ',', '=', '|' };
 
 		public string TestName {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/TestEnvironment.cs
@@ -170,8 +170,6 @@ namespace Xamarin.ProjectTools
 			}
 		}
 
-		public static bool CommercialBuildAvailable => File.Exists (Path.Combine (AndroidMSBuildDirectory, "Xamarin.Android.Common.Debugging.targets"));
-
 		public static string OSBinDirectory {
 			get {
 				var osSubdirName = IsMacOS ? "Darwin" :

--- a/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/DebuggingTest.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Android.Build.Tests
 				IsRelease = isRelease,
 			};
 			proj.SetRuntime (runtime);
-			if (isRelease || !TestEnvironment.CommercialBuildAvailable) {
+			if (isRelease) {
 				proj.SetRuntimeIdentifiers (new[] { DeviceAbi });
 			}
 			proj.SetDefaultTargetDevice ();
@@ -139,9 +139,6 @@ namespace Xamarin.Android.Build.Tests
 				ProjectName = "MyApp",
 			};
 			app.SetRuntime (runtime);
-			if (!TestEnvironment.CommercialBuildAvailable) {
-				app.SetRuntimeIdentifiers (new[] { DeviceAbi });
-			}
 			app.SetDefaultTargetDevice ();
 			app.SetProperty ("AndroidEnablePreloadAssemblies", preloadAssemblies.ToString ());
 
@@ -245,7 +242,6 @@ namespace Xamarin.Android.Build.Tests
 				return;
 			}
 
-			AssertCommercialBuild ();
 			SwitchUser ();
 
 			var path = Path.Combine (Root, "temp", TestName);
@@ -470,7 +466,6 @@ namespace ${ROOT_NAMESPACE} {
 				return;
 			}
 
-			AssertCommercialBuild ();
 			SwitchUser ();
 			WaitFor (5000);
 

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -288,8 +288,6 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 		[Test]
 		public void DotNetRunWaitForExit ()
 		{
-			AssertCommercialBuild (); //FIXME: https://github.com/dotnet/android/issues/10832
-
 			const string logcatMessage = "DOTNET_RUN_TEST_MESSAGE_12345";
 			var proj = new XamarinAndroidApplicationProject ();
 
@@ -357,8 +355,6 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 		[Test]
 		public void DotNetRunCtrlC ()
 		{
-			AssertCommercialBuild (); //FIXME: https://github.com/dotnet/android/issues/10832
-
 			const string logcatMessage = "DOTNET_RUN_CTRLC_TEST_99999";
 			var proj = new XamarinAndroidApplicationProject ();
 
@@ -456,8 +452,6 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 		[Test]
 		public void DotNetRunWithDeviceParameter ()
 		{
-			AssertCommercialBuild (); //FIXME: https://github.com/dotnet/android/issues/10832
-
 			const string logcatMessage = "DOTNET_RUN_DEVICE_TEST_67890";
 			var proj = new XamarinAndroidApplicationProject ();
 
@@ -662,15 +656,9 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			dotnet.AssertTargetIsNotSkipped ("_EnsureDeviceBooted");
 
 			// Verify correct targets ran based on FastDev support
-			if (TestEnvironment.CommercialBuildAvailable) {
-				dotnet.AssertTargetIsNotSkipped ("_Upload");
-				dotnet.AssertTargetIsSkipped ("_DeployApk", defaultIfNotUsed: true);
-				dotnet.AssertTargetIsSkipped ("_DeployAppBundle", defaultIfNotUsed: true);
-			} else {
-				dotnet.AssertTargetIsSkipped ("_Upload", defaultIfNotUsed: true);
-				dotnet.AssertTargetIsNotSkipped ("_DeployApk");
-				dotnet.AssertTargetIsNotSkipped ("_DeployAppBundle");
-			}
+			dotnet.AssertTargetIsNotSkipped ("_Upload");
+			dotnet.AssertTargetIsSkipped ("_DeployApk", defaultIfNotUsed: true);
+			dotnet.AssertTargetIsSkipped ("_DeployAppBundle", defaultIfNotUsed: true);
 
 			// Launch the app using adb
 			ClearAdbLogcat ();
@@ -801,7 +789,7 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			};
 			proj.SetRuntime (runtime);
 
-			if (isRelease || !TestEnvironment.CommercialBuildAvailable) {
+			if (isRelease) {
 				if (runtime == AndroidRuntime.MonoVM) {
 					proj.SetRuntimeIdentifiers (new[] { "armeabi-v7a", "arm64-v8a", "x86", "x86_64" });
 				} else {
@@ -1262,7 +1250,7 @@ namespace Library1 {
 			// error SYSLIB0011: 'BinaryFormatter.Serialize(Stream, object)' is obsolete: 'BinaryFormatter serialization is obsolete and should not be used. See https://aka.ms/binaryformatter for more information.'
 			proj.SetProperty ("NoWarn", "SYSLIB0011");
 
-			if (isRelease || !TestEnvironment.CommercialBuildAvailable) {
+			if (isRelease) {
 				proj.SetRuntimeIdentifiers (new[] { DeviceAbi });
 			}
 
@@ -1447,8 +1435,6 @@ using System.Runtime.Serialization.Json;
 				// TODO: investigate, it's odd it doesn't work
 				Assert.Ignore ("NativeAOT doesn't currently work in test-only applications.");
 			}
-
-			AssertCommercialBuild ();
 
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {
 				IsRelease = isRelease,
@@ -2160,7 +2146,6 @@ namespace UnnamedProject
 			}
 
 			if (embedAssembliesIntoApk) {
-				AssertCommercialBuild ();
 			}
 
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {

--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -655,7 +655,7 @@ static int InvokeIntMethod (Java.Lang.Object instance, string methodName)
 			// Verify _EnsureDeviceBooted actually ran in the chain
 			dotnet.AssertTargetIsNotSkipped ("_EnsureDeviceBooted");
 
-			// Verify correct targets ran based on FastDev support
+			// Verify FastDev targets ran (Fast Deployment is always available now)
 			dotnet.AssertTargetIsNotSkipped ("_Upload");
 			dotnet.AssertTargetIsSkipped ("_DeployApk", defaultIfNotUsed: true);
 			dotnet.AssertTargetIsSkipped ("_DeployAppBundle", defaultIfNotUsed: true);

--- a/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallTests.cs
@@ -32,8 +32,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void ReInstallIfUserUninstalled ([Values (false, true)] bool isRelease)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
@@ -60,8 +58,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstallAndUnInstall ([Values (false, true)] bool isRelease)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = isRelease,
 			};
@@ -93,8 +89,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void ChangeKeystoreRedeploy ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 				PackageName = "com.xamarin.keytest"
 			};
@@ -122,8 +116,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void SwitchConfigurationsShouldRedeploy ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = false,
 			};
@@ -167,8 +159,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstallWithoutSharedRuntime ([Values (AndroidRuntime.MonoVM, AndroidRuntime.CoreCLR)] AndroidRuntime runtimeType)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 				IsRelease = true,
 			};
@@ -217,8 +207,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstallErrorCode ()
 		{
-			AssertCommercialBuild ();
-
 			//Setup a situation where we get INSTALL_FAILED_NO_MATCHING_ABIS
 			var abi = "armeabi-v7a";
 			var proj = new XamarinAndroidApplicationProject {
@@ -241,8 +229,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void ToggleFastDev ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject {
 				EmbedAssembliesIntoApk = false,
 				OtherBuildItems = {
@@ -278,7 +264,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void ToggleDebugReleaseWithSigning ([Values ("aab", "apk")] string packageFormat)
 		{
-			AssertCommercialBuild ();
 			AssertHasDevices ();
 
 			string path = Path.Combine ("temp", TestName.Replace ("\"", string.Empty));
@@ -323,8 +308,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void LoggingPropsShouldCreateOverrideDirForRelease ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject {
 				IsRelease = true,
 			};
@@ -350,8 +333,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void BlankAdbTarget ()
 		{
-			AssertCommercialBuild ();
-
 			var serial = GetAttachedDeviceSerial ();
 			var proj = new XamarinAndroidApplicationProject () {
 			};
@@ -469,8 +450,6 @@ namespace Xamarin.Android.Build.Tests
 		[TestCase ("aab")]
 		public void LocalizedAssemblies_ShouldBeFastDeployed (string packageFormat)
 		{
-			AssertCommercialBuild ();
-
 			var path = Path.Combine ("temp", TestName);
 			var lib = new XamarinAndroidLibraryProject {
 				ProjectName = "Localization",
@@ -511,8 +490,6 @@ namespace Xamarin.Android.Build.Tests
 		[TestCase ("aab")]
 		public void IncrementalFastDeployment (string packageFormat)
 		{
-			AssertCommercialBuild ();
-
 			var class1src = new BuildItem.Source ("Class1.cs") {
 				TextContent = () => "namespace Library1 { public class Class1 { public static int foo = 500; } }"
 			};
@@ -638,7 +615,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void AdbTargetArchitecture ()
 		{
-			AssertCommercialBuild ();
 			AssertHasDevices ();
 
 			const string abi = "x86_64";

--- a/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs
@@ -14,8 +14,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunSimpleBuild ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinFormsAndroidApplicationProject {
 			};
 			var b = CreateApkBuilder ();
@@ -43,8 +41,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void TargetsSkipped ([Values(false, true)] bool useManagedResourceGenerator)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedResourceGenerator.ToString ());
@@ -117,8 +113,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void SimpleInstallAndUninstall ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject {
 			};
 			proj.SetDefaultTargetDevice ();
@@ -131,8 +125,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void SkipFastDevAlreadyInstalledFile ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject {
 			};
 			proj.SetDefaultTargetDevice ();
@@ -176,8 +168,6 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource ("SkipFastDevAlreadyInstalledResourcesSource")] // test for both cases that there is external resources or there are some.
 		public void SkipFastDevAlreadyInstalledResources (Package [] packages, string baseActivityClass)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 			};
 			proj.SetDefaultTargetDevice ();
@@ -205,8 +195,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunResourceChange ()
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 			};
 			proj.SetDefaultTargetDevice ();
@@ -236,8 +224,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void InstantRunFastDevDexes ([Values (false, true)] bool useEmbeddedDex)
 		{
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject () {
 			};
 			proj.SetDefaultTargetDevice ();

--- a/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/MonoAndroidExportTest.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Android.Build.Tests
 				return;
 			}
 
-			AssertCommercialBuild ();
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {
 				IsRelease = isRelease,
 				References = {
@@ -119,7 +118,6 @@ namespace UnnamedProject
 				return;
 			}
 
-			AssertCommercialBuild ();
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {
 				IsRelease = isRelease,
 				References = {

--- a/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/PerformanceTest.cs
@@ -194,8 +194,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_CSharp_Change ()
 		{
-			AssertCommercialBuild (); // This test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			proj.MainActivity = proj.DefaultMainActivity;
 			using (var builder = CreateBuilderWithoutLogFile ()) {
@@ -214,8 +212,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidResource_Change ()
 		{
-			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
@@ -233,8 +229,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidAsset_Change ()
 		{
-			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
-
 			var bytes = new byte [1024*1024*10];
 			var rnd = new Random ();
 			rnd.NextBytes (bytes);
@@ -272,8 +266,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_AndroidManifest_Change ()
 		{
-			AssertCommercialBuild (); // If <BuildApk/> runs, this test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			using (var builder = CreateBuilderWithoutLogFile ()) {
 				builder.Target = "Build";
@@ -292,8 +284,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Build_XAML_Change ([Values (true, false)] bool install)
 		{
-			AssertCommercialBuild (); // This test will fail without Fast Deployment
-
 			var path = Path.Combine ("temp", TestName);
 			var xaml =
 @"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -364,8 +354,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Install_CSharp_Change ()
 		{
-			AssertCommercialBuild (); // This test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			proj.PackageName = "com.xamarin.install_csharp_change";
 			proj.MainActivity = proj.DefaultMainActivity;
@@ -385,8 +373,6 @@ namespace Xamarin.Android.Build.Tests
 		[Retry (Retry)]
 		public void Install_CSharp_FromClean ()
 		{
-			AssertCommercialBuild (); // This test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			proj.PackageName = "com.xamarin.install_csharp_change";
 			proj.MainActivity = proj.DefaultMainActivity;
@@ -405,8 +391,6 @@ namespace Xamarin.Android.Build.Tests
 		[Test]
 		public void DesignTimeBuild_CSharp_From_Clean ()
 		{
-			AssertCommercialBuild (); // This test will fail without Fast Deployment
-
 			var proj = CreateApplicationProject ();
 			proj.PackageName = "com.xamarin.designtimebuild_csharp_from_clean";
 			proj.PackageReferences.Add (KnownPackages.AndroidXAppCompat);

--- a/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/SystemApplicationTests.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Android.Build.Tests
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
-			AssertCommercialBuild ();
-
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {
 				IsRelease = false,
 				EmbedAssembliesIntoApk = false,


### PR DESCRIPTION
### Context

PR #11529 inlined `external/android-platform-support` into dotnet/android. `Xamarin.Android.Common.Debugging.targets` is now always built and shipped, so `TestEnvironment.CommercialBuildAvailable` is always `true` and `AssertCommercialBuild()` is a no-op.

### Changes

- Removed `TestEnvironment.CommercialBuildAvailable` property.
- Removed `BaseTest.AssertCommercialBuild()` helper.
- Dropped every `AssertCommercialBuild ();` callsite (~40 lines across 19 files).
- Simplified all `CommercialBuildAvailable` predicate usages, since the value is always `true`:
  - `if (TestEnvironment.CommercialBuildAvailable) { X }` → unwrapped to `X`
  - `if (!TestEnvironment.CommercialBuildAvailable) { X }` → block deleted
  - `if (isRelease || !TestEnvironment.CommercialBuildAvailable)` → `if (isRelease)`
  - `TestEnvironment.CommercialBuildAvailable ? "debug" : "release"` → `"debug"`
  - `!(TestEnvironment.CommercialBuildAvailable && !isRelease)` → `isRelease`
  - `!TestEnvironment.CommercialBuildAvailable && !isRelease` → `false`
- In `InstallAndRunTests.cs`, the `if (TestEnvironment.CommercialBuildAvailable) { ... } else { ... }` block keeps only the (now always-taken) true branch.

### Out of scope

The MSBuild gates (`_HasCommercialFiles`, `_AndroidFastDeploymentSupported`, etc.) are intentionally left alone — those will follow in a separate PR.

### Verification

- `git grep -n AssertCommercialBuild` → 0 hits
- `git grep -n CommercialBuildAvailable` → 0 hits
- Brace-balance check on every modified `.cs` file matches the baseline (HEAD) delta exactly.