### PR TITLE
[build] skip DownloadOneFileWithRetry on no-op builds

### DIFF
--- a/build-tools/scripts/DownloadFileWithRetry.targets
+++ b/build-tools/scripts/DownloadFileWithRetry.targets
@@ -49,6 +49,18 @@
                                      whose contents drove the expected hash)
                                      so the next build re-fetches them.
 
+    Incremental no-op gate:
+      A per-file stamp file next to the cached download
+      (`$(_DownloadFolder)\$(_DownloadFileName).$(_DownloadSha256).stamp`,
+      or `.stamp` when no hash is supplied) is touched once the download
+      and SHA verification succeed. The target's `Inputs`/`Outputs` then
+      lets MSBuild skip re-running it - and re-hashing the cached file -
+      on no-op builds. The expected SHA is encoded in the stamp file
+      name so changing `_DownloadSha256` in a caller invalidates the
+      cached stamp and forces re-verification. Listing the cached file
+      itself in `Outputs` preserves self-heal: if it disappears between
+      builds the target still runs and re-fetches.
+
     Usage pattern. The `_DownloadFile` item group must be built inside the
     caller's target body (so the items are visible to `<MSBuild>`). Each
     item carries its per-file parameters as `AdditionalProperties` metadata,
@@ -81,13 +93,19 @@
     <DownloadFileWithRetryFile>$(MSBuildThisFileFullPath)</DownloadFileWithRetryFile>
     <_DownloadRetries>5</_DownloadRetries>
     <_DownloadRetryDelayMilliseconds>5000</_DownloadRetryDelayMilliseconds>
+    <!-- Computed up-front (vs inside the target body) so the per-file
+         destination and stamp paths are visible to the target's
+         Inputs/Outputs incremental gate below. Each `<MSBuild>` build
+         request that calls into this file gets its own evaluated
+         scope with these AdditionalProperties already set. -->
+    <_DownloadPath>$(_DownloadFolder)\$(_DownloadFileName)</_DownloadPath>
+    <_DownloadStamp Condition=" '$(_DownloadSha256)' != '' ">$(_DownloadPath).$(_DownloadSha256).stamp</_DownloadStamp>
+    <_DownloadStamp Condition=" '$(_DownloadSha256)' == '' ">$(_DownloadPath).stamp</_DownloadStamp>
   </PropertyGroup>
 
-  <Target Name="DownloadOneFileWithRetry">
-    <PropertyGroup>
-      <_DownloadPath>$(_DownloadFolder)\$(_DownloadFileName)</_DownloadPath>
-    </PropertyGroup>
-
+  <Target Name="DownloadOneFileWithRetry"
+      Inputs="$(MSBuildThisFileFullPath)"
+      Outputs="$(_DownloadPath);$(_DownloadStamp)">
     <!-- Self-heal: if a cached file already exists AND we know the expected
          hash, verify it up-front. On mismatch, delete (along with any
          CleanupOnMismatch siblings) so the download attempts below actually
@@ -146,6 +164,12 @@
         Condition=" '$(_DownloadSha256)' != '' and '$(_DownloadActualSha256)' != '$(_DownloadSha256)' "
         Text="SHA256 mismatch for $(_DownloadFileName). Expected: $(_DownloadSha256) Actual: $(_DownloadActualSha256)"
     />
+
+    <!-- Record success so subsequent no-op builds can skip this target via
+         the Inputs/Outputs gate above (and avoid re-hashing the cached
+         file). Reached only when the SHA check above passed - or when no
+         hash was supplied to verify against. -->
+    <Touch Files="$(_DownloadStamp)" AlwaysCreate="True" />
   </Target>
 
 </Project>

--- a/build-tools/scripts/DownloadFileWithRetry.targets
+++ b/build-tools/scripts/DownloadFileWithRetry.targets
@@ -57,9 +57,14 @@
       lets MSBuild skip re-running it - and re-hashing the cached file -
       on no-op builds. The expected SHA is encoded in the stamp file
       name so changing `_DownloadSha256` in a caller invalidates the
-      cached stamp and forces re-verification. Listing the cached file
-      itself in `Outputs` preserves self-heal: if it disappears between
-      builds the target still runs and re-fetches.
+      cached stamp and forces re-verification. Self-heal for a missing
+      cached file is preserved by `_PrepareDownloadOneFileWithRetry`,
+      which always runs and drops the stamp if the cached file is gone -
+      so this target's `Outputs` becomes incomplete and MSBuild forces
+      it to re-run. Only the stamp is listed in `Outputs`: including the
+      cached file there would defeat the gate, because cache files
+      restored from CI caches keep their original old timestamps and
+      would always look out of date relative to this targets file.
 
     Usage pattern. The `_DownloadFile` item group must be built inside the
     caller's target body (so the items are visible to `<MSBuild>`). Each
@@ -104,8 +109,9 @@
   </PropertyGroup>
 
   <Target Name="DownloadOneFileWithRetry"
+      DependsOnTargets="_PrepareDownloadOneFileWithRetry"
       Inputs="$(MSBuildThisFileFullPath)"
-      Outputs="$(_DownloadPath);$(_DownloadStamp)">
+      Outputs="$(_DownloadStamp)">
     <!-- Self-heal: if a cached file already exists AND we know the expected
          hash, verify it up-front. On mismatch, delete (along with any
          CleanupOnMismatch siblings) so the download attempts below actually
@@ -170,6 +176,17 @@
          file). Reached only when the SHA check above passed - or when no
          hash was supplied to verify against. -->
     <Touch Files="$(_DownloadStamp)" AlwaysCreate="True" />
+  </Target>
+
+  <!-- Self-heal helper for the Inputs/Outputs gate on DownloadOneFileWithRetry.
+       Always runs (no Inputs/Outputs of its own) and is cheap: a single Exists
+       check per file. If the stamp claims a previous successful validation but
+       the cached file is gone, we drop the stamp so the parent target sees its
+       Outputs as incomplete and re-runs to re-fetch. -->
+  <Target Name="_PrepareDownloadOneFileWithRetry">
+    <Delete Condition=" Exists('$(_DownloadStamp)') and !Exists('$(_DownloadPath)') "
+        Files="$(_DownloadStamp)"
+    />
   </Target>
 
 </Project>


### PR DESCRIPTION
## Problem

On a no-op build of `Xamarin.Android.sln`, `DownloadOneFileWithRetry` runs 18 times and spends ~20s re-running `GetFileHash` (SHA-256) over already-cached files (e.g. `xamarin-android-toolchain-L_18.1.6-8.0.0-1.7z`, `build-tools_r36_macosx.zip`, `bundletool-all-1.18.1.jar`). Nothing has changed since the last build — those hashes are guaranteed to match — but the target has no incremental gate, so it always re-hashes.

From a representative no-op binlog: 77.3s total, **20.08s spent inside `DownloadOneFileWithRetry`** across 18 invocations. The single most expensive non-trivial target.

## Fix

Add an `Inputs`/`Outputs` gate to `DownloadOneFileWithRetry`, using a per-file stamp file:

- Stamp lives next to the cached download: `$(_DownloadFolder)\$(_DownloadFileName).$(_DownloadSha256).stamp`.
- Encoding the expected SHA in the file *name* means bumping `_DownloadSha256` in any caller produces a new stamp filename — MSBuild sees the output as missing and re-runs the target, including the existing self-heal + redownload + verify path.
- `<Touch Files="$(_DownloadStamp)" AlwaysCreate="True" />` at the very end of the target body — only after download + SHA check have succeeded.
- The cached file itself is **not** in `Outputs`. Including it would defeat the gate the moment cache files are restored from a CI cache (or a `git clean`-style rebuild) with timestamps older than this targets file: `Inputs.max > Outputs.min` would always force a re-run.
- Self-heal of a missing cached file is preserved by a tiny `_PrepareDownloadOneFileWithRetry` helper as `DependsOnTargets`. It always runs (no Inputs/Outputs of its own) and deletes the stamp when the cached file is gone — so MSBuild re-runs the parent target with an incomplete output set and re-fetches.

No public contract changes — all 5 callers (`aapt2`, `androidsdk`, `binutils`, `bundletool`, `openjdk`) keep working exactly as before. The big comment block at the top of the file is updated to document the new convention.

## Validation

End-to-end measured against `Xamarin.Android.sln` on Windows, with parents (`_DownloadOpenJDK`, `_DownloadAndroidSdkPackages`, `_DownloadBuildTools`, `_DownloadBinutils`) forced to re-invoke the target:

| Scenario | `DownloadOneFileWithRetry` invocations | Time in target | Build wall time |
|---|---|---|---|
| **Before** (master)             | 18 | **22.53s** (16 ran, 2 trivial) | 101.94s |
| **After** (this PR)             | 18 | **1ms** (all 18 skipped) | **62.39s** |
| **Saved**                       | — | **~22s of redundant SHA-256 hashing** | **~40s wall** |

The wall-clock saving exceeds the per-target saving because the hashing was serializing parent targets and starving downstream work. The user's reference no-op binlog (77.3s total, 20.08s in `DownloadOneFileWithRetry`) is consistent with the "Before" row above.

### Self-heal scenarios verified with a minimal driver harness

- ✅ **Stamp + cache file present (no-op)** → target *skipped*, `GetFileHash` not invoked.
- ✅ **Stamp present but cache file deleted** → `_PrepareDownloadOneFileWithRetry` drops the stamp, target re-runs and re-fetches.
- ✅ **Cache file present, stamp absent** (first build, or `_DownloadSha256` bumped) → target runs, validates, writes new stamp.
- ✅ **Cache file with ancient mtime** (CI cache restore scenario) → still skipped, because the cache file is no longer in `Outputs`.

## Files changed

- `build-tools/scripts/DownloadFileWithRetry.targets` — only this one file. No callers updated.