### PR TITLE
[tests] Verbose apkdiff output for BuildReleaseArm64 regressions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -313,8 +314,78 @@ namespace Xamarin.Android.Build.Tests
 				var apkDescPath = Path.Combine (Root, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);
 				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression {regressionCheckArgs} {apkDescReferencePath} {apkFile}", Path.Combine (Root, b.ProjectDirectory, "apkdiff.log"));
-				Assert.IsTrue (code == 0, $"apkdiff regression test failed with exit code: {code}. See test attachments.");
+				if (code != 0) {
+					if (File.Exists (apkDescPath)) {
+						TestContext.AddTestAttachment (apkDescPath, apkDescFilename);
+					}
+
+					var message = new StringBuilder ();
+					message.AppendLine ($"apkdiff regression test failed with exit code: {code}.");
+					message.AppendLine ();
+					message.AppendLine ("== apkdiff output ==");
+					if (!stdOut.IsNullOrEmpty ()) {
+						message.AppendLine (stdOut);
+					}
+					if (!stdErr.IsNullOrEmpty ()) {
+						message.AppendLine (stdErr);
+					}
+					message.AppendLine ();
+					message.AppendLine ("== .apkdesc diff (reference -> current) ==");
+					message.AppendLine (GetApkDescDiff (apkDescReferencePath, apkDescPath));
+					message.AppendLine ();
+					message.AppendLine ($"If this change is intended, update the reference '{apkDescFilename}' with the current '.apkdesc' attached to this test (or run build-tools/scripts/UpdateApkSizeReference.sh).");
+					Assert.Fail (message.ToString ());
+				}
 			}
+		}
+
+		static string GetApkDescDiff (string referencePath, string currentPath)
+		{
+			if (!File.Exists (referencePath)) {
+				return $"(reference apkdesc not found: {referencePath})";
+			}
+			if (!File.Exists (currentPath)) {
+				return $"(current apkdesc not found: {currentPath})";
+			}
+
+			var reference = ReadApkDescEntries (referencePath);
+			var current = ReadApkDescEntries (currentPath);
+
+			var sb = new StringBuilder ();
+			foreach (var key in reference.Keys.Union (current.Keys).OrderBy (k => k, StringComparer.Ordinal)) {
+				bool inReference = reference.TryGetValue (key, out long oldSize);
+				bool inCurrent = current.TryGetValue (key, out long newSize);
+				if (inReference && inCurrent) {
+					if (oldSize != newSize) {
+						sb.AppendLine ($"  {key}");
+						sb.AppendLine ($"-     \"Size\": {oldSize}");
+						sb.AppendLine ($"+     \"Size\": {newSize}   ({(newSize - oldSize):+#,0;-#,0;0} bytes)");
+					}
+				} else if (inReference) {
+					sb.AppendLine ($"- {key} (\"Size\": {oldSize}) [removed]");
+				} else {
+					sb.AppendLine ($"+ {key} (\"Size\": {newSize}) [added]");
+				}
+			}
+
+			if (sb.Length == 0) {
+				return "(no per-entry size differences)";
+			}
+			return sb.ToString ();
+		}
+
+		static Dictionary<string, long> ReadApkDescEntries (string path)
+		{
+			var result = new Dictionary<string, long> (StringComparer.Ordinal);
+			using var doc = JsonDocument.Parse (File.ReadAllText (path));
+			if (doc.RootElement.TryGetProperty ("Entries", out var entries)) {
+				foreach (var entry in entries.EnumerateObject ()) {
+					if (entry.Value.TryGetProperty ("Size", out var size)) {
+						result [entry.Name] = size.GetInt64 ();
+					}
+				}
+			}
+			return result;
 		}
 
 		static IEnumerable<object[]> Get_BuildHasNoWarningsData ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -333,7 +333,14 @@ namespace Xamarin.Android.Build.Tests
 					message.AppendLine ("== .apkdesc diff (reference -> current) ==");
 					message.AppendLine (GetApkDescDiff (apkDescReferencePath, apkDescPath));
 					message.AppendLine ();
-					message.AppendLine ($"If this change is intended, update the reference '{apkDescFilename}' with the current '.apkdesc' attached to this test (or run build-tools/scripts/UpdateApkSizeReference.sh).");
+					message.AppendLine ($"== current '{apkDescFilename}' (copy/paste to update the reference) ==");
+					if (File.Exists (apkDescPath)) {
+						message.AppendLine (File.ReadAllText (apkDescPath));
+					} else {
+						message.AppendLine ($"(current apkdesc not found: {apkDescPath})");
+					}
+					message.AppendLine ();
+					message.AppendLine ($"If this change is intended, update the reference '{apkDescFilename}' with the current '.apkdesc' above (or attached to this test), or run build-tools/scripts/UpdateApkSizeReference.sh.");
 					Assert.Fail (message.ToString ());
 				}
 			}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -124,6 +124,7 @@ namespace Xamarin.Android.Build.Tests
 				$"\ncontext: https://github.com/xamarin/xamarin-android/blob/main/Documentation/project-docs/ApkSizeRegressionChecks.md" +
 				$"\nstdOut:\n{result.stdOutput}\nstdErr:\n{result.stdError}";
 			File.WriteAllText (logFilePath, logContent);
+			TestContext.AddTestAttachment (logFilePath, Path.GetFileName (logFilePath));
 			return result;
 		}
 


### PR DESCRIPTION
## Summary

When the `BuildReleaseArm64` APK size regression check fails, the only feedback was:

```
apkdiff regression test failed with exit code: 3. See test attachments.
Expected: True
But was:  False
```

The referenced `apkdiff.log` (which holds the actual apkdiff report) was written to the build directory but **never added as a test attachment** — so "See test attachments" was misleading, and diagnosing a regression meant digging through the CI build artifacts archive.

This PR makes the failure self-explanatory and copy-paste-ready, so the regression details (and the updated reference) can go straight into a PR without hunting through CI artifacts.

## Changes

- **`BaseTest.cs` — `RunApkDiffCommand`**: now adds `apkdiff.log` (the full apkdiff stdout/stderr report) as a real `TestContext.AddTestAttachment`.
- **`BuildTest2.cs` — `BuildReleaseArm64`**: on a regression (`exit code != 0`), replaces the terse `Assert.IsTrue` with an `Assert.Fail` that includes:
  - the **full apkdiff output** (stdout + stderr);
  - a **per-entry `.apkdesc` diff** (reference → current) with `"Size"` `-`/`+` lines and `(±N bytes)` deltas, plus `[added]`/`[removed]` entries, so the regression is obvious at a glance;
  - the **raw, full contents of the current `.apkdesc`**, so it can be copy-pasted directly into the reference file and committed without downloading any attachment.
  - The freshly-generated `.apkdesc` is also added as an attachment.
  - The detailed message is built **only on failure** (no overhead on the passing path).
- Added small `GetApkDescDiff` / `ReadApkDescEntries` helpers using `System.Text.Json` (already used elsewhere in this test project).

## Example output on failure

```
apkdiff regression test failed with exit code: 3.

== apkdiff output ==
Size difference in bytes ([*1] apk1 only, [*2] apk2 only):
  +      47,648 classes.dex
Error: apkdiff: File 'classes.dex' has changed by 47,648 bytes (10.59 %). This exceeds the threshold of 5.00 %.
  -      61,344 lib/arm64-v8a/libassembly-store.so
Summary:
  +      47,648 Dalvik executables 11.84% (of 402,352)
  -      61,344 Shared libraries -0.44% (of 14,089,448)
Error: apkdiff: Size regression occured, 1 check(s) failed.

== .apkdesc diff (reference -> current) ==
  classes.dex
-     "Size": 402352
+     "Size": 450000   (+47,648 bytes)
  lib/arm64-v8a/libassembly-store.so
-     "Size": 3461344
+     "Size": 3400000   (-61,344 bytes)

== current 'BuildReleaseArm64SimpleDotNet.CoreCLR.apkdesc' (copy/paste to update the reference) ==
{
  "Comment": null,
  "Entries": {
    "AndroidManifest.xml": {
      "Size": 3036
    },
    ...
  }
}

If this change is intended, update the reference '...apkdesc' with the current '.apkdesc' above (or attached to this test), or run build-tools/scripts/UpdateApkSizeReference.sh.
```

## Notes

- Test-infrastructure only — no product code, dependency, or threshold changes; the passing path is unchanged.
- See `Documentation/project-docs/ApkSizeRegressionChecks.md` for background on these checks.