### PR TITLE
Bump `$(AndroidPackVersion)` to 37.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -36,7 +36,7 @@
          * Major/Minor match Android stable API level, such as 30.0 for API 30.
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
-    <AndroidPackVersion>36.99.0</AndroidPackVersion>
+    <AndroidPackVersion>37.0.0</AndroidPackVersion>
     <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
     <!-- Final value set by GetXAVersionInfo target -->
     <IsStableBuild>false</IsStableBuild>


### PR DESCRIPTION
API-37 bindings are now stable on `main`, so move the main product version off the `36.99.x` preview placeholder introduced in #10976 and onto `37.0.x`.

Per the rules already documented in `Directory.Build.props`:

> * Major/Minor match Android stable API level, such as 30.0 for API 30.

Only `$(AndroidPackVersion)` changes here; `$(AndroidPackVersionSuffix)` (`preview.6`) is left alone since main is still on .NET 11 previews.