### PR TITLE
$(AndroidPackVersionSuffix)=preview.7; main is .NET 11 preview 7

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -44,6 +44,6 @@
          * Bump first digit of the patch version for feature releases (and reset the first two digits to 0)
     -->
     <AndroidPackVersion>37.0.0</AndroidPackVersion>
-    <AndroidPackVersionSuffix>preview.6</AndroidPackVersionSuffix>
+    <AndroidPackVersionSuffix>preview.7</AndroidPackVersionSuffix>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Context: https://github.com/dotnet/android/tree/release/11.0.1xx-preview6

We branched for .NET 11 Preview 6 into `release/11.0.1xx-preview6`; the `main` branch is now .NET 11 Preview 7.

Bumps `$(AndroidPackVersionSuffix)` in `eng/Versions.props` from `preview.6` to `preview.7`.