### PR TITLE
[Tests] Enable SubscribeToAppDomainUnhandledException on CoreCLR

### DIFF
--- a/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/InstallAndRunTests.cs
@@ -823,8 +823,8 @@ $@"button.ViewTreeObserver.GlobalLayout += Button_ViewTreeObserver_GlobalLayout;
 				return;
 			}
 
-			if (runtime == AndroidRuntime.CoreCLR || runtime == AndroidRuntime.NativeAOT) {
-				Assert.Ignore ("AppDomain.CurrentDomain.UnhandledException doesn't work in CoreCLR or NativeAOT");
+			if (runtime == AndroidRuntime.NativeAOT) {
+				Assert.Ignore ("AppDomain.CurrentDomain.UnhandledException doesn't work in NativeAOT");
 			}
 
 			var proj = new XamarinAndroidApplicationProject (packageName: PackageUtils.MakePackageName (runtime)) {


### PR DESCRIPTION
### Description

`MSBuildDeviceIntegration.InstallAndRunTests.SubscribeToAppDomainUnhandledException` was previously skipped via `Assert.Ignore` for both `CoreCLR` and `NativeAOT`, with the reason *"AppDomain.CurrentDomain.UnhandledException doesn''t work in CoreCLR or NativeAOT"*.

However, the rest of the test body was already wired up for CoreCLR:

```csharp
string? expectedSender = runtime switch
{
    AndroidRuntime.MonoVM => "System.Object", // MonoVM passes the current domain as the sender
    AndroidRuntime.CoreCLR => null, // CoreCLR explicitly passes a `null` sender
    _ => throw new NotImplementedException($"Test does not support runtime {runtime}"),
};
```

…and `IgnoreUnsupportedConfiguration(CoreCLR, release: true)` already returns `false` (i.e. CoreCLR + Release is supported).

### Change

Tighten the `Assert.Ignore` block so it only skips on `NativeAOT`, letting the test exercise `AppDomain.CurrentDomain.UnhandledException` on CoreCLR. With `sender == null`, the formatted logcat line becomes `# Unhandled Exception: sender=; e.IsTerminating=True; e.ExceptionObject=System.Exception: CRASH`, which the existing `expectedSender` switch already produces.

### Test status on `main` (build [14389667](https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=14389667))

| Runtime | Before | After |
|---|---|---|
| MonoVM | ✅ Passed | ✅ Passed |
| CoreCLR | ⏭️ NotExecuted | ▶️ Now runs |
| NativeAOT | ⏭️ NotExecuted | ⏭️ NotExecuted (still skipped) |