### PR TITLE
[ci] Cache Android toolchain downloads + bump `DownloadFile` retries

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -31,6 +31,10 @@ steps:
   parameters:
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
+- template: /build-tools/automation/yaml-templates/cache-android-archives.yaml
+  parameters:
+    xaSourcePath: ${{ parameters.xaSourcePath }}
+
 - script: make jenkins PREPARE_CI=1 PREPARE_AUTOPROVISION=1 CONFIGURATION=$(XA.Build.Configuration) MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins

--- a/build-tools/automation/yaml-templates/build-macos-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-macos-steps.yaml
@@ -40,6 +40,10 @@ steps:
   parameters:
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
+- template: /build-tools/automation/yaml-templates/cache-android-archives.yaml
+  parameters:
+    xaSourcePath: ${{ parameters.xaSourcePath }}
+
 # Prepare and Build everything
 - script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 PREPARE_AUTOPROVISION=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
   workingDirectory: ${{ parameters.xaSourcePath }}

--- a/build-tools/automation/yaml-templates/build-windows-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-windows-steps.yaml
@@ -27,6 +27,10 @@ steps:
   parameters:
     xaSourcePath: $(System.DefaultWorkingDirectory)
 
+- template: /build-tools/automation/yaml-templates/cache-android-archives.yaml
+  parameters:
+    xaSourcePath: $(System.DefaultWorkingDirectory)
+
 - task: DotNetCoreCLI@2
   displayName: Prepare Solution
   retryCountOnTaskFailure: 1

--- a/build-tools/automation/yaml-templates/cache-android-archives.yaml
+++ b/build-tools/automation/yaml-templates/cache-android-archives.yaml
@@ -1,0 +1,40 @@
+# Shared Android toolchain archives cache template
+# Caches downloads under $(AndroidToolchainCacheDirectory) (default:
+# $HOME/android-archives) between pipeline runs to avoid transient
+# network failures when downloading from dl.google.com, aka.ms, and
+# github.com (binutils, bundletool).
+#
+# Cache safety: every download under this directory is verified against
+# a hardcoded SHA-256 hash by the corresponding MSBuild target (see
+# src/androidsdk/androidsdk.targets, src/openjdk/openjdk.targets,
+# src/binutils/binutils.targets, src/aapt2/aapt2.targets,
+# src/bundletool/bundletool.targets). Any stale/corrupt cached file is
+# deleted and re-downloaded.
+#
+# See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
+
+parameters:
+  xaSourcePath: $(System.DefaultWorkingDirectory)/android
+
+steps:
+- script: echo "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]$HOME/android-archives"
+  displayName: prepare android-archives cache variables
+  condition: ne(variables['Agent.OS'], 'Windows_NT')
+
+- pwsh: |
+    $dir = Join-Path $env:USERPROFILE 'android-archives'
+    Write-Host "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]$dir"
+  displayName: prepare android-archives cache variables
+  condition: eq(variables['Agent.OS'], 'Windows_NT')
+
+# Key off every file that defines what gets downloaded or its expected hash.
+# Bumping a version or hash in any of these invalidates the cache; the
+# `restoreKeys` fallback still recovers most of the previous cache when only
+# a subset changes (e.g. a single component bump).
+- task: Cache@2
+  displayName: cache Android toolchain archives
+  inputs:
+    key: '"android-archives" | "v1" | "$(Agent.OS)" | ${{ parameters.xaSourcePath }}/Configuration.props | ${{ parameters.xaSourcePath }}/src/androidsdk/androidsdk.targets | ${{ parameters.xaSourcePath }}/src/openjdk/openjdk.targets | ${{ parameters.xaSourcePath }}/src/binutils/binutils.targets | ${{ parameters.xaSourcePath }}/src/aapt2/aapt2.targets | ${{ parameters.xaSourcePath }}/src/bundletool/bundletool.targets'
+    restoreKeys: |
+      "android-archives" | "v1" | "$(Agent.OS)"
+    path: $(ANDROID_ARCHIVES_DIR)

--- a/build-tools/automation/yaml-templates/cache-android-archives.yaml
+++ b/build-tools/automation/yaml-templates/cache-android-archives.yaml
@@ -4,12 +4,15 @@
 # network failures when downloading from dl.google.com, aka.ms, and
 # github.com (binutils, bundletool).
 #
-# Cache safety: every download under this directory is verified against
-# a hardcoded SHA-256 hash by the corresponding MSBuild target (see
+# Cache safety: every download under this directory is verified after
+# extraction by the corresponding MSBuild target (see
 # src/androidsdk/androidsdk.targets, src/openjdk/openjdk.targets,
 # src/binutils/binutils.targets, src/aapt2/aapt2.targets,
-# src/bundletool/bundletool.targets). Any stale/corrupt cached file is
-# deleted and re-downloaded.
+# src/bundletool/bundletool.targets). Most targets check the downloaded
+# file's SHA-256 against a hash hardcoded in Configuration.props; openjdk
+# instead downloads Microsoft's published .sha256sum.txt and verifies
+# against that. In all cases a corrupt/stale archive is deleted, the
+# build is failed, and the next run re-downloads the file fresh.
 #
 # See: https://learn.microsoft.com/azure/devops/pipelines/release/caching
 

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -41,7 +41,8 @@
         SourceUrl="$(_AndroidRepositoryUrl)%(_BuildTools.Identity)"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="%(_BuildTools.Identity)"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <GetFileHash Files="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_ActualHash" />

--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -287,7 +287,8 @@
         SourceUrl="$(_AndroidRepositoryUrl)%(_AndroidSdkPackage.Url)"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="%(_AndroidSdkPackage.Identity)"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <GetFileHash Files="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_ActualHash" />

--- a/src/binutils/binutils.targets
+++ b/src/binutils/binutils.targets
@@ -17,7 +17,8 @@
         SourceUrl="$(_BinutilsArchiveUrl)"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="xamarin-android-toolchain-$(XABinutilsVersion).7z"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <GetFileHash Files="$(_BinutilsArchive)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_BinutilsActualHash" />

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -14,7 +14,8 @@
         SourceUrl="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="bundletool-all-$(XABundleToolVersion).jar"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <GetFileHash Files="$(_BundleToolDownloadLocation)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_BundleToolActualHash" />

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -20,6 +20,10 @@
     <GetFileHash Files="$(_BundleToolDownloadLocation)" Algorithm="SHA256">
       <Output TaskParameter="Hash" PropertyName="_BundleToolActualHash" />
     </GetFileHash>
+    <Delete
+        Condition=" '$(_BundleToolActualHash)' != '$(XABundleToolHash)' "
+        Files="$(_BundleToolDownloadLocation)"
+    />
     <Error
         Condition=" '$(_BundleToolActualHash)' != '$(XABundleToolHash)' "
         Text="SHA256 mismatch for bundletool-all-$(XABundleToolVersion).jar. Expected: $(XABundleToolHash) Actual: $(_BundleToolActualHash)"

--- a/src/openjdk/openjdk.targets
+++ b/src/openjdk/openjdk.targets
@@ -41,7 +41,8 @@
         SourceUrl="$(_OpenJDKArchiveUrl)"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="$(_OpenJDKFileName)"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <!-- Download the SHA-256 hash file from Microsoft and parse the expected hash.
          File format: "6ecfa864...  microsoft-jdk-21.0.8-windows-x64.zip" -->
@@ -49,7 +50,8 @@
         SourceUrl="$(_OpenJDKHashUrl)"
         DestinationFolder="$(AndroidToolchainCacheDirectory)"
         DestinationFileName="$(_OpenJDKHashFileName)"
-        Retries="3"
+        Retries="5"
+        RetryDelayMilliseconds="5000"
     />
     <PropertyGroup>
       <_OpenJDKExpectedHash>$([System.IO.File]::ReadAllText('$(_OpenJDKHashFile)').Substring(0, 64).ToUpperInvariant())</_OpenJDKExpectedHash>


### PR DESCRIPTION
## Context

PR builds frequently fail on `dl.google.com` DNS / TCP errors during the initial download of the Android toolchain (commandlinetools, build-tools, emulator, system images, m2repository, docs, source, etc.) on dnceng-public agents. Example from a recent build:

```
error MSB3923: Failed to download file
"https://dl.google.com/android/repository/source-36_r01.zip".
nodename nor servname provided, or not known (dl.google.com:443)
```

This costs the entire ~4 hour pipeline run for one transient DNS hiccup.

## Changes

### 1. Cache `$(AndroidToolchainCacheDirectory)` between runs

New `build-tools/automation/yaml-templates/cache-android-archives.yaml` template, modeled exactly on the existing `cache-gradle.yaml`. Wired into all three of `build-{linux,macos,windows}-steps.yaml` right next to the existing Gradle cache step.

**Cache safety.** Every download under `$HOME/android-archives` is verified after download by the corresponding MSBuild target (`androidsdk` / `openjdk` / `binutils` / `aapt2` / `bundletool`). Most targets check the downloaded file's SHA-256 against a hash hardcoded in `Configuration.props`; `openjdk` instead verifies against Microsoft's published `.sha256sum.txt`. In all cases a corrupt or stale archive is deleted, the build is failed, and the next run re-downloads it fresh — so cache hits cannot mask a version bump.

**Cache key:** `Configuration.props` + each download `*.targets` file. Any version or hash change invalidates the cache. The `restoreKeys` fallback (`Agent.OS` only) still recovers most bytes when only a subset of components changes.

**Cache size.** ~2 GB physical / ~10.7 GB raw per OS, comfortably within Azure Pipelines' per-key limit.

### 2. Bump `DownloadFile` retries

`Retries="3"` → `Retries="5"` and added `RetryDelayMilliseconds="5000"` on every `DownloadFile` invocation. This helps the first (cold-cache) and scheduled runs — which are responsible for warming the shared cache — better tolerate transient flakes on `dl.google.com` / `aka.ms` / `github.com`.

### 3. Delete corrupt `bundletool.jar` on SHA-256 mismatch

`bundletool.targets` previously errored on hash mismatch but left the corrupt jar in place. With the new pipeline cache, that bad jar could be persisted and repeatedly break future builds. Now matches the pattern used in `androidsdk`/`binutils`/`aapt2`/`openjdk`.

## Verification — what we actually save

Measured against build [#1456864](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1456864) (first run with the cache, so all three OSes are a **cache miss** — they still downloaded everything; the cache **save** for the *next* build is what completed successfully):

| Job | Cache step (miss) | What actually got downloaded | Time the cache will save on hit |
|-----|---|---|---|
| **Linux > Build** | ✅ 5s — miss | ~2 GB SDK fresh (`00:37:00` → `00:38:33`) | **~1.5 min per build** |
| **macOS > Build** | ✅ 54s — miss | Nothing — agent already had every archive on disk ("Did not download file … `SkipUnchangedFiles=true`") | ~0 (agents persist `$HOME`) |
| **Windows > Build & Smoke Test** | ✅ 1s — miss | Only JDK (~200 MB, a few seconds); SDK comes from agent image | ~0 |

So the wall-clock savings are modest: **~1.5–2 min per Linux build on a cache hit, near-zero on macOS / Windows.**

The bigger value of this PR is **reliability**, not throughput. dnceng-public Linux agents are ephemeral and download ~2 GB from `dl.google.com` on every build today. The previous motivating failure (build [#1456555](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1456555)) lost a 4-hour run to a single DNS resolution error on one of those downloads. Cache hits avoid the request entirely; the bumped retries help the cold-cache and scheduled runs that have to repopulate the cache.