### PR TITLE
[tests] Use Android.Util.Log in JnienvTest.ThreadReuse callback

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -79,14 +79,23 @@ namespace Java.InteropTests
 		{
 			Java.Lang.JavaSystem.LoadLibrary ("reuse-threads");
 			CB cb = (env, instance) => {
-				Console.WriteLine ("CrossThreadObjectInteractions: JNIEnv.Handle={0} env={1}, instance={2}",
+				// NOTE: this callback runs on a raw native pthread spawned by
+				// libreuse-threads.so and attached to the JVM. NUnit 3 replaces
+				// Console.Out with a TextCapture that resolves the current
+				// TestExecutionContext on every write; from a thread NUnit doesn't
+				// know about it tries to manufacture an AdhocContext and NREs in
+				// MethodWrapper.get_Name, which SIGABRTs the entire process and
+				// causes the test host to report "0 tests ran" for the assembly.
+				// Route diagnostics through Android.Util.Log instead.
+				Android.Util.Log.Info ("ThreadReuse",
+						"CrossThreadObjectInteractions: JNIEnv.Handle={0} env={1}, instance={2}",
 						JNIEnv.Handle.ToString ("x"), env.ToString ("x"), instance.ToString ("x"));
 				if (env != JNIEnv.Handle)
-					Console.WriteLine ("GOOD: they should differ (on the second call)....");
+					Android.Util.Log.Info ("ThreadReuse", "GOOD: they should differ (on the second call)....");
 				if (instance == IntPtr.Zero)
 					return;
 				using (var o = Java.Lang.Object.GetObject<Java.Lang.Object>(env, instance, JniHandleOwnership.DoNotTransfer)) {
-					Console.WriteLine ("CrossThreadObjectInteractions: o.Handle={0}", o.Handle.ToString ("x"));
+					Android.Util.Log.Info ("ThreadReuse", "CrossThreadObjectInteractions: o.Handle={0}", o.Handle.ToString ("x"));
 				}
 			};
 			rt_invoke_callback_on_new_thread (cb);


### PR DESCRIPTION
### Context

When the `JnienvTest.ThreadReuse` callback runs on a raw native pthread spawned by `libreuse-threads.so` and attached to the JVM, calling `Console.WriteLine` is unsafe: NUnit 3 replaces `Console.Out` with a `TextCapture` that resolves the current `TestExecutionContext` on every write. From a thread NUnit doesn''t know about, it tries to manufacture an `AdhocContext` and NREs in `MethodWrapper.get_Name`, which SIGABRTs the entire process and causes the test host to report **"0 tests ran"** for the whole assembly:

```
E DOTNET: Unhandled exception. System.NullReferenceException
  at NUnit.Framework.Internal.MethodWrapper.get_Name()
  at NUnit.Framework.Internal.TestExecutionContext.AdhocContext..ctor()
  at NUnit.Framework.Internal.Execution.TextCapture.WriteLine(String)
  at System.Console.WriteLine(...)
  at Java.InteropTests.JnienvTest.<>c.<ThreadReuse>b__7_0(IntPtr, IntPtr)
F libc: Fatal signal 6 (SIGABRT) in tid 5229 (Thread-14)
```

### Fix

Route the diagnostics through `Android.Util.Log.Info` to bypass NUnit''s `Console.Out` redirect entirely. No `try`/`catch` is needed — the `Console -> Log` conversion is the actual fix.

Split out of #11224 as a small, standalone change so it can land independently.