### PR TITLE
[TrimmableTypeMap] Keep user AndroidJavaSource Java under R8 shrinking

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -37,6 +37,10 @@ namespace Xamarin.Android.Tasks
 		public ITaskItem []? ProguardConfigurationFiles { get; set; }
 		public bool UseTrimmableNativeAotProguardConfiguration { get; set; }
 
+		// User-authored AndroidJavaSource (Bind != true) .java files. These have no managed peer and are
+		// therefore absent from the acw-map, so they must be kept explicitly when shrinking is enabled.
+		public ITaskItem []? JavaSourceFiles { get; set; }
+
 		protected override string MainClass => "com.android.tools.r8.R8";
 
 		readonly List<string> tempFiles = new List<string> ();
@@ -50,6 +54,52 @@ namespace Xamarin.Android.Tasks
 					File.Delete (temp);
 				}
 			}
+		}
+
+		// Derive the fully-qualified Java type name from each user .java source file. Java requires the
+		// public top-level type name to match the file name, so '<package>.<FileNameWithoutExtension>' is
+		// the type to keep. Files that no longer exist are skipped.
+		IEnumerable<string> GetUserJavaTypes ()
+		{
+			if (JavaSourceFiles == null) {
+				yield break;
+			}
+			var seen = new HashSet<string> (StringComparer.Ordinal);
+			foreach (var item in JavaSourceFiles) {
+				var path = item.ItemSpec;
+				if (path.IsNullOrEmpty () || !File.Exists (path)) {
+					continue;
+				}
+				var typeName = Path.GetFileNameWithoutExtension (path);
+				var package = ReadJavaPackage (path);
+				if (!package.IsNullOrEmpty ()) {
+					typeName = $"{package}.{typeName}";
+				}
+				if (seen.Add (typeName)) {
+					yield return typeName;
+				}
+			}
+		}
+
+		static string? ReadJavaPackage (string path)
+		{
+			foreach (var raw in File.ReadLines (path)) {
+				var line = raw.Trim ();
+				if (line.Length == 0 || line.StartsWith ("//", StringComparison.Ordinal) || line.StartsWith ("*", StringComparison.Ordinal) || line.StartsWith ("/*", StringComparison.Ordinal)) {
+					continue;
+				}
+				if (line.StartsWith ("package ", StringComparison.Ordinal)) {
+					var end = line.IndexOf (';');
+					if (end > "package ".Length) {
+						return line.Substring ("package ".Length, end - "package ".Length).Trim ();
+					}
+				}
+				// The package declaration, if present, must precede any type declaration.
+				if (line.StartsWith ("import ", StringComparison.Ordinal) || line.Contains ("class ") || line.Contains ("interface ") || line.Contains ("enum ")) {
+					break;
+				}
+			}
+			return null;
 		}
 
 		/// <summary>
@@ -107,6 +157,11 @@ namespace Xamarin.Android.Tasks
 					javaTypes.Sort (StringComparer.Ordinal);
 					using (var appcfg = File.CreateText (ProguardGeneratedApplicationConfiguration)) {
 						foreach (var java in javaTypes) {
+							appcfg.WriteLine ($"-keep class {java} {{ *; }}");
+						}
+						// User-authored AndroidJavaSource (Bind != true) has no managed peer and is absent
+						// from the acw-map, so keep it explicitly; otherwise shrinking removes it.
+						foreach (var java in GetUserJavaTypes ()) {
 							appcfg.WriteLine ($"-keep class {java} {{ *; }}");
 						}
 					}

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Android.Tasks
 			}
 		}
 
-		static string? ReadJavaPackage (string path)
+		internal static string? ReadJavaPackage (string path)
 		{
 			foreach (var raw in File.ReadLines (path)) {
 				var line = raw.Trim ();

--- a/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/R8.cs
@@ -58,7 +58,8 @@ namespace Xamarin.Android.Tasks
 
 		// Derive the fully-qualified Java type name from each user .java source file. Java requires the
 		// public top-level type name to match the file name, so '<package>.<FileNameWithoutExtension>' is
-		// the type to keep. Files that no longer exist are skipped.
+		// the type to keep. Files that no longer exist are skipped. Only the public top-level type is kept;
+		// secondary/non-public types in the same file rely on the public type's '{ *; }' or being unused.
 		IEnumerable<string> GetUserJavaTypes ()
 		{
 			if (JavaSourceFiles == null) {
@@ -94,7 +95,9 @@ namespace Xamarin.Android.Tasks
 						return line.Substring ("package ".Length, end - "package ".Length).Trim ();
 					}
 				}
-				// The package declaration, if present, must precede any type declaration.
+				// The package declaration, if present, must precede any type declaration. This is a
+				// lightweight scan (not a full Java parser): the first 'import'/type keyword ends the
+				// search, and earlier comment lines are skipped, so package always wins in practice.
 				if (line.StartsWith ("import ", StringComparison.Ordinal) || line.Contains ("class ") || line.Contains ("interface ") || line.Contains ("enum ")) {
 					break;
 				}

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Android.Build.Tests
 		[TestCase ("public class Foo {}",                                     null)] // no package
 		[TestCase ("import java.util.List;\npackage com.late;\nclass Foo {}", null)] // package after import is ignored
 		[TestCase ("class Foo {\npackage com.late;\n}",                       null)] // package after type is ignored
-		public void ReadJavaPackage (string content, string expected)
+		public void ReadJavaPackage (string content, string? expected)
 		{
 			var path = Path.GetTempFileName ();
 			try {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/R8Tests.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using NUnit.Framework;
 using Xamarin.Android.Tasks;
 
@@ -29,6 +30,23 @@ namespace Xamarin.Android.Build.Tests
 			var actual = R8.TryGetDisallowedOption (line, out var option);
 			Assert.AreEqual (expected, actual);
 			Assert.AreEqual (expectedOption, option);
+		}
+
+		[TestCase ("package com.example.app;\npublic class Foo {}",            "com.example.app")]
+		[TestCase ("package com.example.app ;\npublic class Foo {}",           "com.example.app")] // space before ';'
+		[TestCase ("// header\n/* license */\npackage com.example.app;\nclass Foo {}", "com.example.app")] // skip comments
+		[TestCase ("public class Foo {}",                                     null)] // no package
+		[TestCase ("import java.util.List;\npackage com.late;\nclass Foo {}", null)] // package after import is ignored
+		[TestCase ("class Foo {\npackage com.late;\n}",                       null)] // package after type is ignored
+		public void ReadJavaPackage (string content, string expected)
+		{
+			var path = Path.GetTempFileName ();
+			try {
+				File.WriteAllText (path, content);
+				Assert.AreEqual (expected, R8.ReadJavaPackage (path));
+			} finally {
+				File.Delete (path);
+			}
 		}
 	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.D8.targets
@@ -51,6 +51,9 @@ Copyright (C) 2018 Xamarin. All rights reserved.
     <ItemGroup>
       <_AndroidD8MapDiagnostics Condition=" '$(AndroidD8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
       <_AndroidR8MapDiagnostics Condition=" '$(AndroidR8IgnoreWarnings)' == 'true' " Include="warning" To="info" />
+      <!-- User-authored AndroidJavaSource (Bind != True) is not in the acw-map; pass it to R8 so it
+           is kept when shrinking is enabled rather than silently removed. -->
+      <_R8KeepJavaSource Include="@(AndroidJavaSource)" Condition=" '%(AndroidJavaSource.Bind)' != 'True' " />
     </ItemGroup>
 
     <R8
@@ -69,6 +72,7 @@ Copyright (C) 2018 Xamarin. All rights reserved.
         EnableDesugar="$(AndroidEnableDesugar)"
         AndroidSdkBuildToolsPath="$(AndroidSdkBuildToolsPath)"
         AcwMapFile="$(_AcwMapFile)"
+        JavaSourceFiles="@(_R8KeepJavaSource)"
         ProguardCommonXamarinConfiguration="$(IntermediateOutputPath)proguard\proguard_xamarin.cfg"
         ProguardGeneratedReferenceConfiguration="$(_ProguardProjectConfiguration)"
         ProguardGeneratedApplicationConfiguration="$(IntermediateOutputPath)proguard\proguard_project_primary.cfg"


### PR DESCRIPTION
## Problem

When R8 code shrinking is enabled, R8 removes any Java type that nothing keeps. .NET for Android keeps the Java callable wrappers (JCWs) of bound managed types by generating `-keep` rules from the **acw-map** (managed peer ↔ Java type). That works for generated JCWs, but **user-authored `AndroidJavaSource` `.java` files marked `Bind` != `true` have no managed peer**, so they never appear in the acw-map — and therefore get no keep rule. With shrinking on, R8 silently deletes them, and the app fails at runtime when it references those classes (often as a `NoClassDefFoundError` that only reproduces in Release/shrunk builds).

## Fix

Pass user `AndroidJavaSource` (`Bind` != `True`) to the `R8` task and emit `-keep class <package>.<Type> { *; }` for each, so user Java survives shrinking:

* **`D8.targets`** — collect `@(AndroidJavaSource)` items where `%(Bind) != 'True'` into `_R8KeepJavaSource` and pass them to `R8` via the new `JavaSourceFiles` property.
* **`R8.cs`** — append keep rules in the same block that emits acw-map keeps. `GetUserJavaTypes()` derives the fully-qualified name as `<package>.<FileNameWithoutExtension>` (Java requires the public top-level type name to match the file name); `ReadJavaPackage()` parses the `package` declaration, skipping comments and stopping at the first `import`/type declaration. Names are de-duplicated.
* **`R8Tests.cs`** — unit tests covering `ReadJavaPackage`: package present, trailing space before `;`, comment headers, no package, and `package` after `import`/type (ignored).

## Why split out

This is being carved out of the trimmable typemap mega-PR #11617. Although the bug surfaced while bringing up the NativeAOT trimmable path, **it is not trimmable-specific** — the acw-map keep logic and R8 shrinking apply equally to legacy/MonoVM and CoreCLR, so user `AndroidJavaSource` was at risk of being shrunk there too. Landing it independently de-risks #11617 and ships a general correctness fix sooner.

## Context / related PRs

- #11617 — parent mega-PR (reflection-free trimmable typemap) this is sliced from.
- #11643 — removes the managed NativeAOT typemap in favor of the trimmable one (the path that exposed this gap).
- Sibling slices already split out off `main`: #11794 (AndroidApplicationJavaClass/multidex), #11796 (manifest generation parity). Other merged groundwork: #11749, #11751, #11752, #11753, #11764, #11769.

## Verification

24/24 R8 unit tests pass (18 existing + 6 new). `BuildAfterMultiDexIsNotRequired` verified locally on NativeAOT and CoreCLR — user Java is retained after shrinking.
