### PR TITLE
[tests] Stream on-device test results to MTP as they finish

### DIFF
--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -74,7 +74,7 @@ steps:
         $env:PATH = "${DOTNET_ROOT};$env:PATH"
         $dotnetPath = "${DOTNET_ROOT}\dotnet.exe"
     }
-    & $dotnetPath test $projectFile --no-build -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog -c ${{ parameters.configuration }} --results-directory $resultsDir --report-trx --report-trx-filename ${{ parameters.testName }}.trx -p:TestingPlatformCaptureOutput=false ${{ parameters.extraBuildArgs }}
+    & $dotnetPath test $projectFile --no-build -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog -c ${{ parameters.configuration }} --results-directory $resultsDir --report-trx --report-trx-filename ${{ parameters.testName }}.trx --output Detailed ${{ parameters.extraBuildArgs }}
     Pop-Location
   displayName: run ${{ parameters.testName }}
   condition: ${{ parameters.condition }}

--- a/build-tools/automation/yaml-templates/apk-instrumentation.yaml
+++ b/build-tools/automation/yaml-templates/apk-instrumentation.yaml
@@ -44,7 +44,7 @@ steps:
         $env:PATH = "${DOTNET_ROOT};$env:PATH"
         $dotnetPath = "${DOTNET_ROOT}\dotnet.exe"
     }
-    & $dotnetPath test $projectFile --no-build -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog -c ${{ parameters.configuration }} --results-directory $resultsDir --report-trx --report-trx-filename ${{ parameters.testName }}.trx ${{ parameters.extraBuildArgs }}
+    & $dotnetPath test $projectFile --no-build -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/run-${{ parameters.testName }}.binlog -c ${{ parameters.configuration }} --results-directory $resultsDir --report-trx --report-trx-filename ${{ parameters.testName }}.trx -p:TestingPlatformCaptureOutput=false ${{ parameters.extraBuildArgs }}
     Pop-Location
   displayName: run ${{ parameters.testName }}
   condition: ${{ parameters.condition }}

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -53,10 +53,11 @@ class AndroidTestAdapter(
 
 	async Task RunAndReportAsync (ExecuteRequestContext context, SessionUid sessionUid)
 	{
-		// Shared state for the streamed run: which tests we've already reported a
-		// final outcome for (so we don't double-report them from the pulled TRX),
-		// and which test — if any — is currently executing (so a crash can resolve
-		// it to a terminal state instead of leaving it "in progress").
+		// Shared state for the streamed run: the set of tests we've streamed a
+		// final outcome for (a non-empty set means streaming was authoritative, so
+		// we skip the TRX fallback), and which test — if any — is currently
+		// executing (so a crash can resolve it to a terminal state instead of
+		// leaving it "in progress").
 		var state = new StreamingState ();
 
 		// 1. Run instrumentation on device, publishing each test to MTP live as
@@ -519,8 +520,9 @@ class InstrumentationBundleResult
 }
 
 /// <summary>
-/// Mutable state shared across a streamed run: the tests already reported with a
-/// final outcome, and the test currently executing (if any).
+/// Mutable state shared across a streamed run: the tests streamed with a final
+/// outcome (a non-empty set means streaming was authoritative, so the TRX
+/// fallback is skipped), and the test currently executing (if any).
 /// </summary>
 sealed class StreamingState
 {
@@ -639,7 +641,6 @@ sealed class StatusStreamParser (ChannelWriter<InstrumentationStatus> writer, St
 		lastKey = null;
 	}
 }
-
 
 enum TrxOutcome
 {

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -153,14 +153,23 @@ class AndroidTestAdapter(
 	/// <summary>
 	/// Publishes a single streamed instrumentation status block to MTP: a "start"
 	/// event becomes an in-progress node; a "finish" event becomes the final
-	/// pass/fail/skip node.
+	/// pass/fail/skip node. Blocks that aren't part of this streaming protocol
+	/// (no recognized "event", or a "finish" without an "outcome") are ignored so
+	/// they neither mis-report a test nor suppress the TRX fallback.
 	/// </summary>
 	async Task PublishStatusAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationStatus status, HashSet<string> reportedFinal)
 	{
+		// Only handle our explicit streaming protocol. Other instrumentation
+		// (e.g. AndroidJUnitRunner) emits status blocks with a "test" key but no
+		// "event"/"outcome"; treating those as results would report them as
+		// passed and, worse, mark reportedFinal non-empty so the TRX fallback
+		// never runs. Skip them and let ReportFromTrxAsync handle the run.
+		if (!status.Values.TryGetValue ("event", out var eventKind) || (eventKind != "start" && eventKind != "finish"))
+			return;
+
 		if (!status.Values.TryGetValue ("test", out var fullyQualifiedName) || string.IsNullOrEmpty (fullyQualifiedName))
 			return;
 
-		status.Values.TryGetValue ("event", out var eventKind);
 		status.Values.TryGetValue ("name", out var displayName);
 		status.Values.TryGetValue ("class", out var className);
 
@@ -174,7 +183,10 @@ class AndroidTestAdapter(
 			return;
 		}
 
-		status.Values.TryGetValue ("outcome", out var outcome);
+		// eventKind == "finish": a valid completion must carry an outcome.
+		if (!status.Values.TryGetValue ("outcome", out var outcome) || string.IsNullOrEmpty (outcome))
+			return;
+
 		var errorMessage = DecodeOrNull (status.Values, "message-b64");
 		var stackTrace = DecodeOrNull (status.Values, "stack-b64");
 

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -178,16 +178,16 @@ class AndroidTestAdapter(
 		// "event"/"outcome"; treating those as results would report them as
 		// passed and, worse, mark ReportedFinal non-empty so the TRX fallback
 		// never runs. Skip them and let ReportFromTrxAsync handle the run.
-		if (!status.Values.TryGetValue ("event", out var eventKind) || (eventKind != "start" && eventKind != "finish"))
+		if (!status.Values.TryGetValue (InstrumentationProtocol.KeyEvent, out var eventKind) || (eventKind != InstrumentationProtocol.EventStart && eventKind != InstrumentationProtocol.EventFinish))
 			return;
 
-		if (!status.Values.TryGetValue ("test", out var fullyQualifiedName) || string.IsNullOrEmpty (fullyQualifiedName))
+		if (!status.Values.TryGetValue (InstrumentationProtocol.KeyTest, out var fullyQualifiedName) || string.IsNullOrEmpty (fullyQualifiedName))
 			return;
 
-		status.Values.TryGetValue ("name", out var displayName);
-		status.Values.TryGetValue ("class", out var className);
+		status.Values.TryGetValue (InstrumentationProtocol.KeyName, out var displayName);
+		status.Values.TryGetValue (InstrumentationProtocol.KeyClass, out var className);
 
-		if (eventKind == "start") {
+		if (eventKind == InstrumentationProtocol.EventStart) {
 			// Remember the running test so a crash can resolve it to a terminal
 			// state instead of leaving a dangling "in progress" node.
 			state.InFlightUid = fullyQualifiedName;
@@ -202,7 +202,7 @@ class AndroidTestAdapter(
 		}
 
 		// eventKind == "finish": a valid completion must carry an outcome.
-		if (!status.Values.TryGetValue ("outcome", out var outcome) || string.IsNullOrEmpty (outcome))
+		if (!status.Values.TryGetValue (InstrumentationProtocol.KeyOutcome, out var outcome) || string.IsNullOrEmpty (outcome))
 			return;
 
 		// The test completed, so it's no longer in flight.
@@ -211,8 +211,8 @@ class AndroidTestAdapter(
 			state.InFlightName = null;
 		}
 
-		var errorMessage = DecodeOrNull (status.Values, "message-b64");
-		var stackTrace = DecodeOrNull (status.Values, "stack-b64");
+		var errorMessage = DecodeOrNull (status.Values, InstrumentationProtocol.KeyMessageBase64);
+		var stackTrace = DecodeOrNull (status.Values, InstrumentationProtocol.KeyStackBase64);
 
 		var failureMessage = errorMessage ?? "Test failed";
 		if (!string.IsNullOrEmpty (stackTrace))
@@ -221,16 +221,16 @@ class AndroidTestAdapter(
 		// An unrecognized outcome is reported as an error rather than silently
 		// counted as a pass.
 		var stateProperty = outcome switch {
-			"passed" => (IProperty) new PassedTestNodeStateProperty (),
-			"failed" => new FailedTestNodeStateProperty (failureMessage),
-			"skipped" => new SkippedTestNodeStateProperty (errorMessage),
+			InstrumentationProtocol.OutcomePassed => (IProperty) new PassedTestNodeStateProperty (),
+			InstrumentationProtocol.OutcomeFailed => new FailedTestNodeStateProperty (failureMessage),
+			InstrumentationProtocol.OutcomeSkipped => new SkippedTestNodeStateProperty (errorMessage),
 			_ => new ErrorTestNodeStateProperty ($"Unrecognized test outcome '{outcome}'."),
 		};
 
 		var properties = new List<IProperty> { stateProperty };
 		if (!string.IsNullOrEmpty (className))
 			properties.Add (new TrxFullyQualifiedTypeNameProperty (className));
-		if (outcome == "failed" && (!string.IsNullOrEmpty (errorMessage) || !string.IsNullOrEmpty (stackTrace)))
+		if (outcome == InstrumentationProtocol.OutcomeFailed && (!string.IsNullOrEmpty (errorMessage) || !string.IsNullOrEmpty (stackTrace)))
 			properties.Add (new TrxExceptionProperty (errorMessage, stackTrace));
 
 		var testNode = new TestNode {
@@ -425,15 +425,15 @@ class AndroidTestAdapter(
 			}
 		}
 
-		if (bundleValues.TryGetValue ("passed", out var passedStr) && int.TryParse (passedStr, out int passed))
+		if (bundleValues.TryGetValue (InstrumentationProtocol.KeyPassedCount, out var passedStr) && int.TryParse (passedStr, out int passed))
 			result.Passed = passed;
-		if (bundleValues.TryGetValue ("failed", out var failedStr) && int.TryParse (failedStr, out int failed))
+		if (bundleValues.TryGetValue (InstrumentationProtocol.KeyFailedCount, out var failedStr) && int.TryParse (failedStr, out int failed))
 			result.Failed = failed;
-		if (bundleValues.TryGetValue ("skipped", out var skippedStr) && int.TryParse (skippedStr, out int skipped))
+		if (bundleValues.TryGetValue (InstrumentationProtocol.KeySkippedCount, out var skippedStr) && int.TryParse (skippedStr, out int skipped))
 			result.Skipped = skipped;
-		if (bundleValues.TryGetValue ("resultsPath", out var resultsPath))
+		if (bundleValues.TryGetValue (InstrumentationProtocol.KeyResultsPath, out var resultsPath))
 			result.ResultsPath = resultsPath;
-		if (bundleValues.TryGetValue ("error", out var bundleError))
+		if (bundleValues.TryGetValue (InstrumentationProtocol.KeyError, out var bundleError))
 			result.Error = bundleError;
 
 		// Surface adb stderr if no results were parsed

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Threading.Channels;
 using System.Xml.Linq;
 using Microsoft.Testing.Extensions.TrxReport.Abstractions;
 using Microsoft.Testing.Platform.Capabilities.TestFramework;
@@ -7,6 +9,7 @@ using Microsoft.Testing.Platform.Extensions.TestFramework;
 using Microsoft.Testing.Platform.Messages;
 using Microsoft.Testing.Platform.Requests;
 using Microsoft.Testing.Platform.TestHost;
+using Xamarin.Android.Tools;
 
 /// <summary>
 /// A Microsoft Testing Platform test framework adapter that runs Android instrumentation
@@ -50,9 +53,186 @@ class AndroidTestAdapter(
 
 	async Task RunAndReportAsync (ExecuteRequestContext context, SessionUid sessionUid)
 	{
-		// 1. Run instrumentation on device
-		var bundleResults = await RunInstrumentationOnDeviceAsync (context.CancellationToken);
+		// Track tests we've already reported (by their final outcome) as they
+		// stream in, so we don't double-report them from the pulled TRX.
+		var reportedFinal = new HashSet<string> (StringComparer.Ordinal);
 
+		// 1. Run instrumentation on device, publishing each test to MTP live as
+		//    its INSTRUMENTATION_STATUS block arrives.
+		var bundleResults = await RunInstrumentationOnDeviceAsync (context, sessionUid, reportedFinal, context.CancellationToken);
+
+		if (verbose) {
+			Console.WriteLine ($"[AndroidTestAdapter] Instrumentation results: passed={bundleResults.Passed}, failed={bundleResults.Failed}, skipped={bundleResults.Skipped}, streamed={reportedFinal.Count}");
+			if (bundleResults.ResultsPath != null)
+				Console.WriteLine ($"[AndroidTestAdapter] TRX path on device: {bundleResults.ResultsPath}");
+		}
+
+		// 2. If we streamed at least one completed test, streaming is authoritative
+		//    (it's resilient to a mid-run crash). Otherwise fall back to the TRX.
+		if (reportedFinal.Count == 0) {
+			await ReportFromTrxAsync (context, sessionUid, bundleResults);
+			return;
+		}
+
+		// 3. We streamed live results. If the run did not finish cleanly (the app
+		//    process crashed before writing the final results bundle), surface a
+		//    synthetic failed test so the run is clearly marked failed rather than
+		//    silently dropping the in-flight/never-run tests.
+		if (bundleResults.Crashed)
+			await PublishCrashNodeAsync (context, sessionUid, bundleResults);
+	}
+
+	/// <summary>
+	/// Publishes each test to MTP as its INSTRUMENTATION_STATUS block arrives from
+	/// the streamed 'am instrument -w -r' output, and returns the parsed final
+	/// results bundle (summary counts, resultsPath, error, crash state).
+	/// </summary>
+	async Task<InstrumentationBundleResult> RunInstrumentationOnDeviceAsync (ExecuteRequestContext context, SessionUid sessionUid, HashSet<string> reportedFinal, CancellationToken cancellationToken)
+	{
+		// '-r' prints raw INSTRUMENTATION_STATUS results (so we can stream them);
+		// '-w' waits for the run to complete.
+		var cmdArgs = $"shell am instrument -w -r {package}/{instrumentation}";
+		var psi = AdbHelper.CreateStartInfo (adbPath, adbTarget, cmdArgs);
+
+		if (verbose)
+			Console.WriteLine ($"Running: adb {psi.Arguments}");
+
+		// Completed status blocks are handed off to a single async consumer that
+		// publishes them to MTP, so the synchronous stdout read loop is never
+		// blocked on an async PublishAsync.
+		var channel = Channel.CreateUnbounded<InstrumentationStatus> (new UnboundedChannelOptions {
+			SingleReader = true,
+			SingleWriter = true,
+		});
+
+		var fullOutput = new StringBuilder ();
+		using var stderr = new StringWriter ();
+
+		var consumer = Task.Run (async () => {
+			await foreach (var status in channel.Reader.ReadAllAsync ()) {
+				await PublishStatusAsync (context, sessionUid, status, reportedFinal);
+			}
+		});
+
+		var parser = new StatusStreamParser (channel.Writer, fullOutput, verbose);
+		using var stdout = new LineWriter (parser.OnLine);
+
+		int exitCode;
+		try {
+			exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken);
+		} finally {
+			stdout.Flush ();
+			parser.Complete ();
+			channel.Writer.Complete ();
+		}
+		await consumer;
+
+		var output = fullOutput.ToString ();
+		if (verbose) {
+			Console.WriteLine ($"[AndroidTestAdapter] Exit code: {exitCode}");
+			Console.WriteLine (output);
+		}
+
+		var result = ParseInstrumentationBundle (output, stderr.ToString ());
+
+		// The final bundle (with resultsPath) is only emitted if Finish() ran to
+		// completion. Its absence — or a non-zero exit / an explicit crash marker —
+		// means the app process died mid-run.
+		result.Crashed =
+			exitCode != 0 ||
+			output.Contains ("INSTRUMENTATION_FAILED", StringComparison.Ordinal) ||
+			output.Contains ("Process crashed", StringComparison.Ordinal) ||
+			(reportedFinal.Count > 0 && result.ResultsPath == null);
+
+		if (result.Crashed && result.Error == null)
+			result.Error = ExtractCrashMessage (output) ?? (exitCode != 0 ? $"Instrumentation exited with code {exitCode}." : "The test process terminated before reporting a result (likely a native crash).");
+
+		return result;
+	}
+
+	/// <summary>
+	/// Publishes a single streamed instrumentation status block to MTP: a "start"
+	/// event becomes an in-progress node; a "finish" event becomes the final
+	/// pass/fail/skip node.
+	/// </summary>
+	async Task PublishStatusAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationStatus status, HashSet<string> reportedFinal)
+	{
+		if (!status.Values.TryGetValue ("test", out var fullyQualifiedName) || string.IsNullOrEmpty (fullyQualifiedName))
+			return;
+
+		status.Values.TryGetValue ("event", out var eventKind);
+		status.Values.TryGetValue ("name", out var displayName);
+		status.Values.TryGetValue ("class", out var className);
+
+		if (eventKind == "start") {
+			var startNode = new TestNode {
+				Uid = new TestNodeUid (fullyQualifiedName),
+				DisplayName = displayName ?? fullyQualifiedName,
+				Properties = new PropertyBag (new InProgressTestNodeStateProperty ()),
+			};
+			await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, startNode));
+			return;
+		}
+
+		status.Values.TryGetValue ("outcome", out var outcome);
+		var errorMessage = DecodeOrNull (status.Values, "message-b64");
+		var stackTrace = DecodeOrNull (status.Values, "stack-b64");
+
+		var failureMessage = errorMessage ?? "Test failed";
+		if (!string.IsNullOrEmpty (stackTrace))
+			failureMessage += "\n" + stackTrace;
+
+		var stateProperty = outcome switch {
+			"passed" => (IProperty) new PassedTestNodeStateProperty (),
+			"failed" => new FailedTestNodeStateProperty (failureMessage),
+			"skipped" => new SkippedTestNodeStateProperty (errorMessage),
+			_ => new PassedTestNodeStateProperty (),
+		};
+
+		var properties = new List<IProperty> { stateProperty };
+		if (!string.IsNullOrEmpty (className))
+			properties.Add (new TrxFullyQualifiedTypeNameProperty (className));
+		if (outcome == "failed" && (!string.IsNullOrEmpty (errorMessage) || !string.IsNullOrEmpty (stackTrace)))
+			properties.Add (new TrxExceptionProperty (errorMessage, stackTrace));
+
+		var testNode = new TestNode {
+			Uid = new TestNodeUid (fullyQualifiedName),
+			DisplayName = displayName ?? fullyQualifiedName,
+			Properties = new PropertyBag (properties.ToArray ()),
+		};
+
+		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, testNode));
+		reportedFinal.Add (fullyQualifiedName);
+	}
+
+	/// <summary>
+	/// Publishes a synthetic failed test node representing a mid-run process crash,
+	/// so the overall run is reported as failed and the crash is visible in results.
+	/// </summary>
+	async Task PublishCrashNodeAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationBundleResult bundleResults)
+	{
+		var message = bundleResults.Error ?? "The test process terminated before all tests completed (likely a native crash).";
+		Console.Error.WriteLine ($"[AndroidTestAdapter] {message}");
+
+		var crashUid = $"{instrumentation}.ProcessCrashed";
+		var crashNode = new TestNode {
+			Uid = new TestNodeUid (crashUid),
+			DisplayName = "Test process crashed before completion",
+			Properties = new PropertyBag (
+				new FailedTestNodeStateProperty (message),
+				new TrxFullyQualifiedTypeNameProperty (instrumentation),
+				new TrxExceptionProperty (message, null)),
+		};
+
+		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, crashNode));
+	}
+
+	/// <summary>
+	/// Fallback path used only when no results were streamed (e.g. an older
+	/// on-device instrumentation): pull and parse the TRX, then publish all tests.
+	/// </summary>
+	async Task ReportFromTrxAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationBundleResult bundleResults)
+	{
 		if (bundleResults.Error != null) {
 			var message = $"Error from instrumentation: {bundleResults.Error}";
 			if (bundleResults.InstrumentationCode.HasValue)
@@ -61,13 +241,6 @@ class AndroidTestAdapter(
 			throw new InvalidOperationException (message);
 		}
 
-		if (verbose) {
-			Console.WriteLine ($"[AndroidTestAdapter] Instrumentation results: passed={bundleResults.Passed}, failed={bundleResults.Failed}, skipped={bundleResults.Skipped}");
-			if (bundleResults.ResultsPath != null)
-				Console.WriteLine ($"[AndroidTestAdapter] TRX path on device: {bundleResults.ResultsPath}");
-		}
-
-		// 2. Pull and parse TRX
 		if (bundleResults.ResultsPath == null)
 			throw new InvalidOperationException ("Instrumentation did not report a resultsPath in the bundle.");
 
@@ -107,27 +280,34 @@ class AndroidTestAdapter(
 		}
 	}
 
-	async Task<InstrumentationBundleResult> RunInstrumentationOnDeviceAsync (CancellationToken cancellationToken)
+	static string? DecodeOrNull (IReadOnlyDictionary<string, string> values, string key)
 	{
-		var cmdArgs = $"shell am instrument -w {package}/{instrumentation}";
-		var (exitCode, output, error) = await AdbHelper.RunAsync (adbPath, adbTarget, cmdArgs, cancellationToken, verbose);
-
-		if (verbose) {
-			Console.WriteLine ($"[AndroidTestAdapter] Exit code: {exitCode}");
-			Console.WriteLine (output);
+		if (!values.TryGetValue (key, out var encoded) || string.IsNullOrEmpty (encoded))
+			return null;
+		try {
+			return Encoding.UTF8.GetString (Convert.FromBase64String (encoded));
+		} catch (FormatException) {
+			return encoded;
 		}
+	}
 
-		if (exitCode != 0) {
-			var failureMessage = !string.IsNullOrWhiteSpace (error) ? error : output;
-			if (string.IsNullOrWhiteSpace (failureMessage))
-				failureMessage = $"adb shell am instrument failed with exit code {exitCode}.";
-			Console.Error.WriteLine ($"[AndroidTestAdapter] {failureMessage}");
-			return new InstrumentationBundleResult {
-				Error = failureMessage,
-			};
+	/// <summary>
+	/// Extracts a human-readable crash reason from the instrumentation output
+	/// (shortMsg/longMsg are emitted by 'am instrument' when the process crashes).
+	/// </summary>
+	static string? ExtractCrashMessage (string output)
+	{
+		string? shortMsg = null, longMsg = null;
+		foreach (var rawLine in output.Split ('\n')) {
+			var line = rawLine.TrimEnd ('\r');
+			if (line.StartsWith ("INSTRUMENTATION_RESULT: shortMsg=", StringComparison.Ordinal))
+				shortMsg = line.Substring ("INSTRUMENTATION_RESULT: shortMsg=".Length).Trim ();
+			else if (line.StartsWith ("INSTRUMENTATION_RESULT: longMsg=", StringComparison.Ordinal))
+				longMsg = line.Substring ("INSTRUMENTATION_RESULT: longMsg=".Length).Trim ();
 		}
-
-		return ParseInstrumentationBundle (output, error);
+		if (longMsg != null || shortMsg != null)
+			return $"The test process crashed: {longMsg ?? shortMsg}";
+		return null;
 	}
 
 	async Task<string?> PullTrxFileAsync (string devicePath, CancellationToken cancellationToken)
@@ -282,7 +462,120 @@ class InstrumentationBundleResult
 	public string? ResultsPath { get; set; }
 	public string? Error { get; set; }
 	public int? InstrumentationCode { get; set; }
+	public bool Crashed { get; set; }
 }
+
+/// <summary>
+/// A single completed <c>INSTRUMENTATION_STATUS</c> block: its key/value pairs
+/// plus the trailing <c>INSTRUMENTATION_STATUS_CODE</c>.
+/// </summary>
+class InstrumentationStatus
+{
+	public required IReadOnlyDictionary<string, string> Values { get; init; }
+	public int Code { get; init; }
+}
+
+/// <summary>
+/// A <see cref="TextWriter"/> that splits the (arbitrarily chunked) writes it
+/// receives from <c>ProcessUtils.StartProcess</c> into complete lines and invokes
+/// a callback for each one, so instrumentation output can be parsed as it streams.
+/// </summary>
+sealed class LineWriter (Action<string> onLine) : TextWriter
+{
+	readonly StringBuilder buffer = new ();
+
+	public override Encoding Encoding => Encoding.UTF8;
+
+	public override void Write (char value)
+	{
+		if (value == '\n')
+			Flush ();
+		else if (value != '\r')
+			buffer.Append (value);
+	}
+
+	public override void Write (char[] buffer, int index, int count)
+	{
+		for (int i = 0; i < count; i++)
+			Write (buffer [index + i]);
+	}
+
+	public override void Write (string? value)
+	{
+		if (value == null)
+			return;
+		foreach (var c in value)
+			Write (c);
+	}
+
+	// Emit whatever has been buffered as a completed line.
+	public override void Flush ()
+	{
+		if (buffer.Length == 0)
+			return;
+		var line = buffer.ToString ();
+		buffer.Clear ();
+		onLine (line);
+	}
+}
+
+/// <summary>
+/// Incrementally parses streamed <c>am instrument -r</c> output. Each completed
+/// <c>INSTRUMENTATION_STATUS</c> block (terminated by <c>INSTRUMENTATION_STATUS_CODE</c>)
+/// is written to <paramref name="writer"/> for the consumer to publish, while the
+/// raw text is also accumulated for the final results-bundle parse.
+/// </summary>
+sealed class StatusStreamParser (ChannelWriter<InstrumentationStatus> writer, StringBuilder fullOutput, bool verbose)
+{
+	const string StatusPrefix = "INSTRUMENTATION_STATUS: ";
+	const string StatusCodePrefix = "INSTRUMENTATION_STATUS_CODE: ";
+
+	Dictionary<string, string>? current;
+	string? lastKey;
+
+	public void OnLine (string line)
+	{
+		fullOutput.Append (line).Append ('\n');
+		if (verbose)
+			Console.WriteLine (line);
+
+		if (line.StartsWith (StatusCodePrefix, StringComparison.Ordinal)) {
+			var codeStr = line.Substring (StatusCodePrefix.Length).Trim ();
+			int.TryParse (codeStr, out int code);
+			if (current != null) {
+				writer.TryWrite (new InstrumentationStatus { Values = current, Code = code });
+				current = null;
+				lastKey = null;
+			}
+			return;
+		}
+
+		if (line.StartsWith (StatusPrefix, StringComparison.Ordinal)) {
+			var kvp = line.Substring (StatusPrefix.Length);
+			var eqIndex = kvp.IndexOf ('=');
+			if (eqIndex > 0) {
+				current ??= new Dictionary<string, string> (StringComparer.Ordinal);
+				lastKey = kvp.Substring (0, eqIndex).Trim ();
+				current [lastKey] = kvp.Substring (eqIndex + 1);
+			}
+			return;
+		}
+
+		// Continuation of a multi-line value (should be rare — message/stack are
+		// Base64-encoded on the device precisely to avoid this).
+		if (current != null && lastKey != null)
+			current [lastKey] += "\n" + line;
+	}
+
+	// Drop any block that never received a terminating status code (e.g. the
+	// process crashed mid-status); it is intentionally not published.
+	public void Complete ()
+	{
+		current = null;
+		lastKey = null;
+	}
+}
+
 
 enum TrxOutcome
 {

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -241,6 +241,14 @@ class AndroidTestAdapter(
 
 		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, testNode));
 		state.ReportedFinal.Add (fullyQualifiedName);
+
+		// Echo every finished test — including passes — to the console so the log
+		// grows steadily and progress stays visible while monitoring a long device
+		// run (MTP's default output only surfaces failures). MTP captures the test
+		// host's console output by default, so this stays silent locally; CI opts
+		// in by passing -p:TestingPlatformCaptureOutput=false, which lets these
+		// lines stream live into the build log.
+		Console.WriteLine ($"[{outcome.ToUpperInvariant ()}] ({state.ReportedFinal.Count}) {fullyQualifiedName}");
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -53,33 +53,35 @@ class AndroidTestAdapter(
 
 	async Task RunAndReportAsync (ExecuteRequestContext context, SessionUid sessionUid)
 	{
-		// Track tests we've already reported (by their final outcome) as they
-		// stream in, so we don't double-report them from the pulled TRX.
-		var reportedFinal = new HashSet<string> (StringComparer.Ordinal);
+		// Shared state for the streamed run: which tests we've already reported a
+		// final outcome for (so we don't double-report them from the pulled TRX),
+		// and which test — if any — is currently executing (so a crash can resolve
+		// it to a terminal state instead of leaving it "in progress").
+		var state = new StreamingState ();
 
 		// 1. Run instrumentation on device, publishing each test to MTP live as
 		//    its INSTRUMENTATION_STATUS block arrives.
-		var bundleResults = await RunInstrumentationOnDeviceAsync (context, sessionUid, reportedFinal, context.CancellationToken);
+		var bundleResults = await RunInstrumentationOnDeviceAsync (context, sessionUid, state, context.CancellationToken);
 
 		if (verbose) {
-			Console.WriteLine ($"[AndroidTestAdapter] Instrumentation results: passed={bundleResults.Passed}, failed={bundleResults.Failed}, skipped={bundleResults.Skipped}, streamed={reportedFinal.Count}");
+			Console.WriteLine ($"[AndroidTestAdapter] Instrumentation results: passed={bundleResults.Passed}, failed={bundleResults.Failed}, skipped={bundleResults.Skipped}, streamed={state.ReportedFinal.Count}");
 			if (bundleResults.ResultsPath != null)
 				Console.WriteLine ($"[AndroidTestAdapter] TRX path on device: {bundleResults.ResultsPath}");
 		}
 
 		// 2. If we streamed at least one completed test, streaming is authoritative
 		//    (it's resilient to a mid-run crash). Otherwise fall back to the TRX.
-		if (reportedFinal.Count == 0) {
+		if (state.ReportedFinal.Count == 0) {
 			await ReportFromTrxAsync (context, sessionUid, bundleResults);
 			return;
 		}
 
 		// 3. We streamed live results. If the run did not finish cleanly (the app
-		//    process crashed before writing the final results bundle), surface a
-		//    synthetic failed test so the run is clearly marked failed rather than
-		//    silently dropping the in-flight/never-run tests.
+		//    process crashed before writing the final results bundle), surface the
+		//    crash so the run is clearly marked failed rather than silently dropping
+		//    the in-flight/never-run tests.
 		if (bundleResults.Crashed)
-			await PublishCrashNodeAsync (context, sessionUid, bundleResults);
+			await PublishCrashAsync (context, sessionUid, bundleResults, state);
 	}
 
 	/// <summary>
@@ -87,7 +89,7 @@ class AndroidTestAdapter(
 	/// the streamed 'am instrument -w -r' output, and returns the parsed final
 	/// results bundle (summary counts, resultsPath, error, crash state).
 	/// </summary>
-	async Task<InstrumentationBundleResult> RunInstrumentationOnDeviceAsync (ExecuteRequestContext context, SessionUid sessionUid, HashSet<string> reportedFinal, CancellationToken cancellationToken)
+	async Task<InstrumentationBundleResult> RunInstrumentationOnDeviceAsync (ExecuteRequestContext context, SessionUid sessionUid, StreamingState state, CancellationToken cancellationToken)
 	{
 		// '-r' prints raw INSTRUMENTATION_STATUS results (so we can stream them);
 		// '-w' waits for the run to complete.
@@ -110,22 +112,33 @@ class AndroidTestAdapter(
 
 		var consumer = Task.Run (async () => {
 			await foreach (var status in channel.Reader.ReadAllAsync ()) {
-				await PublishStatusAsync (context, sessionUid, status, reportedFinal);
+				try {
+					await PublishStatusAsync (context, sessionUid, status, state);
+				} catch (OperationCanceledException) {
+					throw;
+				} catch (Exception ex) {
+					// One malformed/unreportable status block must not abort
+					// reporting for the rest of the run.
+					Console.Error.WriteLine ($"[AndroidTestAdapter] Failed to report a streamed test result: {ex}");
+				}
 			}
 		});
 
 		var parser = new StatusStreamParser (channel.Writer, fullOutput, verbose);
 		using var stdout = new LineWriter (parser.OnLine);
 
-		int exitCode;
+		int exitCode = 0;
 		try {
 			exitCode = await ProcessUtils.StartProcess (psi, stdout, stderr, cancellationToken);
 		} finally {
+			// Flush the trailing partial line, discard any unterminated status
+			// block, then complete the channel and always observe the consumer —
+			// even if StartProcess threw or was cancelled.
 			stdout.Flush ();
 			parser.Complete ();
 			channel.Writer.Complete ();
+			await consumer;
 		}
-		await consumer;
 
 		var output = fullOutput.ToString ();
 		if (verbose) {
@@ -142,7 +155,7 @@ class AndroidTestAdapter(
 			exitCode != 0 ||
 			output.Contains ("INSTRUMENTATION_FAILED", StringComparison.Ordinal) ||
 			output.Contains ("Process crashed", StringComparison.Ordinal) ||
-			(reportedFinal.Count > 0 && result.ResultsPath == null);
+			(state.ReportedFinal.Count > 0 && result.ResultsPath == null);
 
 		if (result.Crashed && result.Error == null)
 			result.Error = ExtractCrashMessage (output) ?? (exitCode != 0 ? $"Instrumentation exited with code {exitCode}." : "The test process terminated before reporting a result (likely a native crash).");
@@ -157,12 +170,12 @@ class AndroidTestAdapter(
 	/// (no recognized "event", or a "finish" without an "outcome") are ignored so
 	/// they neither mis-report a test nor suppress the TRX fallback.
 	/// </summary>
-	async Task PublishStatusAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationStatus status, HashSet<string> reportedFinal)
+	async Task PublishStatusAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationStatus status, StreamingState state)
 	{
 		// Only handle our explicit streaming protocol. Other instrumentation
 		// (e.g. AndroidJUnitRunner) emits status blocks with a "test" key but no
 		// "event"/"outcome"; treating those as results would report them as
-		// passed and, worse, mark reportedFinal non-empty so the TRX fallback
+		// passed and, worse, mark ReportedFinal non-empty so the TRX fallback
 		// never runs. Skip them and let ReportFromTrxAsync handle the run.
 		if (!status.Values.TryGetValue ("event", out var eventKind) || (eventKind != "start" && eventKind != "finish"))
 			return;
@@ -174,6 +187,10 @@ class AndroidTestAdapter(
 		status.Values.TryGetValue ("class", out var className);
 
 		if (eventKind == "start") {
+			// Remember the running test so a crash can resolve it to a terminal
+			// state instead of leaving a dangling "in progress" node.
+			state.InFlightUid = fullyQualifiedName;
+			state.InFlightName = displayName;
 			var startNode = new TestNode {
 				Uid = new TestNodeUid (fullyQualifiedName),
 				DisplayName = displayName ?? fullyQualifiedName,
@@ -187,6 +204,12 @@ class AndroidTestAdapter(
 		if (!status.Values.TryGetValue ("outcome", out var outcome) || string.IsNullOrEmpty (outcome))
 			return;
 
+		// The test completed, so it's no longer in flight.
+		if (state.InFlightUid == fullyQualifiedName) {
+			state.InFlightUid = null;
+			state.InFlightName = null;
+		}
+
 		var errorMessage = DecodeOrNull (status.Values, "message-b64");
 		var stackTrace = DecodeOrNull (status.Values, "stack-b64");
 
@@ -194,11 +217,13 @@ class AndroidTestAdapter(
 		if (!string.IsNullOrEmpty (stackTrace))
 			failureMessage += "\n" + stackTrace;
 
+		// An unrecognized outcome is reported as an error rather than silently
+		// counted as a pass.
 		var stateProperty = outcome switch {
 			"passed" => (IProperty) new PassedTestNodeStateProperty (),
 			"failed" => new FailedTestNodeStateProperty (failureMessage),
 			"skipped" => new SkippedTestNodeStateProperty (errorMessage),
-			_ => new PassedTestNodeStateProperty (),
+			_ => new ErrorTestNodeStateProperty ($"Unrecognized test outcome '{outcome}'."),
 		};
 
 		var properties = new List<IProperty> { stateProperty };
@@ -214,27 +239,43 @@ class AndroidTestAdapter(
 		};
 
 		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, testNode));
-		reportedFinal.Add (fullyQualifiedName);
+		state.ReportedFinal.Add (fullyQualifiedName);
 	}
 
 	/// <summary>
-	/// Publishes a synthetic failed test node representing a mid-run process crash,
-	/// so the overall run is reported as failed and the crash is visible in results.
+	/// Reports a mid-run process crash. If a test was executing when the process
+	/// died, that test is resolved from "in progress" to an <see cref="ErrorTestNodeStateProperty"/>
+	/// (an infrastructure error, not an assertion failure) so it isn't left
+	/// dangling and the crash is attributed to it. Otherwise a synthetic error
+	/// node is published so the overall run is still clearly marked failed.
 	/// </summary>
-	async Task PublishCrashNodeAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationBundleResult bundleResults)
+	async Task PublishCrashAsync (ExecuteRequestContext context, SessionUid sessionUid, InstrumentationBundleResult bundleResults, StreamingState state)
 	{
 		var message = bundleResults.Error ?? "The test process terminated before all tests completed (likely a native crash).";
 		Console.Error.WriteLine ($"[AndroidTestAdapter] {message}");
 
-		var crashUid = $"{instrumentation}.ProcessCrashed";
-		var crashNode = new TestNode {
-			Uid = new TestNodeUid (crashUid),
-			DisplayName = "Test process crashed before completion",
-			Properties = new PropertyBag (
-				new FailedTestNodeStateProperty (message),
-				new TrxFullyQualifiedTypeNameProperty (instrumentation),
-				new TrxExceptionProperty (message, null)),
-		};
+		TestNode crashNode;
+		if (state.InFlightUid != null) {
+			crashNode = new TestNode {
+				Uid = new TestNodeUid (state.InFlightUid),
+				DisplayName = state.InFlightName ?? state.InFlightUid,
+				Properties = new PropertyBag (
+					new ErrorTestNodeStateProperty ($"The test process crashed while running this test.\n{message}"),
+					new TrxExceptionProperty (message, null)),
+			};
+			state.ReportedFinal.Add (state.InFlightUid);
+			state.InFlightUid = null;
+			state.InFlightName = null;
+		} else {
+			crashNode = new TestNode {
+				Uid = new TestNodeUid ($"{instrumentation}.ProcessCrashed"),
+				DisplayName = "Test process crashed before completion",
+				Properties = new PropertyBag (
+					new ErrorTestNodeStateProperty (message),
+					new TrxFullyQualifiedTypeNameProperty (instrumentation),
+					new TrxExceptionProperty (message, null)),
+			};
+		}
 
 		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, crashNode));
 	}
@@ -475,6 +516,17 @@ class InstrumentationBundleResult
 	public string? Error { get; set; }
 	public int? InstrumentationCode { get; set; }
 	public bool Crashed { get; set; }
+}
+
+/// <summary>
+/// Mutable state shared across a streamed run: the tests already reported with a
+/// final outcome, and the test currently executing (if any).
+/// </summary>
+sealed class StreamingState
+{
+	public HashSet<string> ReportedFinal { get; } = new (StringComparer.Ordinal);
+	public string? InFlightUid { get; set; }
+	public string? InFlightName { get; set; }
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -70,19 +70,21 @@ class AndroidTestAdapter(
 				Console.WriteLine ($"[AndroidTestAdapter] TRX path on device: {bundleResults.ResultsPath}");
 		}
 
-		// 2. If we streamed at least one completed test, streaming is authoritative
-		//    (it's resilient to a mid-run crash). Otherwise fall back to the TRX.
-		if (state.ReportedFinal.Count == 0) {
-			await ReportFromTrxAsync (context, sessionUid, bundleResults);
+		// 2. If the run did not finish cleanly (the app process crashed before
+		//    writing the final results bundle), surface the crash. This resolves an
+		//    in-flight streamed test to a terminal state, or publishes a synthetic
+		//    crash node when nothing streamed, instead of falling through to the TRX
+		//    path — which has no results file to read after a crash and would throw.
+		if (bundleResults.Crashed) {
+			await PublishCrashAsync (context, sessionUid, bundleResults, state);
 			return;
 		}
 
-		// 3. We streamed live results. If the run did not finish cleanly (the app
-		//    process crashed before writing the final results bundle), surface the
-		//    crash so the run is clearly marked failed rather than silently dropping
-		//    the in-flight/never-run tests.
-		if (bundleResults.Crashed)
-			await PublishCrashAsync (context, sessionUid, bundleResults, state);
+		// 3. No crash: if we streamed at least one completed test, streaming is
+		//    authoritative and we're done. Otherwise fall back to the TRX (e.g. an
+		//    older on-device instrumentation that didn't stream results).
+		if (state.ReportedFinal.Count == 0)
+			await ReportFromTrxAsync (context, sessionUid, bundleResults);
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Run/AndroidTestAdapter.cs
+++ b/src/Microsoft.Android.Run/AndroidTestAdapter.cs
@@ -241,14 +241,6 @@ class AndroidTestAdapter(
 
 		await context.MessageBus.PublishAsync (this, new TestNodeUpdateMessage (sessionUid, testNode));
 		state.ReportedFinal.Add (fullyQualifiedName);
-
-		// Echo every finished test — including passes — to the console so the log
-		// grows steadily and progress stays visible while monitoring a long device
-		// run (MTP's default output only surfaces failures). MTP captures the test
-		// host's console output by default, so this stays silent locally; CI opts
-		// in by passing -p:TestingPlatformCaptureOutput=false, which lets these
-		// lines stream live into the build log.
-		Console.WriteLine ($"[{outcome.ToUpperInvariant ()}] ({state.ReportedFinal.Count}) {fullyQualifiedName}");
 	}
 
 	/// <summary>

--- a/src/Microsoft.Android.Run/InstrumentationProtocol.cs
+++ b/src/Microsoft.Android.Run/InstrumentationProtocol.cs
@@ -1,0 +1,36 @@
+/// <summary>
+/// Wire contract for the on-device test instrumentation streaming protocol. The
+/// device side (<c>Xamarin.Android.UnitTests.TestInstrumentation</c>) emits
+/// <c>INSTRUMENTATION_STATUS</c>/<c>INSTRUMENTATION_RESULT</c> bundles through
+/// <c>am instrument -r</c>, and the host side (<c>AndroidTestAdapter</c>) parses
+/// them. Values are kept as human-readable strings so the raw instrumentation
+/// output stays legible in logcat. This file is source-linked into both the
+/// device test runner and the host so the two sides cannot drift out of sync.
+/// </summary>
+static class InstrumentationProtocol
+{
+	// Keys used in the per-test streaming status blocks.
+	public const string KeyEvent = "event";
+	public const string KeyTest = "test";
+	public const string KeyName = "name";
+	public const string KeyClass = "class";
+	public const string KeyOutcome = "outcome";
+	public const string KeyMessageBase64 = "message-b64";
+	public const string KeyStackBase64 = "stack-b64";
+
+	// Keys used in the final results bundle.
+	public const string KeyPassedCount = "passed";
+	public const string KeyFailedCount = "failed";
+	public const string KeySkippedCount = "skipped";
+	public const string KeyResultsPath = "resultsPath";
+	public const string KeyError = "error";
+
+	// "event" values.
+	public const string EventStart = "start";
+	public const string EventFinish = "finish";
+
+	// "outcome" values.
+	public const string OutcomePassed = "passed";
+	public const string OutcomeFailed = "failed";
+	public const string OutcomeSkipped = "skipped";
+}

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -137,6 +137,7 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApproveRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -163,6 +164,7 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_RejectRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -181,6 +183,7 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApprovesRequestWithInvalidCertificate ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -208,6 +211,7 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_IgnoresCertificateHostnameMismatch ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -229,6 +233,7 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
+		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_Redirects ()
 		{
 			int callbackCounter = 0;

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -137,7 +137,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApproveRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -164,7 +163,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_RejectRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -183,7 +181,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApprovesRequestWithInvalidCertificate ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -211,7 +208,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_IgnoresCertificateHostnameMismatch ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -233,7 +229,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_Redirects ()
 		{
 			int callbackCounter = 0;

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -106,14 +106,14 @@ public abstract class TestInstrumentation : Instrumentation
 			Log.Info (LogTag, $"TRX written to: {trxPath}");
 			Log.Info (LogTag, $"Results: passed={passed}, failed={failed}, skipped={skipped}");
 
-			bundle.PutInt ("passed", passed);
-			bundle.PutInt ("failed", failed);
-			bundle.PutInt ("skipped", skipped);
-			bundle.PutString ("resultsPath", trxPath);
+			bundle.PutInt (InstrumentationProtocol.KeyPassedCount, passed);
+			bundle.PutInt (InstrumentationProtocol.KeyFailedCount, failed);
+			bundle.PutInt (InstrumentationProtocol.KeySkippedCount, skipped);
+			bundle.PutString (InstrumentationProtocol.KeyResultsPath, trxPath);
 			Finish (Result.Ok, bundle);
 		} catch (Exception ex) {
 			Log.Error (LogTag, $"Test run failed: {ex}");
-			bundle.PutString ("error", ex.ToString ());
+			bundle.PutString (InstrumentationProtocol.KeyError, ex.ToString ());
 			Finish (Result.Canceled, bundle);
 		}
 	}
@@ -322,15 +322,23 @@ public abstract class TestInstrumentation : Instrumentation
 	/// (potentially multi-line) failure message and stack trace are Base64-encoded
 	/// so every value stays on a single line.
 	/// </summary>
+	/// <summary>
+	/// Android <c>am instrument</c> status codes emitted on the
+	/// <c>INSTRUMENTATION_STATUS_CODE</c> line. The values mirror
+	/// AndroidJUnitRunner's conventions so tools scraping the raw output see
+	/// familiar codes; the host keys off the explicit <c>event</c>/<c>outcome</c>
+	/// bundle values rather than these numbers.
+	/// </summary>
+	enum InstrumentationStatusCode
+	{
+		Passed = 0,
+		Start = 1,
+		Failed = -2,
+		Skipped = -3,
+	}
+
 	class TestListener (Instrumentation instrumentation) : ITestListener
 	{
-		// Status codes mirror AndroidJUnitRunner conventions so the values are
-		// familiar, but the host relies on the explicit "event"/"outcome" keys.
-		const int StatusStart = 1;
-		const int StatusPassed = 0;
-		const int StatusFailed = -2;
-		const int StatusSkipped = -3;
-
 		public void TestStarted (ITest test)
 		{
 			if (test.IsSuite)
@@ -338,11 +346,11 @@ public abstract class TestInstrumentation : Instrumentation
 			Log.Info (LogTag, $"[START] {test.FullName}");
 
 			var b = new Bundle ();
-			b.PutString ("event", "start");
-			b.PutString ("test", test.FullName);
-			b.PutString ("name", test.Name);
-			b.PutString ("class", test.ClassName ?? "");
-			instrumentation.SendStatus ((Result) StatusStart, b);
+			b.PutString (InstrumentationProtocol.KeyEvent, InstrumentationProtocol.EventStart);
+			b.PutString (InstrumentationProtocol.KeyTest, test.FullName);
+			b.PutString (InstrumentationProtocol.KeyName, test.Name);
+			b.PutString (InstrumentationProtocol.KeyClass, test.ClassName ?? "");
+			instrumentation.SendStatus ((Result) (int) InstrumentationStatusCode.Start, b);
 		}
 
 		public void TestFinished (ITestResult result)
@@ -351,24 +359,24 @@ public abstract class TestInstrumentation : Instrumentation
 				return;
 
 			var (outcome, statusCode) = result.ResultState.Status switch {
-				TestStatus.Passed => ("passed", StatusPassed),
-				TestStatus.Failed => ("failed", StatusFailed),
-				_ => ("skipped", StatusSkipped),
+				TestStatus.Passed => (InstrumentationProtocol.OutcomePassed, InstrumentationStatusCode.Passed),
+				TestStatus.Failed => (InstrumentationProtocol.OutcomeFailed, InstrumentationStatusCode.Failed),
+				_ => (InstrumentationProtocol.OutcomeSkipped, InstrumentationStatusCode.Skipped),
 			};
 
 			Log.Info (LogTag, $"[{outcome.ToUpperInvariant ()}] {result.FullName}");
 
 			var b = new Bundle ();
-			b.PutString ("event", "finish");
-			b.PutString ("test", result.FullName);
-			b.PutString ("name", result.Test.Name);
-			b.PutString ("class", result.Test.ClassName ?? "");
-			b.PutString ("outcome", outcome);
+			b.PutString (InstrumentationProtocol.KeyEvent, InstrumentationProtocol.EventFinish);
+			b.PutString (InstrumentationProtocol.KeyTest, result.FullName);
+			b.PutString (InstrumentationProtocol.KeyName, result.Test.Name);
+			b.PutString (InstrumentationProtocol.KeyClass, result.Test.ClassName ?? "");
+			b.PutString (InstrumentationProtocol.KeyOutcome, outcome);
 			if (result.Message is not null)
-				b.PutString ("message-b64", Encode (result.Message));
+				b.PutString (InstrumentationProtocol.KeyMessageBase64, Encode (result.Message));
 			if (result.StackTrace is not null)
-				b.PutString ("stack-b64", Encode (result.StackTrace));
-			instrumentation.SendStatus ((Result) statusCode, b);
+				b.PutString (InstrumentationProtocol.KeyStackBase64, Encode (result.StackTrace));
+			instrumentation.SendStatus ((Result) (int) statusCode, b);
 		}
 
 		static string Encode (string value)

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -311,18 +311,6 @@ public abstract class TestInstrumentation : Instrumentation
 	}
 
 	/// <summary>
-	/// Streams per-test status updates through the instrumentation protocol
-	/// (<c>am instrument -r</c>) so the host adapter can report each test to MTP
-	/// as it finishes. This makes results resilient to a mid-run process crash:
-	/// every test completed before the crash has already been reported, instead
-	/// of the whole run being lost because the final TRX was never written.
-	///
-	/// Each <c>SendStatus</c> emits an <c>INSTRUMENTATION_STATUS</c> block that
-	/// the host parses line-by-line. Because that protocol is line-based, the
-	/// (potentially multi-line) failure message and stack trace are Base64-encoded
-	/// so every value stays on a single line.
-	/// </summary>
-	/// <summary>
 	/// Android <c>am instrument</c> status codes emitted on the
 	/// <c>INSTRUMENTATION_STATUS_CODE</c> line. The values mirror
 	/// AndroidJUnitRunner's conventions so tools scraping the raw output see
@@ -337,6 +325,18 @@ public abstract class TestInstrumentation : Instrumentation
 		Skipped = -3,
 	}
 
+	/// <summary>
+	/// Streams per-test status updates through the instrumentation protocol
+	/// (<c>am instrument -r</c>) so the host adapter can report each test to MTP
+	/// as it finishes. This makes results resilient to a mid-run process crash:
+	/// every test completed before the crash has already been reported, instead
+	/// of the whole run being lost because the final TRX was never written.
+	///
+	/// Each <c>SendStatus</c> emits an <c>INSTRUMENTATION_STATUS</c> block that
+	/// the host parses line-by-line. Because that protocol is line-based, the
+	/// (potentially multi-line) failure message and stack trace are Base64-encoded
+	/// so every value stays on a single line.
+	/// </summary>
 	class TestListener (Instrumentation instrumentation) : ITestListener
 	{
 		public void TestStarted (ITest test)

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -311,15 +311,38 @@ public abstract class TestInstrumentation : Instrumentation
 	}
 
 	/// <summary>
-	/// Sends test status updates through the instrumentation protocol.
+	/// Streams per-test status updates through the instrumentation protocol
+	/// (<c>am instrument -r</c>) so the host adapter can report each test to MTP
+	/// as it finishes. This makes results resilient to a mid-run process crash:
+	/// every test completed before the crash has already been reported, instead
+	/// of the whole run being lost because the final TRX was never written.
+	///
+	/// Each <c>SendStatus</c> emits an <c>INSTRUMENTATION_STATUS</c> block that
+	/// the host parses line-by-line. Because that protocol is line-based, the
+	/// (potentially multi-line) failure message and stack trace are Base64-encoded
+	/// so every value stays on a single line.
 	/// </summary>
 	class TestListener (Instrumentation instrumentation) : ITestListener
 	{
+		// Status codes mirror AndroidJUnitRunner conventions so the values are
+		// familiar, but the host relies on the explicit "event"/"outcome" keys.
+		const int StatusStart = 1;
+		const int StatusPassed = 0;
+		const int StatusFailed = -2;
+		const int StatusSkipped = -3;
+
 		public void TestStarted (ITest test)
 		{
 			if (test.IsSuite)
 				return;
 			Log.Info (LogTag, $"[START] {test.FullName}");
+
+			var b = new Bundle ();
+			b.PutString ("event", "start");
+			b.PutString ("test", test.FullName);
+			b.PutString ("name", test.Name);
+			b.PutString ("class", test.ClassName ?? "");
+			instrumentation.SendStatus (StatusStart, b);
 		}
 
 		public void TestFinished (ITestResult result)
@@ -327,19 +350,29 @@ public abstract class TestInstrumentation : Instrumentation
 			if (result.Test.IsSuite)
 				return;
 
-			var outcome = result.ResultState.Status switch {
-				TestStatus.Passed => "passed",
-				TestStatus.Failed => "failed",
-				_ => "skipped",
+			var (outcome, statusCode) = result.ResultState.Status switch {
+				TestStatus.Passed => ("passed", StatusPassed),
+				TestStatus.Failed => ("failed", StatusFailed),
+				_ => ("skipped", StatusSkipped),
 			};
 
 			Log.Info (LogTag, $"[{outcome.ToUpperInvariant ()}] {result.FullName}");
 
 			var b = new Bundle ();
+			b.PutString ("event", "finish");
 			b.PutString ("test", result.FullName);
+			b.PutString ("name", result.Test.Name);
+			b.PutString ("class", result.Test.ClassName ?? "");
 			b.PutString ("outcome", outcome);
-			instrumentation.SendStatus (0, b);
+			if (result.Message is not null)
+				b.PutString ("message-b64", Encode (result.Message));
+			if (result.StackTrace is not null)
+				b.PutString ("stack-b64", Encode (result.StackTrace));
+			instrumentation.SendStatus (statusCode, b);
 		}
+
+		static string Encode (string value)
+			=> Convert.ToBase64String (System.Text.Encoding.UTF8.GetBytes (value));
 
 		public void TestOutput (TestOutput output) { }
 		public void SendMessage (TestMessage message) { }

--- a/tests/TestRunner.Core/TestInstrumentation.cs
+++ b/tests/TestRunner.Core/TestInstrumentation.cs
@@ -342,7 +342,7 @@ public abstract class TestInstrumentation : Instrumentation
 			b.PutString ("test", test.FullName);
 			b.PutString ("name", test.Name);
 			b.PutString ("class", test.ClassName ?? "");
-			instrumentation.SendStatus (StatusStart, b);
+			instrumentation.SendStatus ((Result) StatusStart, b);
 		}
 
 		public void TestFinished (ITestResult result)
@@ -368,7 +368,7 @@ public abstract class TestInstrumentation : Instrumentation
 				b.PutString ("message-b64", Encode (result.Message));
 			if (result.StackTrace is not null)
 				b.PutString ("stack-b64", Encode (result.StackTrace));
-			instrumentation.SendStatus (statusCode, b);
+			instrumentation.SendStatus ((Result) statusCode, b);
 		}
 
 		static string Encode (string value)

--- a/tests/TestRunner.Core/TestRunner.Core.NET.csproj
+++ b/tests/TestRunner.Core/TestRunner.Core.NET.csproj
@@ -22,4 +22,10 @@
     <PackageReference Include="NUnit" Version="$(NUnitVersion)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Shared wire contract for the instrumentation streaming protocol, kept in
+         sync with the host in src/Microsoft.Android.Run. -->
+    <Compile Include="..\..\src\Microsoft.Android.Run\InstrumentationProtocol.cs" Link="InstrumentationProtocol.cs" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

The MTP test adapter (`Microsoft.Android.Run`) reports on-device test results **all-or-nothing at the very end** of a run, which means a mid-run crash discards the entire run.

### The bug

While investigating a CoreCLRTrimmable CI failure (build 1487907, PR #11802) that reported `Zero tests ran` after 52s, I found the app had actually **run 263 tests (251 passed)** and then crashed with a native SIGSEGV in the CoreCLR GC. Despite that, MTP reported nothing.

Root cause — reporting is buffered until the end:
- **Device** (`TestInstrumentation.OnStart`): runs the whole suite, buffers every result, and only writes the TRX + reports `resultsPath` in the final `Finish()` call.
- **Host** (`AndroidTestAdapter`): blocks on `am instrument -w`, parses only the final bundle, then publishes all `TestNodeUpdateMessage`s in one batch.

So when the process crashes mid-run, `Finish()` never runs → no TRX, no `resultsPath` → host throws *"Instrumentation did not report a resultsPath in the bundle."* → **Zero tests ran**, with every passed test discarded and no sign a crash happened.

An `INSTRUMENTATION_STATUS` was already sent per test (that's the `[PASSED]`/`[FAILED]` in logcat), but the host used `-w` without `-r` and ignored it.

### The fix — stream results live

- **Device** (`TestInstrumentation.TestListener`): emit an enriched `INSTRUMENTATION_STATUS` block per test on **start** and **finish**, carrying class/name/outcome and (Base64-encoded, to stay single-line) failure message + stack trace.
- **Host** (`AndroidTestAdapter`): run `am instrument -w -r`, parse status blocks **line-by-line**, and publish each test to MTP **as it finishes**. A `LineWriter` splits process output into lines; a `StatusStreamParser` hands completed blocks to an async consumer via a channel (the synchronous read loop never blocks on `PublishAsync`).

Now a mid-run crash only loses the in-flight test — every test completed beforehand is already reported. When the run doesn't finish cleanly, a **synthetic failed test node** is published so the run is clearly marked failed instead of silently empty. The TRX-pull path is retained as a fallback for instrumentation that doesn't stream.

### Also

`[Ignore]` the `AndroidMessageHandlerTests.ServerCertificateCustomValidationCallback_*` tests, which crash the test process with a native SIGSEGV (#8608). The root cause will be diagnosed separately; this unblocks the CoreCLR/Trimmable device test runs.

## Testing

Host adapter builds clean. Full validation requires the on-device CI matrix (device build not run locally).
