### PR TITLE
[testing] Bump R8 to 9.1.43

### DIFF
--- a/src/r8/build.gradle
+++ b/src/r8/build.gradle
@@ -12,10 +12,19 @@ java {
 repositories {
     google()
     mavenCentral()
+    // R8 patch releases newer than what is published to maven.google.com
+    // are available here. See: https://r8.googlesource.com/r8/#replacing-r8-in-agp
+    maven {
+        url 'https://storage.googleapis.com/r8-releases/raw'
+    }
 }
 
 dependencies {
-    implementation 'com.android.tools:r8:9.1.31'
+    // 9.1.43 contains the fix for the NullPointerException in
+    // AndroidApiLevelCompute.of() when --no-tree-shaking is passed.
+    // See: https://issuetracker.google.com/issues/524775142
+    // See: https://github.com/dotnet/android/issues/11672
+    implementation 'com.android.tools:r8:9.1.43'
 }
 
 jar {


### PR DESCRIPTION
> ⚠️ **For testing only** — not intended to merge as-is.

Bumps the R8/D8 shipped in .NET for Android from `9.1.31` → `9.1.43`.

### Why

R8 `9.1.31` throws a `NullPointerException` in `AndroidApiLevelCompute.of()` when invoked with `--no-tree-shaking`. Google's R8 team fixed this in `9.1.43`.

- https://issuetracker.google.com/issues/524775142
- https://github.com/dotnet/android/issues/11672

### How

`9.1.43` is a stable tagged R8 release, but it has not yet been published to `maven.google.com` (which still tops out at `9.1.31`). It *is* published on the R8 team's own release feed at `https://storage.googleapis.com/r8-releases/raw`, which is the channel Google's R8 docs point users at for exactly this case — see [Replacing R8 in AGP](https://r8.googlesource.com/r8/#replacing-r8-in-agp).

`src/r8/build.gradle` now:

1. Adds `https://storage.googleapis.com/r8-releases/raw` as a maven repository (after `google()` and `mavenCentral()`, so Google Maven is still preferred when a version is available there).
2. Bumps the dependency to `com.android.tools:r8:9.1.43`.

### Verification

Built locally via the existing gradle build that backs `src/r8/r8.csproj`:

```
> Task :jar
BUILD SUCCESSFUL in 9s
```

And confirmed the produced fat-jar reports the right version:

```
$ java -cp src/r8/build/libs/r8.jar com.android.tools.r8.R8 --version
R8 9.1.43 (build 97a09ffd53fb2082ad69827578fed444da540740 from go/r8bot ...)
$ java -cp src/r8/build/libs/r8.jar com.android.tools.r8.D8 --version
D8 9.1.43 (build 97a09ffd53fb2082ad69827578fed444da540740 from go/r8bot ...)
```