### PR TITLE
[TrimmableTypeMap] Keep user AndroidJavaSource Java under R8 shrinking

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -37,6 +37,10 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem []? ProguardConfigurationFiles { get; set; }
 		public bool UseTrimmableNativeAotProguardConfiguration { get; set; }
 
+		// User-authored AndroidJavaSource (Bind != true) .java files. These have no managed peer and are
+		// therefore absent from the acw-map, so they must be kept explicitly when shrinking is enabled.
+		public ITaskItem []? JavaSourceFiles { get; set; }
+
 		protected override string MainClass => "com.android.tools.r8.R8";
 
 		readonly List<string> tempFiles = new List<string> ();
@@ -50,6 +54,52 @@ namespace Xamarin.Android.Tasks
 					File.Delete (temp);
 				}
 			}
+		}
+
+		// Derive the fully-qualified Java type name from each user .java source file. Java requires the
+		// public top-level type name to match the file name, so '<package>.<FileNameWithoutExtension>' is
+		// the type to keep. Files that no longer exist are skipped.
+		IEnumerable<string> GetUserJavaTypes ()
+		{
+			if (JavaSourceFiles == null) {
+				yield break;
+			}
+			var seen = new HashSet<string> (StringComparer.Ordinal);
+			foreach (var item in JavaSourceFiles) {
+				var path = item.ItemSpec;
+				if (path.IsNullOrEmpty () || !File.Exists (path)) {
+					continue;
+				}
+				var typeName = Path.GetFileNameWithoutExtension (path);
+				var package = ReadJavaPackage (path);
+				if (!package.IsNullOrEmpty ()) {
+					typeName = $"{package}.{typeName}";
+				}
+				if (seen.Add (typeName)) {
+					yield return typeName;
+				}
+			}
+		}
+
+		static string? ReadJavaPackage (string path)
+		{
+			foreach (var raw in File.ReadLines (path)) {
+				var line = raw.Trim ();
+				if (line.Length == 0 || line.StartsWith ("//", StringComparison.Ordinal) || line.StartsWith ("*", StringComparison.Ordinal) || line.StartsWith ("/*", StringComparison.Ordinal)) {
+					continue;
+				}
+				if (line.StartsWith ("package ", StringComparison.Ordinal)) {
+					var end = line.IndexOf (';');
+					if (end > "package ".Length) {
+						return line.Substring ("package ".Length, end - "package ".Length).Trim ();
+					}
+				}
+				// The package declaration, if present, must precede any type declaration.
+				if (line.StartsWith ("import ", StringComparison.Ordinal) || line.Contains ("class ") || line.Contains ("interface ") || line.Contains ("enum ")) {
+					break;
+				}
+			}
+			return null;
 		}
 
 		/// <summary>
@@ -107,6 +157,11 @@ namespace Xamarin.Android.Tasks
 					javaTypes.Sort (StringComparer.Ordinal);
 					using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration)) {
 						foreach (var java in javaTypes) {
+							appcfg.WriteLine ($"-keep class {java} {{ *; }}");
+						}
+						// User-authored AndroidJavaSource (Bind != true) has no managed peer and is absent
+						// from the acw-map, so keep it explicitly; otherwise shrinking removes it.
+						foreach (var java in GetUserJavaTypes ()) {
 							appcfg.WriteLine ($"-keep class {java} {{ *; }}");
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -51,6 +51,9 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <ItemGroup>
       <_AndroidD8MapDiagnostics Condition=" '$(AndroidD8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
       <_AndroidR8MapDiagnostics Condition=" '$(AndroidR8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
+      <!-- User-authored AndroidJavaSource (Bind != True) is not in the acw-map; pass it to R8 so it
+           is kept when shrinking is enabled rather than silently removed. -->
+      <_R8KeepJavaSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' != 'True' " />
     </ItemGroup>
 
     <R8
@@ -69,6 +72,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         EnableDesugar="$(AndroidEnableDesugar)"
         AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
         AcwMapFile="$(_AcwMapFile)"
+        JavaSourceFiles="@(_R8KeepJavaSource)"
         ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
         ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
         ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"


### PR DESCRIPTION
### Summary

User-authored `AndroidJavaSource` (`.java` files with `Bind != True`) are plain Java the developer adds to their project. They have **no managed (.NET) peer**, so they are **not present in the acw-map** (the map of Java types that have a generated Android Callable Wrapper).

When R8 generates the application ProGuard configuration from the acw-map (the `else if (!AcwMapFile.IsNullOrEmpty ())` branch in `R8.cs` — the default for R8 release builds), it only emits `-keep` rules for the acw-map's managed-mapped Java types. Because user `AndroidJavaSource` isn't in that map, **no keep rule is emitted for it and R8 shrinks it away.**

This is most visible on the **trimmable NativeAOT** path, which enables R8 with shrinking by default (`AndroidLinkTool=r8` → `_R8EnableShrinking=True`). It made `BuildAfterMultiDexIsNotRequired(NativeAOT)` fail: the test's huge `ManyMethods.java` user-Java classes were removed, so the app no longer exceeded the per-dex method limit, multidex was no longer required, and the expected `classes2.dex` was never produced.

Fixes #11774.

### Fix

Pass the user `AndroidJavaSource` (`.java` with `Bind != True`) to the `R8` task and emit an explicit keep rule for each so it survives shrinking:

```
-keep class <package>.<TypeName> { *; }
```

The type name is `<package>.<FileNameWithoutExtension>` — Java requires the public top-level type name to match the file name. The package is read from the file's `package …;` declaration (skipping comments, and bailing once a type/import is reached, since the package declaration must precede them).

- `R8.cs`: new `JavaSourceFiles` input + `GetUserJavaTypes()`/`ReadJavaPackage()` helpers; emits the keep rules alongside the existing acw-map keep rules.
- `Xamarin.Android.D8.targets`: collect `@(AndroidJavaSource)` with `Bind != True` into `@(_R8KeepJavaSource)` and pass it to the task.

### Scope / risk

The keep rules are emitted in the acw-map-generated config branch, which is the default for R8 **release** builds across runtimes — not NativeAOT-only. The effect is purely additive (more `-keep` rules), so it can only *prevent* removal of user-authored Java; it never removes anything that was previously kept. User-authored Java is generally intended to be present (e.g. referenced via JNI/reflection from native), so keeping it is the conservative, correct behavior.

### Testing

Verified locally: `BuildAfterMultiDexIsNotRequired(NativeAOT)` and `(CoreCLR)` both pass. The change is also exercised by the full test matrix in #11617, from which it is sliced for focused review.
