### PR TITLE
[build] Switch lz4 submodule to upstream lz4/lz4

### DIFF
--- a/.github/skills/update-tpn/SKILL.md
+++ b/.github/skills/update-tpn/SKILL.md
@@ -56,7 +56,7 @@ Read `.gitmodules` for all submodules. Current submodules and their license file
 | Submodule | URL | License File |
 |-----------|-----|-------------|
 | Java.Interop | https://github.com/dotnet/java-interop | `external/Java.Interop/LICENSE` |
-| lz4 | https://github.com/dotnet/lz4 (fork of https://github.com/lz4/lz4) | `external/lz4/lib/LICENSE` |
+| lz4 | https://github.com/lz4/lz4 | `external/lz4/lib/LICENSE` |
 | xxHash | https://github.com/Cyan4973/xxHash | `external/xxHash/LICENSE` |
 | constexpr-xxh3 | https://github.com/chys87/constexpr-xxh3 | `external/constexpr-xxh3/LICENSE` |
 | robin-map | https://github.com/xamarin/robin-map (fork of https://github.com/Tessil/robin-map) | `external/robin-map/LICENSE` |

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,8 +20,8 @@
     branch = v1.8-stable
 [submodule "external/lz4"]
     path = external/lz4
-    url = https://github.com/dotnet/lz4
-    branch = release
+    url = https://github.com/lz4/lz4
+    branch = dev
 [submodule "external/robin-map"]
     path = external/robin-map
     url = https://github.com/xamarin/robin-map


### PR DESCRIPTION
### Summary

The `external/lz4` submodule has been pointing at [`dotnet/lz4`](https://github.com/dotnet/lz4) (a fork of [`lz4/lz4`](https://github.com/lz4/lz4)) for historical reasons. The fork carries **zero downstream changes** -- every commit "ahead" of upstream is just a no-op merge from the periodic mirror sync. This PR switches the submodule to track upstream `lz4/lz4` directly so we can pick up active maintenance and security fixes when we next bump the pin.

### Verification: the fork has no custom changes

Confirmed via:

```
gh api repos/lz4/lz4/compare/68959d27c3ec37b339b3b8ecfea155faf0ef94f2...dotnet:lz4:ebb370ca83af193212df4dcbadcc5d87bc0de2f0
```

→ `ahead_by=5, behind_by=0, files-changed=0`. The 5 "ahead" commits are all merge commits with no file changes; last sync was July 2024.

### Changes

- **`.gitmodules`**: `url = https://github.com/lz4/lz4`, `branch = dev`.
- **`external/lz4` gitlink**: bumped from `ebb370ca83af193212df4dcbadcc5d87bc0de2f0` (a merge commit owned by the fork) to `68959d27c3ec37b339b3b8ecfea155faf0ef94f2`, which is the upstream `dev`-side parent of that merge. The two trees are **byte-identical** (same root tree SHA `1ff35e0f086e3b431ea0efd001eb5c6254561953`), so this is a no-op for the source content.
- **`.github/skills/update-tpn/SKILL.md`**: drop the "(fork of ...)" note on the lz4 row -- it's no longer a fork.

`THIRD-PARTY-NOTICES.TXT` is left alone -- the existing `lz4/lz4` block is already correctly attributed to upstream.

### Build verification

```
dotnet-local.cmd build src/native/native-mono.csproj -p:Configuration=Debug
```

Produces **0 errors** (81 unrelated warnings) and the expected `libxa-lz4-release.a` artifacts for all four ABIs:

| ABI | Size |
| --- | --- |
| `android-arm` | 320,240 bytes |
| `android-arm64` | 484,704 bytes |
| `android-x64` | 540,856 bytes |
| `android-x86` | 364,448 bytes |

### Related

Supersedes #11658, which had vendored the lz4 sources into `src-ThirdParty/lz4/`; that approach was abandoned in favor of this simpler submodule URL switch.
