### PR TITLE
[Xamarin.Android.Build.Tasks] warn XA0149 on legacy `__AndroidEnvironment__` resources

### DIFF
--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -111,7 +111,7 @@ or 'Help->Report a Problem' in Visual Studio for Mac.
 + [XA0146](xa0146.md): Attempt to check whether '{0}' is a correctly aligned ELF file failed with exception, ignoring alignment check for the file.
 + [XA0147](xa0147.md): Attempt to check whether '{0}' is a valid ELF file failed with exception, ignoring AOT check for the file.
 + [XA0148](xa0148.md): Attempt to check whether '{0}' is a valid ELF file failed with exception, ignoring symbol '{1}@{2}' check for the file.
-+ [XA0149](xa0149.md): Ignoring legacy Xamarin.Android environment file '{0}' embedded in assembly '{1}' (from NuGet package '{2}' version '{3}'). Environment files from Xamarin.Android class libraries are not supported in .NET for Android.
++ [XA0149](xa0149.md): Ignoring legacy Xamarin.Android environment file '{0}' from NuGet package '{1}' version '{2}' in assembly '{3}'. Environment files from Xamarin.Android class libraries are not supported in .NET for Android.
 
 ## XA1xxx: Project related
 

--- a/Documentation/docs-mobile/messages/index.md
+++ b/Documentation/docs-mobile/messages/index.md
@@ -111,6 +111,7 @@ or 'Help->Report a Problem' in Visual Studio for Mac.
 + [XA0146](xa0146.md): Attempt to check whether '{0}' is a correctly aligned ELF file failed with exception, ignoring alignment check for the file.
 + [XA0147](xa0147.md): Attempt to check whether '{0}' is a valid ELF file failed with exception, ignoring AOT check for the file.
 + [XA0148](xa0148.md): Attempt to check whether '{0}' is a valid ELF file failed with exception, ignoring symbol '{1}@{2}' check for the file.
++ [XA0149](xa0149.md): Ignoring legacy Xamarin.Android environment file '{0}' embedded in assembly '{1}' (from NuGet package '{2}' version '{3}'). Environment files from Xamarin.Android class libraries are not supported in .NET for Android.
 
 ## XA1xxx: Project related
 

--- a/Documentation/docs-mobile/messages/xa0149.md
+++ b/Documentation/docs-mobile/messages/xa0149.md
@@ -1,0 +1,45 @@
+---
+title: .NET for Android warning XA0149
+description: XA0149 warning code
+ms.date: 06/18/2026
+f1_keywords:
+  - "XA0149"
+---
+
+# .NET for Android warning XA0149
+
+## Example messages
+
+> warning XA0149: Ignoring legacy Xamarin.Android environment file '__AndroidEnvironment__abc123' from NuGet package 'Some.Old.Package' version '1.2.3' in assembly '/path/to/Some.Old.Package.dll'. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this NuGet package or notify the library author.
+
+> warning XA0149: Ignoring legacy Xamarin.Android environment file '__AndroidEnvironment__abc123' in assembly '/path/to/SomeLibrary.dll'. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this assembly or notify the library author.
+
+## Issue
+
+A referenced assembly (typically from an older Xamarin.Android class
+library or a NuGet package targeting `MonoAndroid`) contains an embedded
+`__AndroidEnvironment__*` resource. .NET for Android does not consume
+environment files contributed by class libraries via this legacy
+mechanism, so the file is being ignored.
+
+This is closely related to the
+[NU1703](https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1703)
+warning that NuGet emits for packages still targeting the deprecated
+`MonoAndroid` framework.
+
+## Solution
+
+Update to a version of the NuGet package or library that targets
+`net-android` (.NET for Android). If you maintain the library, rebuild
+it as a .NET for Android class library so that any environment variables
+are produced in the supported `.net/env/` AAR layout.
+
+If the environment variables are required by your application, declare
+them directly in your app project using an `@(AndroidEnvironment)`
+item:
+
+```xml
+<ItemGroup>
+  <AndroidEnvironment Include="env.txt" />
+</ItemGroup>
+```

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.Designer.cs
@@ -630,6 +630,24 @@ namespace Xamarin.Android.Tasks.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Ignoring legacy Xamarin.Android environment file &apos;{0}&apos; from NuGet package &apos;{1}&apos; version &apos;{2}&apos; in assembly &apos;{3}&apos;. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this NuGet package or notify the library author..
+        /// </summary>
+        public static string XA0149 {
+            get {
+                return ResourceManager.GetString("XA0149", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ignoring legacy Xamarin.Android environment file &apos;{0}&apos; in assembly &apos;{1}&apos;. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this assembly or notify the library author..
+        /// </summary>
+        public static string XA0149_Assembly {
+            get {
+                return ResourceManager.GetString("XA0149_Assembly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There was a problem parsing {0}. This is likely due to incomplete or invalid XML. Exception: {1}.
         /// </summary>
         public static string XA1000 {

--- a/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
+++ b/src/Xamarin.Android.Build.Tasks/Properties/Resources.resx
@@ -1194,6 +1194,20 @@ To use a custom JDK path for a command line build, set the 'JavaSdkDirectory' MS
 {1} - The symbol name.
 {2} - The section name.</comment>
   </data>
+  <data name="XA0149" xml:space="preserve">
+    <value>Ignoring legacy Xamarin.Android environment file '{0}' from NuGet package '{1}' version '{2}' in assembly '{3}'. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this NuGet package or notify the library author.</value>
+    <comment>The following are literal names and should not be translated: Xamarin.Android, .NET for Android, NuGet.
+{0} - The name of the embedded environment resource (such as __AndroidEnvironment__abc123).
+{1} - The NuGet package id.
+{2} - The NuGet package version.
+{3} - The full path to the assembly that contains the environment resource.</comment>
+  </data>
+  <data name="XA0149_Assembly" xml:space="preserve">
+    <value>Ignoring legacy Xamarin.Android environment file '{0}' in assembly '{1}'. Environment files from Xamarin.Android class libraries are not supported in .NET for Android. Use a newer version of this assembly or notify the library author.</value>
+    <comment>The following are literal names and should not be translated: Xamarin.Android, .NET for Android.
+{0} - The name of the embedded environment resource (such as __AndroidEnvironment__abc123).
+{1} - The full path to the assembly that contains the environment resource.</comment>
+  </data>
   <data name="XAGRDL1000" xml:space="preserve">
     <value>Executable 'gradlew' not found in project directory '{0}'. Please ensure the path to your Gradle project folder is correct, and that it contains Gradle Wrapper scripts.</value>
     <comment>The following are literal names and should not be translated: gradlew, Gradle, Gradle Wrapper

--- a/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/ResolveLibraryProjectImports.cs
@@ -243,13 +243,6 @@ namespace Xamarin.Android.Tasks
 							[NuGetPackageId] = nuGetPackageId,
 							[NuGetPackageVersion] = nuGetPackageVersion,
 						}));
-					foreach (var env in Directory.EnumerateFiles (outDirForDll, "__AndroidEnvironment__*", SearchOption.TopDirectoryOnly)) {
-						resolvedEnvironments.Add (new TaskItem (env, new Dictionary<string, string> {
-							[OriginalFile] = assemblyPath,
-							[NuGetPackageId] = nuGetPackageId,
-							[NuGetPackageVersion] = nuGetPackageVersion,
-						}));
-					}
 					continue;
 				}
 
@@ -267,15 +260,11 @@ namespace Xamarin.Android.Tasks
 
 						// android environment files
 						if (name.StartsWith ("__AndroidEnvironment__", StringComparison.OrdinalIgnoreCase)) {
-							var outFile = Path.Combine (outDirForDll, name);
-							using (var stream = pe.GetEmbeddedResourceStream (resource)) {
-								updated |= Files.CopyIfStreamChanged (stream, outFile);
+							if (nuGetPackageId.IsNullOrEmpty ()) {
+								Log.LogCodedWarning ("XA0149", Properties.Resources.XA0149_Assembly, name, assemblyPath);
+							} else {
+								Log.LogCodedWarning ("XA0149", Properties.Resources.XA0149, name, nuGetPackageId, nuGetPackageVersion, assemblyPath);
 							}
-							resolvedEnvironments.Add (new TaskItem (Path.GetFullPath (outFile), new Dictionary<string, string> {
-								[OriginalFile] = assemblyPath,
-								[NuGetPackageId] = nuGetPackageId,
-								[NuGetPackageVersion] = nuGetPackageVersion,
-							}));
 						}
 						// embedded jars (EmbeddedJar, EmbeddedReferenceJar)
 						else if (name.EndsWith (".jar", StringComparison.InvariantCultureIgnoreCase)) {


### PR DESCRIPTION
Class libraries built with the legacy Xamarin.Android tooling embed
`__AndroidEnvironment__*` resources inside the managed assembly. The
.NET for Android replacement format places these files inside the
`.aar` produced by an Android class library under `.net/env/`.

NuGet already warns [NU1703][0] for packages that still target the
deprecated `MonoAndroid` target framework (see also the breaking-change
notice in [dotnet/docs#53550][1]), but it does not call out that any
embedded environment files would be silently extracted and merged into
the application by `ResolveLibraryProjectImports`.

### Changes

* `Tasks/ResolveLibraryProjectImports.cs`:
  * Refresh path: stop extracting `__AndroidEnvironment__*` embedded
    resources; emit `XA0149` instead.
  * Cached path: drop the enumeration that re-surfaced previously
    extracted env files. We don't warn again on incremental builds —
    the warning is intended to be loud on the build that actually
    refreshes the assembly.
* New warning code `XA0149` with two variants, modeled on the
  `XA0141` (16 KB shared-library) warning so the message always names
  the assembly and, when available, the NuGet package id and version:
  * `XA0149`: `Ignoring legacy Xamarin.Android environment file '{0}'
    from NuGet package '{1}' version '{2}' in assembly '{3}'. …`
  * `XA0149_Assembly`: `Ignoring legacy Xamarin.Android environment
    file '{0}' in assembly '{1}'. …`
* `Documentation/docs-mobile/messages/xa0149.md` + `index.md` entry.

The new `.net/env/*.env` AAR layout used by .NET for Android class
libraries is untouched and still flows through `@(LibraryEnvironments)`.

[0]: https://learn.microsoft.com/nuget/reference/errors-and-warnings/nu1703
[1]: https://github.com/dotnet/docs/issues/53550