### PR TITLE
[Tests] Remove dead GetInnerHandlerType helper

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidHandlerTestBase.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidHandlerTestBase.cs
@@ -29,11 +29,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -165,19 +163,6 @@ namespace Xamarin.Android.NetTests {
 		static bool IsSecureChannelFailure (Exception e)
 		{
 			return Exceptions (e).Any (v => (v as WebException)?.Status == WebExceptionStatus.SecureChannelFailure);
-		}
-
-		[UnconditionalSuppressMessage ("Trimming", "IL2075", Justification = "Tests private fields are preserved by other means")]
-		static Type GetInnerHandlerType (HttpClient httpClient)
-		{
-			BindingFlags bflags = BindingFlags.Instance | BindingFlags.NonPublic;
-			FieldInfo handlerField = typeof (HttpMessageInvoker).GetField ("_handler", bflags);
-			Assert.IsNotNull (handlerField);
-			object handler = handlerField.GetValue (httpClient);
-			FieldInfo innerHandlerField = handler.GetType ().GetField ("_delegatingHandler", bflags);
-			Assert.IsNotNull (handlerField);
-			object innerHandler = innerHandlerField.GetValue (handler);
-			return innerHandler.GetType ();
 		}
 
 		[Test]


### PR DESCRIPTION
## Description

`AndroidHandlerTestBase.GetInnerHandlerType` is a private `static` test helper with **zero callers** (confirmed via find-references — it appears only at its own declaration). It is dead code.

**When did it become dead?** Its last caller was removed by #6678 (*"[Mono.Android-Tests] Stop using tls-test.internalx.com"*, merged 2022-01-28), which deleted the TLS handler tests whose `Assert.AreEqual ("SocketsHttpHandler", GetInnerHandlerType (c).Name, …)` assertion was the only thing using it. It has been unused ever since.

It also:
- reflected into BCL **private** fields (`HttpMessageInvoker._handler` / `_delegatingHandler`), which is fragile across runtime versions, and
- contained a copy-paste assertion bug (it null-checked `handlerField` twice instead of `innerHandlerField`),
- all guarded by an `[UnconditionalSuppressMessage ("Trimming", "IL2075")]`.

Since the method is unreachable, this removes:
- the method,
- its `[UnconditionalSuppressMessage]`,
- the now-unused `using System.Reflection;` and `using System.Diagnostics.CodeAnalysis;`.

## Why

Contributes to #10794 (*"[TrimmableTypeMap] Address all trimming and AOT warnings"*, which includes *"No `[UnconditionalSuppressMessage]` used in the dotnet/android repo"*) by removing one more `[UnconditionalSuppressMessage]` — here the cleanest fix is simply deleting the dead code rather than annotating it.

No behavioral change: the method has been unreachable since #6678.
