### PR TITLE
[androidsdk] Fix SDK extraction incrementality

### DIFF
--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -348,7 +348,7 @@
         Condition=" '$(HostOS)' != 'Windows' "
         Command="unzip -q -o &quot;$(_ZipPath)&quot; -d &quot;$(_StagingDir)&quot;"
     />
-    <ItemGroup Condition=" '$(HostOS)' != 'Windows' And '$(_StripComponents)' == '1' ">
+    <ItemGroup Condition=" '$(HostOS)' != 'Windows' And '$(_StripComponents)' == '1' And Exists('$(_StagingDir)') ">
       <_StagedTopDir Remove="@(_StagedTopDir)" />
       <_StagedTopDir Include="$([System.IO.Directory]::GetDirectories('$(_StagingDir)'))" />
     </ItemGroup>
@@ -356,7 +356,7 @@
       <_GlobRoot Condition=" '$(_StripComponents)' == '1' ">@(_StagedTopDir)</_GlobRoot>
       <_GlobRoot Condition=" '$(_StripComponents)' == '0' ">$(_StagingDir)</_GlobRoot>
     </PropertyGroup>
-    <ItemGroup Condition=" '$(HostOS)' != 'Windows' ">
+    <ItemGroup Condition=" '$(HostOS)' != 'Windows' And '$(_GlobRoot)' != '' ">
       <_StagedFile Remove="@(_StagedFile)" />
       <_StagedFile Include="$(_GlobRoot)\**\*" />
     </ItemGroup>
@@ -366,6 +366,12 @@
         DestinationFiles="@(_StagedFile->'$(_DestDir)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
     <RemoveDir Condition=" '$(HostOS)' != 'Windows' " Directories="$(_StagingDir)" />
+    <Error
+        Condition=" !Exists('%(_AndroidSdkPackage.Destination)\source.properties') "
+        Text="Expected Android SDK package '%(_AndroidSdkPackage.Identity)' to extract source.properties under '%(_AndroidSdkPackage.Destination)'."
+    />
+    <!-- Unzip preserves archive mtimes, so refresh the sentinel used by MSBuild Outputs. -->
+    <Touch Files="%(_AndroidSdkPackage.Destination)\source.properties" />
   </Target>
 
   <!--
@@ -373,17 +379,21 @@
     Reads `package.xml.in` next to this targets file and replaces the `@PKG_*@`
     placeholders from per-item metadata (PkgPath/PkgDesc/PkgRevision).
   -->
-  <Target Name="_GenerateAndroidPackageXmls"
-      DependsOnTargets="_ExtractAndroidSdkPackages"
-      Inputs="$(MSBuildThisFileDirectory)package.xml.in;@(_AndroidSdkPackage->'%(Destination)\source.properties')"
-      Outputs="@(_AndroidSdkPackage->'%(Destination)\package.xml')">
+  <Target Name="_AddGeneratedPackageXmls" BeforeTargets="_GenerateAndroidPackageXmls">
     <ItemGroup>
-      <_PkgXmlItem Include="@(_AndroidSdkPackage)"
+      <_GeneratedPackageXml Remove="@(_GeneratedPackageXml)" />
+      <_GeneratedPackageXml Include="@(_AndroidSdkPackage)"
           Condition=" '%(_AndroidSdkPackage.GeneratePackageXml)' == 'true' " />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_GenerateAndroidPackageXmls"
+      DependsOnTargets="_ExtractAndroidSdkPackages"
+      Inputs="$(MSBuildThisFileDirectory)package.xml.in;@(_GeneratedPackageXml->'%(Destination)\source.properties')"
+      Outputs="@(_GeneratedPackageXml->'%(Destination)\package.xml')">
     <WriteLinesToFile
-        File="%(_PkgXmlItem.Destination)\package.xml"
-        Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)package.xml.in').Replace('@PKG_PATH@', '%(_PkgXmlItem.PkgPath)').Replace('@PKG_DESC@', '%(_PkgXmlItem.PkgDesc)').Replace('@PKG_REVISION_MAJOR@', $([System.Version]::Parse('%(_PkgXmlItem.PkgRevision)').Major.ToString())).Replace('@PKG_REVISION_MINOR@', $([System.Version]::Parse('%(_PkgXmlItem.PkgRevision)').Minor.ToString())).Replace('@PKG_REVISION_MICRO@', $([System.Version]::Parse('%(_PkgXmlItem.PkgRevision)').Build.ToString())))"
+        File="%(_GeneratedPackageXml.Destination)\package.xml"
+        Lines="$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)package.xml.in').Replace('@PKG_PATH@', '%(_GeneratedPackageXml.PkgPath)').Replace('@PKG_DESC@', '%(_GeneratedPackageXml.PkgDesc)').Replace('@PKG_REVISION_MAJOR@', $([System.Version]::Parse('%(_GeneratedPackageXml.PkgRevision)').Major.ToString())).Replace('@PKG_REVISION_MINOR@', $([System.Version]::Parse('%(_GeneratedPackageXml.PkgRevision)').Minor.ToString())).Replace('@PKG_REVISION_MICRO@', $([System.Version]::Parse('%(_GeneratedPackageXml.PkgRevision)').Build.ToString())))"
         Overwrite="true"
     />
   </Target>

--- a/src/androidsdk/androidsdk.targets
+++ b/src/androidsdk/androidsdk.targets
@@ -367,11 +367,11 @@
     />
     <RemoveDir Condition=" '$(HostOS)' != 'Windows' " Directories="$(_StagingDir)" />
     <Error
-        Condition=" !Exists('%(_AndroidSdkPackage.Destination)\source.properties') "
-        Text="Expected Android SDK package '%(_AndroidSdkPackage.Identity)' to extract source.properties under '%(_AndroidSdkPackage.Destination)'."
+        Condition=" !Exists('$(_DestDir)\source.properties') "
+        Text="Expected Android SDK package '%(_AndroidSdkPackage.Identity)' to extract source.properties under '$(_DestDir)'."
     />
     <!-- Unzip preserves archive mtimes, so refresh the sentinel used by MSBuild Outputs. -->
-    <Touch Files="%(_AndroidSdkPackage.Destination)\source.properties" />
+    <Touch Files="$(_DestDir)\source.properties" />
   </Target>
 
   <!--
@@ -379,7 +379,7 @@
     Reads `package.xml.in` next to this targets file and replaces the `@PKG_*@`
     placeholders from per-item metadata (PkgPath/PkgDesc/PkgRevision).
   -->
-  <Target Name="_AddGeneratedPackageXmls" BeforeTargets="_GenerateAndroidPackageXmls">
+  <Target Name="_AddGeneratedPackageXmls">
     <ItemGroup>
       <_GeneratedPackageXml Remove="@(_GeneratedPackageXml)" />
       <_GeneratedPackageXml Include="@(_AndroidSdkPackage)"
@@ -388,7 +388,7 @@
   </Target>
 
   <Target Name="_GenerateAndroidPackageXmls"
-      DependsOnTargets="_ExtractAndroidSdkPackages"
+      DependsOnTargets="_ExtractAndroidSdkPackages;_AddGeneratedPackageXmls"
       Inputs="$(MSBuildThisFileDirectory)package.xml.in;@(_GeneratedPackageXml->'%(Destination)\source.properties')"
       Outputs="@(_GeneratedPackageXml->'%(Destination)\package.xml')">
     <WriteLinesToFile


### PR DESCRIPTION
## Summary

This fixes `src/androidsdk/androidsdk.csproj` being slow on repeated builds by making the SDK extraction targets genuinely incremental.

The important change is that after extracting each Android SDK/NDK archive, we now refresh the extracted `source.properties` file that MSBuild uses as the target output. That lets later builds see the extraction output as newer than the cached archive input and skip the expensive unzip/delete/recreate work.

## What was happening before

`_DownloadAndroidSdkPackages` was not the main problem: the archives were already cached under `$(AndroidToolchainCacheDirectory)`/`~/android-archives`, and the shared `DownloadFileWithRetry.targets` stamp files meant the download/hash-validation work was normally skipped.

The slow part was `_ExtractAndroidSdkPackages`. It is batched per package and declares:

```xml
Inputs="$(AndroidToolchainCacheDirectory)\%(_AndroidSdkPackage.Identity)"
Outputs="%(_AndroidSdkPackage.Destination)\source.properties"
```

That looks correct at first: cached zip in, extracted `source.properties` out. The problem is that `unzip` preserves timestamps from the zip entries. Many Android SDK zips contain very old file mtimes, for example `source.properties` dated 2008, 2010, 2024, or 2025, while the cached zip file in `~/android-archives` has the time it was downloaded/restored.

So after a successful extraction, MSBuild still saw:

```text
cached zip input          newer
extracted source.properties output  older
```

That made `_ExtractAndroidSdkPackages` out-of-date on every build. Each repeated build deleted the existing SDK/NDK destination, recreated a staging directory, and unzipped/moved the package contents again. On my machine this showed up as `_ExtractAndroidSdkPackages` taking about 205s on an otherwise repeated build.

## Why this works now

After extraction completes, the target verifies that the expected `source.properties` exists and then touches it:

```xml
<Touch Files="%(_AndroidSdkPackage.Destination)\source.properties" />
```

That does not modify package contents semantically; it only updates the incremental-build sentinel that this target already chose as its output. On the next build, the output timestamp is newer than the cached zip input, so MSBuild can correctly skip the batch instead of re-extracting the package.

Making extraction actually skippable exposed two related incremental-build issues, both fixed here:

1. On Unix, the target enumerated the temporary `.staging` directory while MSBuild was doing skipped-target output inference. Once extraction is skipped, that staging directory correctly does not exist, so the target now guards the staging directory enumeration and staged-file glob.
2. `_GenerateAndroidPackageXmls` declared `package.xml` outputs for every SDK package, but only packages with `GeneratePackageXml=true` synthesize one. For packages that never produce `package.xml`, the target was permanently missing outputs and ran every build. It now builds a filtered `_GeneratedPackageXml` item list and makes the incremental Inputs/Outputs apply only to those packages.

## Validation

Ran repeated builds of the standalone project:

```bash
dotnet build src/androidsdk/androidsdk.csproj -c Debug -nologo -v:diag
```

After the one expected re-extraction to refresh sentinels, the steady-state diagnostic build shows:

```text
Skipping target "_ExtractAndroidSdkPackages" because all output files are up-to-date with respect to the input files.
Skipping target "_GenerateAndroidPackageXmls" because all output files are up-to-date with respect to the input files.
Skipping target "_AcceptAndroidSdkLicenses" because all output files are up-to-date with respect to the input files.

_ExtractAndroidSdkPackages      4 ms / 11 calls
_GenerateAndroidPackageXmls     1 ms / 1 call
Build succeeded.
Time Elapsed 00:00:01.41
```
