### PR TITLE
Migrate nuget-msi-convert to v5.yml (WiX 6)

### DIFF
--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -21,6 +21,13 @@ resources:
     type: git
     name: DevDiv/Xamarin.yaml-templates
     ref: refs/heads/main
+  # TODO: Temporary feature branch to smoke-test the WiX 6 migration of nuget-msi-convert
+  # (Xamarin.yaml-templates PR #752740). Revert this back to using yaml-templates@main
+  # once that PR merges.
+  - repository: yaml-templates-v5
+    type: git
+    name: DevDiv/Xamarin.yaml-templates
+    ref: refs/heads/jonathanpeppers-nuget-msi-convert-v5
   - repository: maui
     type: github
     name: dotnet/maui
@@ -75,6 +82,7 @@ extends:
       sourceRepositoriesToScan:
         exclude:
         - repository: yaml-templates
+        - repository: yaml-templates-v5
         - repository: maui
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
@@ -274,9 +282,9 @@ extends:
           timeoutInMinutes: 120
 
       # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-      - template: nuget-msi-convert/job/v4.yml@yaml-templates
+      - template: nuget-msi-convert/job/v5.yml@yaml-templates-v5
         parameters:
-          yamlResourceName: yaml-templates
+          yamlResourceName: yaml-templates-v5
           dependsOn: sign_net_mac_win
           artifactName: nuget-signed
           artifactPatterns: |
@@ -375,7 +383,7 @@ extends:
             Write-Host "##vso[task.setvariable variable=ReleaseDropPrefix]$dropPrefix"
           displayName: Set variable ReleaseDropPrefix
 
-        # Download nugets drop created by nuget-msi-convert/job/v4.yml and publish to maestro
+        # Download nugets drop created by nuget-msi-convert/job/v5.yml and publish to maestro
         - task: ms-vscs-artifact.build-tasks.artifactDropDownloadTask-1.artifactDropDownloadTask@1
           displayName: Download $(ReleaseDropPrefix)/nugets
           inputs:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,13 +20,9 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
-  # TODO: Temporary feature branch to smoke-test the WiX 6 migration of nuget-msi-convert
-  # (Xamarin.yaml-templates PR #752740). Revert this back to using yaml-templates@main
-  # once that PR merges.
-  - repository: yaml-templates-v5
-    type: git
-    name: DevDiv/Xamarin.yaml-templates
+    # TODO: Temporary feature branch to smoke-test the WiX 6 migration of
+    # nuget-msi-convert (Xamarin.yaml-templates PR #752740).
+    # Revert back to refs/heads/main once that PR merges.
     ref: refs/heads/jonathanpeppers-nuget-msi-convert-v5
   - repository: maui
     type: github
@@ -82,7 +78,6 @@ extends:
       sourceRepositoriesToScan:
         exclude:
         - repository: yaml-templates
-        - repository: yaml-templates-v5
         - repository: maui
       suppression:
         suppressionFile: $(Build.SourcesDirectory)\.gdn\.gdnsuppress
@@ -282,9 +277,9 @@ extends:
           timeoutInMinutes: 120
 
       # Check - "Xamarin.Android (Prepare .NET Release Convert NuGet to MSI)"
-      - template: nuget-msi-convert/job/v5.yml@yaml-templates-v5
+      - template: nuget-msi-convert/job/v5.yml@yaml-templates
         parameters:
-          yamlResourceName: yaml-templates-v5
+          yamlResourceName: yaml-templates
           dependsOn: sign_net_mac_win
           artifactName: nuget-signed
           artifactPatterns: |

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,10 +20,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    # TODO: Temporary feature branch to smoke-test the WiX 6 migration of
-    # nuget-msi-convert (Xamarin.yaml-templates PR #752740).
-    # Revert back to refs/heads/main once that PR merges.
-    ref: refs/heads/jonathanpeppers-nuget-msi-convert-v5
+    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,7 +20,10 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    ref: refs/heads/main
+    # TODO: Temporary feature branch for the BundledNETCoreAppTargetFramework
+    # fix (Xamarin.yaml-templates PR #754224). Revert back to refs/heads/main
+    # once that PR merges.
+    ref: refs/heads/jonathanpeppers-nuget-msi-convert-v5-bundledtfm
   - repository: maui
     type: github
     name: dotnet/maui

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -20,10 +20,7 @@ resources:
   - repository: yaml-templates
     type: git
     name: DevDiv/Xamarin.yaml-templates
-    # TODO: Temporary feature branch for the BundledNETCoreAppTargetFramework
-    # fix (Xamarin.yaml-templates PR #754224). Revert back to refs/heads/main
-    # once that PR merges.
-    ref: refs/heads/jonathanpeppers-nuget-msi-convert-v5-bundledtfm
+    ref: refs/heads/main
   - repository: maui
     type: github
     name: dotnet/maui


### PR DESCRIPTION
Migrates `dotnet/android`'s signed pipeline from the WiX 3 `nuget-msi-convert/v4.yml` template to the WiX 6 `v5.yml` template (`Microsoft.Wix 6.0.3-dotnet.4`).

## Changes

Switches the nuget-msi-convert template reference from `nuget-msi-convert/job/v4.yml@yaml-templates` to `nuget-msi-convert/job/v5.yml@yaml-templates`, and updates an adjacent comment. All other consumers of `yaml-templates@main` (sign-artifacts, policheck, build-summary) are unchanged — this is a single-template swap.

## Related Xamarin.yaml-templates work (all merged to `main`)

- [PR #752740 — WiX 6 migration of `nuget-msi-convert` (adds `v5.yml`)](https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/752740)
- [PR #754224 — Synthesize `$(BundledNETCoreAppTargetFramework)` for .NET 10 SDK](https://devdiv.visualstudio.com/DevDiv/_git/Xamarin.yaml-templates/pullrequest/754224)

Intermediate fix commits that landed inside #752740 before it merged:

- `baf73ec` — Build `convert.proj` with Core MSBuild (`DotNetCoreCLI@2`), not desktop msbuild
- `981d2a6` — Pass absolute paths to `CreateVisualStudioWorkload`
- `d8a73d8` — Rename `WixPackageVersion` → `MicrosoftWixToolsetSdkVersion` (arcade-canonical)

## What changed in v5 vs v4 (for reviewer context)

- WiX packages bumped to `6.0.3-dotnet.4` (was WiX 3)
- `swixBuildPackageVersion: 1.1.922` (was 1.1.392)
- `arcadePackageVersion: 11.0.0-beta.26325.102` (was 9.0.0-beta.24509.3)
- `arcadeTasksFxVersion: net` (was `netcoreapp3.1`)
- `dotNetSdkVersion: 10.0.x` (was 9.0.x — required; arcade 11.x tasks are net10.0)
- `convert.proj` now built with `DotNetCoreCLI@2 / dotnet msbuild` (Core MSBuild) instead of `MSBuild@1` desktop msbuild, because arcade 11.x workload tasks ship only `tools/net/` (.NETCoreApp v10). SwixBuild still uses desktop msbuild via the internal `_FindMSBuild` target.
- WiX property renamed `WixPackageVersion` → `MicrosoftWixToolsetSdkVersion` (arcade-canonical, matches dotnet/dotnet VMR).

All new parameters have sensible defaults in `v5.yml`, so dotnet/android does not need to override any of them.

## End-to-end CI validation (build [14529573](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14529573&view=results))

Internal `Xamarin.Android` signed build against this branch succeeded. The `Convert NuGet to MSI` job produced:

- **39 signed `.msi` installers** = 13 workload packages × 3 host architectures (x86/x64/arm64)
- **39 wrapping `*.msi.<arch>.<version>.nupkg` packages**, all MicroBuild-verified (`Certificate : Passed`)
- VS-insertion manifest pack: `microsoft.net.sdk.android.manifest-11.0.100-preview.7`

### MSI / nupkg spot-check (`Microsoft.Android.Sdk.Windows.Msi.x64`)

- MSI Summary Information `CreatedBy` field (PID 18): **`WiX Dev Build (6.0.3.4)`** — confirms WiX 6 toolset.
- MSI dependency-provider table renamed from `WixDependencyProvider` (WiX 3) → **`Wix4DependencyProvider`** (WiX 4+ versioned name), populated with the correct `ProviderKey`: `Microsoft.Android.Sdk.Windows,<version>,x64`.
- SWIX-generated `data/msi.json` inside the nupkg has identical schema to the WiX 3 baseline (`36.99.0-preview.5.308`), with `ProviderKeyName` correctly extracted in canonical `PackageName,Version,Arch` form. New `RelatedProducts` array additionally surfaces `WIX_UPGRADE_DETECTED` / `WIX_DOWNGRADE_DETECTED` upgrade metadata — feature gain, not a regression.