### PR TITLE
[tests] Verbose apkdiff output for BuildReleaseArm64 regressions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using System.Xml;
 using System.Xml.Linq;
@@ -313,8 +314,78 @@ namespace Xamarin.Android.Build.Tests
 				var apkDescPath = Path.Combine (Root, apkDescFilename);
 				var apkDescReferencePath = Path.Combine (Root, b.ProjectDirectory, apkDescReference);
 				var (code, stdOut, stdErr) = RunApkDiffCommand ($"-s --save-description-2={apkDescPath} --descrease-is-regression {regressionCheckArgs} {apkDescReferencePath} {apkFile}", Path.Combine (Root, b.ProjectDirectory, "apkdiff.log"));
-				Assert.IsTrue (code == 0, $"apkdiff regression test failed with exit code: {code}. See test attachments.");
+				if (code != 0) {
+					if (File.Exists (apkDescPath)) {
+						TestContext.AddTestAttachment (apkDescPath, apkDescFilename);
+					}
+
+					var message = new StringBuilder ();
+					message.AppendLine ($"apkdiff regression test failed with exit code: {code}.");
+					message.AppendLine ();
+					message.AppendLine ("== apkdiff output ==");
+					if (!stdOut.IsNullOrEmpty ()) {
+						message.AppendLine (stdOut);
+					}
+					if (!stdErr.IsNullOrEmpty ()) {
+						message.AppendLine (stdErr);
+					}
+					message.AppendLine ();
+					message.AppendLine ("== .apkdesc diff (reference -> current) ==");
+					message.AppendLine (GetApkDescDiff (apkDescReferencePath, apkDescPath));
+					message.AppendLine ();
+					message.AppendLine ($"If this change is intended, update the reference '{apkDescFilename}' with the current '.apkdesc' attached to this test (or run build-tools/scripts/UpdateApkSizeReference.sh).");
+					Assert.Fail (message.ToString ());
+				}
 			}
+		}
+
+		static string GetApkDescDiff (string referencePath, string currentPath)
+		{
+			if (!File.Exists (referencePath)) {
+				return $"(reference apkdesc not found: {referencePath})";
+			}
+			if (!File.Exists (currentPath)) {
+				return $"(current apkdesc not found: {currentPath})";
+			}
+
+			var reference = ReadApkDescEntries (referencePath);
+			var current = ReadApkDescEntries (currentPath);
+
+			var sb = new StringBuilder ();
+			foreach (var key in reference.Keys.Union (current.Keys).OrderBy (k => k, StringComparer.Ordinal)) {
+				bool inReference = reference.TryGetValue (key, out long oldSize);
+				bool inCurrent = current.TryGetValue (key, out long newSize);
+				if (inReference && inCurrent) {
+					if (oldSize != newSize) {
+						sb.AppendLine ($"  {key}");
+						sb.AppendLine ($"-     \"Size\": {oldSize}");
+						sb.AppendLine ($"+     \"Size\": {newSize}   ({(newSize - oldSize):+#,0;-#,0;0} bytes)");
+					}
+				} else if (inReference) {
+					sb.AppendLine ($"- {key} (\"Size\": {oldSize}) [removed]");
+				} else {
+					sb.AppendLine ($"+ {key} (\"Size\": {newSize}) [added]");
+				}
+			}
+
+			if (sb.Length == 0) {
+				return "(no per-entry size differences)";
+			}
+			return sb.ToString ();
+		}
+
+		static Dictionary<string, long> ReadApkDescEntries (string path)
+		{
+			var result = new Dictionary<string, long> (StringComparer.Ordinal);
+			using var doc = JsonDocument.Parse (File.ReadAllText (path));
+			if (doc.RootElement.TryGetProperty ("Entries", out var entries)) {
+				foreach (var entry in entries.EnumerateObject ()) {
+					if (entry.Value.TryGetProperty ("Size", out var size)) {
+						result [entry.Name] = size.GetInt64 ();
+					}
+				}
+			}
+			return result;
 		}
 
 		static IEnumerable<object[]> Get_BuildHasNoWarningsData ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/BaseTest.cs
@@ -124,6 +124,7 @@ namespace Xamarin.Android.Build.Tests
 				$"\ncontext: https://github.com/xamarin/xamarin-android/blob/main/Documentation/project-docs/ApkSizeRegressionChecks.md" +
 				$"\nstdOut:\n{result.stdOutput}\nstdErr:\n{result.stdError}";
 			File.WriteAllText (logFilePath, logContent);
+			TestContext.AddTestAttachment (logFilePath, Path.GetFileName (logFilePath));
 			return result;
 		}
 


### PR DESCRIPTION
## Why

The `BuildReleaseArm64` test guards against APK size regressions by running `apkdiff` against a checked-in `.apkdesc` reference. When a regression trips the check, the test used to fail with nothing but an exit code:

```
apkdiff regression test failed with exit code: 3. See test attachments.
Expected: True
But was:  False
```

The "test attachments" it pointed at didn't actually exist: the `apkdiff.log` was written to the build directory but never registered as an NUnit test attachment, and the freshly-generated `.apkdesc` wasn't surfaced either. In practice, diagnosing a size regression meant SSH-ing into the build, hunting through CI artifacts to find which entry grew, by how much, and then manually regenerating the reference. That's slow and error-prone — especially for first-time contributors who just bumped a dependency.

This makes the failure **self-explanatory and copy-paste-ready** straight from the test output.

## What

**`BaseTest.RunApkDiffCommand`** now registers the `apkdiff.log` it writes as a real test attachment, so the full apkdiff report is always available in the test results (pass or fail).

**`BuildTest2.BuildReleaseArm64`** now, on failure (`code != 0`):

- Attaches the freshly-generated `.apkdesc` so the updated reference can be downloaded directly from the test results.
- Fails via `Assert.Fail` with a rich message that includes:
  - the full apkdiff output (stdout + stderr),
  - a per-entry `.apkdesc` diff (**reference → current**) showing `"Size"` `-`/`+` lines with signed, thousands-separated byte deltas, and `[added]`/`[removed]` markers for entries that appear or disappear,
  - a one-line hint on how to accept the change (update the reference `.apkdesc` / run `build-tools/scripts/UpdateApkSizeReference.sh`).

The diff is computed by parsing the `Entries` object of both `.apkdesc` JSON files (`GetApkDescDiff` / `ReadApkDescEntries`) and comparing the `Size` of each entry, so only entries that actually changed are shown.

### Example of the new failure output

```
apkdiff regression test failed with exit code: 3.

== apkdiff output ==
Size difference in bytes ([reference] [current] [difference]):
  + assemblies/UnnamedProject.dll : 18432 19456 1024
  + lib/arm64-v8a/libxamarin-app.so : 1359872 1372160 12288
Total size difference: +13312 bytes
Error: size increased by 13312 bytes, which is a regression.

== .apkdesc diff (reference -> current) ==
  assemblies/UnnamedProject.dll
-     "Size": 18432
+     "Size": 19456   (+1,024 bytes)
  lib/arm64-v8a/libxamarin-app.so
-     "Size": 1359872
+     "Size": 1372160   (+12,288 bytes)
+ lib/arm64-v8a/libnew-feature.so ("Size": 4096) [added]

If this change is intended, update the reference 'UnnamedProject.apkdesc' with the current '.apkdesc' attached to this test (or run build-tools/scripts/UpdateApkSizeReference.sh).
```

Attachments on the failed test: `apkdiff.log` (full report) and the current `*.apkdesc` (the new reference candidate).

## Notes

- Pure test-infrastructure change — no product code is touched, so there is no runtime/behavioral impact on shipped builds.
- When the apkdesc files can't be read (missing reference/current, or no per-entry size differences), the diff helper degrades gracefully with an explanatory placeholder instead of throwing.

## Checklist

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [x] Unit tests — improves the diagnostics of the existing `BuildReleaseArm64` regression test; no new behavior to cover beyond the richer failure reporting.
