### PR TITLE
[xaprepare] Remove redundant Configuration.Generated.props generation

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -8,10 +8,6 @@
       Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <Import
-      Project="$(MSBuildThisFileDirectory)Build$(Configuration)\Configuration.Generated.props"
-      Condition="Exists('$(MSBuildThisFileDirectory)Build$(Configuration)\Configuration.Generated.props')"
-  />
-  <Import
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -162,7 +162,6 @@ namespace Xamarin.Android.Prepare
 			public static string TestBinDir                          => GetCachedPath (ref testBinDir, ()                          => Path.Combine (Configurables.Paths.BinDirRoot, $"Test{ctx.Configuration}"));
 			public static string BinDir                              => GetCachedPath (ref binDir, ()                              => Path.Combine (Configurables.Paths.BinDirRoot, ctx.Configuration));
 			public static string BuildBinDir                         => GetCachedPath (ref buildBinDir, ()                         => Path.Combine (Configurables.Paths.BinDirRoot, $"Build{ctx.Configuration}"));
-			public static string ConfigurationPropsGeneratedPath     => GetCachedPath (ref configurationPropsGeneratedPath, ()     => Path.Combine (BuildBinDir, "Configuration.Generated.props"));
 			public static string MonoAndroidFrameworksSubDir         = Path.Combine ("xbuild-frameworks", "MonoAndroid");
 			public static string MonoAndroidFrameworksRootDir        => GetCachedPath (ref monoAndroidFrameworksRootDir, ()        => Path.Combine (XAInstallPrefix, MonoAndroidFrameworksSubDir));
 
@@ -226,7 +225,6 @@ namespace Xamarin.Android.Prepare
 			static string? binDir;
 			static string? monoAndroidFrameworksRootDir;
 			static string? externalJavaInteropDir;
-			static string? configurationPropsGeneratedPath;
 			static string? netcoreAppRuntimeAndroidARM;
 			static string? netcoreAppRuntimeAndroidARM64;
 			static string? netcoreAppRuntimeAndroidX86;

--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.Generated.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.Generated.props.in
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != '' ">$(NUGET_PACKAGES)</XAPackagesDir>
-    <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' ">@XA_PACKAGES_DIR@</XAPackagesDir>
-  </PropertyGroup>
-</Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -55,7 +55,6 @@ namespace Xamarin.Android.Prepare
 				if (onlyRequired) {
 					return new List<GeneratedFile> {
 						Get_SourceLink_Json (context),
-						Get_Configuration_Generated_Props (context),
 						Get_Cmake_XA_Build_Configuration (context),
 						Get_Cmake_Presets (context),
 					};
@@ -63,7 +62,6 @@ namespace Xamarin.Android.Prepare
 					return new List <GeneratedFile> {
 						Get_SourceLink_Json (context),
 						Get_Configuration_OperatingSystem_props (context),
-						Get_Configuration_Generated_Props (context),
 						Get_Cmake_XA_Build_Configuration (context),
 						Get_Cmake_Presets (context),
 						Get_Ndk_projitems (context),
@@ -133,21 +131,6 @@ namespace Xamarin.Android.Prepare
 		GeneratedFile Get_Cmake_Presets (Context context)
 		{
 			return GetCmakePresetsCommon (context, Configurables.Paths.NativeSourcesDir);
-		}
-
-		GeneratedFile Get_Configuration_Generated_Props (Context context)
-		{
-			const string OutputFileName = "Configuration.Generated.props";
-
-			var replacements = new Dictionary<string, string> (StringComparer.Ordinal) {
-				{ "@XA_PACKAGES_DIR@",                    Configurables.Paths.XAPackagesDir },
-			};
-
-			return new GeneratedPlaceholdersFile (
-				replacements,
-				Path.Combine (Configurables.Paths.BootstrapResourcesDir, $"{OutputFileName}.in"),
-				Configurables.Paths.ConfigurationPropsGeneratedPath
-			);
 		}
 
 		GeneratedFile Get_Configuration_OperatingSystem_props (Context context)


### PR DESCRIPTION
### Summary

xaprepare generated a `Configuration.Generated.props` file whose *only*
content was an `XAPackagesDir` fallback:

```xml
<XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != '' ">$(NUGET_PACKAGES)</XAPackagesDir>
<XAPackagesDir Condition=" '$(XAPackagesDir)' == '' ">@XA_PACKAGES_DIR@</XAPackagesDir>
```

The `@XA_PACKAGES_DIR@` substitution was just the MSBuild-evaluated value of
`$(XAPackagesDir)` baked back into a file that MSBuild then re-imports — pure
circularity.

`Configuration.props` already has equivalent (and better, OS-aware)
`XAPackagesDir` fallback logic inline:

```xml
<XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
<XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
<XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>
```

The generated file was imported via `Condition="Exists(...)"`, so its import
was a no-op in practice. This removes the dead, circular generation entirely.

### Changes

- Delete `Get_Configuration_Generated_Props` and its two dispatch entries from
  `Step_GenerateFiles.cs`.
- `git rm` the `Configuration.Generated.props.in` template.
- Delete the unused `ConfigurationPropsGeneratedPath` configurable (property +
  backing field) from `Configurables.cs`.
- Delete the dead `<Import>` of `Configuration.Generated.props` from
  `Configuration.props`.

### Verification

- `git grep` for `Configuration.Generated.props`, `Configuration_Generated_Props`,
  and `ConfigurationPropsGeneratedPath` → 0 matches.
- `dotnet build build-tools/xaprepare/xaprepare/xaprepare.csproj -c Debug` → 0 errors.
- Confirmed `Configuration.props` still resolves `XAPackagesDir` to a non-empty
  value (`C:\Users\<user>\.nuget\packages`) via the inline OS-aware fallback,
  with the generated file absent and `NUGET_PACKAGES` unset.

Reference precedent: #11568, #11580, #11608, #11613, #11631, #11657, #11658.
