### PR TITLE
[Mono.Android] broaden assignability check escape hatch

### DIFF
--- a/build-tools/automation/yaml-templates/stage-package-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-package-tests.yaml
@@ -198,6 +198,16 @@ stages:
     - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
       parameters:
         configuration: $(XA.Build.Configuration)
+        testName: Mono.Android.NET_Tests-CoreCLR-IsAssignableFrom
+        project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
+        testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)CoreCLRIsAssignableFrom.xml
+        extraBuildArgs: -p:TestsFlavor=CoreCLRIsAssignableFrom -p:IncludeCategories=Intune -p:_AndroidIsAssignableFromCheck=false -p:UseMonoRuntime=false
+        artifactSource: bin/Test$(XA.Build.Configuration)/$(DotNetTargetFramework)-android/Mono.Android.NET_Tests-Signed.aab
+        artifactFolder: $(DotNetTargetFramework)-CoreCLR-IsAssignableFrom
+
+    - template: /build-tools/automation/yaml-templates/apk-instrumentation.yaml
+      parameters:
+        configuration: $(XA.Build.Configuration)
         testName: Mono.Android.NET_Tests-CoreCLR
         project: tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj
         testResultsFiles: TestResult-Mono.Android.NET_Tests-$(XA.Build.Configuration)CoreCLR.xml

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -540,16 +540,16 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			}
 		}
 
-		targetType = targetType ?? typeof (global::Java.Interop.JavaObject);
-		targetType = ResolvePeerType (targetType);
+		var peerTargetType = ResolvePeerType (targetType ?? typeof (global::Java.Interop.JavaObject))
+			?? typeof (global::Java.Interop.JavaObject);
 
-		if (!typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
-			throw new ArgumentException ($"targetType `{targetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
+		if (!typeof (IJavaPeerable).IsAssignableFrom (peerTargetType)) {
+			throw new ArgumentException ($"targetType `{peerTargetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
 		}
 
-		var targetSig = Runtime.TypeManager.GetTypeSignature (targetType);
+		var targetSig = Runtime.TypeManager.GetTypeSignature (peerTargetType);
 		if (!targetSig.IsValid || targetSig.SimpleReference == null) {
-			throw new ArgumentException ($"Could not determine Java type corresponding to `{targetType.AssemblyQualifiedName}`.", nameof (targetType));
+			throw new ArgumentException ($"Could not determine Java type corresponding to `{peerTargetType.AssemblyQualifiedName}`.", nameof (targetType));
 		}
 
 		var refClass = JniEnvironment.Types.GetObjectClass (reference);
@@ -573,10 +573,10 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 		JniObjectReference.Dispose (ref targetClass);
 
-		var createdPeer = CreatePeerInstance (ref refClass, targetType, ref reference, transfer);
+		var createdPeer = CreatePeerInstance (ref refClass, peerTargetType, ref reference, transfer);
 		if (createdPeer == null) {
 			throw new NotSupportedException (string.Format (CultureInfo.InvariantCulture, "Could not find an appropriate constructable wrapper type for Java type '{0}', targetType='{1}'.",
-					JniEnvironment.Types.GetJniTypeNameFromInstance (reference), targetType));
+					JniEnvironment.Types.GetJniTypeNameFromInstance (reference), peerTargetType));
 		}
 		createdPeer.SetJniManagedPeerState (createdPeer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
 		return createdPeer;
@@ -685,38 +685,36 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			ref JniObjectReference reference,
 			Type targetType)
 	{
-		if (!RuntimeFeature.IsAssignableFromCheck) {
-			return false;
-		}
-
-		if (!typeMap.TryGetJniNameForManagedType (targetType, out var targetJniName)) {
-			throw new ArgumentException (
-				$"Could not determine Java type corresponding to '{targetType.AssemblyQualifiedName}'.",
-				nameof (targetType));
-		}
-
-		var instanceClass = JniEnvironment.Types.GetObjectClass (reference);
-		JniObjectReference targetClass = default;
-		try {
-			try {
-				targetClass = JniEnvironment.Types.FindClass (targetJniName);
-			} catch (Java.Lang.ClassNotFoundException e) {
+		if (RuntimeFeature.IsAssignableFromCheck) {
+			if (!typeMap.TryGetJniNameForManagedType (targetType, out var targetJniName)) {
 				throw new ArgumentException (
-					$"Could not find Java class '{targetJniName}'.",
-					nameof (targetType), e);
+					$"Could not determine Java type corresponding to '{targetType.AssemblyQualifiedName}'.",
+					nameof (targetType));
 			}
 
-			if (!JniEnvironment.Types.IsAssignableFrom (instanceClass, targetClass)) {
-				if (Logger.LogAssembly) {
-					var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetJniName}'";
-					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+			var instanceClass = JniEnvironment.Types.GetObjectClass (reference);
+			JniObjectReference targetClass = default;
+			try {
+				try {
+					targetClass = JniEnvironment.Types.FindClass (targetJniName);
+				} catch (Java.Lang.ClassNotFoundException e) {
+					throw new ArgumentException (
+						$"Could not find Java class '{targetJniName}'.",
+						nameof (targetType), e);
 				}
-				// Bad casts translate to null.
-				return true;
+
+				if (!JniEnvironment.Types.IsAssignableFrom (instanceClass, targetClass)) {
+					if (Logger.LogAssembly) {
+						var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetJniName}'";
+						Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+					}
+					// Bad casts translate to null.
+					return true;
+				}
+			} finally {
+				JniObjectReference.Dispose (ref instanceClass);
+				JniObjectReference.Dispose (ref targetClass);
 			}
-		} finally {
-			JniObjectReference.Dispose (ref instanceClass);
-			JniObjectReference.Dispose (ref targetClass);
 		}
 
 		// Compatible classes mean a proxy/activation gap.

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -540,33 +540,16 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			}
 		}
 
-		if (!RuntimeFeature.IsAssignableFromCheck) {
-			return CreatePeerAllowingIncompatibleJavaType (ref reference, transfer, targetType);
+		targetType = targetType ?? typeof (global::Java.Interop.JavaObject);
+		targetType = ResolvePeerType (targetType);
+
+		if (!typeof (IJavaPeerable).IsAssignableFrom (targetType)) {
+			throw new ArgumentException ($"targetType `{targetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
 		}
 
-		return base.CreatePeer (ref reference, transfer, targetType);
-	}
-
-	IJavaPeerable? CreatePeerAllowingIncompatibleJavaType (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions transfer,
-			[DynamicallyAccessedMembers (Constructors)]
-			Type? targetType)
-	{
-		// Mirrors Java.Interop's CreatePeer path, but lets the Android assignability
-		// feature switch decide whether a Java type mismatch rejects peer creation.
-		var resolvedTargetType = ResolvePeerType (targetType ?? typeof (global::Java.Interop.JavaObject));
-		if (resolvedTargetType is null) {
-			return null;
-		}
-
-		if (!typeof (IJavaPeerable).IsAssignableFrom (resolvedTargetType)) {
-			throw new ArgumentException ($"targetType `{resolvedTargetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
-		}
-
-		var targetSig = Runtime.TypeManager.GetTypeSignature (resolvedTargetType);
+		var targetSig = Runtime.TypeManager.GetTypeSignature (targetType);
 		if (!targetSig.IsValid || targetSig.SimpleReference == null) {
-			throw new ArgumentException ($"Could not determine Java type corresponding to `{resolvedTargetType.AssemblyQualifiedName}`.", nameof (targetType));
+			throw new ArgumentException ($"Could not determine Java type corresponding to `{targetType.AssemblyQualifiedName}`.", nameof (targetType));
 		}
 
 		var refClass = JniEnvironment.Types.GetObjectClass (reference);
@@ -580,98 +563,101 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 					e);
 		}
 
-		if (!JniEnvironment.Types.IsAssignableFrom (refClass, targetClass) && Logger.LogAssembly) {
-			var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetSig.SimpleReference}'";
-			Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+		if (RuntimeFeature.IsAssignableFromCheck) {
+			if (!JniEnvironment.Types.IsAssignableFrom (refClass, targetClass)) {
+				JniObjectReference.Dispose (ref refClass);
+				JniObjectReference.Dispose (ref targetClass);
+				return null;
+			}
 		}
 
 		JniObjectReference.Dispose (ref targetClass);
 
-		var peer = CreatePeerInstance (ref refClass, resolvedTargetType, ref reference, transfer);
-		if (peer == null) {
+		var createdPeer = CreatePeerInstance (ref refClass, targetType, ref reference, transfer);
+		if (createdPeer == null) {
 			throw new NotSupportedException (string.Format (CultureInfo.InvariantCulture, "Could not find an appropriate constructable wrapper type for Java type '{0}', targetType='{1}'.",
-					JniEnvironment.Types.GetJniTypeNameFromInstance (reference), resolvedTargetType));
+					JniEnvironment.Types.GetJniTypeNameFromInstance (reference), targetType));
 		}
-		peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
-		return peer;
-	}
+		createdPeer.SetJniManagedPeerState (createdPeer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+		return createdPeer;
 
-	IJavaPeerable? CreatePeerInstance (
-			ref JniObjectReference klass,
-			[DynamicallyAccessedMembers (Constructors)]
-			Type targetType,
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions transfer)
-	{
-		var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
+		IJavaPeerable? CreatePeerInstance (
+				ref JniObjectReference klass,
+				[DynamicallyAccessedMembers (Constructors)]
+				Type targetType,
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions transfer)
+		{
+			var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
 
-		while (jniTypeName != null) {
-			if (!JniTypeSignature.TryParse (jniTypeName, out var sig)) {
+			while (jniTypeName != null) {
+				if (!JniTypeSignature.TryParse (jniTypeName, out var sig)) {
+					return null;
+				}
+
+				Type? type = GetTypeAssignableTo (sig, targetType);
+				if (type != null) {
+					var createdPeer = TryCreatePeerInstance (ref reference, transfer, type);
+
+					if (createdPeer != null) {
+						JniObjectReference.Dispose (ref klass);
+						return createdPeer;
+					}
+				}
+
+				var super = JniEnvironment.Types.GetSuperclass (klass);
+				jniTypeName = super.IsValid
+					? JniEnvironment.Types.GetJniTypeNameFromClass (super)
+					: null;
+
+				JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
+				klass = super;
+			}
+			JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
+
+			return TryCreatePeerInstance (ref reference, transfer, targetType);
+
+			[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
+			[return: DynamicallyAccessedMembers (Constructors)]
+			Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
+			{
+				foreach (var type in Runtime.TypeManager.GetTypes (sig)) {
+					if (targetType.IsAssignableFrom (type)) {
+						return type;
+					}
+				}
 				return null;
 			}
-
-			Type? type = GetTypeAssignableTo (sig, targetType);
-			if (type != null) {
-				var peer = TryCreatePeerInstance (ref reference, transfer, type);
-
-				if (peer != null) {
-					JniObjectReference.Dispose (ref klass);
-					return peer;
-				}
-			}
-
-			var super = JniEnvironment.Types.GetSuperclass (klass);
-			jniTypeName = super.IsValid
-				? JniEnvironment.Types.GetJniTypeNameFromClass (super)
-				: null;
-
-			JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
-			klass = super;
 		}
-		JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
 
-		return TryCreatePeerInstance (ref reference, transfer, targetType);
-
-		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
-		[return: DynamicallyAccessedMembers (Constructors)]
-		Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
-		{
-			foreach (var type in Runtime.TypeManager.GetTypes (sig)) {
-				if (targetType.IsAssignableFrom (type)) {
-					return type;
-				}
-			}
-			return null;
-		}
-	}
-
-	IJavaPeerable? TryCreatePeerInstance (
-			ref JniObjectReference reference,
-			JniObjectReferenceOptions options,
-			[DynamicallyAccessedMembers (Constructors)]
-			Type type)
-	{
-		type = Runtime.TypeManager.GetInvokerType (type) ?? type;
-
-		var self = GetUninitializedObject (type);
-		var constructed = false;
-		try {
-			constructed = TryConstructPeer (self, ref reference, options, type);
-		} finally {
-			if (!constructed) {
-				GC.SuppressFinalize (self);
-				self = null;
-			}
-		}
-		return self;
-
-		static IJavaPeerable GetUninitializedObject (
+		IJavaPeerable? TryCreatePeerInstance (
+				ref JniObjectReference reference,
+				JniObjectReferenceOptions options,
 				[DynamicallyAccessedMembers (Constructors)]
 				Type type)
 		{
-			var value = (IJavaPeerable) RuntimeHelpers.GetUninitializedObject (type);
-			value.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
-			return value;
+			type = Runtime.TypeManager.GetInvokerType (type) ?? type;
+
+			var self = GetUninitializedObject (type);
+			var constructed = false;
+			try {
+				constructed = TryConstructPeer (self, ref reference, options, type);
+			} finally {
+				if (!constructed) {
+					GC.SuppressFinalize (self);
+					self = null;
+				}
+			}
+			return self;
+
+			static IJavaPeerable GetUninitializedObject (
+					[DynamicallyAccessedMembers (Constructors)]
+					Type type)
+			{
+				var value = (IJavaPeerable) RuntimeHelpers.GetUninitializedObject (type);
+				value.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+				return value;
+			}
 		}
 	}
 
@@ -699,6 +685,10 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			ref JniObjectReference reference,
 			Type targetType)
 	{
+		if (!RuntimeFeature.IsAssignableFromCheck) {
+			return false;
+		}
+
 		if (!typeMap.TryGetJniNameForManagedType (targetType, out var targetJniName)) {
 			throw new ArgumentException (
 				$"Could not determine Java type corresponding to '{targetType.AssemblyQualifiedName}'.",
@@ -721,8 +711,8 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 					var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetJniName}'";
 					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 				}
-				// Bad casts translate to null unless the assignability check is explicitly disabled.
-				return RuntimeFeature.IsAssignableFromCheck;
+				// Bad casts translate to null.
+				return true;
 			}
 		} finally {
 			JniObjectReference.Dispose (ref instanceClass);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -540,7 +540,139 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			}
 		}
 
+		if (!RuntimeFeature.IsAssignableFromCheck) {
+			return CreatePeerAllowingIncompatibleJavaType (ref reference, transfer, targetType);
+		}
+
 		return base.CreatePeer (ref reference, transfer, targetType);
+	}
+
+	IJavaPeerable? CreatePeerAllowingIncompatibleJavaType (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions transfer,
+			[DynamicallyAccessedMembers (Constructors)]
+			Type? targetType)
+	{
+		// Mirrors Java.Interop's CreatePeer path, but lets the Android assignability
+		// feature switch decide whether a Java type mismatch rejects peer creation.
+		var resolvedTargetType = ResolvePeerType (targetType ?? typeof (global::Java.Interop.JavaObject));
+		if (resolvedTargetType is null) {
+			return null;
+		}
+
+		if (!typeof (IJavaPeerable).IsAssignableFrom (resolvedTargetType)) {
+			throw new ArgumentException ($"targetType `{resolvedTargetType.AssemblyQualifiedName}` must implement IJavaPeerable!", nameof (targetType));
+		}
+
+		var targetSig = Runtime.TypeManager.GetTypeSignature (resolvedTargetType);
+		if (!targetSig.IsValid || targetSig.SimpleReference == null) {
+			throw new ArgumentException ($"Could not determine Java type corresponding to `{resolvedTargetType.AssemblyQualifiedName}`.", nameof (targetType));
+		}
+
+		var refClass = JniEnvironment.Types.GetObjectClass (reference);
+		JniObjectReference targetClass;
+		try {
+			targetClass = JniEnvironment.Types.FindClass (targetSig.SimpleReference);
+		} catch (Exception e) {
+			JniObjectReference.Dispose (ref refClass);
+			throw new ArgumentException ($"Could not find Java class `{targetSig.SimpleReference}`.",
+					nameof (targetType),
+					e);
+		}
+
+		if (!JniEnvironment.Types.IsAssignableFrom (refClass, targetClass) && Logger.LogAssembly) {
+			var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetSig.SimpleReference}'";
+			Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+		}
+
+		JniObjectReference.Dispose (ref targetClass);
+
+		var peer = CreatePeerInstance (ref refClass, resolvedTargetType, ref reference, transfer);
+		if (peer == null) {
+			throw new NotSupportedException (string.Format (CultureInfo.InvariantCulture, "Could not find an appropriate constructable wrapper type for Java type '{0}', targetType='{1}'.",
+					JniEnvironment.Types.GetJniTypeNameFromInstance (reference), resolvedTargetType));
+		}
+		peer.SetJniManagedPeerState (peer.JniManagedPeerState | JniManagedPeerStates.Replaceable);
+		return peer;
+	}
+
+	IJavaPeerable? CreatePeerInstance (
+			ref JniObjectReference klass,
+			[DynamicallyAccessedMembers (Constructors)]
+			Type targetType,
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions transfer)
+	{
+		var jniTypeName = JniEnvironment.Types.GetJniTypeNameFromClass (klass);
+
+		while (jniTypeName != null) {
+			if (!JniTypeSignature.TryParse (jniTypeName, out var sig)) {
+				return null;
+			}
+
+			Type? type = GetTypeAssignableTo (sig, targetType);
+			if (type != null) {
+				var peer = TryCreatePeerInstance (ref reference, transfer, type);
+
+				if (peer != null) {
+					JniObjectReference.Dispose (ref klass);
+					return peer;
+				}
+			}
+
+			var super = JniEnvironment.Types.GetSuperclass (klass);
+			jniTypeName = super.IsValid
+				? JniEnvironment.Types.GetJniTypeNameFromClass (super)
+				: null;
+
+			JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
+			klass = super;
+		}
+		JniObjectReference.Dispose (ref klass, JniObjectReferenceOptions.CopyAndDispose);
+
+		return TryCreatePeerInstance (ref reference, transfer, targetType);
+
+		[UnconditionalSuppressMessage ("Trimming", "IL2073", Justification = "Types returned here should be preserved via other means.")]
+		[return: DynamicallyAccessedMembers (Constructors)]
+		Type? GetTypeAssignableTo (JniTypeSignature sig, Type targetType)
+		{
+			foreach (var type in Runtime.TypeManager.GetTypes (sig)) {
+				if (targetType.IsAssignableFrom (type)) {
+					return type;
+				}
+			}
+			return null;
+		}
+	}
+
+	IJavaPeerable? TryCreatePeerInstance (
+			ref JniObjectReference reference,
+			JniObjectReferenceOptions options,
+			[DynamicallyAccessedMembers (Constructors)]
+			Type type)
+	{
+		type = Runtime.TypeManager.GetInvokerType (type) ?? type;
+
+		var self = GetUninitializedObject (type);
+		var constructed = false;
+		try {
+			constructed = TryConstructPeer (self, ref reference, options, type);
+		} finally {
+			if (!constructed) {
+				GC.SuppressFinalize (self);
+				self = null;
+			}
+		}
+		return self;
+
+		static IJavaPeerable GetUninitializedObject (
+				[DynamicallyAccessedMembers (Constructors)]
+				Type type)
+		{
+			var value = (IJavaPeerable) RuntimeHelpers.GetUninitializedObject (type);
+			value.SetJniManagedPeerState (JniManagedPeerStates.Replaceable | JniManagedPeerStates.Activatable);
+			return value;
+		}
 	}
 
 	[return: DynamicallyAccessedMembers (Constructors)]
@@ -585,8 +717,12 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			}
 
 			if (!JniEnvironment.Types.IsAssignableFrom (instanceClass, targetClass)) {
-				// Bad cast: callers translate null to the expected result.
-				return true;
+				if (Logger.LogAssembly) {
+					var message = $"Handle 0x{reference.Handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (reference)}' which is not assignable to '{targetJniName}'";
+					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+				}
+				// Bad casts translate to null unless the assignability check is explicitly disabled.
+				return RuntimeFeature.IsAssignableFromCheck;
 			}
 		} finally {
 			JniObjectReference.Dispose (ref instanceClass);

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -597,11 +597,11 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 				Type? type = GetTypeAssignableTo (sig, targetType);
 				if (type != null) {
-					var createdPeer = TryCreatePeerInstance (ref reference, transfer, type);
+					var peer = TryCreatePeerInstance (ref reference, transfer, type);
 
-					if (createdPeer != null) {
+					if (peer != null) {
 						JniObjectReference.Dispose (ref klass);
-						return createdPeer;
+						return peer;
 					}
 				}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -374,12 +374,12 @@ public class TrimmableTypeMap
 					// ArgumentException instead of leaking ClassNotFoundException.
 					return null;
 				}
-				var isAssignable = JniEnvironment.Types.IsAssignableFrom (objClass, targetClass);
-				if (!isAssignable && RuntimeFeature.IsAssignableFromCheck) {
-					return null;
-				}
-				if (!isAssignable && Logger.LogAssembly) {
-					var message = $"Handle 0x{handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (selfRef)}' which is not assignable to '{targetJniName}'";
+				if (RuntimeFeature.IsAssignableFromCheck) {
+					if (!JniEnvironment.Types.IsAssignableFrom (objClass, targetClass)) {
+						return null;
+					}
+				} else if (Logger.LogAssembly) {
+					var message = $"Skipping Java assignability check for handle 0x{handle:x} targeting '{targetJniName}' because {nameof (RuntimeFeature.IsAssignableFromCheck)} is disabled.";
 					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 				}
 				return proxy;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -375,7 +375,14 @@ public class TrimmableTypeMap
 					return null;
 				}
 				var isAssignable = JniEnvironment.Types.IsAssignableFrom (objClass, targetClass);
-				return isAssignable ? proxy : null;
+				if (!isAssignable && RuntimeFeature.IsAssignableFromCheck) {
+					return null;
+				}
+				if (!isAssignable && Logger.LogAssembly) {
+					var message = $"Handle 0x{handle:x} is of type '{JniEnvironment.Types.GetJniTypeNameFromInstance (selfRef)}' which is not assignable to '{targetJniName}'";
+					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
+				}
+				return proxy;
 			} finally {
 				JniObjectReference.Dispose (ref objClass);
 				JniObjectReference.Dispose (ref targetClass);

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -378,9 +378,6 @@ public class TrimmableTypeMap
 					if (!JniEnvironment.Types.IsAssignableFrom (objClass, targetClass)) {
 						return null;
 					}
-				} else if (Logger.LogAssembly) {
-					var message = $"Skipping Java assignability check for handle 0x{handle:x} targeting '{targetJniName}' because {nameof (RuntimeFeature.IsAssignableFromCheck)} is disabled.";
-					Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 				}
 				return proxy;
 			} finally {

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Views/LayoutInflaterTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Android.Views/LayoutInflaterTest.cs
@@ -1,5 +1,7 @@
 using System;
 using Android.App;
+using Android.Content;
+using Android.Runtime;
 using Android.Views;
 using Microsoft.Android.Runtime;
 using NUnit.Framework;
@@ -19,5 +21,18 @@ public class LayoutInflaterTest
 		// Remapped to "net/dot/android/test/MyLayoutInflater"
 		var from = LayoutInflater.From (Application.Context);
 		Assert.IsNotNull (from);
+	}
+
+	[Test]
+	[Category ("Intune")]
+	public void FromSystemService ()
+	{
+		Console.WriteLine ($"{nameof (LayoutInflaterTest)}: RuntimeFeature.IsAssignableFromCheck={RuntimeFeature.IsAssignableFromCheck}");
+
+		var service = Application.Context.GetSystemService (Context.LayoutInflaterService);
+		Assert.IsNotNull (service);
+
+		var inflater = Java.Lang.Object.GetObject<LayoutInflater> (service.Handle, JniHandleOwnership.DoNotTransfer);
+		Assert.IsNotNull (inflater);
 	}
 }


### PR DESCRIPTION
## Summary

- Extend `Microsoft.Android.Runtime.RuntimeFeature.IsAssignableFromCheck` to CoreCLR peer creation paths in `JavaMarshalValueManager`.
- Keep the default behavior unchanged, but when `_AndroidIsAssignableFromCheck=false`, skip Java assignability checks (`IsAssignableFrom`) so peer creation can continue without running the check.
- Keep the implementation focused on specific assignability decision points (no duplicated feature-specific peer-creation flow), and use standalone `if (RuntimeFeature.IsX)` blocks for trimmer-friendly branching.
- Add coverage for wrapping a remapped `LayoutInflater` returned from `Context.LayoutInflaterService`, and add a CoreCLR Intune assignability package-test leg.

## Motivation

`dotnet/android#10475` introduced `_AndroidIsAssignableFromCheck=false` for the Mono.Android typemap path. In MAUI + Intune remapping scenarios, `LayoutInflater.From(Context)` can still return null through the CoreCLR/Java.Interop peer creation path, which performs a separate assignability check not covered by the existing switch.

This draft explores making the switch consistently mean: when explicitly disabled, Java remapping-induced assignability mismatches should not reject managed peer creation.

## Validation

- `MSBUILDDISABLENODEREUSE=1 ./dotnet-local.sh build src/Mono.Android/Mono.Android.csproj --no-restore -m:1 -v:minimal` ✅
- `./dotnet-local.sh build tests/Mono.Android-Tests/Mono.Android-Tests/Mono.Android.NET-Tests.csproj -f net11.0-android -p:TestsFlavor=CoreCLRIsAssignableFrom -p:IncludeCategories=Intune -p:_AndroidIsAssignableFromCheck=false -p:UseMonoRuntime=false -m:1 -v:minimal` ⚠️ blocked locally with `XA5300` because the Android SDK directory is not available in this environment.