### PR TITLE
Fix Android SDK installer build warnings

### DIFF
--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/AndroidSDKInstaller.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/AndroidSDKInstaller.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="googleAddonsListURL">Google repository only: URL of the addon manifest (optional)</param>
 		/// <param name="googleRepositoryBaseURL">Google repository only: base URL of the repository</param>
 		/// <param name="useManifestCaching">If <c>true</c>, load local manifest when offline</param>
+		/// <param name="licensesStorage">Instance of a class implementing the <see cref="ILicensesStorage"/> interface (optional)</param>
 		public AndroidSDKInstaller (IHelpers helpers, AndroidManifestType manifestType = AndroidManifestType.Xamarin, Uri manifestURL = null, Uri googleAddonsListURL = null, Uri googleRepositoryBaseURL = null, bool useManifestCaching = false, ILicensesStorage licensesStorage = null)
 		{
 			CommonUtilities.Helpers = helpers ?? new Helper();
@@ -163,7 +164,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <seealso cref="IAndroidComponent.StatusChanged"/>
 		/// </para>
 		/// <para>
-		/// If <paramref name="performFullDetection"/> is <c>true</> then the method will start a full detection cycle. This means that the
+		/// If <paramref name="performFullDetection"/> is <c>true</c> then the method will start a full detection cycle. This means that the
 		/// <paramref name="instance"/> will be modified - all of its components will be replaced with fresh instances. This is to ensure that
 		/// the metadata in the components is 100% accurate. By default full detection is not performed.
 		/// </para>
@@ -454,6 +455,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="instance">Android SDK instance.</param>
 		/// <param name="componentsToInstall">Components to install</param>
 		/// <param name="throwIfInvalidComponentsFound">Throw an exception if any component with invalid archives is found, if set to <c>true</c></param>
+		/// <param name="monitor">Progress monitor (optional)</param>
 		public void Install (AndroidSdkInstance instance, IList<IAndroidComponent> componentsToInstall, bool throwIfInvalidComponentsFound = true,
 			IProgressMonitor monitor = null)
 		{
@@ -746,6 +748,8 @@ namespace Xamarin.Installer.AndroidSDK
 		/// <param name="licenses">list of licenses to accept</param>
 		/// <param name="token">cancellation token</param>
 		/// <param name="logPath">log file path</param>
+		/// <param name="javaSdkPath">path to java sdk</param>
+		/// <param name="throwsErrorIfValidationFailed">if true, throws an exception if license validation fails</param>
 		public Task AcceptLicensesAsync(AndroidSdkInstance instance, IEnumerable<License> licenses, CancellationToken token, string javaSdkPath = null, string logPath = null, bool throwsErrorIfValidationFailed = false)
 		{
 			if (instance != null) {

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/AndroidLicensesStorage.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/AndroidLicensesStorage.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Installer.AndroidSDK.Common
 		/// <param name="licenses">list of licenses to accept</param>
 		/// <param name="token">cancellation token</param>
 		/// <param name="logPath">log file path</param>
+		/// <param name="throwsErrorIfValidationFailed">if true, throws an exception if license validation fails</param>
 		public Task AcceptLicensesAsync(
 			string androidSdkPath,
 			string javaSdkPath,

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/Archive.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/Archive.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Installer.AndroidSDK.Common
     {
         /// <summary>
         /// Gets the collection of patches for this archive. This library currently does not support applying these
-        /// patches, instead it always downloads the full archive from the specified <see cref="Url"/>
+        /// patches, instead it always downloads the full archive from the specified URL
         /// </summary>
         /// <value>The list of patches (if any)</value>
         public IList<ArchivePatch> Patches { get; set; }
@@ -49,6 +49,10 @@ namespace Xamarin.Installer.AndroidSDK.Common
         /// <value>The owner component.</value>
         public IAndroidComponent Owner { get; internal set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Xamarin.Installer.AndroidSDK.Common.Archive"/> class.
+        /// </summary>
+        /// <param name="hostOS">The host operating system.</param>
         public Archive(string hostOS) : base(hostOS)
         {
         }

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/HttpClientProvider.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Common/HttpClientProvider.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Installer.AndroidSDK.Manager
 		/// </summary>
 		/// <returns>The HttpClient.</returns>
 		/// <param name="uri">The request url.</param>
+		/// <param name="cookieContainer">The cookie container to use for the HttpClient.</param>
+		/// <param name="automaticDecompression">The decompression methods to use for the HttpClient.</param>
 		public static HttpClient CreateHttpClient (Uri uri, CookieContainer cookieContainer = null, DecompressionMethods automaticDecompression = DecompressionMethods.None)
 		{
 			if (httpClientFactory != null)

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/DirectorySizeMonitoringTimer.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/DirectorySizeMonitoringTimer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Installer.AndroidSDK
 		/// Move operation will take different time depending on number of files in an archive
 		/// so we split the 100% installation progress according these values (unzip + move = 100%)
 		/// </summary>
-		/// <param name="zipFile"></param>
+		/// <param name="archivePath">The path to the archive file.</param>
 		/// <returns>Amount of percents for the Move part of the installation</returns>
 		public static int CalculateMoveProgressSplit (string archivePath)
 		{

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/IProgressMonitor.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/IProgressMonitor.cs
@@ -44,6 +44,10 @@ namespace Xamarin.Installer.AndroidSDK.Manager
 		/// Reports the total progress of all the download and installation steps
 		/// </summary>
 		/// <param name="loadPercentage">Overall progress percentage from 0.0 to 1.0</param>
+		/// <param name="mainComponentsCount">Total number of main components to be installed</param>
+		/// <param name="mainComponentIndex">Index of the main component currently being installed</param>
+		/// <param name="subComponentsCount">Total number of subcomponents to be installed for the current main component</param>
+		/// <param name="subComponentIndex">Index of the subcomponent currently being installed</param>
 		void ReportTotalProgress (double loadPercentage,
 			int mainComponentsCount, int mainComponentIndex,
 			int subComponentsCount, int subComponentIndex);

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/JavaDependencyInstaller.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Installer.AndroidSDK
 			// If the requested path is not writable, request a different path
 			try {
 				Directory.CreateDirectory (JdkPath);
-				using (File.Create (Path.Combine (JdkPath, "tmp"), 1, FileOptions.DeleteOnClose));
+				using var _ = File.Create (Path.Combine (JdkPath, "tmp"), 1, FileOptions.DeleteOnClose);
 			} catch (Exception) {
 				return false;
 			}

--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Repository.cs
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK/Repository.cs
@@ -236,7 +236,6 @@ namespace Xamarin.Installer.AndroidSDK
         /// If it fails, tries to load local cached manifest;
         /// If local manifest is loaded, sets <c>IsOffline</c> to <c>true</c> and returns it.
         /// </summary>
-        /// <param name="useManifestCaching"></param>
         /// <returns></returns>
         protected string LoadManifest()
         {


### PR DESCRIPTION
## Summary
- fix XML documentation issues in Xamarin.Installer.AndroidSDK
- use a declaration `using` for the temporary JDK writeability probe

## Testing
- `dotnet build src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK.csproj -p:_AndroidTreatWarningsAsErrors=true -v:minimal`