### PR TITLE
Address build log warnings

### DIFF
--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -521,9 +521,7 @@ namespace Xamarin.Android.JniEnv
 		public ParamInfo [] Parameters;
 
 		// If true, then we initialize the binding on the static ctor, we dont lazy-define it
-#pragma warning disable CS0649 // Field 'JniFunction.Prebind' is never assigned to, and will always have its default value false
-		public bool Prebind;
-#pragma warning restore CS0649
+		public bool Prebind = false;
 
 		// If there is a custom wrapper in JNIEnv (so an automatic one shouldn't be generated)
 		public bool CustomWrapper;

--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -521,7 +521,9 @@ namespace Xamarin.Android.JniEnv
 		public ParamInfo [] Parameters;
 
 		// If true, then we initialize the binding on the static ctor, we dont lazy-define it
+#pragma warning disable CS0649 // Field 'JniFunction.Prebind' is never assigned to, and will always have its default value false
 		public bool Prebind;
+#pragma warning restore CS0649
 
 		// If there is a custom wrapper in JNIEnv (so an automatic one shouldn't be generated)
 		public bool CustomWrapper;

--- a/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
+++ b/src/Microsoft.Android.Runtime.NativeAOT/Microsoft.Android.Runtime.NativeAOT.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="..\Mono.Android\Microsoft.Android.Runtime\RuntimeFeature.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\external\Java.Interop\src\Java.Interop\Java.Interop.csproj" />
     <ProjectReference Include="..\Mono.Android\Mono.Android.csproj" />
   </ItemGroup>

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -124,7 +124,7 @@ namespace Android.Runtime {
 		{
 			var r = base.CreateLocalReference (value, ref localReferenceCount);
 
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogLocalRef) {
 					var tname = Thread.CurrentThread.Name;
 					var tid   = Thread.CurrentThread.ManagedThreadId;
@@ -138,7 +138,7 @@ namespace Android.Runtime {
 
 		public override void DeleteLocalReference (ref JniObjectReference value, ref int localReferenceCount)
 		{
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogLocalRef) {
 					var tname = Thread.CurrentThread.Name;
 					var tid   = Thread.CurrentThread.ManagedThreadId;
@@ -152,7 +152,7 @@ namespace Android.Runtime {
 		public override void CreatedLocalReference (JniObjectReference value, ref int localReferenceCount)
 		{
 			base.CreatedLocalReference (value, ref localReferenceCount);
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogLocalRef) {
 					var tname = Thread.CurrentThread.Name;
 					var tid   = Thread.CurrentThread.ManagedThreadId;
@@ -165,7 +165,7 @@ namespace Android.Runtime {
 		public override IntPtr ReleaseLocalReference (ref JniObjectReference value, ref int localReferenceCount)
 		{
 			var r = base.ReleaseLocalReference (ref value, ref localReferenceCount);
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogLocalRef) {
 					var tname = Thread.CurrentThread.Name;
 					var tid   = Thread.CurrentThread.ManagedThreadId;
@@ -181,7 +181,7 @@ namespace Android.Runtime {
 
 		public override void WriteLocalReferenceLine (string format, params object?[] args)
 		{
-			if (!RuntimeFeature.ObjectReferenceLogging) {
+			if (!AndroidRuntimeFeature.ObjectReferenceLogging) {
 				return;
 			}
 			if (!Logger.LogLocalRef) {
@@ -194,7 +194,7 @@ namespace Android.Runtime {
 
 		public override void WriteGlobalReferenceLine (string format, params object?[] args)
 		{
-			if (!RuntimeFeature.ObjectReferenceLogging) {
+			if (!AndroidRuntimeFeature.ObjectReferenceLogging) {
 				return;
 			}
 			if (!Logger.LogGlobalRef) {
@@ -210,7 +210,7 @@ namespace Android.Runtime {
 			var r = base.CreateGlobalReference (value);
 
 			int gc;
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogGlobalRef) {
 					var ctype = GetObjectRefType (value.Type);
 					var ntype = GetObjectRefType (r.Type);
@@ -249,7 +249,7 @@ namespace Android.Runtime {
 
 		public override void DeleteGlobalReference (ref JniObjectReference value)
 		{
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogGlobalRef) {
 					var ctype = GetObjectRefType (value.Type);
 					var tname = Thread.CurrentThread.Name;
@@ -270,7 +270,7 @@ namespace Android.Runtime {
 		{
 			var r = base.CreateWeakGlobalReference (value);
 
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogGlobalRef) {
 					var ctype = GetObjectRefType (value.Type);
 					var ntype = GetObjectRefType (r.Type);
@@ -290,7 +290,7 @@ namespace Android.Runtime {
 
 		public override void DeleteWeakGlobalReference (ref JniObjectReference value)
 		{
-			if (RuntimeFeature.ObjectReferenceLogging) {
+			if (AndroidRuntimeFeature.ObjectReferenceLogging) {
 				if (Logger.LogGlobalRef) {
 					var ctype = GetObjectRefType (value.Type);
 					var tname = Thread.CurrentThread.Name;

--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
-using System.Runtime.CompilerServices;
-using System.Runtime.Versioning;
 using System.Threading;
 using System.Reflection;
 
@@ -868,7 +866,7 @@ namespace Android.Runtime {
 							value.GetType ().ToString (),
 							value.PeerReference.ToString (),
 							value.JniIdentityHashCode,
-							RuntimeHelpers.GetHashCode (value)));
+							System.Runtime.CompilerServices.RuntimeHelpers.GetHashCode (value)));
 			}
 
 			// FIXME: need hash cleanup mechanism.

--- a/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntimeInternal.cs
@@ -15,11 +15,11 @@ namespace Android.Runtime
 
 		static AndroidRuntimeInternal ()
 		{
-			if (RuntimeFeature.IsMonoRuntime) {
+			if (AndroidRuntimeFeature.IsMonoRuntime) {
 				mono_unhandled_exception = MonoUnhandledException;
-			} else if (RuntimeFeature.IsCoreClrRuntime) {
+			} else if (AndroidRuntimeFeature.IsCoreClrRuntime) {
 				mono_unhandled_exception = CoreClrUnhandledException;
-			} else if (RuntimeFeature.IsNativeAotRuntime) {
+			} else if (AndroidRuntimeFeature.IsNativeAotRuntime) {
 				mono_unhandled_exception = CoreClrUnhandledException;
 			} else {
 				throw new NotSupportedException ("Internal error: unknown runtime not supported");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -26,7 +26,7 @@ namespace Android.Runtime {
 
 		static Array ArrayCreateInstance (Type elementType, int length)
 		{
-			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
 					// CoreCLR runtime type loader can construct any T[] dynamically.
 					// IsDynamicCodeSupported is a [FeatureGuard] so this branch is
@@ -134,11 +134,11 @@ namespace Android.Runtime {
 				Logger.Log (LogLevel.Info, "MonoDroid", "UNHANDLED EXCEPTION:");
 				Logger.Log (LogLevel.Info, "MonoDroid", javaException.ToString ());
 
-				if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
+				if (AndroidRuntimeFeature.IsMonoRuntime) {
 					MonoDroidUnhandledException (innerException ?? javaException);
-				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
+				} else if (AndroidRuntimeFeature.IsCoreClrRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
-				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsNativeAotRuntime) {
+				} else if (AndroidRuntimeFeature.IsNativeAotRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -471,7 +471,7 @@ namespace Android.Runtime {
 
 		internal static unsafe string? TypemapManagedToJava (Type type)
 		{
-			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				// The trimmable typemap doesn't use the native typemap tables.
 				// Delegate to the managed TrimmableTypeMap instead.
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
@@ -491,9 +491,9 @@ namespace Android.Runtime {
 
 			IntPtr ret;
 			fixed (byte* mvidptr = mvid_data) {
-				if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
+				if (AndroidRuntimeFeature.IsMonoRuntime) {
 					ret = monovm_typemap_managed_to_java (type, mvidptr);
-				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
+				} else if (AndroidRuntimeFeature.IsCoreClrRuntime) {
 					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -26,7 +26,7 @@ namespace Android.Runtime {
 
 		static Array ArrayCreateInstance (Type elementType, int length)
 		{
-			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
 				if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
 					// CoreCLR runtime type loader can construct any T[] dynamically.
 					// IsDynamicCodeSupported is a [FeatureGuard] so this branch is
@@ -134,11 +134,11 @@ namespace Android.Runtime {
 				Logger.Log (LogLevel.Info, "MonoDroid", "UNHANDLED EXCEPTION:");
 				Logger.Log (LogLevel.Info, "MonoDroid", javaException.ToString ());
 
-				if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
+				if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
 					MonoDroidUnhandledException (innerException ?? javaException);
-				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
+				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
-				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsNativeAotRuntime) {
+				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsNativeAotRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -471,7 +471,7 @@ namespace Android.Runtime {
 
 		internal static unsafe string? TypemapManagedToJava (Type type)
 		{
-			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
 				// The trimmable typemap doesn't use the native typemap tables.
 				// Delegate to the managed TrimmableTypeMap instead.
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
@@ -491,9 +491,9 @@ namespace Android.Runtime {
 
 			IntPtr ret;
 			fixed (byte* mvidptr = mvid_data) {
-				if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
+				if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
 					ret = monovm_typemap_managed_to_java (type, mvidptr);
-				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
+				} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
 					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -26,7 +26,7 @@ namespace Android.Runtime {
 
 		static Array ArrayCreateInstance (Type elementType, int length)
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
 				if (System.Runtime.CompilerServices.RuntimeFeature.IsDynamicCodeSupported) {
 					// CoreCLR runtime type loader can construct any T[] dynamically.
 					// IsDynamicCodeSupported is a [FeatureGuard] so this branch is
@@ -134,11 +134,11 @@ namespace Android.Runtime {
 				Logger.Log (LogLevel.Info, "MonoDroid", "UNHANDLED EXCEPTION:");
 				Logger.Log (LogLevel.Info, "MonoDroid", javaException.ToString ());
 
-				if (RuntimeFeature.IsMonoRuntime) {
+				if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
 					MonoDroidUnhandledException (innerException ?? javaException);
-				} else if (RuntimeFeature.IsCoreClrRuntime) {
+				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
-				} else if (RuntimeFeature.IsNativeAotRuntime) {
+				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsNativeAotRuntime) {
 					ExceptionHandling.RaiseAppDomainUnhandledExceptionEvent (innerException ?? javaException);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -441,7 +441,7 @@ namespace Android.Runtime {
 				return NewObject (jclass, jmethod, p);
 		}
 
-		public static string GetClassNameFromInstance (IntPtr jobject)
+		public static string? GetClassNameFromInstance (IntPtr jobject)
 		{
 			return JniEnvironment.Types.GetJniTypeNameFromInstance (new JniObjectReference (jobject));
 		}
@@ -471,7 +471,7 @@ namespace Android.Runtime {
 
 		internal static unsafe string? TypemapManagedToJava (Type type)
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
 				// The trimmable typemap doesn't use the native typemap tables.
 				// Delegate to the managed TrimmableTypeMap instead.
 				return TrimmableTypeMap.Instance.TryGetJniNameForManagedType (type, out var jniName) ? jniName : null;
@@ -491,9 +491,9 @@ namespace Android.Runtime {
 
 			IntPtr ret;
 			fixed (byte* mvidptr = mvid_data) {
-				if (RuntimeFeature.IsMonoRuntime) {
+				if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
 					ret = monovm_typemap_managed_to_java (type, mvidptr);
-				} else if (RuntimeFeature.IsCoreClrRuntime) {
+				} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
 					ret = RuntimeNativeMethods.clr_typemap_managed_to_java (type.FullName, (IntPtr)mvidptr);
 				} else {
 					throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -696,7 +696,7 @@ namespace Android.Runtime {
 					// FIXME: Since a Dictionary<Type, Func> is used here, the trimmer will not be able to properly analyze `Type t`
 					// error IL2111: Method 'lambda expression' with parameters or return value with `DynamicallyAccessedMembersAttribute` is accessed via reflection. Trimmer can't guarantee availability of the requirements of the method.
 					[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "FIXME: https://github.com/xamarin/xamarin-android/issues/8724")]
-					static object? GetObject (IntPtr e, Type t) =>
+					static object? GetObject (IntPtr e, Type? t) =>
 						Java.Lang.Object.GetObject (e, JniHandleOwnership.TransferLocalRef, t);
 				} },
 				{ typeof (Array), (type, source, index) => {
@@ -718,7 +718,7 @@ namespace Android.Runtime {
 			}
 
 			if (array != IntPtr.Zero) {
-				string type = GetClassNameFromInstance (array);
+				string? type = GetClassNameFromInstance (array);
 				if (type == null || type.Length < 1 || type [0] != '[')
 					throw new InvalidOperationException ("Unsupported java array type: " + type);
 

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -9,7 +9,6 @@ using Java.Interop;
 using Java.Interop.Tools.TypeNameMappings;
 
 using Microsoft.Android.Runtime;
-using RuntimeFeature = Microsoft.Android.Runtime.AndroidRuntimeFeature;
 
 namespace Android.Runtime
 {
@@ -108,10 +107,10 @@ namespace Android.Runtime
 		// Only used for NativeAOT after the runtime has been created. MonoVM and CoreCLR use Initialize().
 		internal static void InitializeNativeAotRuntime (JniRuntime runtime, JnienvInitializeArgs args)
 		{
-			if (!RuntimeFeature.IsNativeAotRuntime) {
+			if (!AndroidRuntimeFeature.IsNativeAotRuntime) {
 				throw new NotSupportedException ("JNIEnvInit.InitializeNativeAotRuntime can only be used to initialize NativeAOT.");
 			}
-			if (RuntimeFeature.IsMonoRuntime || RuntimeFeature.IsCoreClrRuntime) {
+			if (AndroidRuntimeFeature.IsMonoRuntime || AndroidRuntimeFeature.IsCoreClrRuntime) {
 				throw new NotSupportedException ("Internal error: NativeAOT cannot be enabled with MonoVM or CoreCLR.");
 			}
 
@@ -125,10 +124,10 @@ namespace Android.Runtime
 		[UnmanagedCallersOnly]
 		internal static unsafe void Initialize (JnienvInitializeArgs* args)
 		{
-			if (RuntimeFeature.IsNativeAotRuntime) {
+			if (AndroidRuntimeFeature.IsNativeAotRuntime) {
 				throw new NotSupportedException ("JNIEnvInit.Initialize cannot be used to initialize NativeAOT.");
 			}
-			if (RuntimeFeature.IsMonoRuntime == RuntimeFeature.IsCoreClrRuntime) {
+			if (AndroidRuntimeFeature.IsMonoRuntime == AndroidRuntimeFeature.IsCoreClrRuntime) {
 				throw new NotSupportedException ("Internal error: exactly one of AndroidRuntimeFeature.IsMonoRuntime or AndroidRuntimeFeature.IsCoreClrRuntime must be enabled.");
 			}
 
@@ -157,7 +156,7 @@ namespace Android.Runtime
 
 			args->propagateUncaughtExceptionFn = (IntPtr)(delegate* unmanaged<IntPtr, IntPtr, IntPtr, void>)&PropagateUncaughtException;
 
-			if (!RuntimeFeature.TrimmableTypeMap) {
+			if (!AndroidRuntimeFeature.TrimmableTypeMap) {
 				args->registerJniNativesFn = (IntPtr)(delegate* unmanaged<IntPtr, int, IntPtr, IntPtr, int, void>)&RegisterJniNatives;
 			}
 			RunStartupHooksIfNeeded ();
@@ -170,11 +169,11 @@ namespace Android.Runtime
 
 		internal static JniRuntime.JniTypeManager CreateTypeManager (JnienvInitializeArgs args)
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				return new TrimmableTypeMapTypeManager ();
 			}
 
-			if (RuntimeFeature.IsNativeAotRuntime || RuntimeFeature.ManagedTypeMap) {
+			if (AndroidRuntimeFeature.IsNativeAotRuntime || AndroidRuntimeFeature.ManagedTypeMap) {
 				return new ManagedTypeManager ();
 			}
 
@@ -183,15 +182,15 @@ namespace Android.Runtime
 
 		internal static JniRuntime.JniValueManager CreateValueManager ()
 		{
-			if (RuntimeFeature.IsMonoRuntime) {
+			if (AndroidRuntimeFeature.IsMonoRuntime) {
 				return new AndroidValueManager ();
 			}
 
-			if (RuntimeFeature.IsCoreClrRuntime) {
+			if (AndroidRuntimeFeature.IsCoreClrRuntime) {
 				return new JavaMarshalValueManager ();
 			}
 
-			if (RuntimeFeature.IsNativeAotRuntime) {
+			if (AndroidRuntimeFeature.IsNativeAotRuntime) {
 				return new JavaMarshalValueManager ();
 			}
 
@@ -217,14 +216,14 @@ namespace Android.Runtime
 
 		static void InitializeTrimmableTypeMapDataIfNeeded ()
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				InitializeTrimmableTypeMapData ();
 			}
 		}
 
 		static void RegisterTrimmableTypeMapNativeMethodsIfNeeded ()
 		{
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				// TypeMapLoader.Initialize() only loads managed typemap data. Registering
 				// mono.android.Runtime natives requires JniRuntime.Current and its ClassLoader.
 				TrimmableTypeMap.RegisterNativeMethods ();
@@ -242,9 +241,9 @@ namespace Android.Runtime
 		static void RunStartupHooksIfNeeded ()
 		{
 			// Return if startup hooks are disabled or not CoreCLR
-			if (!RuntimeFeature.IsCoreClrRuntime)
+			if (!AndroidRuntimeFeature.IsCoreClrRuntime)
 				return;
-			if (!RuntimeFeature.StartupHookSupport)
+			if (!AndroidRuntimeFeature.StartupHookSupport)
 				return;
 
 			RunStartupHooks ();

--- a/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnvInit.cs
@@ -9,7 +9,7 @@ using Java.Interop;
 using Java.Interop.Tools.TypeNameMappings;
 
 using Microsoft.Android.Runtime;
-using RuntimeFeature = Microsoft.Android.Runtime.RuntimeFeature;
+using RuntimeFeature = Microsoft.Android.Runtime.AndroidRuntimeFeature;
 
 namespace Android.Runtime
 {
@@ -129,7 +129,7 @@ namespace Android.Runtime
 				throw new NotSupportedException ("JNIEnvInit.Initialize cannot be used to initialize NativeAOT.");
 			}
 			if (RuntimeFeature.IsMonoRuntime == RuntimeFeature.IsCoreClrRuntime) {
-				throw new NotSupportedException ("Internal error: exactly one of RuntimeFeature.IsMonoRuntime or RuntimeFeature.IsCoreClrRuntime must be enabled.");
+				throw new NotSupportedException ("Internal error: exactly one of AndroidRuntimeFeature.IsMonoRuntime or AndroidRuntimeFeature.IsCoreClrRuntime must be enabled.");
 			}
 
 			IntPtr total_timing_sequence = IntPtr.Zero;

--- a/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
+++ b/src/Mono.Android/Android.Runtime/RuntimeNativeMethods.cs
@@ -115,7 +115,7 @@ namespace Android.Runtime
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]
-		internal static partial IntPtr clr_typemap_managed_to_java (string fullName, IntPtr mvid);
+		internal static partial IntPtr clr_typemap_managed_to_java (string? fullName, IntPtr mvid);
 
 		[LibraryImport (RuntimeConstants.InternalDllName, StringMarshalling = StringMarshalling.Utf8)]
 		[UnmanagedCallConv (CallConvs = new[] { typeof (CallConvCdecl) })]

--- a/src/Mono.Android/Java.Interop/JavaConvert.cs
+++ b/src/Mono.Android/Java.Interop/JavaConvert.cs
@@ -81,7 +81,7 @@ namespace Java.Interop {
 			if (target.IsArray)
 				return (h, t) => JNIEnv.GetArray (h, t, target.GetElementType ());
 
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				var factoryConverter = TryGetFactoryBasedConverter (target);
 				if (factoryConverter != null)
 					return factoryConverter;
@@ -148,7 +148,7 @@ namespace Java.Interop {
 			if (!typeof (IJavaPeerable).IsAssignableFrom (elementType))
 				return null;
 
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				return TrimmableTypeMap.Instance?.GetContainerFactory (elementType);
 			}
 
@@ -198,7 +198,7 @@ namespace Java.Interop {
 					return JNIEnv.GetArray (handle, transfer, elementType.GetElementType ());
 
 				if (elementType != null && typeof (IJavaPeerable).IsAssignableFrom (elementType)) {
-					if (RuntimeFeature.TrimmableTypeMap)
+					if (AndroidRuntimeFeature.TrimmableTypeMap)
 						return FromJniHandleWithTrimmableTypeMapping (handle, transfer, elementType);
 					return Java.Lang.Object.GetObject (handle, transfer, elementType);
 				}

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
-using Java.Interop.Tools.TypeNameMappings;
 
 using Android.Runtime;
 using Microsoft.Android.Runtime;
@@ -238,7 +236,11 @@ namespace Java.Interop {
 				return null;
 			}
 
-			string managedAssemblyName = Marshal.PtrToStringAnsi (managedAssemblyNamePointer);
+			string? managedAssemblyName = Marshal.PtrToStringAnsi (managedAssemblyNamePointer);
+			if (string.IsNullOrEmpty (managedAssemblyName)) {
+				return null;
+			}
+
 			Assembly assembly = Assembly.Load (managedAssemblyName);
 			Type? ret = null;
 			foreach (Module module in assembly.Modules) {
@@ -262,20 +264,20 @@ namespace Java.Interop {
 			}
 		}
 
-		static Type? GetJavaToManagedTypeCore (string class_name)
+		static Type? GetJavaToManagedTypeCore (string? class_name)
 		{
-			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
+			if (class_name is not null && TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
 				return type;
 			}
 
-			if (RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
 				throw new System.Diagnostics.UnreachableException (
 					$"{nameof (TypeManager)}.{nameof (GetJavaToManagedTypeCore)} should not be used when " +
-					$"{nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
+					$"{nameof (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
 					$"types through {nameof (TrimmableTypeMapTypeManager)}.");
-			} else if (RuntimeFeature.IsMonoRuntime) {
+			} else if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
 				type = monovm_typemap_java_to_managed (class_name);
-			} else if (RuntimeFeature.IsCoreClrRuntime) {
+			} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
 				type = clr_typemap_java_to_managed (class_name);
 			} else {
 				throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -370,7 +372,7 @@ namespace Java.Interop {
 						var message = $"Handle 0x{handle:x} is of type '{JNIEnv.GetClassNameFromInstance (handle)}' which is not assignable to '{typeSig.SimpleReference}'";
 						Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 					}
-					if (RuntimeFeature.IsAssignableFromCheck) {
+					if (Microsoft.Android.Runtime.RuntimeFeature.IsAssignableFromCheck) {
 						return null;
 					}
 				}

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -274,14 +274,14 @@ namespace Java.Interop {
 				return type;
 			}
 
-			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
+			if (AndroidRuntimeFeature.TrimmableTypeMap) {
 				throw new System.Diagnostics.UnreachableException (
 					$"{nameof (TypeManager)}.{nameof (GetJavaToManagedTypeCore)} should not be used when " +
-					$"{nameof (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
+					$"{nameof (AndroidRuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
 					$"types through {nameof (TrimmableTypeMapTypeManager)}.");
-			} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
+			} else if (AndroidRuntimeFeature.IsMonoRuntime) {
 				type = monovm_typemap_java_to_managed (class_name);
-			} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
+			} else if (AndroidRuntimeFeature.IsCoreClrRuntime) {
 				type = clr_typemap_java_to_managed (class_name);
 			} else {
 				throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -376,7 +376,7 @@ namespace Java.Interop {
 						var message = $"Handle 0x{handle:x} is of type '{JNIEnv.GetClassNameFromInstance (handle)}' which is not assignable to '{typeSig.SimpleReference}'";
 						Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 					}
-					if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsAssignableFromCheck) {
+					if (AndroidRuntimeFeature.IsAssignableFromCheck) {
 						return null;
 					}
 				}

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -274,14 +274,14 @@ namespace Java.Interop {
 				return type;
 			}
 
-			if (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap) {
+			if (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap) {
 				throw new System.Diagnostics.UnreachableException (
 					$"{nameof (TypeManager)}.{nameof (GetJavaToManagedTypeCore)} should not be used when " +
-					$"{nameof (Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
+					$"{nameof (Microsoft.Android.Runtime.AndroidRuntimeFeature.TrimmableTypeMap)} is enabled. The trimmable path should resolve " +
 					$"types through {nameof (TrimmableTypeMapTypeManager)}.");
-			} else if (Microsoft.Android.Runtime.RuntimeFeature.IsMonoRuntime) {
+			} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsMonoRuntime) {
 				type = monovm_typemap_java_to_managed (class_name);
-			} else if (Microsoft.Android.Runtime.RuntimeFeature.IsCoreClrRuntime) {
+			} else if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsCoreClrRuntime) {
 				type = clr_typemap_java_to_managed (class_name);
 			} else {
 				throw new NotSupportedException ("Internal error: unknown runtime not supported");
@@ -376,7 +376,7 @@ namespace Java.Interop {
 						var message = $"Handle 0x{handle:x} is of type '{JNIEnv.GetClassNameFromInstance (handle)}' which is not assignable to '{typeSig.SimpleReference}'";
 						Logger.Log (LogLevel.Debug, "monodroid-assembly", message);
 					}
-					if (Microsoft.Android.Runtime.RuntimeFeature.IsAssignableFromCheck) {
+					if (Microsoft.Android.Runtime.AndroidRuntimeFeature.IsAssignableFromCheck) {
 						return null;
 					}
 				}

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -266,7 +266,11 @@ namespace Java.Interop {
 
 		static Type? GetJavaToManagedTypeCore (string? class_name)
 		{
-			if (class_name is not null && TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
+			if (class_name is null) {
+				return null;
+			}
+
+			if (TypeManagerMapDictionaries.JniToManaged.TryGetValue (class_name, out Type? type)) {
 				return type;
 			}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/JavaMarshalValueManager.cs
@@ -244,7 +244,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 	public override void ActivatePeer (JniObjectReference reference, [DynamicallyAccessedMembers (Constructors)] Type type, ConstructorInfo cinfo, object?[]? argumentValues)
 	{
-		if (RuntimeFeature.TrimmableTypeMap)
+		if (AndroidRuntimeFeature.TrimmableTypeMap)
 			throw new PlatformNotSupportedException ("Activating Java peers is not supported when TrimmableTypeMap is enabled.");
 
 		base.ActivatePeer (reference, type, cinfo, argumentValues);
@@ -500,7 +500,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 			return null;
 		}
 
-		if (RuntimeFeature.TrimmableTypeMap) {
+		if (AndroidRuntimeFeature.TrimmableTypeMap) {
 			try {
 				// Mirror legacy GetPeerType: callers commonly request universal
 				// interfaces / boxes (IJavaPeerable, object, Exception) — map these
@@ -533,7 +533,7 @@ class JavaMarshalValueManager : JniRuntime.JniValueManager
 
 				throw new NotSupportedException (
 					$"No generated {nameof (JavaPeerProxy)} was found for Java type '{javaType}' " +
-					$"with targetType '{targetName}' while {nameof (RuntimeFeature.TrimmableTypeMap)} is enabled. " +
+					$"with targetType '{targetName}' while {nameof (AndroidRuntimeFeature.TrimmableTypeMap)} is enabled. " +
 					$"This indicates a missing trimmable typemap proxy or association and should be fixed in the generator.");
 			} finally {
 				JniObjectReference.Dispose (ref reference, transfer);

--- a/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/RuntimeFeature.cs
@@ -3,7 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.Android.Runtime;
 
-static class RuntimeFeature
+static class AndroidRuntimeFeature
 {
 	const bool ManagedTypeMapEnabledByDefault = false;
 	const bool IsMonoRuntimeEnabledByDefault = true;

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -27,7 +27,7 @@ public class TrimmableTypeMap
 
 	internal static TrimmableTypeMap Instance =>
 		s_instance ?? throw new InvalidOperationException (
-			"TrimmableTypeMap has not been initialized. Ensure RuntimeFeature.TrimmableTypeMap is enabled and the JNI runtime is initialized.");
+			"TrimmableTypeMap has not been initialized. Ensure AndroidRuntimeFeature.TrimmableTypeMap is enabled and the JNI runtime is initialized.");
 
 	readonly ITypeMap _typeMap;
 	readonly ConcurrentDictionary<Type, JavaPeerProxy> _proxyCache = new ();
@@ -138,7 +138,7 @@ public class TrimmableTypeMap
 
 			if (s_instance is null) {
 				throw new InvalidOperationException (
-					"TrimmableTypeMap has not been initialized. Ensure RuntimeFeature.TrimmableTypeMap is enabled and the JNI runtime is initialized.");
+					"TrimmableTypeMap has not been initialized. Ensure AndroidRuntimeFeature.TrimmableTypeMap is enabled and the JNI runtime is initialized.");
 			}
 
 			using var runtimeClass = new JniType ("mono/android/Runtime"u8);

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -366,7 +366,6 @@
     <Compile Include="Microsoft.Android.Runtime\ManagedTypeManager.cs" />
     <Compile Include="Microsoft.Android.Runtime\ManagedTypeMapping.cs" />
     <Compile Include="Microsoft.Android.Runtime\JavaMarshalValueManager.cs" />
-    <Compile Include="Microsoft.Android.Runtime\RuntimeFeature.cs" />
     <Compile Include="Microsoft.Android.Runtime\SimpleValueManager.cs" />
     <Compile Include="Microsoft.Android.Runtime\SingleUniverseTypeMap.cs" />
     <Compile Include="Microsoft.Android.Runtime\TrimmableTypeMap.cs" />

--- a/src/Mono.Android/Mono.Android.csproj
+++ b/src/Mono.Android/Mono.Android.csproj
@@ -366,6 +366,7 @@
     <Compile Include="Microsoft.Android.Runtime\ManagedTypeManager.cs" />
     <Compile Include="Microsoft.Android.Runtime\ManagedTypeMapping.cs" />
     <Compile Include="Microsoft.Android.Runtime\JavaMarshalValueManager.cs" />
+    <Compile Include="Microsoft.Android.Runtime\RuntimeFeature.cs" />
     <Compile Include="Microsoft.Android.Runtime\SimpleValueManager.cs" />
     <Compile Include="Microsoft.Android.Runtime\SingleUniverseTypeMap.cs" />
     <Compile Include="Microsoft.Android.Runtime\TrimmableTypeMap.cs" />

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Globalization;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -16,7 +16,9 @@ namespace Xamarin.ProjectTools
 		static string GetPathFromRegistry (string valueName)
 		{
 			if (TestEnvironment.IsWindows) {
+#pragma warning disable CA1416 // This call site is reachable on all platforms. 'Registry.GetValue(string, string?, object?)' is only supported on: 'windows'.
 				return (string) Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android", valueName, null);
+#pragma warning restore CA1416
 			}
 			return null;
 		}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Xamarin.ProjectTools
 {
@@ -20,6 +20,7 @@ namespace Xamarin.ProjectTools
 			Projects = new List<XamarinProject> ();
 		}
 
+		[MemberNotNull(nameof(SolutionPath))]
 		public void Save ()
 		{
 			ArgumentNullException.ThrowIfNull (SolutionPath);

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK.csproj
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\Configuration.props" />
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <NoWarn>$(NoWarn);CA1305;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/AndroidSDKInstaller.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/AndroidSDKInstaller.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="googleAddonsListURL">Google repository only: URL of the addon manifest (optional)</param>
 		/// <param name="googleRepositoryBaseURL">Google repository only: base URL of the repository</param>
 		/// <param name="useManifestCaching">If <c>true</c>, load local manifest when offline</param>
+		/// <param name="licensesStorage">Custom licenses storage (optional)</param>
 		public AndroidSDKInstaller (IHelpers helpers, AndroidManifestType manifestType = AndroidManifestType.Xamarin, Uri manifestURL = null, Uri googleAddonsListURL = null, Uri googleRepositoryBaseURL = null, bool useManifestCaching = false, ILicensesStorage licensesStorage = null)
 		{
 			CommonUtilities.Helpers = helpers ?? new Helper();
@@ -163,7 +164,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <seealso cref="IAndroidComponent.StatusChanged"/>
 		/// </para>
 		/// <para>
-		/// If <paramref name="performFullDetection"/> is <c>true</> then the method will start a full detection cycle. This means that the
+		/// If <paramref name="performFullDetection"/> is <c>true</c> then the method will start a full detection cycle. This means that the
 		/// <paramref name="instance"/> will be modified - all of its components will be replaced with fresh instances. This is to ensure that
 		/// the metadata in the components is 100% accurate. By default full detection is not performed.
 		/// </para>
@@ -454,6 +455,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="instance">Android SDK instance.</param>
 		/// <param name="componentsToInstall">Components to install</param>
 		/// <param name="throwIfInvalidComponentsFound">Throw an exception if any component with invalid archives is found, if set to <c>true</c></param>
+		/// <param name="monitor">Progress monitor</param>
 		public void Install (AndroidSdkInstance instance, IList<IAndroidComponent> componentsToInstall, bool throwIfInvalidComponentsFound = true,
 			IProgressMonitor monitor = null)
 		{
@@ -746,6 +748,8 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="licenses">list of licenses to accept</param>
 		/// <param name="token">cancellation token</param>
 		/// <param name="logPath">log file path</param>
+		/// <param name="javaSdkPath">custom Java SDK path (optional)</param>
+		/// <param name="throwsErrorIfValidationFailed">if <c>true</c>, throws an exception if license validation failed, otherwise it will just log the error and return</param>
 		public Task AcceptLicensesAsync(AndroidSdkInstance instance, IEnumerable<License> licenses, CancellationToken token, string javaSdkPath = null, string logPath = null, bool throwsErrorIfValidationFailed = false)
 		{
 			if (instance != null) {

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/AndroidLicensesStorage.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/AndroidLicensesStorage.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Installer.AndroidSDK.Common
 		/// <param name="licenses">list of licenses to accept</param>
 		/// <param name="token">cancellation token</param>
 		/// <param name="logPath">log file path</param>
+		/// <param name="throwsErrorIfValidationFailed">if <c>true</c>, throws an exception if the validation of arguments fails, if set to <c>false</c> the method returns without accepting any license</param>
 		public Task AcceptLicensesAsync(
 			string androidSdkPath,
 			string javaSdkPath,

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/Archive.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/Archive.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Installer.AndroidSDK.Common
     {
         /// <summary>
         /// Gets the collection of patches for this archive. This library currently does not support applying these
-        /// patches, instead it always downloads the full archive from the specified <see cref="Url"/>
+        /// patches, instead it always downloads the full archive from the specified Url
         /// </summary>
         /// <value>The list of patches (if any)</value>
         public IList<ArchivePatch> Patches { get; set; }

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/HttpClientProvider.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/HttpClientProvider.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Installer.AndroidSDK.Manager
 		/// </summary>
 		/// <returns>The HttpClient.</returns>
 		/// <param name="uri">The request url.</param>
+		/// <param name="cookieContainer">The cookie container to use, or null to not use cookies.</param>
+		/// <param name="automaticDecompression">The decompression methods to support.</param>
 		public static HttpClient CreateHttpClient (Uri uri, CookieContainer cookieContainer = null, DecompressionMethods automaticDecompression = DecompressionMethods.None)
 		{
 			if (httpClientFactory != null)

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/DirectorySizeMonitoringTimer.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/DirectorySizeMonitoringTimer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// Move operation will take different time depending on number of files in an archive
 		/// so we split the 100% installation progress according these values (unzip + move = 100%)
 		/// </summary>
-		/// <param name="zipFile"></param>
+		/// <param name="archivePath">The path to the archive file.</param>
 		/// <returns>Amount of percents for the Move part of the installation</returns>
 		public static int CalculateMoveProgressSplit (string archivePath)
 		{

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/IProgressMonitor.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/IProgressMonitor.cs
@@ -58,6 +58,10 @@ namespace Xamarin.Installer.AndroidSDK.Manager
 		/// Reports the total progress of all the download and installation steps
 		/// </summary>
 		/// <param name="loadPercentage">Overall progress percentage from 0.0 to 1.0</param>
+		/// <param name="mainComponentsCount">Total number of main components</param>
+		/// <param name="mainComponentIndex">Index of the current main component</param>
+		/// <param name="subComponentsCount">Total number of sub-components</param>
+		/// <param name="subComponentIndex">Index of the current sub-component</param>
 		void ReportTotalProgress (double loadPercentage,
 			int mainComponentsCount, int mainComponentIndex,
 			int subComponentsCount, int subComponentIndex);

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
@@ -72,7 +72,9 @@ namespace Xamarin.Installer.AndroidSDK
 			// If the requested path is not writable, request a different path
 			try {
 				Directory.CreateDirectory (JdkPath);
+#pragma warning disable CS0642 // Possible mistaken empty statement
 				using (File.Create (Path.Combine (JdkPath, "tmp"), 1, FileOptions.DeleteOnClose));
+#pragma warning restore CS0642
 			} catch (Exception) {
 				return false;
 			}

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
@@ -72,9 +72,7 @@ namespace Xamarin.Installer.AndroidSDK
 			// If the requested path is not writable, request a different path
 			try {
 				Directory.CreateDirectory (JdkPath);
-#pragma warning disable CS0642 // Possible mistaken empty statement
-				using (File.Create (Path.Combine (JdkPath, "tmp"), 1, FileOptions.DeleteOnClose));
-#pragma warning restore CS0642
+				using var _ = File.Create (Path.Combine (JdkPath, "tmp"), 1, FileOptions.DeleteOnClose);
 			} catch (Exception) {
 				return false;
 			}

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Repository.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Repository.cs
@@ -236,7 +236,6 @@ namespace Xamarin.Installer.AndroidSDK
         /// If it fails, tries to load local cached manifest;
         /// If local manifest is loaded, sets <c>IsOffline</c> to <c>true</c> and returns it.
         /// </summary>
-        /// <param name="useManifestCaching"></param>
         /// <returns></returns>
         protected string LoadManifest()
         {

--- a/src/Xamarin.Installer.Common/Xamarin.Installer.Common.csproj
+++ b/src/Xamarin.Installer.Common/Xamarin.Installer.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\Configuration.props" />
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <NoWarn>$(NoWarn);CA1305;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>12</LangVersion>


### PR DESCRIPTION
This separates warning cleanups from the Java.Interop work branch so they can be reviewed independently.\n\nThe changes address warnings surfaced in local build logs across runtime, installer, and test infrastructure code.