### PR TITLE
[build] Add shared DownloadFileWithRetry target and use it for SDK downloads

### DIFF
--- a/build-tools/scripts/DownloadFileWithRetry.targets
+++ b/build-tools/scripts/DownloadFileWithRetry.targets
@@ -1,0 +1,151 @@
+<Project>
+
+  <!--
+    Shared download helper. Wraps MSBuild's `<DownloadFile>` task in an outer
+    retry loop and an optional SHA-256 self-heal step.
+
+    Why this exists:
+      MSBuild's built-in `DownloadFile` task has `Retries` /
+      `RetryDelayMilliseconds`, but its internal `IsRetriable` check only
+      retries when a `HttpRequestException` wraps an inner `IOException`.
+      The `ResponseEnded` failure that flaky CDNs produce is thrown as a
+      top-level `HttpIOException`, so `Retries` does NOT cover it - the task
+      errors out on the first mid-stream disconnect. This file's
+      `DownloadOneFileWithRetry` target wraps `<DownloadFile>` in three
+      outer attempts using `ContinueOnError="WarnAndContinue"`, so transient
+      stream failures get up to 3 retries before failing the build.
+
+    Why callers dispatch via `<MSBuild>` (and not `<CallTarget>`):
+      Two MSBuild semantics force this:
+        1. Items added inside a target body are NOT visible to a target
+           invoked via `<CallTarget>` from that same body. They ARE visible
+           to tasks called from the same body, including the `<MSBuild>`
+           task. Without that, every caller would silently pass an empty
+           item list and download nothing.
+        2. A target executes at most once per build context, so a
+           `<CallTarget>` cannot be used twice (e.g. openjdk's two-phase
+           hash-then-archive flow). `<MSBuild>` with distinct
+           `AdditionalProperties` per item creates distinct build requests,
+           so the same target body runs once per file - and `BuildInParallel`
+           lets MSBuild fan those requests out across worker nodes when
+           there is more than one file to download.
+
+    Required input properties for `DownloadOneFileWithRetry`:
+      _DownloadUrl                 = source URL
+      _DownloadFolder              = destination folder
+      _DownloadFileName            = file name to write inside _DownloadFolder
+
+    Optional input properties:
+      _DownloadSha256              = expected SHA-256 (uppercase hex). When
+                                     set, the downloaded file is hashed and
+                                     removed/errored if the hash does not
+                                     match. If a previously cached file is
+                                     present with the wrong hash, it is also
+                                     deleted up-front so this run re-downloads
+                                     instead of failing.
+      _DownloadCleanupOnMismatch   = semicolon-separated list of additional
+                                     files to delete on Sha256 mismatch. Use
+                                     for sibling files (e.g. a .sha256sum.txt
+                                     whose contents drove the expected hash)
+                                     so the next build re-fetches them.
+
+    Usage pattern. The `_DownloadFile` item group must be built inside the
+    caller's target body (so the items are visible to `<MSBuild>`). Each
+    item carries its per-file parameters as `AdditionalProperties` metadata,
+    and the `<MSBuild>` call projects every item onto this targets file so
+    MSBuild treats each one as a distinct, parallelizable build request:
+
+      <ItemGroup>
+        <_DownloadFile Include="@(_BuildTools)">
+          <AdditionalProperties>_DownloadUrl=$(BaseUrl)%(Identity);_DownloadFolder=$(Cache);_DownloadFileName=%(Identity);_DownloadSha256=%(Hash)</AdditionalProperties>
+        </_DownloadFile>
+      </ItemGroup>
+      <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+          Targets="DownloadOneFileWithRetry"
+          BuildInParallel="true" />
+
+    For a single file, the same shape works - use the file name as the
+    Include so each item still has a distinct identity:
+
+      <ItemGroup>
+        <_DownloadFile Include="$(FileName)">
+          <AdditionalProperties>_DownloadUrl=$(Url);_DownloadFolder=$(Cache);_DownloadFileName=$(FileName);_DownloadSha256=$(Hash)</AdditionalProperties>
+        </_DownloadFile>
+      </ItemGroup>
+      <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+          Targets="DownloadOneFileWithRetry"
+          BuildInParallel="true" />
+  -->
+
+  <PropertyGroup>
+    <DownloadFileWithRetryFile>$(MSBuildThisFileFullPath)</DownloadFileWithRetryFile>
+    <_DownloadRetries>5</_DownloadRetries>
+    <_DownloadRetryDelayMilliseconds>5000</_DownloadRetryDelayMilliseconds>
+  </PropertyGroup>
+
+  <Target Name="DownloadOneFileWithRetry">
+    <PropertyGroup>
+      <_DownloadPath>$(_DownloadFolder)\$(_DownloadFileName)</_DownloadPath>
+    </PropertyGroup>
+
+    <!-- Self-heal: if a cached file already exists AND we know the expected
+         hash, verify it up-front. On mismatch, delete (along with any
+         CleanupOnMismatch siblings) so the download attempts below actually
+         re-fetch in this same build. Without this, a stale/corrupt cached
+         file would skip the download (because of the !Exists guard below)
+         and the final SHA check would fail the build with no recovery. -->
+    <GetFileHash Condition=" Exists('$(_DownloadPath)') and '$(_DownloadSha256)' != '' "
+        Files="$(_DownloadPath)"
+        Algorithm="SHA256">
+      <Output TaskParameter="Hash" PropertyName="_DownloadExistingSha256" />
+    </GetFileHash>
+    <Delete
+        Condition=" '$(_DownloadExistingSha256)' != '' and '$(_DownloadExistingSha256)' != '$(_DownloadSha256)' "
+        Files="$(_DownloadPath);$(_DownloadCleanupOnMismatch)"
+    />
+
+    <!-- Outer retry loop. Each `<DownloadFile>` is gated by `!Exists()`, so
+         once a download succeeds the remaining attempts no-op. The first
+         two use `WarnAndContinue` so transient failures don't fail the
+         build; the third lets the error propagate. -->
+    <DownloadFile Condition=" !Exists('$(_DownloadPath)') "
+        SourceUrl="$(_DownloadUrl)"
+        DestinationFolder="$(_DownloadFolder)"
+        DestinationFileName="$(_DownloadFileName)"
+        Retries="$(_DownloadRetries)"
+        RetryDelayMilliseconds="$(_DownloadRetryDelayMilliseconds)"
+        ContinueOnError="WarnAndContinue"
+    />
+    <DownloadFile Condition=" !Exists('$(_DownloadPath)') "
+        SourceUrl="$(_DownloadUrl)"
+        DestinationFolder="$(_DownloadFolder)"
+        DestinationFileName="$(_DownloadFileName)"
+        Retries="$(_DownloadRetries)"
+        RetryDelayMilliseconds="$(_DownloadRetryDelayMilliseconds)"
+        ContinueOnError="WarnAndContinue"
+    />
+    <DownloadFile Condition=" !Exists('$(_DownloadPath)') "
+        SourceUrl="$(_DownloadUrl)"
+        DestinationFolder="$(_DownloadFolder)"
+        DestinationFileName="$(_DownloadFileName)"
+        Retries="$(_DownloadRetries)"
+        RetryDelayMilliseconds="$(_DownloadRetryDelayMilliseconds)"
+    />
+
+    <!-- Final SHA-256 verification (covers the just-downloaded case). -->
+    <GetFileHash Condition=" '$(_DownloadSha256)' != '' "
+        Files="$(_DownloadPath)"
+        Algorithm="SHA256">
+      <Output TaskParameter="Hash" PropertyName="_DownloadActualSha256" />
+    </GetFileHash>
+    <Delete
+        Condition=" '$(_DownloadSha256)' != '' and '$(_DownloadActualSha256)' != '$(_DownloadSha256)' "
+        Files="$(_DownloadPath);$(_DownloadCleanupOnMismatch)"
+    />
+    <Error
+        Condition=" '$(_DownloadSha256)' != '' and '$(_DownloadActualSha256)' != '$(_DownloadSha256)' "
+        Text="SHA256 mismatch for $(_DownloadFileName). Expected: $(_DownloadSha256) Actual: $(_DownloadActualSha256)"
+    />
+  </Target>
+
+</Project>

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -32,29 +32,21 @@
     </_BuildTools>
   </ItemGroup>
 
+  <Import Project="..\..\build-tools\scripts\DownloadFileWithRetry.targets" />
+
   <UsingTask AssemblyFile="$(BootstrapTasksAssembly)" TaskName="Xamarin.Android.Tools.BootstrapTasks.UnzipDirectoryChildren" TaskFactory="TaskHostFactory" Runtime="NET" />
 
   <Target Name="_DownloadBuildTools"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
       Outputs="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)">
-    <DownloadFile
-        SourceUrl="$(_AndroidRepositoryUrl)%(_BuildTools.Identity)"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="%(_BuildTools.Identity)"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
-    <GetFileHash Files="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)" Algorithm="SHA256">
-      <Output TaskParameter="Hash" PropertyName="_ActualHash" />
-    </GetFileHash>
-    <Delete
-        Condition=" '$(_ActualHash)' != '%(_BuildTools.Hash)' "
-        Files="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)"
-    />
-    <Error
-        Condition=" '$(_ActualHash)' != '%(_BuildTools.Hash)' "
-        Text="SHA256 mismatch for %(_BuildTools.Identity). Expected: %(_BuildTools.Hash) Actual: $(_ActualHash)"
-    />
+    <ItemGroup>
+      <_DownloadFile Include="@(_BuildTools)">
+        <AdditionalProperties>_DownloadUrl=$(_AndroidRepositoryUrl)%(Identity);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=%(Identity);_DownloadSha256=%(Hash)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
   </Target>
 
   <Target Name="_ExtractAapt2" BeforeTargets="Build" DependsOnTargets="_DownloadBuildTools"

--- a/src/aapt2/aapt2.targets
+++ b/src/aapt2/aapt2.targets
@@ -38,7 +38,7 @@
 
   <Target Name="_DownloadBuildTools"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
-      Outputs="$(AndroidToolchainCacheDirectory)\%(_BuildTools.Identity)">
+      Outputs="@(_BuildTools->'$(AndroidToolchainCacheDirectory)\%(Identity)')">
     <ItemGroup>
       <_DownloadFile Include="@(_BuildTools)">
         <AdditionalProperties>_DownloadUrl=$(_AndroidRepositoryUrl)%(Identity);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=%(Identity);_DownloadSha256=%(Hash)</AdditionalProperties>

--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="..\..\build-tools\scripts\DownloadFileWithRetry.targets" />
+
   <!--
     All of the Android SDK component downloads/extractions that used to live in
     `Step_Android_SDK_NDK` in xaprepare. Each component is just a row in the
@@ -277,30 +279,20 @@
   </Target>
 
   <!--
-    Download every `_AndroidSdkPackage` into the toolchain cache, verifying SHA-256.
-    Target batching via `Outputs="...%(Identity)"` runs the body once per item.
+    Download every `_AndroidSdkPackage` into the toolchain cache in parallel,
+    verifying SHA-256 via the shared `DownloadOneFileWithRetry` target.
   -->
   <Target Name="_DownloadAndroidSdkPackages"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
       Outputs="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)">
-    <DownloadFile
-        SourceUrl="$(_AndroidRepositoryUrl)%(_AndroidSdkPackage.Url)"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="%(_AndroidSdkPackage.Identity)"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
-    <GetFileHash Files="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)" Algorithm="SHA256">
-      <Output TaskParameter="Hash" PropertyName="_ActualHash" />
-    </GetFileHash>
-    <Delete
-        Condition=" '$(_ActualHash)' != '%(_AndroidSdkPackage.Hash)' "
-        Files="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)"
-    />
-    <Error
-        Condition=" '$(_ActualHash)' != '%(_AndroidSdkPackage.Hash)' "
-        Text="SHA256 mismatch for %(_AndroidSdkPackage.Identity). Expected: %(_AndroidSdkPackage.Hash) Actual: $(_ActualHash)"
-    />
+    <ItemGroup>
+      <_DownloadFile Include="@(_AndroidSdkPackage)">
+        <AdditionalProperties>_DownloadUrl=$(_AndroidRepositoryUrl)%(Url);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=%(Identity);_DownloadSha256=%(Hash)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
   </Target>
 
   <!--

--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -284,7 +284,7 @@
   -->
   <Target Name="_DownloadAndroidSdkPackages"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
-      Outputs="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)">
+      Outputs="@(_AndroidSdkPackage->'$(AndroidToolchainCacheDirectory)\%(Identity)')">
     <ItemGroup>
       <_DownloadFile Include="@(_AndroidSdkPackage)">
         <AdditionalProperties>_DownloadUrl=$(_AndroidRepositoryUrl)%(Url);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=%(Identity);_DownloadSha256=%(Hash)</AdditionalProperties>

--- a/src/binutils/binutils.targets
+++ b/src/binutils/binutils.targets
@@ -1,4 +1,6 @@
 <Project>
+  <Import Project="..\..\build-tools\scripts\DownloadFileWithRetry.targets" />
+
   <PropertyGroup>
     <_BinutilsArchiveUrl>https://github.com/dotnet/android-native-tools/releases/download/$(XABinutilsVersion)/xamarin-android-toolchain-$(XABinutilsVersion).7z</_BinutilsArchiveUrl>
     <_BinutilsArchive>$(AndroidToolchainCacheDirectory)\xamarin-android-toolchain-$(XABinutilsVersion).7z</_BinutilsArchive>
@@ -13,24 +15,14 @@
   <Target Name="_DownloadBinutils"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
       Outputs="$(_BinutilsArchive)">
-    <DownloadFile
-        SourceUrl="$(_BinutilsArchiveUrl)"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="xamarin-android-toolchain-$(XABinutilsVersion).7z"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
-    <GetFileHash Files="$(_BinutilsArchive)" Algorithm="SHA256">
-      <Output TaskParameter="Hash" PropertyName="_BinutilsActualHash" />
-    </GetFileHash>
-    <Delete
-        Condition=" '$(_BinutilsActualHash)' != '$(XABinutilsHash)' "
-        Files="$(_BinutilsArchive)"
-    />
-    <Error
-        Condition=" '$(_BinutilsActualHash)' != '$(XABinutilsHash)' "
-        Text="SHA256 mismatch for xamarin-android-toolchain-$(XABinutilsVersion).7z. Expected: $(XABinutilsHash) Actual: $(_BinutilsActualHash)"
-    />
+    <ItemGroup>
+      <_DownloadFile Include="xamarin-android-toolchain-$(XABinutilsVersion).7z">
+        <AdditionalProperties>_DownloadUrl=$(_BinutilsArchiveUrl);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=xamarin-android-toolchain-$(XABinutilsVersion).7z;_DownloadSha256=$(XABinutilsHash)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
   </Target>
 
   <Target Name="_ExtractBinutils"

--- a/src/bundletool/bundletool.targets
+++ b/src/bundletool/bundletool.targets
@@ -9,25 +9,17 @@
     <_JarPath Condition=" '$(_JarPath)' == '' ">jar</_JarPath>
   </PropertyGroup>
 
+  <Import Project="..\..\build-tools\scripts\DownloadFileWithRetry.targets" />
+
   <Target Name="_DownloadBundleTool">
-    <DownloadFile
-        SourceUrl="https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="bundletool-all-$(XABundleToolVersion).jar"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
-    <GetFileHash Files="$(_BundleToolDownloadLocation)" Algorithm="SHA256">
-      <Output TaskParameter="Hash" PropertyName="_BundleToolActualHash" />
-    </GetFileHash>
-    <Delete
-        Condition=" '$(_BundleToolActualHash)' != '$(XABundleToolHash)' "
-        Files="$(_BundleToolDownloadLocation)"
-    />
-    <Error
-        Condition=" '$(_BundleToolActualHash)' != '$(XABundleToolHash)' "
-        Text="SHA256 mismatch for bundletool-all-$(XABundleToolVersion).jar. Expected: $(XABundleToolHash) Actual: $(_BundleToolActualHash)"
-    />
+    <ItemGroup>
+      <_DownloadFile Include="bundletool-all-$(XABundleToolVersion).jar">
+        <AdditionalProperties>_DownloadUrl=https://github.com/google/bundletool/releases/download/$(XABundleToolVersion)/bundletool-all-$(XABundleToolVersion).jar;_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=bundletool-all-$(XABundleToolVersion).jar;_DownloadSha256=$(XABundleToolHash)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
   </Target>
 
   <Target Name="_StripAndCopyBundleTool"

--- a/src/openjdk/openjdk.targets
+++ b/src/openjdk/openjdk.targets
@@ -1,5 +1,7 @@
 <Project>
 
+  <Import Project="..\..\build-tools\scripts\DownloadFileWithRetry.targets" />
+
   <!-- Determine platform-specific download properties -->
   <PropertyGroup Condition=" '$(HostOS)' == 'Windows' ">
     <_OpenJDKPlatform>windows-x64</_OpenJDKPlatform>
@@ -37,36 +39,34 @@
   <Target Name="_DownloadOpenJDK"
       Inputs="$(MSBuildThisFileFullPath);$(MSBuildProjectFullPath);..\..\Configuration.props"
       Outputs="$(_OpenJDKArchive)">
-    <DownloadFile
-        SourceUrl="$(_OpenJDKArchiveUrl)"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="$(_OpenJDKFileName)"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
-    <!-- Download the SHA-256 hash file from Microsoft and parse the expected hash.
+    <!-- Phase 1: download the .sha256sum.txt to learn the expected hash.
          File format: "6ecfa864...  microsoft-jdk-21.0.8-windows-x64.zip" -->
-    <DownloadFile
-        SourceUrl="$(_OpenJDKHashUrl)"
-        DestinationFolder="$(AndroidToolchainCacheDirectory)"
-        DestinationFileName="$(_OpenJDKHashFileName)"
-        Retries="5"
-        RetryDelayMilliseconds="5000"
-    />
+    <ItemGroup>
+      <_DownloadFile Include="$(_OpenJDKHashFileName)">
+        <AdditionalProperties>_DownloadUrl=$(_OpenJDKHashUrl);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=$(_OpenJDKHashFileName)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
+
+    <!-- Parse expected hash from the .sha256sum.txt file -->
     <PropertyGroup>
       <_OpenJDKExpectedHash>$([System.IO.File]::ReadAllText('$(_OpenJDKHashFile)').Substring(0, 64).ToUpperInvariant())</_OpenJDKExpectedHash>
     </PropertyGroup>
-    <GetFileHash Files="$(_OpenJDKArchive)" Algorithm="SHA256">
-      <Output TaskParameter="Hash" PropertyName="_OpenJDKActualHash" />
-    </GetFileHash>
-    <Delete
-        Condition=" '$(_OpenJDKActualHash)' != '$(_OpenJDKExpectedHash)' "
-        Files="$(_OpenJDKArchive);$(_OpenJDKHashFile)"
-    />
-    <Error
-        Condition=" '$(_OpenJDKActualHash)' != '$(_OpenJDKExpectedHash)' "
-        Text="SHA256 mismatch for $(_OpenJDKFileName). Expected: $(_OpenJDKExpectedHash) Actual: $(_OpenJDKActualHash)"
-    />
+
+    <!-- Phase 2: download the archive and verify against the parsed hash.
+         If the hash check fails, also delete the .sha256sum.txt so the next
+         build re-fetches it in case the cached copy is what's stale/corrupt. -->
+    <ItemGroup>
+      <_DownloadFile Remove="@(_DownloadFile)" />
+      <_DownloadFile Include="$(_OpenJDKFileName)">
+        <AdditionalProperties>_DownloadUrl=$(_OpenJDKArchiveUrl);_DownloadFolder=$(AndroidToolchainCacheDirectory);_DownloadFileName=$(_OpenJDKFileName);_DownloadSha256=$(_OpenJDKExpectedHash);_DownloadCleanupOnMismatch=$(_OpenJDKHashFile)</AdditionalProperties>
+      </_DownloadFile>
+    </ItemGroup>
+    <MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
+        Targets="DownloadOneFileWithRetry"
+        BuildInParallel="true" />
   </Target>
 
   <Target Name="_InstallOpenJDK"


### PR DESCRIPTION
Fixes transient `MSB3923 ... ResponseEnded` build failures when downloading SDK components (emulator, build-tools, NDK, JDK, etc.) from `dl.google.com` and `aka.ms`. Example failure: [dnceng-public build 1461495](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1461495):

```
error MSB3923: Failed to download file "https://dl.google.com/android/repository/emulator-darwin_x64-15004761.zip". The response ended prematurely. (ResponseEnded)
```

### Root cause

MSBuild's built-in `<DownloadFile>` task has `Retries` and `RetryDelayMilliseconds`, but its internal `IsRetriable` check only retries when a `HttpRequestException` wraps an inner `IOException`. The `ResponseEnded` failure that flaky CDNs produce is thrown as a top-level `HttpIOException` (added in .NET 8), so `Retries` does **not** cover it — the task errors out on the first mid-stream disconnect with no retry attempt. (Confirmed by reading the failing build's log: zero "Retrying" messages.)

### Change

New `build-tools/scripts/DownloadFileWithRetry.targets` exposes:

* `$(DownloadFileWithRetryFile)` — absolute path to itself
* `DownloadOneFileWithRetry` — target that wraps `<DownloadFile>` in three outer attempts (first two with `ContinueOnError="WarnAndContinue"`, third lets the error propagate) and optionally verifies SHA-256.

When the caller supplies `_DownloadSha256` and a cached file already exists with the wrong hash, the target deletes it (and any `_DownloadCleanupOnMismatch` siblings) up-front so the download attempts actually re-fetch in the same build, rather than failing at the post-download verify step. `openjdk.targets` uses this to invalidate a cached `.sha256sum.txt` if the archive ever fails verification.

Callers build a `_DownloadFile` item group in their target body with per-file params as `AdditionalProperties` metadata, then invoke:

```xml
<MSBuild Projects="@(_DownloadFile->'$(DownloadFileWithRetryFile)')"
    Targets="DownloadOneFileWithRetry"
    BuildInParallel="true" />
```

The projection turns each item into a distinct `(project, properties)` build request, so MSBuild fans them out across worker nodes. For multi-file callers (`aapt2`, `androidsdk`) this means downloads happen in parallel.

### Why `<MSBuild>` instead of `<CallTarget>`

Two MSBuild semantics forced this:

1. Items added inside a target body are **not** visible to a target invoked via `<CallTarget>` from that same body, so the shared target could not see a collection assembled by the caller.
2. A target executes at most once per build context, so a `<CallTarget>` could not be used for `openjdk`'s two-phase hash-file-then-archive flow.

### Migrated callers

* `src/binutils/binutils.targets`
* `src/bundletool/bundletool.targets`
* `src/aapt2/aapt2.targets`
* `src/openjdk/openjdk.targets` (two-phase: `.sha256sum.txt` then archive)
* `src/androidsdk/androidsdk.targets` (~30 SDK packages, now in parallel)

### Verified locally

| Scenario | Result |
| --- | --- |
| `bundletool` single file | Downloads successfully |
| `aapt2` (3 files, ~200 MB) | Downloads in parallel (~3.6 s) |
| Cache-hit re-run | Target-skip (~0.4 s) |
| Corrupted cached file + correct expected hash | Detected → deleted → re-fetched in same build |
| Wrong expected hash | Errors and deletes both file and cleanup sibling |