### PR TITLE
[ci] Fix network isolation requirements

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -411,7 +411,7 @@ extends:
           - task: AzureCLI@2
             inputs:
               azureSubscription: "Darc: Maestro Production"
-              scriptType: pscore
+              scriptType: ps
               scriptLocation: inlineScript
               inlineScript: |
                 $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -411,13 +411,25 @@ extends:
           - task: AzureCLI@2
             inputs:
               azureSubscription: "Darc: Maestro Production"
-              scriptType: ps
+              scriptType: pscore
               scriptLocation: inlineScript
               inlineScript: |
                 $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
                 $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
                 $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-                & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --add-source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
+                # Write an isolated NuGet.config that clears all sources and lists only the dnceng
+                # 'dotnet-eng' feed, and pass it via --configfile so 'dotnet tool update'
+                # policy. See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
+                $darcNuGetConfig = Join-Path "$(Agent.TempDirectory)" 'darc-nuget.config'
+                Set-Content -Path $darcNuGetConfig -Encoding utf8 -Value @(
+                  '<?xml version="1.0" encoding="utf-8"?>',
+                  '<configuration>',
+                  '  <packageSources>',
+                  '    <clear />',
+                  "    <add key=""dotnet-eng"" value=""$arcadeServicesSource"" />",
+                  '  </packageSources>',
+                  '</configuration>')
+                & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --configfile "$darcNuGetConfig" --tool-path $(Agent.ToolsDirectory)\darc -v n
                 & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --ci --publishing-infra-version 3 --azdev-pat $(System.AccessToken)
             displayName: add build to default darc channel
             condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -417,9 +417,6 @@ extends:
                 $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
                 $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
                 $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-                # --source clears all default feeds and uses only the dnceng 'dotnet-eng' feed,
-                # so the install does not depend on nuget.org for network-isolated builds.
-                # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
                 & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
                 & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --ci --publishing-infra-version 3 --azdev-pat $(System.AccessToken)
             displayName: add build to default darc channel

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -417,19 +417,10 @@ extends:
                 $versionEndpoint = 'https://maestro.dot.net/api/assets/darc-version?api-version=2019-01-16'
                 $darcVersion = $(Invoke-WebRequest -Uri $versionEndpoint -UseBasicParsing).Content
                 $arcadeServicesSource = 'https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json'
-                # Write an isolated NuGet.config that clears all sources and lists only the dnceng
-                # 'dotnet-eng' feed, and pass it via --configfile so 'dotnet tool update'
-                # policy. See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
-                $darcNuGetConfig = Join-Path "$(Agent.TempDirectory)" 'darc-nuget.config'
-                Set-Content -Path $darcNuGetConfig -Encoding utf8 -Value @(
-                  '<?xml version="1.0" encoding="utf-8"?>',
-                  '<configuration>',
-                  '  <packageSources>',
-                  '    <clear />',
-                  "    <add key=""dotnet-eng"" value=""$arcadeServicesSource"" />",
-                  '  </packageSources>',
-                  '</configuration>')
-                & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --configfile "$darcNuGetConfig" --tool-path $(Agent.ToolsDirectory)\darc -v n
+                # --source clears all default feeds and uses only the dnceng 'dotnet-eng' feed,
+                # so the install does not depend on nuget.org for network-isolated builds.
+                # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
+                & dotnet tool update microsoft.dotnet.darc --version "$darcVersion" --source "$arcadeServicesSource" --tool-path $(Agent.ToolsDirectory)\darc -v n
                 & $(Agent.ToolsDirectory)\darc\darc add-build-to-channel --default-channels --id $(BARBuildId) --ci --publishing-infra-version 3 --azdev-pat $(System.AccessToken)
             displayName: add build to default darc channel
             condition: and(succeeded(), eq('${{ parameters.pushXAPackagesToMaestro }}', 'true'))

--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -17,9 +17,6 @@ steps:
   inputs:
     command: custom
     custom: tool
-    # --source clears all default feeds and uses only the dnceng public 'dotnet-public'
-    # mirror, so the install does not depend on nuget.org for network-isolated builds.
-    # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
     arguments: >-
       update ${{ parameters.toolName }} -v:diag
       --tool-path $(Agent.ToolsDirectory)

--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -10,24 +10,6 @@ steps:
   ignoreLASTEXITCODE: true
   condition: ${{ parameters.condition }}
 
-# Write an isolated NuGet.config (clear + only the dnceng public feeds)
-# referenced via --configfile below.
-# See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
-- pwsh: |
-    $cfg = Join-Path "$(Agent.TempDirectory)" 'install-dotnet-tool-nuget.config'
-    Set-Content -Path $cfg -Encoding utf8 -Value @(
-      '<?xml version="1.0" encoding="utf-8"?>',
-      '<configuration>',
-      '  <packageSources>',
-      '    <clear />',
-      '    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />',
-      '    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />',
-      '    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />',
-      '  </packageSources>',
-      '</configuration>')
-  displayName: write isolated NuGet.config for ${{ parameters.toolName }}
-  condition: ${{ parameters.condition }}
-
 - task: DotNetCoreCLI@2
   displayName: install ${{ parameters.toolName }} ${{ parameters.version }}
   condition: ${{ parameters.condition }}
@@ -35,9 +17,12 @@ steps:
   inputs:
     command: custom
     custom: tool
+    # --source clears all default feeds and uses only the dnceng public 'dotnet-public'
+    # mirror, so the install does not depend on nuget.org for network-isolated builds.
+    # See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
     arguments: >-
       update ${{ parameters.toolName }} -v:diag
       --tool-path $(Agent.ToolsDirectory)
       --version ${{ parameters.version }}
-      --configfile "$(Agent.TempDirectory)/install-dotnet-tool-nuget.config"
+      --source "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json"
 

--- a/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
+++ b/build-tools/automation/yaml-templates/install-dotnet-tool.yaml
@@ -10,6 +10,24 @@ steps:
   ignoreLASTEXITCODE: true
   condition: ${{ parameters.condition }}
 
+# Write an isolated NuGet.config (clear + only the dnceng public feeds)
+# referenced via --configfile below.
+# See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
+- pwsh: |
+    $cfg = Join-Path "$(Agent.TempDirectory)" 'install-dotnet-tool-nuget.config'
+    Set-Content -Path $cfg -Encoding utf8 -Value @(
+      '<?xml version="1.0" encoding="utf-8"?>',
+      '<configuration>',
+      '  <packageSources>',
+      '    <clear />',
+      '    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />',
+      '    <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />',
+      '    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />',
+      '  </packageSources>',
+      '</configuration>')
+  displayName: write isolated NuGet.config for ${{ parameters.toolName }}
+  condition: ${{ parameters.condition }}
+
 - task: DotNetCoreCLI@2
   displayName: install ${{ parameters.toolName }} ${{ parameters.version }}
   condition: ${{ parameters.condition }}
@@ -21,5 +39,5 @@ steps:
       update ${{ parameters.toolName }} -v:diag
       --tool-path $(Agent.ToolsDirectory)
       --version ${{ parameters.version }}
-      --add-source "https://api.nuget.org/v3/index.json"
+      --configfile "$(Agent.TempDirectory)/install-dotnet-tool-nuget.config"
 

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -76,3 +76,9 @@ variables:
   value: true
 - name: DOTNET_GENERATE_ASPNET_CERTIFICATE
   value: false
+# Fix network isolation requirements
+# See https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/750402
+- name: DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE
+  value: 'true'
+- name: DOTNET_SDK_VULNERABILITY_CHECK_DISABLE
+  value: 'true'


### PR DESCRIPTION
This pull request makes several updates to the build automation configuration, primarily focused on improving network isolation, updating package sources, and ensuring compatibility with Azure DevOps pipelines. The most important changes are grouped below:

**Network Isolation Improvements:**

* Added variables `DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE` and `DOTNET_SDK_VULNERABILITY_CHECK_DISABLE` in `variables.yaml` to address network isolation requirements and disable certain .NET notifications and vulnerability checks.

**Package Source Updates:**

* Changed the NuGet source for installing .NET tools in `install-dotnet-tool.yaml` from the public NuGet feed to the internal Azure DevOps feed (`dotnet-public`).
* Updated the `darc` tool installation in `azure-pipelines.yaml` to use `--source` instead of the deprecated `--add-source` parameter, aligning with current .NET CLI conventions.

These changes help ensure builds are more reliable in isolated network environments and modernize the way .NET tools are installed.