### PR TITLE
[native] Skip cmake reconfigure on no-op builds

### DIFF
--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -35,7 +35,6 @@
       <_ConfigureRuntimesInputs  Include="..\..\build-tools\scripts\Ndk.targets" />
       <_ConfigureRuntimesInputs  Include="CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\java-interop\CMakeLists.txt" />
-      <_ConfigureRuntimesInputs  Include="common\libstub\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\libunwind\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\lz4\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="common\runtime-base\CMakeLists.txt" />
@@ -51,9 +50,7 @@
       <_ConfigureRuntimesInputs  Include="mono\monodroid\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\runtime-base\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\shared\CMakeLists.txt" />
-      <_ConfigureRuntimesInputs  Include="mono\shared\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\tracing\CMakeLists.txt" />
-      <_ConfigureRuntimesInputs  Include="mono\xamarin-app-debug-helper\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\xamarin-app-stub\CMakeLists.txt" />
 
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-asan-Debug\CMakeCache.txt')"    Condition="'$(EnableNativeAnalyzers)' == 'true'" />
@@ -218,7 +215,6 @@
       <_RuntimeSources Include="$(JavaInteropFullPath)\src\java-interop\*.cc;$(JavaInteropFullPath)\src\java-interop\*.h" />
       <_RuntimeSources Include="common\archive-dso-stub\*.cc" />
       <_RuntimeSources Include="common\include\**\*.hh" />
-      <_RuntimeSources Include="common\libstub\*.cc;common\libstub\*.hh" />
       <_RuntimeSources Include="common\runtime-base\*.cc" />
       <_RuntimeSources Include="$(LZ4SourceFullPath)\lib\lz4.c;$(LZ4SourceFullPath)\lib\lz4.h" />
     </ItemGroup>
@@ -229,7 +225,6 @@
       <_RuntimeSources Include="mono\shared\*.cc;mono\shared\*.hh" />
       <_RuntimeSources Include="mono\tracing\*.cc;mono\tracing\*.hh" />
       <_RuntimeSources Include="mono\xamarin-app-stub\*.cc;mono\xamarin-app-stub\*.hh" />
-      <_RuntimeSources Include="mono\xamarin-debug-app-helper\*.cc;mono\xamarin-debug-app-helper\*.hh" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' ">

--- a/src/native/native.targets
+++ b/src/native/native.targets
@@ -52,6 +52,7 @@
       <_ConfigureRuntimesInputs  Include="mono\shared\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\tracing\CMakeLists.txt" />
       <_ConfigureRuntimesInputs  Include="mono\xamarin-app-stub\CMakeLists.txt" />
+      <_ConfigureRuntimesInputs  Include="mono\xamarin-debug-app-helper\CMakeLists.txt" />
 
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-asan-Debug\CMakeCache.txt')"    Condition="'$(EnableNativeAnalyzers)' == 'true'" />
       <_ConfigureRuntimesOutputs Include="@(AndroidSupportedTargetJitAbi->'$(FlavorIntermediateOutputPath)\%(AndroidRID)-asan-Release\CMakeCache.txt')"  Condition="'$(EnableNativeAnalyzers)' == 'true'" />
@@ -225,6 +226,7 @@
       <_RuntimeSources Include="mono\shared\*.cc;mono\shared\*.hh" />
       <_RuntimeSources Include="mono\tracing\*.cc;mono\tracing\*.hh" />
       <_RuntimeSources Include="mono\xamarin-app-stub\*.cc;mono\xamarin-app-stub\*.hh" />
+      <_RuntimeSources Include="mono\xamarin-debug-app-helper\*.cc;mono\xamarin-debug-app-helper\*.hh" />
     </ItemGroup>
 
     <ItemGroup Condition=" '$(CMakeRuntimeFlavor)' == 'CoreCLR' ">


### PR DESCRIPTION
## Why

On every `dotnet build` (with no source changes), the `_ConfigureRuntimes` target was re-running `cmake` for every supported ABI × {Debug, Release} (~10 directories), regenerating `CMakeCache.txt`, `build.ninja`, `rules.ninja`, `.ninja_log`, etc. That in turn invalidated `_BuildAndroidRuntimes`'s inputs, so `ninja` was re-invoked for every ABI × configuration too -- on a build where literally nothing had changed.

## Root cause

`_ConfigureRuntimesInputs` in `src/native/native.targets` referenced two `CMakeLists.txt` files that no longer exist in the tree:

- `common/libstub/CMakeLists.txt` was deleted in #9990 (April 2025).
- `mono/xamarin-app-debug-helper/CMakeLists.txt` never existed at this path. The sibling directory `mono/xamarin-debug-app-helper` (note the swapped words) is referenced from `_FindRuntimeSources`, but neither directory has ever shipped a CMakeLists.

MSBuild's `Inputs`/`Outputs` incremental skip requires every declared input file to exist on disk. When an explicit input is missing, MSBuild cannot compute whether outputs are up to date and re-runs the target on every build. That defeated the incremental skip for `_ConfigureRuntimes` and cascaded into `_BuildAndroidRuntimes` re-invoking `ninja` for every ABI × configuration.

## What changed

- Drop the two missing `CMakeLists.txt` entries from `_ConfigureRuntimesInputs`.
- Drop a duplicate `mono/shared/CMakeLists.txt` entry that was listed twice.
- Drop the matching dead globs in `_FindRuntimeSources` for `common/libstub/*.{cc,hh}` and `mono/xamarin-debug-app-helper/*.{cc,hh}`. Globs against missing directories evaluate to empty, so those are purely a code-hygiene cleanup -- they were not contributing to the rerun.

## Validation

Two consecutive no-op `dotnet build Xamarin.Android.sln` runs after the fix:

- Wall time ~15s (steady state).
- Zero `CMakeCache.txt`, `build.ninja`, `rules.ninja`, or `.ninja_log` files touched under `src/native/obj/`.

Before the fix, the same no-op build touched all of those files across every ABI × {Debug, Release} directory on every invocation.