### PR TITLE
Enable ManagedPeer native registration for LLVM typemap

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.LlvmIr.targets
@@ -20,9 +20,9 @@
 
   <ItemGroup>
     <RuntimeHostConfigurationOption Include="Microsoft.Android.Runtime.RuntimeFeature.TrimmableTypeMap"
-        Value="false"
-        Trim="true"
-    />
+        Value="false" Trim="true" />
+    <RuntimeHostConfigurationOption Include="Java.Interop.RuntimeFeature.ManagedPeerNativeRegistration"
+        Value="true" Trim="true" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Non-trimmable LLVM typemap builds require Java.Interop's ManagedPeer native registration path. This makes the runtime host configuration explicit for the LLVM typemap target so the feature remains enabled when trimming/runtimeconfig options are generated.