### PR TITLE
[build] Drop unused protobuf-net references from Mono.AndroidTools

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -63,8 +63,6 @@
     <MicrosoftWin32RegistryVersion>5.0.0</MicrosoftWin32RegistryVersion>
     <MonoUnixVersion>7.1.0-final.1.21458.1</MonoUnixVersion>
     <PollyVersion>7.2.4</PollyVersion>
-    <ProtobufNetVersion>3.2.26</ProtobufNetVersion>
-    <ProtobufNetCoreVersion>3.2.26</ProtobufNetCoreVersion>
     <SharpZipLibVersion>1.3.3</SharpZipLibVersion>
     <SystemTextEncodingCodePagesVersion>7.0.0</SystemTextEncodingCodePagesVersion>
   </PropertyGroup>

--- a/src/Mono.AndroidTools/Mono.AndroidTools.csproj
+++ b/src/Mono.AndroidTools/Mono.AndroidTools.csproj
@@ -24,20 +24,10 @@
       <Authenticode>Microsoft400</Authenticode>
     </FilesToSign>
   </ItemGroup>
-  <ItemGroup Condition=" '$(Configuration)' == 'Release' Or '$(Configuration)' == 'ReleaseWindows'">
-    <NuGetFilesToSign Include="$(PkgProtobuf-net)\lib\*\protobuf-net.dll">
-      <Authenticode>3PartySHA2</Authenticode>
-    </NuGetFilesToSign>
-    <NuGetFilesToSign Include="$(Pkgprotobuf-net_Core)\lib\*\protobuf-net.Core.dll">
-      <Authenticode>3PartySHA2</Authenticode>
-    </NuGetFilesToSign>
-  </ItemGroup>
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="$(GitInfoVersion)" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="$(MicrosoftWin32RegistryVersion)" />
     <PackageReference Include="System.Collections.Immutable" Version="$(SystemCollectionsImmutableVersion)" />
-    <PackageReference Include="protobuf-net" Version="$(ProtobufNetVersion)" GeneratePathProperty="true" />
-    <PackageReference Include="protobuf-net.Core" Version="$(ProtobufNetCoreVersion)" GeneratePathProperty="true" />
 
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(MicroBuildCoreVersion)">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
## Summary

PR #11529 inlined `Mono.AndroidTools` from `android-platform-support`, which carried `PackageReference`s to `protobuf-net` 3.2.26 and `protobuf-net.Core` 3.2.26. The original consumer of these packages was the native `tools/base/deploy/installer` binary, which was removed in the same PR. None of the inlined managed code (`Mono.AndroidTools`, `Xamarin.AndroidTools`, `Xamarin.Installer.*`, `Xamarin.Android.Build.Debugging.Tasks`) actually uses the `ProtoBuf` namespace, `[ProtoContract]` / `[ProtoMember]` attributes, or `Serializer.*` calls — so the references are dead weight.

## The actual bug

The unused references were also breaking `class-parse`'s Kotlin metadata parsing on every PR build:

```
class-parse : warning : Unable to parse Kotlin metadata on 'Utf8("foo/UnsignedInstanceMethods")':
System.IO.FileNotFoundException: Could not load file or assembly
'protobuf-net.Core, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67'.
```

…manifesting downstream as:

```
KotlinUnsignedTypesTests.cs(17,64): error CS1503: Argument 1: cannot convert from 'uint' to 'int'
KotlinUnsignedTypesTests.cs(20,35): error CS0266: Cannot implicitly convert type 'uint' to 'int'.
…
```

`Mono.AndroidTools.csproj` outputs to `$(MicrosoftAndroidSdkOutDir)`, where it dropped a v3 `protobuf-net.dll` (a thin facade) that overwrote the v2 self-contained DLL shipped by Java.Interop's `Xamarin.Android.Tools.Bytecode` (pinned to `protobuf-net` 2.4.4). Because `protobuf-net.Core.dll` was never added to the SDK pack file lists in `build-tools/installers/create-installers.targets` or `Microsoft.Android.Sdk.proj`, `class-parse` failed at runtime and `KotlinFixups.Fixup` silently skipped Kotlin metadata. Bindings then regenerated unsigned types as their signed counterparts, breaking the hand-written `KotlinUnsignedTypesTests.cs`.

## Fix

Drop the v3 references from `src/Mono.AndroidTools/Mono.AndroidTools.csproj` (both the `PackageReference`s and the dependent `NuGetFilesToSign` group), and the now-unused `ProtobufNetVersion` / `ProtobufNetCoreVersion` properties from `Directory.Build.props`. The v2 `protobuf-net.dll` from Java.Interop's class-parse becomes the only `protobuf-net.dll` in `$(MicrosoftAndroidSdkOutDir)` again, restoring Kotlin metadata parsing.

The existing entries that ship the v2 DLL into the SDK pack — `_MSBuildFiles Include="$(MicrosoftAndroidSdkOutDir)protobuf-net.dll"` in `build-tools/installers/create-installers.targets` and `<ThirdParty Include="protobuf-net.dll" />` in `build-tools/create-packs/SignList.xml`, both added by #5529 — continue to do their job.

## Verification

- Audited `src/Mono.AndroidTools` and all transitive consumers: zero usage of `using ProtoBuf`, `[Proto*]` attributes, or `Serializer.*` calls.
- `dotnet restore src/Mono.AndroidTools/Mono.AndroidTools.csproj` completes cleanly with no transitive protobuf-net resolution.
- `KotlinUnsignedTypesTests.cs` should compile and pass once `class-parse` can again deserialize Kotlin metadata.