### PR TITLE
Disable failing weak reference leak test

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs
@@ -507,6 +507,7 @@ namespace Java.InteropTests
 		}
 
 		[Test, Category ("GCBridge")]
+		[Ignore ("Failing in NativeAOT: https://github.com/dotnet/android/issues/11690")]
 		public void DoNotLeakWeakReferences ()
 		{
 			GC.Collect ();


### PR DESCRIPTION
The  `Java.InteropTests.JnienvTest.DoNotLeakWeakReferences` test is very flaky and we should look into why that is - is there a bug in the gc bridge/value manager/somewhere else or is it just the test that's unreliable?

There is an existing issue to look into this problem: https://github.com/dotnet/android/issues/11690

## Testing
- `git diff --check -- tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JnienvTest.cs`