### PR TITLE
[TrimmableTypeMap] Improve trimmable typemap build incrementality

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -102,13 +102,13 @@ compilation. For `CoreCLR` + `PublishTrimmed`, the JCWs are sourced from the
 which is itself incremental; the stamp remains the sentinel so a no-op build
 still skips `_GenerateJavaStubs`.
 
-### 3. Stale generated Java sources are pruned
+### 3. Stale generated Java sources are pruned (both passes)
 
-When a managed type is removed, its JCW must not linger. The task's
-`DeleteStaleJavaSources` enumerates the JCW output directory and deletes any
-`*.java` the current pass did not produce, returning them as `DeletedJavaFiles`
-(with `RelativePath` metadata). The target mirrors each deletion into the
-`android/src` copy and, if anything was deleted, deletes
+When a managed type is removed — or trimmed away on the `PublishTrimmed` path —
+its JCW must not linger in `android/src`, where it would otherwise be compiled
+and packaged. Both generator passes report the JCWs they no longer produce as
+`DeletedJavaFiles` (with `RelativePath` metadata), and the owning target mirrors
+each deletion into the `android/src` copy and, if anything was deleted, deletes
 `$(_AndroidCompileJavaStampFile)` so `_CompileJava` re-runs and drops the stale
 `.class` outputs:
 
@@ -116,6 +116,24 @@ When a managed type is removed, its JCW must not linger. The task's
 <Delete Files="@(_DeletedCopiedJavaFiles)" />
 <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
 ```
+
+The two passes compute the deleted set differently because of how each manages
+its output directory:
+
+- **Pre-trim** (`_GenerateTrimmableTypeMap`, writing `typemap/java`): the task
+  scans the output directory and deletes any `*.java` the current pass did not
+  produce.
+- **Post-trim** (`_GeneratePostTrimTrimmableTypeMapJavaSources`, writing
+  `typemap/linked-java` with `CleanJavaSourceOutputDirectory=true`): the
+  directory is wiped before regeneration, so the task snapshots the previous
+  `*.java` set *before* the wipe and reports `previous − regenerated`. This keeps
+  the deletion precise — only files the generator itself previously produced are
+  ever removed from `android/src`, never unrelated sources such as
+  `ApplicationRegistration.java`.
+
+The invariant is two-directional: **`android/src` contains exactly the JCWs the
+active pass produces** — no missing files (copied via `_GenerateJavaStubs`) and
+no stale files (pruned via `DeletedJavaFiles`).
 
 ### 4. Dynamic `FileWrites` are re-emitted on no-op builds
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/README.md
@@ -1,0 +1,147 @@
+# Trimmable typemap build pipeline
+
+This document describes how the **trimmable** typemap implementation
+(`_AndroidTypeMapImplementation=trimmable`) is produced during an Android app
+build, and how the MSBuild targets are kept incremental. It is aimed at
+contributors working on the targets in
+`src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable*.targets`
+and the `GenerateTrimmableTypeMap` MSBuild task.
+
+## Background
+
+The legacy typemap implementations (`llvm-ir`, `managed`) embed the
+managed&nbsp;↔&nbsp;Java type mapping into native binaries. The **trimmable**
+implementation instead generates a set of small managed *TypeMap assemblies*
+(one per input assembly, plus a `_Microsoft.Android.TypeMaps` root) and the Java
+Callable Wrapper (JCW) `*.java` sources from the same scan. This keeps the
+mapping trimmer-friendly: unused entries are removed by the IL linker.
+
+The work happens in the `GenerateTrimmableTypeMap` task, invoked from the
+`_GenerateTrimmableTypeMap` target. The runtime is selected by `_AndroidRuntime`
+(`CoreCLR` or `NativeAOT`); the runtime-specific imports
+(`*.Trimmable.CoreCLR.targets`, `*.Trimmable.NativeAOT.targets`) extend the
+shared pipeline.
+
+## Target pipeline (CoreCLR, non-trimmed Debug build)
+
+```
+CoreCompile
+   └─► _GenerateTrimmableTypeMap   (AfterTargets="CoreCompile")
+          • scans @(ReferencePath) + framework/SDK assemblies + the app .dll
+          • writes typemap/_*.TypeMap.dll + _Microsoft.Android.TypeMaps.dll
+          • writes typemap/java/**/*.java (JCWs) and acw-map.txt
+          • writes the merged AndroidManifest.xml
+          • touches typemap/_GenerateTrimmableTypeMap.stamp
+   ...
+_ReadGeneratedTrimmableTypeMapAssemblies    (reads typemap-assemblies.txt)
+_PrepareTrimmableNativeConfigAssemblies     (feeds _GeneratePackageManagerJava)
+_PrepareTrimmableTypeMapAssemblies          (feeds packaging / assembly store)
+_CollectTrimmableTypeMapJavaFiles           (globs the JCW *.java)
+_GenerateJavaStubs                          (copies JCWs into android/src, manifest, acw-map)
+   └─► _CompileJava ─► _CompileToDalvik ─► packaging
+```
+
+`_GenerateJavaStubs` **overrides** the legacy target of the same name from
+`BuildOrder.targets`; in the trimmable path the JCWs already exist, so this
+target only copies them into `$(IntermediateOutputPath)android/src` and wires up
+the manifest, `acw-map.txt`, and native config.
+
+For `CoreCLR` + `PublishTrimmed=true`, a second pass
+(`_GeneratePostTrimTrimmableTypeMapJavaSources`, in the CoreCLR targets)
+regenerates the JCWs from the **linked** assemblies into a `linked-java`
+directory, which then becomes the source for `_GenerateJavaStubs`.
+
+## Incrementality design
+
+The pipeline follows the repository's
+[MSBuild best practices](../../Documentation/guides/MSBuildBestPractices.md):
+every expensive target declares `Inputs`/`Outputs`, re-emits its dynamic
+`FileWrites`, and uses stamp files where a real output cannot serve as a
+reliable timestamp sentinel.
+
+### 1. A stamp file is the generator's incremental sentinel
+
+`_GenerateTrimmableTypeMap` declares:
+
+```xml
+Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)"
+```
+
+The generated TypeMap DLLs are written with `Files.CopyIfStreamChanged`, so an
+assembly whose **content** is unchanged keeps its old timestamp. If those DLLs
+were the only `Outputs`, MSBuild would consider the target perpetually
+out-of-date (its inputs are always newer than the untouched outputs) and re-run
+it on every build. To avoid this, the target unconditionally `Touch`es a
+dedicated stamp:
+
+```xml
+<Touch Files="@(_GeneratedTypeMapAssemblies);$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
+```
+
+so the stamp is always newer than the inputs after a run, and the target is
+correctly **skipped** when none of the inputs changed.
+
+> All assemblies that can contribute managed&nbsp;↔&nbsp;Java mappings must be
+> inputs — including `@(PrivateSdkAssemblies)` and `@(FrameworkAssemblies)` —
+> otherwise a change in one of them would not trigger regeneration.
+
+### 2. `_GenerateJavaStubs` keys off the stamp
+
+```xml
+Inputs="$(_TrimmableTypeMapOutputStamp);@(_EnvironmentFiles)"
+Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp"
+```
+
+The stamp captures "the generator ran because its inputs changed" and is left
+stable when the generator is skipped, so the JCW copy into `android/src` only
+re-runs when something relevant actually changed. The copy uses
+`SkipUnchangedFiles="true"` so unchanged JCWs do not churn downstream Java
+compilation. For `CoreCLR` + `PublishTrimmed`, the JCWs are sourced from the
+`linked-java` directory produced by `_GeneratePostTrimTrimmableTypeMapJavaSources`,
+which is itself incremental; the stamp remains the sentinel so a no-op build
+still skips `_GenerateJavaStubs`.
+
+### 3. Stale generated Java sources are pruned
+
+When a managed type is removed, its JCW must not linger. The task's
+`DeleteStaleJavaSources` enumerates the JCW output directory and deletes any
+`*.java` the current pass did not produce, returning them as `DeletedJavaFiles`
+(with `RelativePath` metadata). The target mirrors each deletion into the
+`android/src` copy and, if anything was deleted, deletes
+`$(_AndroidCompileJavaStampFile)` so `_CompileJava` re-runs and drops the stale
+`.class` outputs:
+
+```xml
+<Delete Files="@(_DeletedCopiedJavaFiles)" />
+<Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
+```
+
+### 4. Dynamic `FileWrites` are re-emitted on no-op builds
+
+The set of generated assemblies and JCWs is data-dependent, so a build that
+*skips* `_GenerateTrimmableTypeMap` never executes the `ItemGroup` that registers
+those files in `@(FileWrites)`. `_RecordTrimmableTypeMapFileWrites` re-reads the
+generated outputs from `typemap-assemblies.txt` (and globs the JCWs) and
+re-emits them — plus the stamp — into `@(FileWrites)` *before* MSBuild's
+`IncrementalClean`, so the outputs are not seen as orphaned and deleted between
+incremental builds.
+
+### 5. The generator does not run in design-time builds, and runs once
+
+`_GenerateTrimmableTypeMap` is gated on `'$(DesignTimeBuild)' != 'true'`: in a
+design-time build, project references may resolve to target paths that are not
+produced when `SkipCompilerExecution=true`, and the generator output is not
+needed to provide IDE information. Combined with the
+`'$(_OuterIntermediateOutputPath)' == ''` guard (which skips inner per-RID
+builds), the generator runs exactly once per outer build.
+
+## Files
+
+| File | Role |
+| ---- | ---- |
+| `Microsoft.Android.Sdk.TypeMap.Trimmable.targets` | Shared pipeline: generation, Java stubs, packaging hookup, incremental `FileWrites`. |
+| `Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets` | CoreCLR specifics, incl. the post-trim `linked-java` regeneration. |
+| `Microsoft.Android.Sdk.TypeMap.Trimmable.NativeAOT.targets` | NativeAOT specifics (ILC inputs, proguard). |
+| `Tasks/GenerateTrimmableTypeMap.cs` | The MSBuild task front-end for the generator. |
+| `Microsoft.Android.Sdk.TrimmableTypeMap/**` | The generator/scanner library invoked by the task. |

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -48,16 +48,29 @@
         OutputFile="$(_ProguardProjectConfiguration)" />
   </Target>
 
-  <Target Name="_GeneratePostTrimTrimmableTypeMapJavaSources"
+  <Target Name="_ComputePostTrimTrimmableTypeMapInputs"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' "
       AfterTargets="_ResolveAssemblies"
-      BeforeTargets="_GenerateJavaStubs;_CompileJava;_CompileToDalvik"
-      Inputs="@(ResolvedFileToPublish)"
-      Outputs="$(_PostTrimTrimmableTypeMapJavaStamp)">
+      BeforeTargets="_GeneratePostTrimTrimmableTypeMapJavaSources">
     <ItemGroup>
+      <_PostTrimTrimmableTypeMapInputAssemblies Remove="@(_PostTrimTrimmableTypeMapInputAssemblies)" />
+      <!-- Only the linked .dll assemblies that already exist on disk are valid inputs.
+           @(ResolvedFileToPublish) also contains non-assembly publish outputs (e.g.
+           runtimeconfig.json) whose paths do not exist when this target runs; declaring a
+           non-existent file as an Input would make MSBuild consider the target perpetually
+           out-of-date and run it on every build. -->
       <_PostTrimTrimmableTypeMapInputAssemblies Include="@(ResolvedFileToPublish)"
-          Condition=" '%(Extension)' == '.dll' and ('%(RuntimeIdentifier)' == '' or '$(_PostTrimTypeMapFirstRuntimeIdentifier)' == '' or '%(RuntimeIdentifier)' == '$(_PostTrimTypeMapFirstRuntimeIdentifier)') " />
+          Condition=" '%(Extension)' == '.dll' and Exists('%(FullPath)') and ('%(RuntimeIdentifier)' == '' or '$(_PostTrimTypeMapFirstRuntimeIdentifier)' == '' or '%(RuntimeIdentifier)' == '$(_PostTrimTypeMapFirstRuntimeIdentifier)') " />
     </ItemGroup>
+  </Target>
+
+  <Target Name="_GeneratePostTrimTrimmableTypeMapJavaSources"
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' "
+      DependsOnTargets="_ComputePostTrimTrimmableTypeMapInputs"
+      AfterTargets="_ResolveAssemblies"
+      BeforeTargets="_GenerateJavaStubs;_CompileJava;_CompileToDalvik"
+      Inputs="@(_PostTrimTrimmableTypeMapInputAssemblies)"
+      Outputs="$(_PostTrimTrimmableTypeMapJavaStamp)">
 
     <GenerateTrimmableTypeMap
         ResolvedAssemblies="@(_PostTrimTrimmableTypeMapInputAssemblies)"

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.CoreCLR.targets
@@ -50,8 +50,7 @@
 
   <Target Name="_ComputePostTrimTrimmableTypeMapInputs"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(PublishTrimmed)' == 'true' and '$(_ComputeFilesToPublishForRuntimeIdentifiers)' != 'true' "
-      AfterTargets="_ResolveAssemblies"
-      BeforeTargets="_GeneratePostTrimTrimmableTypeMapJavaSources">
+      AfterTargets="_ResolveAssemblies">
     <ItemGroup>
       <_PostTrimTrimmableTypeMapInputAssemblies Remove="@(_PostTrimTrimmableTypeMapInputAssemblies)" />
       <!-- Only the linked .dll assemblies that already exist on disk are valid inputs.
@@ -86,18 +85,33 @@
         AcwMapOutputFile="$(IntermediateOutputPath)acw-map.txt"
         ApplicationRegistrationOutputFile="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java">
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_PostTrimGeneratedJavaFiles" />
+      <Output TaskParameter="DeletedJavaFiles" ItemName="_PostTrimDeletedJavaFiles" />
     </GenerateTrimmableTypeMap>
+
+    <!-- Mirror any JCWs the post-trim pass no longer produces (e.g. trimmed-away types) into
+         the android/src copies so a stale .java (and stale .class) is not left behind. Busting
+         the Java compile stamp forces _CompileJava to drop the corresponding class output. -->
+    <ItemGroup>
+      <_PostTrimDeletedCopiedJavaFiles Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
+      <_PostTrimDeletedCopiedJavaFiles Include="@(_PostTrimDeletedJavaFiles->'$(IntermediateOutputPath)android/src/%(RelativePath)')" />
+    </ItemGroup>
+    <Delete Files="@(_PostTrimDeletedCopiedJavaFiles)" />
+    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_PostTrimDeletedCopiedJavaFiles->Count())' != '0' " />
 
     <MakeDir Directories="$([System.IO.Path]::GetDirectoryName('$(_PostTrimTrimmableTypeMapJavaStamp)'))" />
     <Touch Files="$(_PostTrimTrimmableTypeMapJavaStamp)" AlwaysCreate="true" />
 
     <ItemGroup>
+      <FileWrites Remove="@(_PostTrimDeletedJavaFiles)" />
+      <FileWrites Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
       <FileWrites Include="@(_PostTrimGeneratedJavaFiles)" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
       <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
       <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" />
       <_PostTrimTrimmableTypeMapInputAssemblies Remove="@(_PostTrimTrimmableTypeMapInputAssemblies)" />
       <_PostTrimGeneratedJavaFiles Remove="@(_PostTrimGeneratedJavaFiles)" />
+      <_PostTrimDeletedJavaFiles Remove="@(_PostTrimDeletedJavaFiles)" />
+      <_PostTrimDeletedCopiedJavaFiles Remove="@(_PostTrimDeletedCopiedJavaFiles)" />
     </ItemGroup>
   </Target>
   <!-- Add linked TypeMap DLLs to the normal publish assembly pipeline.  The SDK R2R

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -34,6 +34,12 @@
     <_PostTrimTrimmableTypeMapJavaStamp>$(_PostTrimTypeMapJavaBaseOutputDir)stamp/_GeneratePostTrimTrimmableTypeMapJavaSources.stamp</_PostTrimTrimmableTypeMapJavaStamp>
     <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' ">$(_PostTrimTrimmableTypeMapJavaStamp)</_TrimmableJavaSourceStamp>
     <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' ">$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll</_TrimmableJavaSourceStamp>
+    <!-- Stamp file touched on every _GenerateTrimmableTypeMap run. It is a stable
+         incremental sentinel: the generated TypeMap DLLs are only rewritten when their
+         content changes (CopyIfStreamChanged), so their timestamps cannot be used as
+         Outputs without making the target run on every build. The stamp is always
+         touched, so the target is correctly skipped when none of its Inputs changed. -->
+    <_TrimmableTypeMapOutputStamp>$(_TypeMapOutputDirectory)_GenerateTrimmableTypeMap.stamp</_TrimmableTypeMapOutputStamp>
     <!-- Max array rank for __ArrayMapRank{N} sentinel emission. Defaults to 3 when
          dynamic code is unavailable, so array creation uses the typemap path;
          defaults to 0 otherwise, where dynamic code can use Array.CreateInstance directly. -->
@@ -78,28 +84,36 @@
     Generate TypeMap assemblies and JCW files.
     AfterTargets="CoreCompile" so it runs after compilation.
     Uses @(ReferencePath) as the primary input (available after compilation).
+    Skipped in design-time builds because project references may resolve to target
+    paths that are not produced when SkipCompilerExecution=true, and because the
+    generator output is not needed to provide IDE design-time information.
     Skipped in inner per-RID builds (_OuterIntermediateOutputPath is set) because
     those builds lack the manifest template and full assembly set needed for correct
     deferred-registration propagation.
   -->
   <Target Name="_GenerateTrimmableTypeMap"
-      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '@(ReferencePath->Count())' != '0' and '$(_OuterIntermediateOutputPath)' == '' "
+      Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(DesignTimeBuild)' != 'true' and '@(ReferencePath->Count())' != '0' and '$(_OuterIntermediateOutputPath)' == '' "
       AfterTargets="CoreCompile"
-      Inputs="@(ReferencePath);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
-      Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;$(_TypeMapAssembliesListFile)">
+      Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+      Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)">
 
     <ItemGroup>
       <_TypeMapInputAssemblies Include="@(ReferencePath)" />
       <_TypeMapInputAssemblies Include="@(ResolvedAssemblies)" />
       <_TypeMapInputAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+      <_TypeMapInputAssemblies Include="@(PrivateSdkAssemblies)" />
+      <_TypeMapInputAssemblies Include="@(FrameworkAssemblies)" />
+      <_TypeMapFrameworkAssemblies Include="@(ResolvedFrameworkAssemblies)" />
+      <_TypeMapFrameworkAssemblies Include="@(PrivateSdkAssemblies)" />
+      <_TypeMapFrameworkAssemblies Include="@(FrameworkAssemblies)" />
       <_TypeMapInputAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)"
           Condition="Exists('$(IntermediateOutputPath)$(TargetFileName)')" />
     </ItemGroup>
 
     <GenerateTrimmableTypeMap
         ResolvedAssemblies="@(_TypeMapInputAssemblies)"
-        ResolvedFrameworkAssemblies="@(ResolvedFrameworkAssemblies)"
-        FrameworkAssemblyNames="@(ResolvedFrameworkAssemblies->'%(Filename)')"
+        ResolvedFrameworkAssemblies="@(_TypeMapFrameworkAssemblies)"
+        FrameworkAssemblyNames="@(_TypeMapFrameworkAssemblies->'%(Filename)')"
         OutputDirectory="$(_TypeMapOutputDirectory)"
         JavaSourceOutputDirectory="$(_TypeMapJavaOutputDirectory)"
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
@@ -125,13 +139,32 @@
         ApplicationRegistrationOutputFile="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java">
       <Output TaskParameter="GeneratedAssemblies" ItemName="_GeneratedTypeMapAssemblies" />
       <Output TaskParameter="GeneratedJavaFiles" ItemName="_GeneratedJavaFiles" />
+      <Output TaskParameter="DeletedJavaFiles" ItemName="_DeletedJavaFiles" />
       <Output TaskParameter="AdditionalProviderSources" ItemName="_AdditionalProviderSources" />
     </GenerateTrimmableTypeMap>
 
+    <!-- Mirror any Java sources the generator deleted into the android/src copies so a
+         removed type does not leave a stale .java (and stale .class) behind. Busting the
+         Java compile stamp forces _CompileJava to drop the corresponding class output. -->
     <ItemGroup>
+      <_DeletedCopiedJavaFiles Remove="@(_DeletedCopiedJavaFiles)" />
+      <_DeletedCopiedJavaFiles Include="@(_DeletedJavaFiles->'$(IntermediateOutputPath)android/src/%(RelativePath)')" />
+    </ItemGroup>
+    <Delete Files="@(_DeletedCopiedJavaFiles)" />
+    <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
+
+    <!-- Touch the generated assemblies, the list file, and the stamp so the target's
+         Outputs are always newer than its Inputs even when CopyIfStreamChanged left an
+         unchanged DLL untouched. This is what makes the target skip on no-op builds. -->
+    <Touch Files="@(_GeneratedTypeMapAssemblies);$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
+
+    <ItemGroup>
+      <FileWrites Remove="@(_DeletedJavaFiles)" />
+      <FileWrites Remove="@(_DeletedCopiedJavaFiles)" />
       <FileWrites Include="@(_GeneratedTypeMapAssemblies)" />
       <FileWrites Include="@(_GeneratedJavaFiles)" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
+      <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" />
       <FileWrites Include="$(IntermediateOutputPath)android/src/net/dot/android/ApplicationRegistration.java" />
@@ -184,6 +217,7 @@
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
+      <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" Condition="Exists('$(_TrimmableTypeMapOutputStamp)')" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" Condition="Exists('$(_TypeMapBaseOutputDir)AndroidManifest.xml')" />
       <FileWrites Include="$(IntermediateOutputPath)AndroidManifest.xml" Condition="Exists('$(IntermediateOutputPath)AndroidManifest.xml')" />
       <FileWrites Include="$(IntermediateOutputPath)acw-map.txt" Condition="Exists('$(IntermediateOutputPath)acw-map.txt')" />
@@ -249,21 +283,22 @@
     so this target only handles JCW file copying, manifest, assembly store setup, and native config.
     We keep the name _GenerateJavaStubs because BuildOrder.targets references it.
 
-    Inputs uses the TypeMap DLL as a focused sentinel — _GenerateTrimmableTypeMap regenerates
-    the DLL whenever any of its own inputs (assemblies, manifest, etc.) change, so the DLL
-    timestamp is a reliable proxy for "something changed that requires re-copying".
+    Inputs uses the TypeMap output stamp as a focused sentinel — _GenerateTrimmableTypeMap
+    touches it whenever any of its own inputs (assemblies, manifest, etc.) change, and is
+    skipped (leaving the stamp stable) on no-op builds. The Copy below then updates
+    android/src only for Java sources whose content changed.
     We keep _GetGenerateJavaStubsInputs in DependsOnTargets so that downstream targets
     (_GetGeneratePackageManagerJavaInputs) can still read @(_GenerateJavaStubsInputs).
   -->
   <Target Name="_GenerateJavaStubs"
       DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsInputs;_DefineBuildTargetAbis;_PrepareNativeAssemblySources"
-      Inputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;@(_EnvironmentFiles)"
+      Inputs="$(_TrimmableTypeMapOutputStamp);@(_EnvironmentFiles)"
       Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
     <ItemGroup>
       <_TypeMapJavaFiles Include="$(_TypeMapJavaStubsSourceDirectory)/**/*.java" />
     </ItemGroup>
-    <Copy SourceFiles="@(_TypeMapJavaFiles)" DestinationFolder="$(IntermediateOutputPath)android/src/%(RecursiveDir)" />
+    <Copy SourceFiles="@(_TypeMapJavaFiles)" DestinationFolder="$(IntermediateOutputPath)android/src/%(RecursiveDir)" SkipUnchangedFiles="true" />
 
     <ItemGroup>
       <FileWrites Include="@(_TypeMapJavaFiles->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -32,14 +32,18 @@
     <_TypeMapJavaStubsSourceDirectory Condition=" '$(_TypeMapJavaStubsSourceDirectory)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' ">$(_PostTrimTypeMapJavaOutputDirectory)</_TypeMapJavaStubsSourceDirectory>
     <_TypeMapJavaStubsSourceDirectory Condition=" '$(_TypeMapJavaStubsSourceDirectory)' == '' ">$(_TypeMapJavaOutputDirectory)</_TypeMapJavaStubsSourceDirectory>
     <_PostTrimTrimmableTypeMapJavaStamp>$(_PostTrimTypeMapJavaBaseOutputDir)stamp/_GeneratePostTrimTrimmableTypeMapJavaSources.stamp</_PostTrimTrimmableTypeMapJavaStamp>
-    <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' ">$(_PostTrimTrimmableTypeMapJavaStamp)</_TrimmableJavaSourceStamp>
-    <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' ">$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll</_TrimmableJavaSourceStamp>
     <!-- Stamp file touched on every _GenerateTrimmableTypeMap run. It is a stable
          incremental sentinel: the generated TypeMap DLLs are only rewritten when their
          content changes (CopyIfStreamChanged), so their timestamps cannot be used as
          Outputs without making the target run on every build. The stamp is always
          touched, so the target is correctly skipped when none of its Inputs changed. -->
     <_TrimmableTypeMapOutputStamp>$(_TypeMapOutputDirectory)_GenerateTrimmableTypeMap.stamp</_TrimmableTypeMapOutputStamp>
+    <!-- Sentinel for _GenerateJavaStubs: the post-trim Java stamp when JCWs are regenerated
+         from the linked assemblies (CoreCLR + PublishTrimmed), otherwise the generator stamp.
+         Both are touched only when their producing target actually runs, so _GenerateJavaStubs
+         stays incremental while still reacting to post-trim JCW regeneration. -->
+    <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' and '$(_AndroidRuntime)' == 'CoreCLR' and '$(PublishTrimmed)' == 'true' ">$(_PostTrimTrimmableTypeMapJavaStamp)</_TrimmableJavaSourceStamp>
+    <_TrimmableJavaSourceStamp Condition=" '$(_TrimmableJavaSourceStamp)' == '' ">$(_TrimmableTypeMapOutputStamp)</_TrimmableJavaSourceStamp>
     <!-- Max array rank for __ArrayMapRank{N} sentinel emission. Defaults to 3 when
          dynamic code is unavailable, so array creation uses the typemap path;
          defaults to 0 otherwise, where dynamic code can use Array.CreateInstance directly. -->
@@ -95,7 +99,7 @@
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(DesignTimeBuild)' != 'true' and '@(ReferencePath->Count())' != '0' and '$(_OuterIntermediateOutputPath)' == '' "
       AfterTargets="CoreCompile"
       Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
-      Outputs="$(_TypeMapOutputDirectory)$(_TypeMapAssemblyName).dll;$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)">
+      Outputs="$(_TrimmableTypeMapOutputStamp)">
 
     <ItemGroup>
       <_TypeMapInputAssemblies Include="@(ReferencePath)" />
@@ -153,10 +157,11 @@
     <Delete Files="@(_DeletedCopiedJavaFiles)" />
     <Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
 
-    <!-- Touch the generated assemblies, the list file, and the stamp so the target's
-         Outputs are always newer than its Inputs even when CopyIfStreamChanged left an
-         unchanged DLL untouched. This is what makes the target skip on no-op builds. -->
-    <Touch Files="@(_GeneratedTypeMapAssemblies);$(_TypeMapAssembliesListFile);$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
+    <!-- Touch only the stamp: it is the target's sole Output and incremental sentinel.
+         The generated TypeMap DLLs and the assemblies list are written via CopyIfStreamChanged
+         (so unchanged content keeps a stable timestamp) and are not consumed as timestamp
+         Inputs by any other target, so they do not need to be touched here. -->
+    <Touch Files="$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
 
     <ItemGroup>
       <FileWrites Remove="@(_DeletedJavaFiles)" />
@@ -206,16 +211,26 @@
     <ItemGroup>
       <_GeneratedTypeMapAssembliesForFileWrites Remove="@(_GeneratedTypeMapAssembliesForFileWrites)" />
       <_TypeMapJavaFilesForFileWrites Remove="@(_TypeMapJavaFilesForFileWrites)" />
+      <_TypeMapPostTrimJavaFilesForFileWrites Remove="@(_TypeMapPostTrimJavaFilesForFileWrites)" />
     </ItemGroup>
     <ReadLinesFromFile File="$(_TypeMapAssembliesListFile)">
       <Output TaskParameter="Lines" ItemName="_GeneratedTypeMapAssembliesForFileWrites" />
     </ReadLinesFromFile>
     <ItemGroup>
       <_TypeMapJavaFilesForFileWrites Include="$(_TypeMapJavaOutputDirectory)/**/*.java" />
+      <!-- For CoreCLR + PublishTrimmed the JCWs copied into android/src come from the post-trim
+           `linked-java` directory. _GeneratePostTrimTrimmableTypeMapJavaSources is now incremental,
+           so re-emit its outputs here too; otherwise IncrementalClean deletes linked-java (and its
+           android/src copies) on builds where post-trim is skipped. The glob is empty for
+           configurations that have no post-trim pass. -->
+      <_TypeMapPostTrimJavaFilesForFileWrites Include="$(_PostTrimTypeMapJavaOutputDirectory)/**/*.java" />
 
       <FileWrites Include="@(_GeneratedTypeMapAssembliesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites)" />
       <FileWrites Include="@(_TypeMapJavaFilesForFileWrites->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
+      <FileWrites Include="@(_TypeMapPostTrimJavaFilesForFileWrites)" />
+      <FileWrites Include="@(_TypeMapPostTrimJavaFilesForFileWrites->'$(IntermediateOutputPath)android/src/%(RecursiveDir)%(Filename)%(Extension)')" />
+      <FileWrites Include="$(_PostTrimTrimmableTypeMapJavaStamp)" Condition="Exists('$(_PostTrimTrimmableTypeMapJavaStamp)')" />
       <FileWrites Include="$(_TypeMapAssembliesListFile)" />
       <FileWrites Include="$(_TrimmableTypeMapOutputStamp)" Condition="Exists('$(_TrimmableTypeMapOutputStamp)')" />
       <FileWrites Include="$(_TypeMapBaseOutputDir)AndroidManifest.xml" Condition="Exists('$(_TypeMapBaseOutputDir)AndroidManifest.xml')" />
@@ -292,7 +307,7 @@
   -->
   <Target Name="_GenerateJavaStubs"
       DependsOnTargets="_SetLatestTargetFrameworkVersion;_PrepareAssemblies;_GetGenerateJavaStubsInputs;_DefineBuildTargetAbis;_PrepareNativeAssemblySources"
-      Inputs="$(_TrimmableTypeMapOutputStamp);@(_EnvironmentFiles)"
+      Inputs="$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
       Outputs="$(_AndroidStampDirectory)_GenerateJavaStubs.stamp">
 
     <ItemGroup>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -10,6 +10,7 @@ using Microsoft.Android.Build.Tasks;
 using Microsoft.Android.Sdk.TrimmableTypeMap;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Xamarin.Android.Tools;
 
 namespace Xamarin.Android.Tasks;
 
@@ -100,6 +101,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public ITaskItem [] GeneratedAssemblies { get; set; } = [];
 	[Output]
 	public ITaskItem [] GeneratedJavaFiles { get; set; } = [];
+	[Output]
+	public ITaskItem [] DeletedJavaFiles { get; set; } = [];
 	[Output]
 	public string[]? AdditionalProviderSources { get; set; }
 
@@ -192,6 +195,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			GeneratedJavaFiles = JavaSourceInputDirectory.IsNullOrEmpty ()
 				? WriteJavaSourcesToDisk (result.GeneratedJavaSources)
 				: CopyJavaSourcesFromInputDirectory (result.GeneratedJavaSources);
+			DeletedJavaFiles = DeleteStaleJavaSources (GeneratedJavaFiles);
 
 			// Write manifest to disk if generated
 			if (result.Manifest is not null && !MergedAndroidManifestOutput.IsNullOrEmpty ()) {
@@ -368,6 +372,34 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			items.Add (new TaskItem (outputPath));
 		}
 		return items.ToArray ();
+	}
+
+	// Removes generated Java sources from a previous build that the current generation pass
+	// no longer produces (for example when a managed type is removed). Returns the deleted
+	// files (with a RelativePath metadata) so the targets can mirror the deletion into the
+	// android/src copies and force a Java recompilation.
+	ITaskItem [] DeleteStaleJavaSources (IReadOnlyCollection<ITaskItem> generatedJavaFiles)
+	{
+		var expectedFiles = new HashSet<string> (
+			generatedJavaFiles.Select (i => Path.GetFullPath (i.ItemSpec)),
+			Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+		var deleted = new List<ITaskItem> ();
+
+		foreach (var path in Directory.EnumerateFiles (JavaSourceOutputDirectory, "*.java", SearchOption.AllDirectories)) {
+			var fullPath = Path.GetFullPath (path);
+			if (expectedFiles.Contains (fullPath)) {
+				continue;
+			}
+
+			File.Delete (fullPath);
+			Log.LogDebugMessage ($"Deleted stale generated Java source '{fullPath}'.");
+
+			var item = new TaskItem (fullPath);
+			item.SetMetadata ("RelativePath", PathUtil.GetRelativePath (JavaSourceOutputDirectory, fullPath));
+			deleted.Add (item);
+		}
+
+		return deleted.ToArray ();
 	}
 
 	static Version ParseTargetFrameworkVersion (string tfv)

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -133,11 +133,17 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 		Directory.CreateDirectory (OutputDirectory);
 		string[]? priorJavaSnapshot = null;
-		if (CleanJavaSourceOutputDirectory && Directory.Exists (JavaSourceOutputDirectory)) {
+		if (CleanJavaSourceOutputDirectory) {
 			// Capture the previously generated set before wiping it, so DeleteStaleJavaSources can
 			// report which Java sources are no longer produced (e.g. a type that was trimmed away).
-			priorJavaSnapshot = Directory.GetFiles (JavaSourceOutputDirectory, "*.java", SearchOption.AllDirectories);
-			Directory.Delete (JavaSourceOutputDirectory, recursive: true);
+			// An empty snapshot (first run, nothing to wipe) still routes through the snapshot-diff
+			// path so clean mode is handled consistently.
+			if (Directory.Exists (JavaSourceOutputDirectory)) {
+				priorJavaSnapshot = Directory.GetFiles (JavaSourceOutputDirectory, "*.java", SearchOption.AllDirectories);
+				Directory.Delete (JavaSourceOutputDirectory, recursive: true);
+			} else {
+				priorJavaSnapshot = [];
+			}
 		}
 		Directory.CreateDirectory (JavaSourceOutputDirectory);
 
@@ -396,6 +402,14 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		var deleted = new List<ITaskItem> ();
 
 		if (priorJavaSnapshot is not null) {
+			// If generation logged errors (e.g. a generated source was missing from the input
+			// directory, XA4255), GeneratedJavaFiles may be incomplete, so the prior-minus-current
+			// diff could wrongly flag a still-valid source as deleted. The build fails on logged
+			// errors anyway; skip pruning to avoid removing a file that should remain.
+			if (Log.HasLoggedErrors) {
+				return [];
+			}
+
 			foreach (var path in priorJavaSnapshot) {
 				var fullPath = Path.GetFullPath (path);
 				if (expectedFiles.Contains (fullPath)) {

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -132,7 +132,11 @@ public class GenerateTrimmableTypeMap : AndroidTask
 		}
 
 		Directory.CreateDirectory (OutputDirectory);
+		string[]? priorJavaSnapshot = null;
 		if (CleanJavaSourceOutputDirectory && Directory.Exists (JavaSourceOutputDirectory)) {
+			// Capture the previously generated set before wiping it, so DeleteStaleJavaSources can
+			// report which Java sources are no longer produced (e.g. a type that was trimmed away).
+			priorJavaSnapshot = Directory.GetFiles (JavaSourceOutputDirectory, "*.java", SearchOption.AllDirectories);
 			Directory.Delete (JavaSourceOutputDirectory, recursive: true);
 		}
 		Directory.CreateDirectory (JavaSourceOutputDirectory);
@@ -195,7 +199,7 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			GeneratedJavaFiles = JavaSourceInputDirectory.IsNullOrEmpty ()
 				? WriteJavaSourcesToDisk (result.GeneratedJavaSources)
 				: CopyJavaSourcesFromInputDirectory (result.GeneratedJavaSources);
-			DeletedJavaFiles = DeleteStaleJavaSources (GeneratedJavaFiles);
+			DeletedJavaFiles = DeleteStaleJavaSources (GeneratedJavaFiles, priorJavaSnapshot);
 
 			// Write manifest to disk if generated
 			if (result.Manifest is not null && !MergedAndroidManifestOutput.IsNullOrEmpty ()) {
@@ -375,15 +379,35 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	}
 
 	// Removes generated Java sources from a previous build that the current generation pass
-	// no longer produces (for example when a managed type is removed). Returns the deleted
-	// files (with a RelativePath metadata) so the targets can mirror the deletion into the
-	// android/src copies and force a Java recompilation.
-	ITaskItem [] DeleteStaleJavaSources (IReadOnlyCollection<ITaskItem> generatedJavaFiles)
+	// no longer produces (for example when a managed type is removed or trimmed away). Returns
+	// the deleted files (with a RelativePath metadata) so the targets can mirror the deletion
+	// into the android/src copies and force a Java recompilation.
+	//
+	// When the output directory was wiped before generation (CleanJavaSourceOutputDirectory, used
+	// by the post-trim pass), the stale files are already gone from disk; the previous contents
+	// are supplied via priorJavaSnapshot and the difference against the freshly generated set is
+	// reported. Otherwise the directory is scanned and any file the current pass did not produce
+	// is deleted.
+	ITaskItem [] DeleteStaleJavaSources (IReadOnlyCollection<ITaskItem> generatedJavaFiles, string[]? priorJavaSnapshot)
 	{
 		var expectedFiles = new HashSet<string> (
 			generatedJavaFiles.Select (i => Path.GetFullPath (i.ItemSpec)),
 			Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
 		var deleted = new List<ITaskItem> ();
+
+		if (priorJavaSnapshot is not null) {
+			foreach (var path in priorJavaSnapshot) {
+				var fullPath = Path.GetFullPath (path);
+				if (expectedFiles.Contains (fullPath)) {
+					continue;
+				}
+
+				Log.LogDebugMessage ($"Post-trim regeneration no longer produces generated Java source '{fullPath}'.");
+				deleted.Add (CreateDeletedJavaItem (fullPath));
+			}
+
+			return deleted.ToArray ();
+		}
 
 		foreach (var path in Directory.EnumerateFiles (JavaSourceOutputDirectory, "*.java", SearchOption.AllDirectories)) {
 			var fullPath = Path.GetFullPath (path);
@@ -393,13 +417,17 @@ public class GenerateTrimmableTypeMap : AndroidTask
 
 			File.Delete (fullPath);
 			Log.LogDebugMessage ($"Deleted stale generated Java source '{fullPath}'.");
-
-			var item = new TaskItem (fullPath);
-			item.SetMetadata ("RelativePath", PathUtil.GetRelativePath (JavaSourceOutputDirectory, fullPath));
-			deleted.Add (item);
+			deleted.Add (CreateDeletedJavaItem (fullPath));
 		}
 
 		return deleted.ToArray ();
+	}
+
+	TaskItem CreateDeletedJavaItem (string fullPath)
+	{
+		var item = new TaskItem (fullPath);
+		item.SetMetadata ("RelativePath", PathUtil.GetRelativePath (JavaSourceOutputDirectory, fullPath));
+		return item;
 	}
 
 	static Version ParseTargetFrameworkVersion (string tfv)

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -68,6 +68,88 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
+		public void Build_WithTrimmableTypeMap_DeletesStaleGeneratedJavaSourcesAndCopies ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			var staleRelativePath = Path.Combine ("crc64stale", "Old.java");
+			var staleClassPath = Path.Combine ("crc64stale", "Old.class");
+			var staleGeneratedJava = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "java", staleRelativePath));
+			var staleCopiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", staleRelativePath));
+			var staleCompiledClass = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", staleClassPath));
+			var staleGeneratedJavaDirectory = Path.GetDirectoryName (staleGeneratedJava);
+			var staleCopiedJavaDirectory = Path.GetDirectoryName (staleCopiedJava);
+			var staleCompiledClassDirectory = Path.GetDirectoryName (staleCompiledClass);
+			if (staleGeneratedJavaDirectory is null || staleCopiedJavaDirectory is null || staleCompiledClassDirectory is null) {
+				throw new InvalidOperationException ("Could not determine stale Java output directories.");
+			}
+			Directory.CreateDirectory (staleGeneratedJavaDirectory);
+			Directory.CreateDirectory (staleCopiedJavaDirectory);
+			Directory.CreateDirectory (staleCompiledClassDirectory);
+			File.WriteAllText (staleGeneratedJava, "package crc64stale; public class Old {}");
+			File.WriteAllText (staleCopiedJava, "package crc64stale; public class Old {}");
+			File.WriteAllBytes (staleCompiledClass, []);
+
+			proj.MainActivity += Environment.NewLine + "// Force trimmable typemap regeneration.";
+			proj.Touch ("MainActivity.cs");
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GenerateTrimmableTypeMap");
+			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
+
+			FileAssert.DoesNotExist (staleGeneratedJava, "Regenerated trimmable typemap should delete stale Java sources.");
+			FileAssert.DoesNotExist (staleCopiedJava, "Regenerated trimmable typemap should delete stale android/src Java copies.");
+			FileAssert.DoesNotExist (staleCompiledClass, "Deleting stale copied Java sources should force Java recompilation and remove stale class outputs.");
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_CopiesUpdatedGeneratedJavaSources ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: false)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject ();
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			var generatedJavaDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "java"));
+			var generatedJavaFiles = Directory.GetFiles (generatedJavaDirectory, "*.java", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (generatedJavaFiles, "Test setup should have generated trimmable typemap Java sources.");
+
+			var generatedJava = generatedJavaFiles [0];
+			var relativePath = Path.GetRelativePath (generatedJavaDirectory, generatedJava);
+			var copiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", relativePath));
+			var typeMapStamp = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "_GenerateTrimmableTypeMap.stamp"));
+			var javaStubsStamp = builder.Output.GetIntermediaryPath (Path.Combine ("stamp", "_GenerateJavaStubs.stamp"));
+			FileAssert.Exists (copiedJava, "First build should have copied generated Java sources to android/src.");
+			FileAssert.Exists (typeMapStamp, "First build should have written the trimmable typemap output stamp.");
+			FileAssert.Exists (javaStubsStamp, "First build should have written the Java stubs output stamp.");
+
+			var updatedJava = File.ReadAllText (generatedJava) + "\n// Force generated Java copy regression.\n";
+			File.WriteAllText (generatedJava, updatedJava);
+			var stampTime = DateTime.UtcNow;
+			File.SetLastWriteTimeUtc (typeMapStamp, stampTime);
+			File.SetLastWriteTimeUtc (javaStubsStamp, stampTime.AddSeconds (-5));
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true), "Second build should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GenerateJavaStubs");
+			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
+			Assert.AreEqual (updatedJava, File.ReadAllText (copiedJava), "Updated generated Java sources should be copied to android/src even when typemap assemblies do not change.");
+		}
+
+		[Test]
 		public void Build_WithTrimmableTypeMap_ArrayRankChangeRegeneratesTypeMap ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -217,19 +217,24 @@ namespace Xamarin.Android.Build.Tests {
 
 			// Simulate a JCW the post-trim pass produced on a previous build but no longer
 			// produces (e.g. its type was trimmed away). It lives in both the post-trim
-			// `linked-java` source directory and its android/src copy.
+			// `linked-java` source directory and its android/src copy, with a compiled .class.
 			var staleRelativePath = Path.Combine ("crc64stale", "Old.java");
+			var staleClassPath = Path.Combine ("crc64stale", "Old.class");
 			var staleLinkedJava = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java", staleRelativePath));
 			var staleCopiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", staleRelativePath));
+			var staleCompiledClass = builder.Output.GetIntermediaryPath (Path.Combine ("android", "bin", "classes", staleClassPath));
 			var staleLinkedJavaDirectory = Path.GetDirectoryName (staleLinkedJava);
 			var staleCopiedJavaDirectory = Path.GetDirectoryName (staleCopiedJava);
-			if (staleLinkedJavaDirectory is null || staleCopiedJavaDirectory is null) {
+			var staleCompiledClassDirectory = Path.GetDirectoryName (staleCompiledClass);
+			if (staleLinkedJavaDirectory is null || staleCopiedJavaDirectory is null || staleCompiledClassDirectory is null) {
 				throw new InvalidOperationException ("Could not determine stale Java output directories.");
 			}
 			Directory.CreateDirectory (staleLinkedJavaDirectory);
 			Directory.CreateDirectory (staleCopiedJavaDirectory);
+			Directory.CreateDirectory (staleCompiledClassDirectory);
 			File.WriteAllText (staleLinkedJava, "package crc64stale; public class Old {}");
 			File.WriteAllText (staleCopiedJava, "package crc64stale; public class Old {}");
+			File.WriteAllBytes (staleCompiledClass, []);
 
 			// Force the post-trim Java generation to re-run by removing its stamp (without a source
 			// change, which would trigger an unrelated incremental CrossGen rebuild). It wipes and
@@ -241,9 +246,11 @@ namespace Xamarin.Android.Build.Tests {
 
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
 			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsNotSkipped ("_CompileJava");
 
 			FileAssert.DoesNotExist (staleLinkedJava, "Post-trim regeneration should drop the stale linked-java JCW.");
 			FileAssert.DoesNotExist (staleCopiedJava, "Regenerated post-trim JCWs should delete the stale android/src copy that is no longer produced.");
+			FileAssert.DoesNotExist (staleCompiledClass, "Deleting the stale android/src copy should force Java recompilation and remove the stale class output.");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -157,11 +157,9 @@ namespace Xamarin.Android.Build.Tests {
 		// skipped while linked-java changed, android/src would be left stale.
 		static void AssertAndroidSrcMatchesLinkedJava (ProjectBuilder builder, string message)
 		{
-			var intermediate = builder.Output.GetIntermediaryPath ("");
-			var linkedJavaDirectory = Directory.GetDirectories (intermediate, "linked-java", SearchOption.AllDirectories).FirstOrDefault ();
-			Assert.IsNotNull (linkedJavaDirectory, $"{message}: post-trim linked-java directory should exist under '{intermediate}'.");
-			// The JCWs that get compiled live in the same intermediate tree under android/src.
-			var androidSrcDirectory = Path.Combine (Path.GetDirectoryName (Path.GetDirectoryName (linkedJavaDirectory)), "android", "src");
+			var linkedJavaDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java"));
+			DirectoryAssert.Exists (linkedJavaDirectory, $"{message}: post-trim linked-java directory should exist.");
+			var androidSrcDirectory = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src"));
 			DirectoryAssert.Exists (androidSrcDirectory, $"{message}: android/src directory should exist.");
 
 			var linkedJavaFiles = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories);
@@ -199,6 +197,53 @@ namespace Xamarin.Android.Build.Tests {
 			// the post-trim Java generation may run again.
 			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
 			AssertAndroidSrcMatchesLinkedJava (builder, "After no-op rebuild");
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_DeletesStaleAndroidSrcWhenLinkedJavaShrinks ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			// Simulate a JCW the post-trim pass produced on a previous build but no longer
+			// produces (e.g. its type was trimmed away). It lives in both the post-trim
+			// `linked-java` source directory and its android/src copy.
+			var staleRelativePath = Path.Combine ("crc64stale", "Old.java");
+			var staleLinkedJava = builder.Output.GetIntermediaryPath (Path.Combine ("typemap", "linked-java", staleRelativePath));
+			var staleCopiedJava = builder.Output.GetIntermediaryPath (Path.Combine ("android", "src", staleRelativePath));
+			var staleLinkedJavaDirectory = Path.GetDirectoryName (staleLinkedJava);
+			var staleCopiedJavaDirectory = Path.GetDirectoryName (staleCopiedJava);
+			if (staleLinkedJavaDirectory is null || staleCopiedJavaDirectory is null) {
+				throw new InvalidOperationException ("Could not determine stale Java output directories.");
+			}
+			Directory.CreateDirectory (staleLinkedJavaDirectory);
+			Directory.CreateDirectory (staleCopiedJavaDirectory);
+			File.WriteAllText (staleLinkedJava, "package crc64stale; public class Old {}");
+			File.WriteAllText (staleCopiedJava, "package crc64stale; public class Old {}");
+
+			// Force the post-trim Java generation to re-run by removing its stamp (without a source
+			// change, which would trigger an unrelated incremental CrossGen rebuild). It wipes and
+			// regenerates linked-java (dropping the stale JCW), so android/src must drop its stale
+			// copy too.
+			var postTrimStamp = builder.Output.GetIntermediaryPath (Path.Combine ("stamp", "_GeneratePostTrimTrimmableTypeMapJavaSources.stamp"));
+			FileAssert.Exists (postTrimStamp, "First build should have written the post-trim Java stamp.");
+			File.Delete (postTrimStamp);
+
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "Second build should have succeeded.");
+			builder.Output.AssertTargetIsNotSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+
+			FileAssert.DoesNotExist (staleLinkedJava, "Post-trim regeneration should drop the stale linked-java JCW.");
+			FileAssert.DoesNotExist (staleCopiedJava, "Regenerated post-trim JCWs should delete the stale android/src copy that is no longer produced.");
 		}
 
 		[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -202,7 +202,6 @@ namespace Xamarin.Android.Build.Tests {
 		}
 
 		[Test]
-		[Ignore ("Documents a known incrementality gap: _GeneratePostTrimTrimmableTypeMapJavaSources currently runs on every Release CoreCLR build. Re-enable once post-trim Java generation is made incremental and _GenerateJavaStubs keys off _TrimmableJavaSourceStamp.")]
 		public void Build_WithTrimmableTypeMap_PublishTrimmed_PostTrimJavaGenerationIsIncremental ()
 		{
 			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/TrimmableTypeMapBuildTests.cs
@@ -149,6 +149,84 @@ namespace Xamarin.Android.Build.Tests {
 			Assert.AreEqual (updatedJava, File.ReadAllText (copiedJava), "Updated generated Java sources should be copied to android/src even when typemap assemblies do not change.");
 		}
 
+		// The JCWs that actually get compiled and packaged are the ones copied into
+		// $(IntermediateOutputPath)android/src. For CoreCLR + PublishTrimmed those come from
+		// the post-trim `typemap/linked-java` directory, which `_GeneratePostTrimTrimmableTypeMapJavaSources`
+		// (re)generates from the linked assemblies. The incrementality contract is that
+		// android/src must always stay consistent with linked-java; if `_GenerateJavaStubs` is
+		// skipped while linked-java changed, android/src would be left stale.
+		static void AssertAndroidSrcMatchesLinkedJava (ProjectBuilder builder, string message)
+		{
+			var intermediate = builder.Output.GetIntermediaryPath ("");
+			var linkedJavaDirectory = Directory.GetDirectories (intermediate, "linked-java", SearchOption.AllDirectories).FirstOrDefault ();
+			Assert.IsNotNull (linkedJavaDirectory, $"{message}: post-trim linked-java directory should exist under '{intermediate}'.");
+			// The JCWs that get compiled live in the same intermediate tree under android/src.
+			var androidSrcDirectory = Path.Combine (Path.GetDirectoryName (Path.GetDirectoryName (linkedJavaDirectory)), "android", "src");
+			DirectoryAssert.Exists (androidSrcDirectory, $"{message}: android/src directory should exist.");
+
+			var linkedJavaFiles = Directory.GetFiles (linkedJavaDirectory, "*.java", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (linkedJavaFiles, $"{message}: post-trim build should have generated linked-java JCWs.");
+
+			foreach (var linkedJava in linkedJavaFiles) {
+				var relativePath = Path.GetRelativePath (linkedJavaDirectory, linkedJava);
+				var copiedJava = Path.Combine (androidSrcDirectory, relativePath);
+				FileAssert.Exists (copiedJava, $"{message}: linked-java JCW '{relativePath}' should be copied to android/src.");
+				Assert.AreEqual (
+					File.ReadAllText (linkedJava),
+					File.ReadAllText (copiedJava),
+					$"{message}: android/src copy of '{relativePath}' should match the post-trim linked-java source.");
+			}
+		}
+
+		[Test]
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_KeepsAndroidSrcConsistentWithLinkedJava ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+			AssertAndroidSrcMatchesLinkedJava (builder, "After first build");
+
+			// A no-op rebuild must not leave android/src out of sync with linked-java, even though
+			// the post-trim Java generation may run again.
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
+			AssertAndroidSrcMatchesLinkedJava (builder, "After no-op rebuild");
+		}
+
+		[Test]
+		[Ignore ("Documents a known incrementality gap: _GeneratePostTrimTrimmableTypeMapJavaSources currently runs on every Release CoreCLR build. Re-enable once post-trim Java generation is made incremental and _GenerateJavaStubs keys off _TrimmableJavaSourceStamp.")]
+		public void Build_WithTrimmableTypeMap_PublishTrimmed_PostTrimJavaGenerationIsIncremental ()
+		{
+			if (IgnoreUnsupportedConfiguration (AndroidRuntime.CoreCLR, release: true)) {
+				return;
+			}
+
+			var proj = new XamarinAndroidApplicationProject {
+				IsRelease = true,
+			};
+			proj.SetRuntime (AndroidRuntime.CoreCLR);
+			proj.SetProperty ("_AndroidTypeMapImplementation", "trimmable");
+
+			using var builder = CreateApkBuilder ();
+			Assert.IsTrue (builder.Build (proj), "First build should have succeeded.");
+
+			// A no-op rebuild should not regenerate the post-trim JCWs or recopy them. If
+			// _GeneratePostTrimTrimmableTypeMapJavaSources runs on every build, the JCWs that feed
+			// _GenerateJavaStubs are rewritten each time, which both wastes work and means
+			// _GenerateJavaStubs must re-run to stay consistent (otherwise android/src goes stale).
+			Assert.IsTrue (builder.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "No-op rebuild should have succeeded.");
+			builder.Output.AssertTargetIsSkipped ("_GeneratePostTrimTrimmableTypeMapJavaSources");
+			builder.Output.AssertTargetIsSkipped ("_GenerateJavaStubs");
+		}
+
 		[Test]
 		public void Build_WithTrimmableTypeMap_ArrayRankChangeRegeneratesTypeMap ()
 		{


### PR DESCRIPTION
## Summary

Makes the **trimmable** typemap build pipeline (`_AndroidTypeMapImplementation=trimmable`, used by CoreCLR and NativeAOT) fully incremental, skipped in design‑time builds, and self‑consistent on every rebuild. Extracted as a focused, well‑tested slice from the larger #11617, and implemented on top of `main`'s current generator/task API rather than the runtime rewrite in that PR.

The bulk of this description is a deep dive into **how incrementality is achieved**, because the pipeline has several non‑obvious moving parts (two generator passes, content‑based writes, dynamic outputs vs. `IncrementalClean`, and a post‑link Java regeneration step).

---

## Background: what the trimmable typemap generator produces

The legacy typemap implementations (`llvm-ir`, `managed`) embed the managed ↔ Java type mapping into native binaries. The **trimmable** implementation instead generates, from a scan of the app's assemblies:

- a set of small managed **TypeMap assemblies** — one `_<Assembly>.TypeMap.dll` per input assembly plus a `_Microsoft.Android.TypeMaps.dll` root — that are trimmer‑friendly (unused entries are removed by the IL linker), and
- the **Java Callable Wrapper** (`*.java`, "JCW") sources that Java needs to call back into managed code, plus `acw-map.txt` and a merged `AndroidManifest.xml`.

This is driven by the `GenerateTrimmableTypeMap` MSBuild task. The active runtime is selected by `$(_AndroidRuntime)` (`CoreCLR` or `NativeAOT`); runtime‑specific targets extend the shared pipeline (`…TypeMap.Trimmable.CoreCLR.targets`, `…TypeMap.Trimmable.NativeAOT.targets`).

---

## The pipeline (target graph)

### Shared / Debug CoreCLR & NativeAOT (no trimming)

```
CoreCompile
   └─► _GenerateTrimmableTypeMap            (AfterTargets="CoreCompile")
          • scans @(ReferencePath) + framework/SDK assemblies + the app .dll
          • writes typemap/_*.TypeMap.dll + _Microsoft.Android.TypeMaps.dll
          • writes typemap/java/**/*.java (JCWs), acw-map.txt, merged AndroidManifest.xml
          • prunes stale JCWs, then touches typemap/_GenerateTrimmableTypeMap.stamp
   …
_ReadGeneratedTrimmableTypeMapAssemblies    (reads typemap-assemblies.txt → items)
_PrepareTrimmableNativeConfigAssemblies     (feeds _GeneratePackageManagerJava)
_PrepareTrimmableTypeMapAssemblies          (feeds packaging / assembly store)
_GenerateJavaStubs                          (copies JCWs → android/src, manifest, acw-map)
   └─► _CompileJava ─► _CompileToDalvik ─► packaging
```

`_GenerateJavaStubs` **overrides** the legacy target of the same name from `BuildOrder.targets`; on the trimmable path the JCWs already exist, so it only copies them into `$(IntermediateOutputPath)android/src` and wires up the manifest/`acw-map.txt`/native config.

### Release CoreCLR (`PublishTrimmed=true`) — two generator passes

```
CoreCompile ─► _GenerateTrimmableTypeMap            (pre-trim: full assembly set)
…
ILLink (trim) ─► CrossGen/R2R
   └─► _ComputePostTrimTrimmableTypeMapInputs        (collect existing linked .dll)
   └─► _GeneratePostTrimTrimmableTypeMapJavaSources   (post-trim)
          • regenerates JCWs from the *linked* assemblies only
          • writes typemap/linked-java/**/*.java (GenerateTypeMapAssemblies=false)
          • touches stamp/_GeneratePostTrimTrimmableTypeMapJavaSources.stamp
_GenerateJavaStubs                                    (copies linked-java → android/src)
```

The post‑trim pass exists because, after trimming, the set of types that still need JCWs is a **subset** of the pre‑trim set. `_GenerateJavaStubs` sources its JCWs from `$(_TypeMapJavaStubsSourceDirectory)`, which is `typemap/linked-java` for CoreCLR + `PublishTrimmed` and `typemap/java` otherwise.

NativeAOT (`PublishTrimmed=true` as well) does **not** use the post‑trim Java pass — it feeds the pre‑trim JCWs to ILC and its own native steps — so for NativeAOT the sources stay `typemap/java`.

---

## How incrementality is achieved (deep dive)

The pipeline follows the repo's [MSBuild best practices](https://github.com/dotnet/android/blob/main/Documentation/guides/MSBuildBestPractices.md): every expensive target declares `Inputs`/`Outputs`, re‑emits its dynamic `FileWrites`, and uses stamp files where a real output can't serve as a reliable timestamp sentinel. There are six principles at work.

### 1. Stamp files are the incremental sentinels — because the real outputs are content‑addressed

`GenerateTrimmableTypeMap` writes every output with `Files.CopyIfStreamChanged` (and the per‑assembly `WriteAssembliesToDisk` additionally compares timestamps): **an output whose content did not change keeps its old timestamp**. That's exactly what you want to avoid churning downstream Java/native compilation — but it makes those files unusable as MSBuild `Outputs`, because their timestamps can be *older* than the `Inputs` even on a successful run, which makes MSBuild consider the target perpetually out‑of‑date and re‑run it every build.

So `_GenerateTrimmableTypeMap` declares a **dedicated stamp** as its sole output and touches only that stamp:

```xml
Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
Outputs="$(_TrimmableTypeMapOutputStamp)"
…
<Touch Files="$(_TrimmableTypeMapOutputStamp)" AlwaysCreate="true" />
```

The stamp is always touched on a run and never touched on a skip, so the target is correctly skipped iff none of its inputs changed. The generated DLLs and `typemap-assemblies.txt` are **not** touched and are **not** declared as outputs — they are content‑addressed, and no other target consumes them as timestamp `Inputs` (verified), so touching them would be pure churn. *(This is the `@jonathanpeppers` review point.)*

> The `Inputs` deliberately include `@(PrivateSdkAssemblies)` and `@(FrameworkAssemblies)`: they can contribute managed ↔ Java mappings, so a change in them must re‑run generation.

`_GenerateJavaStubs` uses the analogous idea, but its sentinel must reflect **whichever** pass produced the JCWs it copies:

```xml
Inputs="$(_TrimmableJavaSourceStamp);@(_EnvironmentFiles)"
```

where `_TrimmableJavaSourceStamp` resolves to the **post‑trim** stamp for CoreCLR + `PublishTrimmed`, and the **pre‑trim generator** stamp otherwise. This is what lets `_GenerateJavaStubs` react to post‑trim JCW regeneration while staying incremental on no‑op builds. *(This is the `@Copilot` review point; the non‑trim default was previously the TypeMap DLL, whose timestamp is unreliable for the reason above.)*

### 2. `Inputs` must reference files that actually exist

MSBuild treats a **non‑existent `Inputs` file as "out of date"** and runs the target. The post‑trim pass originally declared `Inputs="@(ResolvedFileToPublish)"`, which also lists non‑assembly publish outputs — e.g. `…/bin/Release/<rid>/UnnamedProject.runtimeconfig.json` — whose paths do not exist when the target runs. That single phantom input made `_GeneratePostTrimTrimmableTypeMapJavaSources` run on **every** build, wiping and regenerating `linked-java` each time.

The fix factors input collection into `_ComputePostTrimTrimmableTypeMapInputs`, which keeps only `.dll` items that exist on disk:

```xml
<_PostTrimTrimmableTypeMapInputAssemblies Include="@(ResolvedFileToPublish)"
    Condition=" '%(Extension)' == '.dll' and Exists('%(FullPath)') and (…RID filter…) " />
```

so the post‑trim pass is now genuinely incremental and its stamp is a trustworthy sentinel for `_GenerateJavaStubs`.

### 3. Dynamic outputs must be re‑published to `@(FileWrites)` on skipped builds

The set of generated assemblies and JCWs is data‑dependent (it comes from scanning), so the `ItemGroup`s that register those files into `@(FileWrites)` live **inside** the generating targets — and therefore don't execute on a no‑op build where those targets are skipped. If nothing re‑declares them, MSBuild's `IncrementalClean` sees the previously‑tracked files as orphaned and **deletes them** before packaging reads its inputs.

`_RecordTrimmableTypeMapFileWrites` runs unconditionally (gated only on the assemblies‑list file existing) and re‑emits the previous dynamic outputs back into `@(FileWrites)` before `IncrementalClean`:

- the generated TypeMap assemblies (read back from `typemap-assemblies.txt`),
- the pre‑trim JCWs (`typemap/java`) **and** their `android/src` copies,
- the post‑trim JCWs (`typemap/linked-java`) **and** their `android/src` copies, plus the post‑trim stamp, and
- the merged manifest, `acw-map.txt`, `ApplicationRegistration.java`, and the generator stamp.

The post‑trim entries are new in this PR: once `_GeneratePostTrimTrimmableTypeMapJavaSources` became skippable (principle 2), its `linked-java` outputs would otherwise be deleted by `IncrementalClean` on the builds where it's skipped. The globs are empty for configurations that have no post‑trim pass, so this is a no‑op there.

> Two more targets — `_PrepareTrimmableNativeConfigAssemblies` and `_PrepareTrimmableTypeMapAssemblies` — exist for the same "skipped target leaves item groups empty" reason: they re‑populate the TypeMap‑assembly item groups (used by packaging, the assembly store, and native config) from the on‑disk list via `BeforeTargets`, so incremental builds that skip generation still package correctly.

### 4. Content‑based writes + explicit stale pruning keep `android/src` exact

Because generation is content‑addressed (`CopyIfStreamChanged`) and the `android/src` copy uses `SkipUnchangedFiles="true"`, an unchanged JCW never updates a timestamp and never triggers Java recompilation.

The flip side is removal: when a JCW disappears between builds — a type deleted from source, or **trimmed away** on the `PublishTrimmed` path — its `android/src` copy must not linger, or it would be compiled and packaged. Both generator passes report the JCWs they no longer produce as `DeletedJavaFiles`; the owning target mirrors each deletion into the `android/src` copy and, if anything was deleted, deletes `$(_AndroidCompileJavaStampFile)` so `_CompileJava` re‑runs and drops the stale `.class`:

```xml
<Delete Files="@(_DeletedCopiedJavaFiles)" />
<Delete Files="$(_AndroidCompileJavaStampFile)" Condition=" '@(_DeletedCopiedJavaFiles->Count())' != '0' " />
```

The two passes compute the deleted set differently because of how each manages its output directory:

- **Pre‑trim** (`_GenerateTrimmableTypeMap`, writing `typemap/java`): the task scans the output dir and deletes any `*.java` the current pass didn't produce.
- **Post‑trim** (`_GeneratePostTrimTrimmableTypeMapJavaSources`, writing `typemap/linked-java` with `CleanJavaSourceOutputDirectory=true`): the dir is wiped before regeneration, so the task snapshots the previous `*.java` set *before* the wipe and reports `previous − regenerated`. This keeps the deletion precise — only files the generator itself previously produced are ever removed from `android/src`, never unrelated sources like `ApplicationRegistration.java`.

The net invariant is two‑directional: **`android/src` contains exactly the JCWs the active pass produces** (`typemap/linked-java` for `PublishTrimmed`, `typemap/java` otherwise) — no missing files (copied by `_GenerateJavaStubs`) and no stale files (pruned via `DeletedJavaFiles`). Exercised directly by the `…KeepsAndroidSrcConsistentWithLinkedJava` and `…DeletesStaleAndroidSrcWhenLinkedJavaShrinks` tests.

### 5. The generator is skipped in design‑time builds and runs exactly once

`_GenerateTrimmableTypeMap` is gated on `'$(DesignTimeBuild)' != 'true'`: in a design‑time build, project references may resolve to target paths that aren't produced when `SkipCompilerExecution=true`, and the output isn't needed for IDE information. Combined with the existing `'$(_OuterIntermediateOutputPath)' == ''` guard (which skips inner per‑RID builds), the generator runs exactly once per outer build.

### 6. Two‑pass consistency under trimming

For CoreCLR + `PublishTrimmed`, correctness depends on the pre‑trim and post‑trim sentinels composing cleanly:

- **No‑op rebuild** — both passes are skipped (their inputs are unchanged); `_GenerateJavaStubs` keys off the stable post‑trim stamp and is also skipped. *(Newly true; previously the post‑trim pass ran every build.)*
- **Managed source change** — the pre‑trim generator re‑runs (its inputs changed) and re‑linking changes the linked assemblies, so the post‑trim pass re‑runs too; `_GenerateJavaStubs` re‑copies.
- **Trim‑only change** (e.g. a change that alters the linked output without touching the pre‑trim inputs) — the linked `.dll` change re‑runs the post‑trim pass, which touches the post‑trim stamp, so `_GenerateJavaStubs` re‑runs even though the pre‑trim generator did not. This is precisely the staleness the `@Copilot` review flagged, and is why `_GenerateJavaStubs` must key off `_TrimmableJavaSourceStamp` rather than the generator stamp alone.

---

## What changed in this PR

| Area | Change |
| ---- | ------ |
| `…TypeMap.Trimmable.targets` | Stamp sentinel for `_GenerateTrimmableTypeMap` (sole `Output`, sole `Touch`); expanded `Inputs` (`PrivateSdkAssemblies`/`FrameworkAssemblies`); design‑time‑build skip; `SkipUnchangedFiles` JCW copy; stale‑JCW deletion wiring; `_GenerateJavaStubs` keyed off `_TrimmableJavaSourceStamp`; post‑trim outputs re‑emitted in `_RecordTrimmableTypeMapFileWrites`. |
| `…TypeMap.Trimmable.CoreCLR.targets` | New `_ComputePostTrimTrimmableTypeMapInputs` (existing‑`.dll` inputs) so `_GeneratePostTrimTrimmableTypeMapJavaSources` is incremental; post‑trim pass now mirrors `DeletedJavaFiles` into `android/src` + busts the Java compile stamp. |
| `Tasks/GenerateTrimmableTypeMap.cs` | New `DeletedJavaFiles` output + `DeleteStaleJavaSources()`; in the `CleanJavaSourceOutputDirectory` (post‑trim) case it snapshots the prior JCW set before the wipe and reports `previous − regenerated`. |
| `Microsoft.Android.Sdk.TrimmableTypeMap/README.md` | Documents the pipeline and its incrementality design. |
| `TrimmableTypeMapBuildTests.cs` | Tests for stale‑JCW pruning (both directions), updated‑JCW copying, the `android/src` ↔ `linked-java` invariant, post‑trim no‑op incrementality, and stale `android/src` removal when `linked-java` shrinks. |

### Review feedback addressed
- **@Copilot** (×2): `_GenerateJavaStubs` now keys off `$(_TrimmableJavaSourceStamp)` (post‑trim stamp for `PublishTrimmed`, generator stamp otherwise), and the non‑trim default of `_TrimmableJavaSourceStamp` was changed from the TypeMap DLL to the generator stamp. The underlying reason the bare generator stamp was insufficient — a non‑incremental post‑trim pass — is fixed too.
- **@jonathanpeppers**: `_GenerateTrimmableTypeMap` declares only the stamp as its `Outputs` and touches only the stamp; the DLLs/list are content‑addressed and not consumed as timestamp inputs elsewhere.

---

## Scope notes (and a little beyond)

- All changes are gated on `_AndroidTypeMapImplementation == 'trimmable'`; non‑trimmable (`llvm-ir`/`managed`) builds are unaffected.
- Unlike #11617, this PR **keeps** `main`'s CoreCLR post‑trim `linked-java` machinery intact and instead makes it incremental.
- **Beyond this PR**, the post‑trim pass still regenerates `linked-java` wholesale (`CleanJavaSourceOutputDirectory=true`) when it runs; it now also reports the JCWs it dropped so `android/src` stays exact. A further optimization would replace the wholesale clean with content‑based writes + in‑place stale pruning (as the pre‑trim pass does), letting unchanged `linked-java` JCWs keep stable timestamps across a post‑trim run. Left as a follow‑up.

---

## Testing

Verified locally against a Debug local SDK.

**Host (`Xamarin.Android.Build.Tests`, full `TrimmableTypeMapBuildTests`): 24 passed, 2 skipped, 0 failed**, including:
- `…IncrementalBuild` (Debug CoreCLR, Release CoreCLR, Release NativeAOT)
- `…DeletesStaleGeneratedJavaSourcesAndCopies`, `…CopiesUpdatedGeneratedJavaSources`
- `…PublishTrimmed_KeepsAndroidSrcConsistentWithLinkedJava` (the `android/src` ↔ `linked-java` invariant)
- `…PublishTrimmed_DeletesStaleAndroidSrcWhenLinkedJavaShrinks` (a JCW dropped from `linked-java` is removed from `android/src`)
- `…PublishTrimmed_PostTrimJavaGenerationIsIncremental` (no‑op rebuild skips post‑trim and `_GenerateJavaStubs`)
- `…Succeeds`, `…ArrayRankChangeRegeneratesTypeMap`, `…DoesNotHitCopyIfChangedMismatch`, R2R/multi‑RID packaging tests

**Emulator (`MSBuildDeviceIntegration`, API 36 / arm64):** `DotNetRun` deploy+run for trimmable CoreCLR (Debug + Release) and NativeAOT (Release), and `TrimmableTypeMapInheritedVirtualOverrideUsesCorrectUco`.

