### PR TITLE
[TrimmableTypeMap] Honor AndroidApplicationJavaClass for the JCW base and manifest

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/JcwJavaSourceGenerator.cs
@@ -45,14 +45,14 @@ public sealed class JcwJavaSourceGenerator
 	/// Generates .java source content for all ACW types and returns them as in-memory
 	/// (relativePath, content) pairs. No filesystem IO is performed.
 	/// </summary>
-	public IReadOnlyList<GeneratedJavaSource> GenerateContent (IReadOnlyList<JavaPeerInfo> types)
+	public IReadOnlyList<GeneratedJavaSource> GenerateContent (IReadOnlyList<JavaPeerInfo> types, string? applicationJavaClass = null)
 	{
 		if (types is null) throw new ArgumentNullException (nameof (types));
 		var results = new List<GeneratedJavaSource> ();
 		foreach (var type in types) {
 			if (type.DoNotGenerateAcw || type.IsInterface) continue;
 			using var writer = new StringWriter ();
-			Generate (type, writer);
+			Generate (type, writer, applicationJavaClass);
 			results.Add (new GeneratedJavaSource (GetRelativePath (type), writer.ToString ()));
 		}
 		return results;
@@ -61,11 +61,11 @@ public sealed class JcwJavaSourceGenerator
 	/// <summary>
 	/// Generates a single .java source file for the given type.
 	/// </summary>
-	public void Generate (JavaPeerInfo type, TextWriter writer)
+	public void Generate (JavaPeerInfo type, TextWriter writer, string? applicationJavaClass = null)
 	{
 		writer.NewLine = "\n";
 		WritePackageDeclaration (type, writer);
-		WriteClassDeclaration (type, writer);
+		WriteClassDeclaration (type, writer, applicationJavaClass);
 		WriteStaticInitializer (type, writer);
 		WriteConstructors (type, writer);
 		WriteFields (type, writer);
@@ -97,7 +97,7 @@ public sealed class JcwJavaSourceGenerator
 		}
 	}
 
-	static void WriteClassDeclaration (JavaPeerInfo type, TextWriter writer)
+	static void WriteClassDeclaration (JavaPeerInfo type, TextWriter writer, string? applicationJavaClass)
 	{
 		string abstractModifier = type.IsAbstract && !type.IsInterface ? "abstract " : "";
 		string className = JniSignatureHelper.GetJavaSimpleName (type.JavaName);
@@ -106,7 +106,14 @@ public sealed class JcwJavaSourceGenerator
 
 		// extends clause
 		if (type.BaseJavaName != null) {
-			writer.WriteLine ($"\textends {JniSignatureHelper.JniNameToJavaName (type.BaseJavaName)}");
+			string baseName = JniSignatureHelper.JniNameToJavaName (type.BaseJavaName);
+			// A user Application subclass normally extends android.app.Application, but when
+			// $(AndroidApplicationJavaClass) is set (e.g. android.support.multidex.MultiDexApplication
+			// when $(AndroidEnableMultiDex) is true) it must extend that class instead.
+			if (!applicationJavaClass.IsNullOrEmpty () && baseName == "android.app.Application") {
+				baseName = applicationJavaClass;
+			}
+			writer.WriteLine ($"\textends {baseName}");
 		}
 
 		// implements clause — always includes IGCUserPeer, plus any implemented interfaces

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -51,7 +51,7 @@ public class TrimmableTypeMapGenerator
 		}
 		MarkFrameworkAssemblyPeers (allPeers, frameworkAssemblyNames);
 
-		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig));
+		RootManifestReferencedTypes (allPeers, PrepareManifestForRooting (manifestTemplate, manifestConfig), manifestConfig?.ApplicationJavaClass);
 		PropagateDeferredRegistrationToBaseClasses (allPeers);
 		PropagateCannotRegisterToDescendants (allPeers);
 
@@ -60,7 +60,7 @@ public class TrimmableTypeMapGenerator
 			: [];
 		var jcwPeers = allPeers.Where (ShouldGenerateJcw).ToList ();
 		logger.LogGeneratingJcwFilesInfo (jcwPeers.Count, allPeers.Count);
-		var generatedJavaSources = GenerateJcwJavaSources (jcwPeers);
+		var generatedJavaSources = GenerateJcwJavaSources (jcwPeers, manifestConfig?.ApplicationJavaClass);
 
 		var appRegTypes = CollectApplicationRegistrationTypes (allPeers);
 		if (appRegTypes.Count > 0) {
@@ -289,15 +289,15 @@ public class TrimmableTypeMapGenerator
 		return result;
 	}
 
-	List<GeneratedJavaSource> GenerateJcwJavaSources (List<JavaPeerInfo> allPeers)
+	List<GeneratedJavaSource> GenerateJcwJavaSources (List<JavaPeerInfo> allPeers, string? applicationJavaClass)
 	{
 		var jcwGenerator = new JcwJavaSourceGenerator ();
-		var sources = jcwGenerator.GenerateContent (allPeers);
+		var sources = jcwGenerator.GenerateContent (allPeers, applicationJavaClass);
 		logger.LogGeneratedJcwFilesInfo (sources.Count);
 		return sources.ToList ();
 	}
 
-	internal void RootManifestReferencedTypes (List<JavaPeerInfo> allPeers, XDocument? doc)
+	internal void RootManifestReferencedTypes (List<JavaPeerInfo> allPeers, XDocument? doc, string? applicationJavaClass = null)
 	{
 		if (doc?.Root is not { } root) {
 			return;
@@ -357,6 +357,13 @@ public class TrimmableTypeMapGenerator
 					}
 				}
 			} else {
+				// $(AndroidApplicationJavaClass) (e.g. android.support.multidex.MultiDexApplication
+				// when $(AndroidEnableMultiDex) is true) is a Java framework type with no managed
+				// peer, so it is expected to be absent from the scanned assemblies — don't warn.
+				if (!applicationJavaClass.IsNullOrEmpty () &&
+				    string.Equals (name, ManifestNameResolver.Resolve (applicationJavaClass, packageName), StringComparison.Ordinal)) {
+					continue;
+				}
 				logger.LogManifestReferencedTypeNotFoundWarning (name);
 			}
 		}

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/JcwJavaSourceGeneratorTests.cs
@@ -121,6 +121,46 @@ public class JcwJavaSourceGeneratorTests : FixtureTestBase
 			Assert.DoesNotContain ("View$OnClickListener", java);
 		}
 
+		[Fact]
+		public void Generate_ApplicationSubclass_WithApplicationJavaClass_ExtendsThatClass ()
+		{
+			// When $(AndroidApplicationJavaClass) is set (e.g. android.support.multidex.MultiDexApplication
+			// under $(AndroidEnableMultiDex)), an android.app.Application subclass must extend it.
+			var type = new JavaPeerInfo {
+				JavaName = "com/foxsports/test/CustomApp",
+				CompatJniName = "com/foxsports/test/CustomApp",
+				ManagedTypeName = "UnnamedProject.CustomApp",
+				ManagedTypeNamespace = "UnnamedProject",
+				ManagedTypeShortName = "CustomApp",
+				AssemblyName = "App",
+				BaseJavaName = "android/app/Application",
+				CannotRegisterInStaticConstructor = true,
+			};
+			var generator = new JcwJavaSourceGenerator ();
+			using var writer = new StringWriter ();
+			generator.Generate (type, writer, "android.support.multidex.MultiDexApplication");
+			var java = writer.ToString ();
+			Assert.Contains ("extends android.support.multidex.MultiDexApplication", java);
+			Assert.DoesNotContain ("extends android.app.Application", java);
+		}
+
+		[Fact]
+		public void Generate_ApplicationSubclass_WithoutApplicationJavaClass_ExtendsApplication ()
+		{
+			var type = new JavaPeerInfo {
+				JavaName = "com/foxsports/test/CustomApp",
+				CompatJniName = "com/foxsports/test/CustomApp",
+				ManagedTypeName = "UnnamedProject.CustomApp",
+				ManagedTypeNamespace = "UnnamedProject",
+				ManagedTypeShortName = "CustomApp",
+				AssemblyName = "App",
+				BaseJavaName = "android/app/Application",
+				CannotRegisterInStaticConstructor = true,
+			};
+			var java = GenerateToString (type);
+			Assert.Contains ("extends android.app.Application", java);
+		}
+
 	}
 
 	public class StaticInitializer

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -367,6 +367,34 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 	}
 
 	[Fact]
+	public void RootManifestReferencedTypes_DoesNotWarnForApplicationJavaClass ()
+	{
+		// android.support.multidex.MultiDexApplication (injected via $(AndroidApplicationJavaClass)
+		// when $(AndroidEnableMultiDex) is true) is a Java framework type with no managed peer,
+		// so it must not produce an XA4250 "not found in any scanned assembly" warning.
+		var peers = new List<JavaPeerInfo> {
+			new JavaPeerInfo {
+				JavaName = "com/example/MyActivity", CompatJniName = "com.example.MyActivity",
+				ManagedTypeName = "MyApp.MyActivity", ManagedTypeNamespace = "MyApp", ManagedTypeShortName = "MyActivity",
+				AssemblyName = "MyApp",
+			},
+		};
+
+		var doc = System.Xml.Linq.XDocument.Parse ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example">
+			  <application android:name="android.support.multidex.MultiDexApplication" />
+			</manifest>
+			""");
+
+		var warnings = new List<string> ();
+		var generator = CreateGenerator (warnings);
+		generator.RootManifestReferencedTypes (peers, doc, "android.support.multidex.MultiDexApplication");
+
+		Assert.DoesNotContain (warnings, w => w.Contains ("MultiDexApplication"));
+	}
+
+	[Fact]
 	public void RootManifestReferencedTypes_SkipsAlreadyUnconditional ()
 	{
 		var peers = new List<JavaPeerInfo> {


### PR DESCRIPTION
## Summary

When `$(AndroidApplicationJavaClass)` is set — e.g. to `android.support.multidex.MultiDexApplication` when `$(AndroidEnableMultiDex)` is `true` — the trimmable typemap (NativeAOT) did not account for it. This caused two NativeAOT-only failures that the legacy typemap implementation handled correctly:

* **`CustomApplicationClassAndMultiDex`** — A user `Application` subclass's JCW extended `android.app.Application` instead of the multidex base, breaking MultiDex apps. `JcwJavaSourceGenerator` now applies the same swap `CallableWrapperType` does: if a type's base is `android.app.Application` and an application-java-class override is set, it emits that override as the `extends` clause.
* **`ClassLibraryHasNoWarnings`** — The injected `MultiDexApplication` manifest name has no managed peer, so `RootManifestReferencedTypes` logged a spurious `XA4250`. It's a Java framework type, so the warning is now skipped when the unresolved name is the configured application-java-class override.

The application-java-class value is threaded from `ManifestConfig` through to both the JCW generator and manifest-reference rooting.

## Context

This was previously part of the trimmable typemap mega-PR (#11617). The fix is fully self-contained — `JcwJavaSourceGenerator` and `TrimmableTypeMapGenerator` already exist on `main`, so it applies cleanly on its own and is split out for independent review/merge.

## Tests

Adds generator unit tests for both behaviors:
* `JcwJavaSourceGeneratorTests` — JCW base-class swap when the override is set.
* `TrimmableTypeMapGeneratorTests` — manifest rooting no longer warns on the override class.

All 82 generator unit tests pass locally.
