### PR TITLE
[Dependabot] Cover /src/proguard-android in gradle updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,11 +41,10 @@ updates:
     schedule:
       interval: "weekly"
   - package-ecosystem: "gradle"
-    directory: "/src/r8/"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "gradle"
-    directory: "/src/manifestmerger/"
+    directories:
+      - "/src/r8"
+      - "/src/manifestmerger"
+      - "/src/proguard-android"
     schedule:
       interval: "weekly"
   - package-ecosystem: "gitsubmodule"


### PR DESCRIPTION
Dependabot wasn't opening PRs to update the `com.android.application` Gradle plugin (pinned at `8.7.0` in `src/proguard-android/build.gradle`) because that directory wasn't listed in `.github/dependabot.yml`. The gradle ecosystem doesn't auto-discover `build.gradle` files; each directory has to be enumerated.

This adds `/src/proguard-android` to the gradle coverage and consolidates the three previously separate gradle entries into a single block using the `directories:` (plural) key. Dependabot still opens one PR per `(directory, dependency)` pair -- this is not batching, just config consolidation.

Test fixtures under `tests/CodeGen-Binding/.../JavaLib/build.gradle` are intentionally left out; they pin old versions on purpose for binding tests.

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests (N/A -- config-only change)