### PR TITLE
[ci] Make "Linux > Build" reruns recover from immutable-artifact collision

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -9,30 +9,40 @@ parameters:
   use1ESTemplate: true
 
 steps:
-# Detect whether a previous attempt of this job already built and published the
-# Linux SDK artifact. Pipeline artifact names are immutable per build, so if an
-# earlier attempt succeeded far enough to publish `nuget-linux-unsigned` but then
-# failed in a later (often post-job) step, blindly rebuilding and republishing on
-# a rerun always fails with "Artifact nuget-linux-unsigned already exists for
-# build". When the artifact is already present we skip the ~20+ minute rebuild and
-# the colliding republish so the rerun can go green, reusing the artifact the
-# earlier attempt produced. Any failure to query the API falls back to building
-# normally (safe default).
+# Detect whether a previous attempt of this job already published the Linux SDK
+# artifacts. Pipeline artifact names are immutable per build, so if an earlier
+# attempt succeeded far enough to publish `nuget-linux-unsigned` (and/or its
+# `-symbols` companion) but then failed in a later (often post-job) step, blindly
+# rebuilding and republishing on a rerun always fails with "Artifact
+# nuget-linux-unsigned already exists for build". We probe each artifact
+# independently and set a per-artifact variable. When BOTH artifacts already
+# exist we skip the ~20+ minute rebuild; each publish step is then skipped only
+# for the artifact that already exists, so a partial prior publish (e.g. the SDK
+# published but `-symbols` missing) still rebuilds and publishes just the missing
+# artifact without colliding on the one that is already there. Any failure to
+# query the API falls back to building normally (safe default).
 - bash: |
     set -eo pipefail
-    artifact_name='${{ parameters.nugetArtifactName }}'
+    sdk_artifact='${{ parameters.nugetArtifactName }}'
+    symbols_artifact='${{ parameters.nugetArtifactName }}-symbols'
     url="$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts?api-version=7.1"
-    echo "Checking whether artifact '$artifact_name' already exists for build $(Build.BuildId)..."
+    echo "Checking whether artifacts already exist for build $(Build.BuildId)..."
     response="$(curl -sS -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" "$url" || true)"
-    if echo "$response" | tr -d '[:space:]' | grep -qF "\"name\":\"$artifact_name\""; then
-      echo "Found existing '$artifact_name'; a previous attempt already built and published the Linux SDK."
-      echo "Skipping the rebuild and republish so this rerun can succeed and reuse that artifact."
-      echo "##vso[task.setvariable variable=AlreadyBuiltLinuxSdk]true"
-    else
-      echo "No existing '$artifact_name' artifact; building the Linux SDK normally."
-      echo "##vso[task.setvariable variable=AlreadyBuiltLinuxSdk]false"
-    fi
-  displayName: check for existing linux sdk artifact
+    normalized="$(echo "$response" | tr -d '[:space:]')"
+    check_artifact () {
+      name="$1"
+      var="$2"
+      if echo "$normalized" | grep -qF "\"name\":\"$name\""; then
+        echo "Found existing '$name'; a previous attempt already published it."
+        echo "##vso[task.setvariable variable=$var]true"
+      else
+        echo "No existing '$name' artifact."
+        echo "##vso[task.setvariable variable=$var]false"
+      fi
+    }
+    check_artifact "$sdk_artifact" AlreadyBuiltLinuxSdk
+    check_artifact "$symbols_artifact" AlreadyBuiltLinuxSdkSymbols
+  displayName: check for existing linux sdk artifacts
   env:
     SYSTEM_ACCESSTOKEN: $(System.AccessToken)
 
@@ -73,17 +83,17 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
   retryCountOnTaskFailure: 1
-  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+  condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))
 
 - script: make create-nupkgs CONFIGURATION=$(XA.Build.Configuration)
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make create-nupkgs
-  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+  condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))
 
 - template: /build-tools/automation/yaml-templates/log-disk-space.yaml
 
 - task: CopyFiles@2
-  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+  condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))
   inputs:
     SourceFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned
     Contents: |
@@ -92,7 +102,7 @@ steps:
     TargetFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols
 
 - task: DeleteFiles@1
-  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+  condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))
   inputs:
     SourceFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned
     Contents: '*.symbols.nupkg'
@@ -106,7 +116,7 @@ steps:
     ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: copy linux sdk
-  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+  condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))
 
 - ${{ if eq(parameters.use1ESTemplate, true) }}:
   - task: 1ES.PublishPipelineArtifact@1
@@ -118,7 +128,7 @@ steps:
 
   - task: 1ES.PublishPipelineArtifact@1
     displayName: upload linux sdk symbols
-    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true'))
     inputs:
       artifactName: ${{ parameters.nugetArtifactName }}-symbols
       targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols
@@ -132,7 +142,7 @@ steps:
 
   - task: PublishPipelineArtifact@1
     displayName: upload linux sdk symbols
-    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true'))
     inputs:
       artifactName: ${{ parameters.nugetArtifactName }}-symbols
       targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols

--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -9,6 +9,33 @@ parameters:
   use1ESTemplate: true
 
 steps:
+# Detect whether a previous attempt of this job already built and published the
+# Linux SDK artifact. Pipeline artifact names are immutable per build, so if an
+# earlier attempt succeeded far enough to publish `nuget-linux-unsigned` but then
+# failed in a later (often post-job) step, blindly rebuilding and republishing on
+# a rerun always fails with "Artifact nuget-linux-unsigned already exists for
+# build". When the artifact is already present we skip the ~20+ minute rebuild and
+# the colliding republish so the rerun can go green, reusing the artifact the
+# earlier attempt produced. Any failure to query the API falls back to building
+# normally (safe default).
+- bash: |
+    set -eo pipefail
+    artifact_name='${{ parameters.nugetArtifactName }}'
+    url="$(System.CollectionUri)$(System.TeamProject)/_apis/build/builds/$(Build.BuildId)/artifacts?api-version=7.1"
+    echo "Checking whether artifact '$artifact_name' already exists for build $(Build.BuildId)..."
+    response="$(curl -sS -H "Authorization: Bearer $SYSTEM_ACCESSTOKEN" "$url" || true)"
+    if echo "$response" | tr -d '[:space:]' | grep -qF "\"name\":\"$artifact_name\""; then
+      echo "Found existing '$artifact_name'; a previous attempt already built and published the Linux SDK."
+      echo "Skipping the rebuild and republish so this rerun can succeed and reuse that artifact."
+      echo "##vso[task.setvariable variable=AlreadyBuiltLinuxSdk]true"
+    else
+      echo "No existing '$artifact_name' artifact; building the Linux SDK normally."
+      echo "##vso[task.setvariable variable=AlreadyBuiltLinuxSdk]false"
+    fi
+  displayName: check for existing linux sdk artifact
+  env:
+    SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+
 - template: /build-tools/automation/yaml-templates/log-disk-space.yaml
 
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
@@ -46,14 +73,17 @@ steps:
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
   retryCountOnTaskFailure: 1
+  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
 
 - script: make create-nupkgs CONFIGURATION=$(XA.Build.Configuration)
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make create-nupkgs
+  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
 
 - template: /build-tools/automation/yaml-templates/log-disk-space.yaml
 
 - task: CopyFiles@2
+  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
   inputs:
     SourceFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned
     Contents: |
@@ -62,6 +92,7 @@ steps:
     TargetFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols
 
 - task: DeleteFiles@1
+  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
   inputs:
     SourceFolder: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-unsigned
     Contents: '*.symbols.nupkg'
@@ -75,16 +106,33 @@ steps:
     ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: copy linux sdk
+  condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
 
-- ${{ if ne(parameters.use1ESTemplate, true) }}:
+- ${{ if eq(parameters.use1ESTemplate, true) }}:
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: upload linux sdk
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+    inputs:
+      artifactName: ${{ parameters.nugetArtifactName }}
+      targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux
+
+  - task: 1ES.PublishPipelineArtifact@1
+    displayName: upload linux sdk symbols
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
+    inputs:
+      artifactName: ${{ parameters.nugetArtifactName }}-symbols
+      targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols
+- ${{ else }}:
   - task: PublishPipelineArtifact@1
     displayName: upload linux sdk
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
     inputs:
       artifactName: ${{ parameters.nugetArtifactName }}
       targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux
 
   - task: PublishPipelineArtifact@1
     displayName: upload linux sdk symbols
+    condition: and(succeeded(), ne(variables['AlreadyBuiltLinuxSdk'], 'true'))
     inputs:
       artifactName: ${{ parameters.nugetArtifactName }}-symbols
       targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols

--- a/build-tools/automation/yaml-templates/build-linux.yaml
+++ b/build-tools/automation/yaml-templates/build-linux.yaml
@@ -34,17 +34,6 @@ stages:
     variables:
       CXX: g++-10
       CC: gcc-10
-    ${{ if eq(parameters.use1ESTemplate, true) }}:
-      templateContext:
-        outputs:
-        - output: pipelineArtifact
-          displayName: upload linux sdk
-          artifactName: ${{ parameters.nugetArtifactName }}
-          targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux
-        - output: pipelineArtifact
-          displayName: upload linux sdk symbols
-          artifactName: ${{ parameters.nugetArtifactName }}-symbols
-          targetPath: ${{ parameters.xaSourcePath }}/bin/Build$(XA.Build.Configuration)/nuget-linux-symbols
     steps:
     - template: sdk-unified/steps/checkout/v1.yml@yaml-templates
       parameters:


### PR DESCRIPTION
## Summary

Make the **`Linux > Build`** CI job recover on a **rerun** instead of getting permanently stuck once it has published its SDK artifact. Today, if the first attempt builds and publishes `nuget-linux-unsigned` but then fails in a later (often post-job) step, every "rerun failed jobs" attempt fails at the publish step with:

```
##[error]Artifact nuget-linux-unsigned already exists for build <id>.
```

…because pipeline artifact names are **immutable per build**. The only recovery is to queue an entirely new build. This PR detects the already-published artifact up front and skips the rebuild + republish so the rerun goes green and reuses what the earlier attempt produced.

## Background — what actually happens

Observed on public build [`1489305`](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1489305) (`dotnet-android`, dnceng-public):

**Attempt 1 (original run) — the build itself succeeded:**
- `make jenkins` ✓ → `make create-nupkgs` ✓ → `copy linux sdk` ✓
- `upload linux sdk` ✓ and `upload linux sdk symbols` ✓ — **`nuget-linux-unsigned` was successfully published**
- Then the auto-injected **post-job `Cache@2` save** ("cache Android toolchain archives") **failed** because the agent disk was full:
  ```
  ##[warning]Free disk space on / is lower than 5%; Currently used: 96.90%
  tar: 42e30a39...archive.tar: Wrote only 4096 of 10240 bytes
  tar: Error is not recoverable: exiting now
  ##[error]Process returned non-zero exit code: 2
  ```
  A failing post-job step marks the whole job failed — even though the real product (the SDK artifact) was already built and uploaded.

**Attempt 2 (rerun failed jobs):**
- The job re-runs from scratch on a fresh, clean agent (`workspace: clean: all`, ephemeral 1ES pool), rebuilds everything (~20+ min), re-uploads the content, then fails at the final *associate* step:
  ```
  Content upload is done!   ← bytes uploaded fine
  ##[error]Artifact nuget-linux-unsigned already exists for build 1489305.
  ```

### Why the build becomes un-rerunnable

Pipeline artifacts are keyed by **(buildId + artifactName)** and are immutable. The artifact *name* only registers **after** its content is fully committed — that is literally the step that fails with "already exists". So once attempt 1 registers `nuget-linux-unsigned` on the build, **every** rerun of that job re-executes the publish and collides. No rerun can ever go green; only a brand-new build (new buildId) will pass.

The underlying trigger here is a full agent disk during the post-job toolchain-cache save — **infrastructure we do not control** on the public pool. Rather than chase the disk-full root cause, this PR makes the job **robust on reruns** regardless of why the earlier attempt failed after publishing.

## What this PR changes

`build-tools/automation/yaml-templates/build-linux-steps.yaml`:

1. **New early guard step — "check for existing linux sdk artifacts".** Queries the build's artifacts REST API (`_apis/build/builds/$(Build.BuildId)/artifacts`) using `$(System.AccessToken)` and probes **each** artifact independently, setting a per-artifact job variable: `AlreadyBuiltLinuxSdk` for `nuget-linux-unsigned` and `AlreadyBuiltLinuxSdkSymbols` for `nuget-linux-unsigned-symbols`. Any API/network error falls back to `false` → build normally (safe default).
2. **Skip the expensive work only when *both* artifacts already exist.** `make jenkins`, `make create-nupkgs`, the symbols `CopyFiles`/`DeleteFiles`, and `copy linux sdk` gain `condition: and(succeeded(), or(ne(variables['AlreadyBuiltLinuxSdk'], 'true'), ne(variables['AlreadyBuiltLinuxSdkSymbols'], 'true')))` — so a partial prior publish still rebuilds the files needed for the missing artifact.
3. **Skip each colliding publish independently.** The SDK publish is gated on `AlreadyBuiltLinuxSdk`, the `-symbols` publish on `AlreadyBuiltLinuxSdkSymbols`. If a prior attempt published the SDK but died before `-symbols`, the rerun rebuilds, skips the SDK publish (no collision), and publishes only the missing `-symbols` artifact.

`build-tools/automation/yaml-templates/build-linux.yaml`:

4. **Moved the 1ES SDK publish out of `templateContext.outputs`** (which always runs at job end and cannot be conditioned) **into inline `1ES.PublishPipelineArtifact@1` steps** in the steps template, guarded by the skip condition. This mirrors the already-approved pattern in `publish-artifact.yaml` (used for the "Build Results - Linux" artifact in this same job), so it stays within 1ES governance.

### Behavior after this change

On a rerun where **both** artifacts already exist, the job: checks the API → sets both `AlreadyBuiltLinuxSdk=true` and `AlreadyBuiltLinuxSdkSymbols=true` → **skips the rebuild and both publishes** → finishes **green in ~1–2 minutes**, reusing the valid artifacts from the earlier attempt. If only one artifact was published before the earlier attempt failed, the rerun rebuilds and republishes just the missing one. Downstream stages already consume `nuget-linux-unsigned` from the build via `DownloadPipelineArtifact`, so they are unaffected. Because nothing heavy runs, the disk never re-fills, so the post-job cache save no longer fails either.

First runs are unchanged: the artifact doesn't exist yet, so the guard returns `false` and the full build runs as before.

## Why not other approaches

- **Attempt-unique artifact name** (like the `(Attempt N)` suffix used for "Build Results") — can't be used for `nuget-linux-unsigned`, because downstream stages reference the fixed name.
- **Fix the disk-full root cause** — the disk pressure is on the public 1ES pool image and not something we can reliably control; and even a well-behaved build can fail *after* publishing for other reasons, so rerun-safety is valuable on its own.
- **Condition on `templateContext.outputs` entries** — output entries always run at job end and there's no in-repo precedent for conditioning them; using inline `1ES.PublishPipelineArtifact@1` (already used elsewhere in the repo) is the more certain, precedented mechanism.

## Testing / validation

- Both templates parse as valid YAML.
- The artifact existence check was validated against build `1489305`: the REST API cleanly reports each artifact present via the exact `"name":"<name>"` fixed-string match, so probing `nuget-linux-unsigned` does **not** false-match `nuget-linux-unsigned-symbols` and each variable is set independently.
- Full validation happens in this PR's own `dotnet-android` run (first run exercises the normal build path; the skip path is exercised on any rerun).

## Notes

Since this only affects CI pipeline YAML, there is no product/runtime impact.

