### PR TITLE
[tests] Capture device state on device-test failure

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -175,6 +175,14 @@ namespace Xamarin.Android.Build.Tests
 		// See dotnet/android#11830.
 		static void CaptureDeviceState (string outputDir)
 		{
+			// Re-check attachment (the cached value can be stale if the device
+			// disconnected mid-test); otherwise each adb command below would wait
+			// the full timeout against an unresponsive device.
+			if (!IsDeviceAttached (refreshCachedValue: true)) {
+				TestContext.WriteLine ("No device attached; skipping device-state capture.");
+				return;
+			}
+
 			var sb = new StringBuilder ();
 			foreach (var (title, command) in new [] {
 					("adb devices -l", "devices -l"),

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Linq;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -159,9 +160,45 @@ namespace Xamarin.Android.Build.Tests
 				} else {
 					TestContext.WriteLine ($"{localUi} did not exist!");
 				}
+
+				CaptureDeviceState (outputDir);
 			}
 
 			base.CleanupTest ();
+		}
+
+		// Best-effort device-state snapshot captured on test failure so that on-device
+		// install/deploy failures can be classified from CI artifacts instead of guessed:
+		// connectivity (adb devices/get-state), disk pressure (df, dumpsys diskstats),
+		// storage-service readiness (dumpsys storaged - the StorageStatsManager NPE seen
+		// during install-create), boot completion, and how many test apps have piled up.
+		// See dotnet/android#11830.
+		static void CaptureDeviceState (string outputDir)
+		{
+			var sb = new StringBuilder ();
+			foreach (var (title, command) in new [] {
+					("adb devices -l", "devices -l"),
+					("adb get-state", "get-state"),
+					("getprop sys.boot_completed", "shell getprop sys.boot_completed"),
+					("getprop dev.bootcomplete", "shell getprop dev.bootcomplete"),
+					("df /data", "shell df /data"),
+					("df /storage/emulated/0", "shell df /storage/emulated/0"),
+					("dumpsys diskstats", "shell dumpsys diskstats"),
+					("dumpsys storaged", "shell dumpsys storaged"),
+					("pm list packages -3", "shell pm list packages -3"),
+				}) {
+				sb.AppendLine ($"===== {title} =====");
+				sb.AppendLine (RunAdbCommand (command));
+				sb.AppendLine ();
+			}
+
+			string localState = Path.Combine (outputDir, "device-state-failed.log");
+			File.WriteAllText (localState, sb.ToString ());
+			if (File.Exists (localState)) {
+				TestContext.AddTestAttachment (localState);
+			} else {
+				TestContext.WriteLine ($"{localState} did not exist!");
+			}
 		}
 
 		protected int GetSdkVersion ()

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -195,7 +195,7 @@ namespace Xamarin.Android.Build.Tests
 					("dumpsys storaged", "shell dumpsys storaged"),
 					("pm list packages -3", "shell pm list packages -3"),
 				}) {
-				sb.AppendLine ($"===== {title} =====");
+				sb.AppendLine (CultureInfo.InvariantCulture, $"===== {title} =====");
 				sb.AppendLine (RunAdbCommand (command));
 				sb.AppendLine ();
 			}


### PR DESCRIPTION
## Description

When an on-device test fails, `DeviceTest.CleanupTest` (`[TearDown]`) already attaches a `screenshot.png`, `logcat-failed.log`, and `ui.xml`. But we capture **no device-state snapshot**, so on-device **install/deploy failures** can't be classified after the fact — we're left guessing between connectivity, disk pressure, and an unready storage service.

This adds a best-effort `device-state-failed.log` to the on-failure teardown, capturing:

- **Connectivity** — `adb devices -l`, `adb get-state`
- **Boot completion** — `getprop sys.boot_completed`, `getprop dev.bootcomplete`
- **Disk pressure** — `df /data`, `df /storage/emulated/0`, `dumpsys diskstats`
- **Storage-service readiness** — `dumpsys storaged` (the `StorageStatsManager.isQuotaSupported(...) on a null object` NPE we've seen thrown from `install-create`)
- **Accumulated apps** — `pm list packages -3`

It covers the `InstallAndRunTests` / `InstallTests` / `FastDevTest` families (e.g. `DeployToDevice`, `IncrementalFastDeployment`), which all derive from `DeviceTest`. The capture is best-effort (`RunAdbCommand` already ignores errors) and only runs when the test failed **and** a device is still attached — for a truly offline device there is nothing to query, and that case is already obvious from `XAGCPU7000`.

## Motivation

Seen on build [1488657](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1488657) (PR #11825, unrelated change): 14 install/deploy tests failed together with

```
InstallException: 'package install-create ...' returns 'Unknown failure: ...
  NullPointerException: ...StorageStatsManager.isQuotaSupported(String) on a null object reference
    at StorageManagerService.getAllocatableBytes(...)
```

We could not tell from the artifacts whether this was disk pressure or an unready storage service. This snapshot makes the next occurrence self-diagnosing.

## Context

Companion to dotnet/android#11831 (which adds the equivalent snapshot to the `apk-instrumentation.yaml` MTP install lane). Both feed the tracking issue dotnet/android#11830.
