### PR TITLE
[TrimmableTypeMap] Use non-generic JavaPeerProxy base for interface proxies (NativeAOT)

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -143,6 +143,16 @@ sealed class JavaPeerProxyData
 	public bool IsGenericDefinition { get; init; }
 
 	/// <summary>
+	/// True if the proxied peer type is a Java interface. Interfaces have no constructors, so
+	/// the proxy must derive from the non-generic <c>JavaPeerProxy</c> base instead of
+	/// <c>JavaPeerProxy&lt;T&gt;</c>: closing the generic (whose <c>T</c> is annotated with
+	/// <c>[DynamicallyAccessedMembers(PublicConstructors|NonPublicConstructors)]</c>) over an
+	/// interface makes ILC fail to load the type (TypeLoadException). Instances are still created
+	/// from <see cref="InvokerType"/> in CreateInstance.
+	/// </summary>
+	public bool IsInterface { get; init; }
+
+	/// <summary>
 	/// True when the Java stub must not call RegisterNatives from a static initializer because
 	/// the type can be instantiated before the runtime is fully ready (for example Application
 	/// or Instrumentation subclasses).

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -290,6 +290,7 @@ static class ModelBuilder
 			},
 			IsAcw = isAcw,
 			IsGenericDefinition = peer.IsGenericDefinition,
+			IsInterface = peer.IsInterface,
 			CannotRegisterInStaticConstructor = peer.CannotRegisterInStaticConstructor,
 		};
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -665,9 +665,16 @@ sealed class TypeMapAssemblyEmitter
 		// placeholder like `Java.Lang.Object` leaks an incorrect TargetType into the typemap.
 		// The non-generic base takes `targetType` as a ctor parameter, so we can pass the real
 		// open-generic type token (a TypeRef, not a closed TypeSpec) and keep TargetType correct.
+		//
+		// Interface peers also use the non-generic base: `JavaPeerProxy<T>` annotates T with
+		// [DynamicallyAccessedMembers(PublicConstructors|NonPublicConstructors)], and closing it
+		// over an interface (which has no constructors) makes ILC fail to load the type
+		// (TypeLoadException: "Failed to load type 'JavaPeerProxy`1<ISomeInterface>'"). The peer is
+		// still activated from its InvokerType in CreateInstance, so behaviour is unchanged.
+		bool useNonGenericBase = proxy.IsGenericDefinition || proxy.IsInterface;
 		EntityHandle proxyBaseType;
 		MemberReferenceHandle baseCtorRef;
-		if (proxy.IsGenericDefinition) {
+		if (useNonGenericBase) {
 			proxyBaseType = _javaPeerProxyNonGenericRef;
 			baseCtorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, ".ctor",
 				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
@@ -709,9 +716,9 @@ sealed class TypeMapAssemblyEmitter
 			encoder => {
 				encoder.OpCode (ILOpCode.Ldarg_0);
 				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
-				if (proxy.IsGenericDefinition) {
-					// Non-generic base ctor signature: (string, Type, Type?). Push the open-generic
-					// target type as the second argument.
+				if (useNonGenericBase) {
+					// Non-generic base ctor signature: (string, Type, Type?). Push the
+					// target type (open-generic definition or interface) as the second argument.
 					encoder.LoadToken (targetTypeRef);
 					encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
 				}
@@ -721,7 +728,7 @@ sealed class TypeMapAssemblyEmitter
 				} else {
 					encoder.OpCode (ILOpCode.Ldnull);
 				}
-				encoder.Call (baseCtorRef, parameterCount: proxy.IsGenericDefinition ? 3 : 2, isInstance: true);
+				encoder.Call (baseCtorRef, parameterCount: useNonGenericBase ? 3 : 2, isInstance: true);
 				encoder.Return ();
 			});
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -142,13 +142,13 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.All (proxyTypes, proxyType => {
 			switch (proxyType.BaseType.Kind) {
 			case HandleKind.TypeSpecification:
-				// Non-generic target types derive from the closed `JavaPeerProxy<T>`.
+				// Concrete (constructible) target types derive from the closed `JavaPeerProxy<T>`.
 				var baseTypeSpec = reader.GetTypeSpecification ((TypeSpecificationHandle) proxyType.BaseType);
 				var baseTypeName = baseTypeSpec.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null);
 				Assert.StartsWith ("Java.Interop.JavaPeerProxy`1<", baseTypeName, StringComparison.Ordinal);
 				break;
 			case HandleKind.TypeReference:
-				// Open generic target types derive from the non-generic `JavaPeerProxy`.
+				// Open generic definitions and interfaces derive from the non-generic `JavaPeerProxy`.
 				var baseTypeRef = reader.GetTypeReference ((TypeReferenceHandle) proxyType.BaseType);
 				Assert.Equal ("Java.Interop", reader.GetString (baseTypeRef.Namespace));
 				Assert.Equal ("JavaPeerProxy", reader.GetString (baseTypeRef.Name));
@@ -163,6 +163,29 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		var objectProxyBaseType = reader.GetTypeSpecification ((TypeSpecificationHandle) objectProxy.BaseType);
 		Assert.Equal ("Java.Interop.JavaPeerProxy`1<Java.Lang.Object>",
 			objectProxyBaseType.DecodeSignature (SignatureTypeProvider.Instance, genericContext: null));
+	}
+
+	[Fact]
+	public void Generate_InterfaceProxyType_UsesNonGenericJavaPeerProxyBase ()
+	{
+		// JavaPeerProxy<T> annotates T with [DynamicallyAccessedMembers(Constructors)]. Closing it
+		// over an interface (which has no constructors) makes ILC fail to load the closed generic
+		// type ("Failed to load type 'JavaPeerProxy`1<ISomeInterface>'"). Interface proxies must
+		// therefore derive from the non-generic JavaPeerProxy base (a plain TypeReference).
+		var peers = ScanFixtures ();
+		using var stream = GenerateAssembly (peers);
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var interfaceProxy = reader.TypeDefinitions
+			.Select (h => reader.GetTypeDefinition (h))
+			.Where (t => reader.GetString (t.Namespace) == "_TypeMap.Proxies")
+			.First (t => reader.GetString (t.Name) == "Android_Views_IOnClickListener_Proxy");
+
+		Assert.Equal (HandleKind.TypeReference, interfaceProxy.BaseType.Kind);
+		var baseTypeRef = reader.GetTypeReference ((TypeReferenceHandle) interfaceProxy.BaseType);
+		Assert.Equal ("Java.Interop", reader.GetString (baseTypeRef.Namespace));
+		Assert.Equal ("JavaPeerProxy", reader.GetString (baseTypeRef.Name));
 	}
 
 	// Regression test: every generated proxy type must carry a custom attribute whose


### PR DESCRIPTION
## Problem

Under the trimmable typemap (NativeAOT), a generated proxy for a Java **interface** peer derived from the closed generic base `JavaPeerProxy<TInterface>`. That base annotates its type parameter with `[DynamicallyAccessedMembers(PublicConstructors | NonPublicConstructors)]` and constructs a `JavaPeerContainerFactory<T>` from it.

Closing that generic over an **interface — which has no constructors** — makes ILC fail to *load* the closed type, aborting the entire NativeAOT build:

```
Failed to load type 'Java.Interop.JavaPeerProxy`1<...INonMarshalingPreviewCallback>' from assembly 'Mono.Android'
```

## Fix

Interface peers now derive from the **non-generic `JavaPeerProxy`** base — the same base already used for open generic definitions. The interface type is passed as the `TargetType` constructor argument, so the runtime `TargetType` identity is unchanged, and instances are still created from the `InvokerType` in `CreateInstance`, so behaviour is preserved. Concrete (constructible) class peers continue to use the closed generic `JavaPeerProxy<T>` base.

Concretely, the base-type selection is widened from `proxy.IsGenericDefinition` to `proxy.IsGenericDefinition || proxy.IsInterface`, with a new `IsInterface` flag plumbed through the proxy model.

## Testing

- Added `Generate_InterfaceProxyType_UsesNonGenericJavaPeerProxyBase`, asserting an interface proxy derives from the non-generic `JavaPeerProxy` base (a plain `TypeReference`, not a closed `TypeSpecification`).
- Updated `Generate_ProxyType_UsesGenericJavaPeerProxyBase` comments to reflect that concrete types use the generic base while open generic definitions and interfaces use the non-generic base.
- Verified with `ZXing.Net.Mobile` (3.0.0-beta5, transitively `ApxLabs.FastAndroidCamera`): the NativeAOT build failed to load `JavaPeerProxy`1<…INonMarshalingPreviewCallback>` before this change and builds successfully after. Basic Mono.Android listeners (`IOnClickListener` / `IOnLongClickListener`) and `AndroidX.Fragment` still build clean.
- All TrimmableTypeMap generator unit tests pass.
