### PR TITLE
[Mono.Android] Remove dead Java.Interop.__TypeRegistrations plumbing

### DIFF
--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -453,23 +453,23 @@ namespace Java.Interop {
 			}
 		}
 
+		const string TypeRegistrationNotSupported =
+			"Java package type registration is no longer supported. Java-to-managed type resolution now goes through the native and trimmable type maps.";
+
 		// The package-based Java-to-managed type registration fallback was removed
 		// (https://github.com/dotnet/android/issues/11663); type resolution now goes
 		// through the native / trimmable type map, and the generator no longer emits
-		// the `Java.Interop.__TypeRegistrations` class that called these methods. They
-		// are retained for API compatibility but no longer register anything.
+		// the `Java.Interop.__TypeRegistrations` class that called these methods. These
+		// shipped public APIs are retained for binary compatibility but now throw, as
+		// they can no longer register anything.
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)
 		{
-			ArgumentNullException.ThrowIfNull (package);
-			ArgumentNullException.ThrowIfNull (lookup);
+			throw new NotSupportedException (TypeRegistrationNotSupported);
 		}
 
 		public static void RegisterPackages (string[] packages, Converter<string, Type?>[] lookups)
 		{
-			ArgumentNullException.ThrowIfNull (packages);
-			ArgumentNullException.ThrowIfNull (lookups);
-			if (packages.Length != lookups.Length)
-				throw new ArgumentException ("`packages` and `lookups` arrays must have same number of elements.");
+			throw new NotSupportedException (TypeRegistrationNotSupported);
 		}
 
 		[Register ("mono/android/TypeManager", DoNotGenerateAcw = true)]

--- a/src/Mono.Android/Java.Interop/TypeManager.cs
+++ b/src/Mono.Android/Java.Interop/TypeManager.cs
@@ -453,47 +453,23 @@ namespace Java.Interop {
 			}
 		}
 
-		static Dictionary<string, List<Converter<string, Type?>>>? packageLookup;
-
-		[MemberNotNull (nameof (packageLookup))]
-		static void LazyInitPackageLookup ()
-		{
-			if (packageLookup == null)
-				packageLookup = new Dictionary<string, List<Converter<string, Type?>>> (StringComparer.Ordinal);
-		}
-
+		// The package-based Java-to-managed type registration fallback was removed
+		// (https://github.com/dotnet/android/issues/11663); type resolution now goes
+		// through the native / trimmable type map, and the generator no longer emits
+		// the `Java.Interop.__TypeRegistrations` class that called these methods. They
+		// are retained for API compatibility but no longer register anything.
 		public static void RegisterPackage (string package, Converter<string, Type> lookup)
 		{
-			LazyInitPackageLookup ();
-
-			lock (packageLookup!) {
-				if (!packageLookup.TryGetValue (package, out var lookups))
-					packageLookup.Add (package, lookups = new List<Converter<string, Type?>> ());
-				lookups.Add (lookup);
-			}
+			ArgumentNullException.ThrowIfNull (package);
+			ArgumentNullException.ThrowIfNull (lookup);
 		}
 
 		public static void RegisterPackages (string[] packages, Converter<string, Type?>[] lookups)
 		{
-			LazyInitPackageLookup ();
-
-			if (packages == null)
-				throw new ArgumentNullException ("packages");
-			if (lookups == null)
-				throw new ArgumentNullException ("lookups");
+			ArgumentNullException.ThrowIfNull (packages);
+			ArgumentNullException.ThrowIfNull (lookups);
 			if (packages.Length != lookups.Length)
 				throw new ArgumentException ("`packages` and `lookups` arrays must have same number of elements.");
-
-			lock (packageLookup!) {
-				for (int i = 0; i < packages.Length; ++i) {
-					string package                  = packages [i];
-					var lookup			= lookups [i];
-
-					if (!packageLookup.TryGetValue (package, out var _lookups))
-						packageLookup.Add (package, _lookups = new List<Converter<string, Type?>> ());
-					_lookups.Add (lookup);
-				}
-			}
 		}
 
 		[Register ("mono/android/TypeManager", DoNotGenerateAcw = true)]


### PR DESCRIPTION
## Description

Removes the dead `Java.Interop.__TypeRegistrations` **runtime plumbing** in `Mono.Android`, part of #11663.

The binding generator emits a `Java.Interop.__TypeRegistrations` class whose `RegisterPackages ()` populated `Java.Interop.TypeManager.packageLookup`. That dictionary was read only by the `TypeRegistrationFallback` path in `GetJavaToManagedTypeCore`, which was put behind a switch in #5629, trimmed in #8572, and **fully removed in #9471**. Since then `packageLookup` has been write-only and unread, and nothing invokes the generated `__TypeRegistrations.RegisterPackages ()` (the class has no module initializer / static-ctor hook). Java→managed type resolution now goes exclusively through the native typemap / `TrimmableTypeMapTypeManager`.

## Changes

`src/Mono.Android/Java.Interop/TypeManager.cs`:

- Removes the dead `packageLookup` field and `LazyInitPackageLookup ()`.
- `RegisterPackage` / `RegisterPackages` are shipped public API (present in `PublicAPI.Shipped.txt` for every API level), so they are **kept** but now throw `NotSupportedException` with an explanatory message (the package-registration mechanism they fed no longer exists), rather than silently doing nothing. Retiring them entirely can follow via the normal API-removal process.
- `LookupTypeMapping` is a pure helper and is left unchanged.

No `PublicAPI.*.txt` changes are required.

## Coordination

This is the **consumer-side** half of #11663. The **generator-side** half — which actually stops emitting the `__TypeRegistrations` class — is **dotnet/java-interop#1470** (`generator-Tests`: 455 passed, 0 failed).

These two are intentionally **decoupled** rather than pinned together via a submodule bump:

- This PR is safe to merge independently. While the currently-pinned generator still emits `__TypeRegistrations` (whose body calls the now-throwing `RegisterPackages`), that generated code is never invoked, so it remains harmless dead code.
- dotnet/java-interop#1470's effect reaches Mono.Android through the **normal `external/Java.Interop` submodule bump** once it merges (which also brings in the other java-interop `main` changes that need their own coordination, e.g. dotnet/java-interop#1441) — not through this PR.

Part of #11663
