### PR TITLE
Fix SolutionBuilder nullability warnings

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Common/SolutionBuilder.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
-using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Xamarin.ProjectTools
 {
@@ -20,6 +20,7 @@ namespace Xamarin.ProjectTools
 			Projects = new List<XamarinProject> ();
 		}
 
+		[MemberNotNull (nameof (SolutionPath))]
 		public void Save ()
 		{
 			ArgumentNullException.ThrowIfNull (SolutionPath);


### PR DESCRIPTION
## Summary
- annotate `SolutionBuilder.Save()` so callers know `SolutionPath` is non-null after validation
- remove the unused `System.Diagnostics` import

## Testing
- `dotnet build src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Xamarin.ProjectTools.csproj -p:_AndroidTreatWarningsAsErrors=true -v:minimal` (blocked in the temporary clean worktree because `bin/BuildDebug/XABuildConfig.cs` is generated by prepare; `make prepare` then failed while cloning unrelated submodules with `Too many open files in system`)