### PR TITLE
Tests: rename InstantRunTest to FastDevTest and drop duplicate

### DIFF
--- a/.github/skills/tests/references/test-catalog.md
+++ b/.github/skills/tests/references/test-catalog.md
@@ -108,7 +108,7 @@ Device: **Yes** (most tests have `[Category("UsesDevice")]`)
 | **bundletool** | `--filter "FullyQualifiedName~BundleToolTests"` | AAB bundle tool tests |
 | **uncaught exceptions** | `--filter "FullyQualifiedName~UncaughtExceptionTests"` | Unhandled exception behavior |
 | **system app** | `--filter "FullyQualifiedName~SystemApplicationTests"` | System application tests |
-| **instant run** | `--filter "FullyQualifiedName~InstantRunTest"` | Hot reload / instant run |
+| **fast dev** | `--filter "FullyQualifiedName~FastDevTest"` | Fast Deployment install/upload flow |
 
 ---
 

--- a/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
+++ b/tests/MSBuildDeviceIntegration/Tests/FastDevTest.cs
@@ -9,10 +9,10 @@ namespace Xamarin.Android.Build.Tests
 {
 	[TestFixture]
 	[Category ("UsesDevice")]
-	public class InstantRunTest : DeviceTest
+	public class FastDevTest : DeviceTest
 	{
 		[Test]
-		public void InstantRunSimpleBuild ()
+		public void FastDevSimpleBuild ()
 		{
 			var proj = new XamarinFormsAndroidApplicationProject {
 			};
@@ -45,7 +45,7 @@ namespace Xamarin.Android.Build.Tests
 			};
 			proj.SetProperty ("AndroidUseManagedDesignTimeResourceGenerator", useManagedResourceGenerator.ToString ());
 			proj.SetProperty ("AndroidUseDesignerAssembly", "False");
-			var b = CreateApkBuilder ($"temp/InstantRunTargetsSkipped_{useManagedResourceGenerator}", cleanupOnDispose: false);
+			var b = CreateApkBuilder ($"temp/FastDevTargetsSkipped_{useManagedResourceGenerator}", cleanupOnDispose: false);
 			Assert.IsTrue (b.Build (proj), "1 build should have succeeded.");
 
 			// unchanged build
@@ -193,36 +193,7 @@ namespace Xamarin.Android.Build.Tests
 		}
 
 		[Test]
-		public void InstantRunResourceChange ()
-		{
-			var proj = new XamarinAndroidApplicationProject () {
-			};
-			proj.SetDefaultTargetDevice ();
-			using (var b = CreateApkBuilder ()) {
-				b.Verbosity = LoggerVerbosity.Detailed;
-				Assert.IsTrue (b.Install (proj), "install should have succeeded. 0");
-				var logLines = b.LastBuildOutput;
-				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_BuildApkFastDev\" completely.") ||
-					l.Contains ("Target _BuildApkFastDev needs to be built")),
-					"Apk should have been built");
-				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_Upload\" completely")), "_Upload target should have run");
-				Assert.IsTrue (b.Output.IsApkInstalled, "app apk was installed");
-
-
-				proj.LayoutMain = proj.LayoutMain.Replace ("LinearLayout", "RelativeLayout");
-				proj.Touch ("Resources\\Layout\\Main.axml");
-				Assert.IsTrue (b.Install (proj, doNotCleanupOnUpdate: true, saveProject: false), "install should have succeeded. 1");
-				logLines = b.LastBuildOutput;
-				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_BuildApkFastDev\" completely.") ||
-					l.Contains ("Target _BuildApkFastDev needs to be built")),
-					"Apk should not have been built");
-				Assert.IsTrue (logLines.Any (l => l.Contains ("Building target \"_Upload\" completely")), "_Upload target should have run");
-				Assert.IsTrue (b.Output.IsApkInstalled, "app apk was installed");
-			}
-		}
-
-		[Test]
-		public void InstantRunFastDevDexes ([Values (false, true)] bool useEmbeddedDex)
+		public void FastDevWithEmbeddedDex ([Values (false, true)] bool useEmbeddedDex)
 		{
 			var proj = new XamarinAndroidApplicationProject () {
 			};


### PR DESCRIPTION
### Why rename?

The "Instant Run" name in `tests/MSBuildDeviceIntegration/Tests/InstantRunTest.cs` is leftover Android Studio jargon from ~2016. We never implemented the Android Studio Instant Run protocol — these tests have always exercised our **Fast Deployment** pipeline (`_BuildApkFastDev` + `_Upload`), which pushes managed assemblies to the on-device override directory so an assembly-only edit can skip repackaging/reinstalling the APK.

To make matters worse, the older **Enhanced Fast Dev** path (which actually did slice/sideload dex on device) was removed. So the `InstantRun` name suggests behavior we never had *and* sits next to behavior we no longer have. Renaming to `FastDev` matches the targets the tests actually assert against (`_BuildApkFastDev`) and the rest of our docs/codebase.

| Before | After |
|---|---|
| `InstantRunTest.cs` | `FastDevTest.cs` |
| `class InstantRunTest` | `class FastDevTest` |
| `InstantRunSimpleBuild` | `FastDevSimpleBuild` |
| `InstantRunFastDevDexes` | `FastDevWithEmbeddedDex` |
| `temp/InstantRunTargetsSkipped_*` | `temp/FastDevTargetsSkipped_*` |

`InstantRunFastDevDexes` also said "FastDev" twice — the test isn't really about dexes, it's about Fast Dev install/launch interacting with the `android:useEmbeddedDex` manifest attribute, so `FastDevWithEmbeddedDex` describes it more honestly.

`.github/skills/tests/references/test-catalog.md` filter alias was updated to match.

### Why remove `InstantRunResourceChange`?

It is fully duplicative of `SkipFastDevAlreadyInstalledResources`:

|  | `InstantRunResourceChange` (removed) | `SkipFastDevAlreadyInstalledResources` (kept) |
|---|---|---|
| Edit applied | `LinearLayout` → `RelativeLayout` in `Main.axml` | Same |
| Install + reinstall flow | Yes | Yes |
| Assertion strategy | Greps build log for `_BuildApkFastDev` / `_Upload` target names | Cracks open the `packaged_resources` zip and asserts the new layout bytes are actually present |
| Catches a real regression that the other doesn't | No | Yes — if the resources weren't actually re-packaged, the kept test fails; the removed test would still pass as long as the targets ran |

The kept test is strictly stronger. Anything the removed test could detect (Fast Dev targets running on a resource edit) is implied by the kept test passing.

### Test impact

No behavior change in product code — this is rename + delete-one-redundant-test in `tests/`.