### PR TITLE
[ci] Move hosted Mac agents to macOS-15

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -46,7 +46,7 @@ variables:
   value: 21
 # Override pool images for public Microsoft-hosted agents
 - name: HostedMacImage
-  value: macOS-14
+  value: macOS-15
 - name: LinuxPoolImage
   value: ubuntu-22.04
 - name: NetCorePublicPoolName

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -30,9 +30,9 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-14-arm64
+  value: macOS-15-arm64
 - name: HostedMacImageWithEmulator
-  value: macOS-14
+  value: macOS-15
 - name: SharedMacPool
   value: VSEng-VSMac-Xamarin-Shared
 - name: SharedMacName


### PR DESCRIPTION
Bump hosted Mac CI images from macOS-14 to macOS-15.

## Why

- **Deprecation**: macOS-14 hosted agents start their deprecation window on **July 6, 2026**, with brownouts October 5–31, 2026 and full removal on **November 2, 2026** (see the [hosted agent deprecation schedule](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted-deprecation-schedule)). We need to migrate ahead of the brownout period.
- **GA**: macOS-15 (Sequoia) has been GA on Azure Pipelines since April 2026.
- **Observed hangs**: In #11477 (the dotnet/dotnet darc bump) the macOS-14 hosted MSBuild + Emulator lanes have been hanging — the parent `dotnet build` CLI spins at ~100% CPU for hours. The same workload on AcesShared / Tahoe (macOS-15) lanes does not exhibit the hang, so bumping the hosted image may also unblock that PR's CI.

## What

`build-tools/automation/yaml-templates/variables.yaml`:

- `HostedMacImage`: `macOS-14-arm64` → `macOS-15-arm64`
- `HostedMacImageWithEmulator`: `macOS-14` → `macOS-15`

That's the entire diff (2 lines).

## Things to watch in CI

- Apple's deprecation of kernel extensions means HAXM-based Android emulator may not boot on macOS-15 hosted Intel agents. If the `HostedMacImageWithEmulator` lanes fail there, we may need to switch to an ARM-compatible emulator on `macOS-15-arm64`.
- Pre-installed Xcode / JDK versions on macOS-15 may differ from macOS-14; the package-tests and msbuild-tests lanes should be verified.