### PR TITLE
[build] Fix `tools//<file>` paths in Microsoft.Android.Sdk pack

### DIFF
--- a/build-tools/create-packs/Microsoft.Android.Sdk.proj
+++ b/build-tools/create-packs/Microsoft.Android.Sdk.proj
@@ -42,8 +42,10 @@ core workload SDK packs imported by WorkloadManifest.targets.
       DependsOnTargets="ConstructInstallerItems;_GetLicense"
       BeforeTargets="GetFilesToPackage" >
     <ItemGroup>
-      <AndroidSdkBuildTools Include="@(MSBuildItemsWin)"  TargetPath="tools\$([System.IO.Path]::GetDirectoryName('%(MSBuildItemsWin.RelativePath)'))"  Condition=" '$(HostOS)' == 'Windows' " />
-      <AndroidSdkBuildTools Include="@(MSBuildItemsUnix)" TargetPath="tools\$([System.IO.Path]::GetDirectoryName('%(MSBuildItemsUnix.RelativePath)'))" Condition=" '$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin' " />
+      <!-- Use Path.Combine so files at the root of MSBuildItems* (RelativePath has no directory)
+           produce 'tools' rather than 'tools\', which would otherwise be packed as 'tools//<file>'. -->
+      <AndroidSdkBuildTools Include="@(MSBuildItemsWin)"  TargetPath="$([System.IO.Path]::Combine('tools', $([System.IO.Path]::GetDirectoryName('%(MSBuildItemsWin.RelativePath)'))))"  Condition=" '$(HostOS)' == 'Windows' " />
+      <AndroidSdkBuildTools Include="@(MSBuildItemsUnix)" TargetPath="$([System.IO.Path]::Combine('tools', $([System.IO.Path]::GetDirectoryName('%(MSBuildItemsUnix.RelativePath)'))))" Condition=" '$(HostOS)' == 'Linux' or '$(HostOS)' == 'Darwin' " />
     </ItemGroup>
 
     <GenerateUnixFilePermissions


### PR DESCRIPTION
### Context

When inspecting `Microsoft.Android.Sdk.Windows.*.nupkg`, every file that lives directly under `tools/` (e.g. `r8.jar`, `aapt2.exe`, `bundletool.jar`, `Xamarin.Android.Build.Tasks.dll`, all the `*.targets` files, etc.) is packed with a malformed entry path containing a double slash:

```
tools//r8.jar
tools//aapt2.exe
tools//bundletool.jar
tools//Xamarin.Android.Build.Tasks.dll
...
```

83 of the 281 entries in the package are affected.

### Root Cause

In `build-tools/create-packs/Microsoft.Android.Sdk.proj`:

```xml
<AndroidSdkBuildTools Include="@(MSBuildItemsWin)"
    TargetPath="tools\$([System.IO.Path]::GetDirectoryName('%(MSBuildItemsWin.RelativePath)'))" ... />
```

For an item whose `RelativePath` is just a filename like `r8.jar`, `Path.GetDirectoryName('r8.jar')` returns `""`, so `TargetPath` becomes `tools\` (trailing slash). The `SharedFramework.Sdk` packaging logic then appends `/r8.jar`, producing `tools//r8.jar`.

Items with a real subdirectory (e.g. `cs\Foo.resources.dll`, `bcl\Foo.dll`) are unaffected, because the directory name suppresses the trailing-slash issue.

### Fix

Switch to `Path.Combine`, which collapses an empty second argument cleanly:

| Input `RelativePath`     | Old result      | New result    |
| ------------------------ | --------------- | ------------- |
| `r8.jar`                 | `tools\` ❌     | `tools` ✅    |
| `cs\Foo.resources.dll`   | `tools\cs` ✅   | `tools\cs` ✅ |
| `bcl\Foo.dll`            | `tools\bcl` ✅  | `tools\bcl` ✅|

This bug has been latent since `dc089720b [build] Use SharedFramework.Sdk to create workload packs (#10000)`. Verified that `Microsoft.Android.Sdk.proj` is the only place in the repo using this dynamic `TargetPath` pattern; the sibling `Microsoft.Android.Ref.proj` uses static path properties, so it is unaffected.