### PR TITLE
Bump MSTest to 4.2.3 in androidtest template

### DIFF
--- a/src/Microsoft.Android.Templates/androidtest/AndroidTest1.csproj
+++ b/src/Microsoft.Android.Templates/androidtest/AndroidTest1.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.1" />
+    <PackageReference Include="MSTest" Version="4.2.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updates the `MSTest` `PackageReference` in the `androidtest` project template from `4.2.1` to [`4.2.3`](https://www.nuget.org/packages/MSTest/4.2.3) so newly created Android test projects pick up the latest stable MSTest release.

- [x] Useful description of *why the change is necessary*: keep the template on the latest stable MSTest so users get current bug fixes and tooling improvements out of the box.
- [ ] Links to issues fixed: N/A
- [ ] Unit tests: N/A — template-only version bump.