### PR TITLE
[installer] Suppress legacy XML doc warnings

### DIFF
--- a/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK.csproj
+++ b/src/Xamarin.Installer.AndroidSDK/Xamarin.Installer.AndroidSDK.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\Configuration.props" />
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <NoWarn>$(NoWarn);CA1305;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>

--- a/src/Xamarin.Installer.Common/Xamarin.Installer.Common.csproj
+++ b/src/Xamarin.Installer.Common/Xamarin.Installer.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(MSBuildThisFileDirectory)..\..\Configuration.props" />
   <PropertyGroup>
-    <NoWarn>$(NoWarn);CA1305</NoWarn>
+    <NoWarn>$(NoWarn);CA1305;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <LangVersion>12</LangVersion>

--- a/src/Xamarin.Installer.Common/Xamarin.Installer.Common/InstallationProgressEventArgs.cs
+++ b/src/Xamarin.Installer.Common/Xamarin.Installer.Common/InstallationProgressEventArgs.cs
@@ -3,7 +3,7 @@
 namespace Xamarin.Installer.Common
 {
 	/// <summary>
-	/// Passed as the argument to the the <see cref="AndroidSDKInstaller.InstallationProgress"/> event
+	/// Passed as the argument to the the <c>AndroidSDKInstaller.InstallationProgress</c> event
 	/// handler.
 	/// </summary>
 	public class InstallationProgressEventArgs : EventArgs
@@ -30,4 +30,3 @@ namespace Xamarin.Installer.Common
 		public delegate void InstallationProgressActionDelegate (float progress);
 	}
 }
-


### PR DESCRIPTION
Fixes the remaining warnings from:

```bash
./dotnet-local.sh build src/Xamarin.Installer.AndroidSDK/
```

PR #11720 fixed the malformed AndroidSDK XML docs; this follow-up suppresses legacy CS1591 missing-public-doc warnings for the installer assemblies and fixes the remaining invalid cross-project XML documentation cref.

Validation:
```bash
./dotnet-local.sh build src/Xamarin.Installer.AndroidSDK/
```

Result: 0 warnings, 0 errors.