### PR TITLE
[ci] Free disk space before post-job cache save on public Linux agents

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -99,3 +99,21 @@ steps:
 - template: /build-tools/automation/yaml-templates/fail-on-dirty-tree.yaml
   parameters:
     xaSourcePath: ${{ parameters.xaSourcePath }}
+
+# Public dnceng-public agents are sometimes provisioned with very small (~29 GB) OS
+# disks. The build fills the disk to ~94% and the post-job 'cache Android toolchain
+# archives' step then fails writing its tar archive with "No space left". Every build
+# artifact has already been uploaded by this point, so reclaim disk by deleting the
+# build intermediates before the implicit post-job Cache@2 save runs.
+# Public-only: the 1ES pipeline uploads 'bin/Build*/nuget-linux*' at post-job via
+# template 'outputs', so its 'bin' must NOT be deleted here.
+- ${{ if ne(parameters.use1ESTemplate, true) }}:
+  - bash: |
+      echo "Disk usage before freeing build intermediates:"
+      df -h /
+      rm -rf "${{ parameters.xaSourcePath }}/bin"
+      find "${{ parameters.xaSourcePath }}" -type d -name obj -prune -exec rm -rf {} +
+      echo "Disk usage after freeing build intermediates:"
+      df -h /
+    displayName: Free disk space before post-job cache save
+    condition: always()

--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -106,9 +106,11 @@ steps:
 # archive to '/' with a "No space left on device" error, failing the whole job. Note the
 # repo working tree (bin/obj) lives on the large /mnt volume, NOT on '/', so deleting it
 # does not help. Every pipeline artifact has already been uploaded by this point, so
-# reclaim space on '/' by deleting caches that are not needed post-build. We must keep
-# $HOME/android-archives and $HOME/.gradle: those are the sources saved by the post-job
-# 'cache Android toolchain archives' and 'cache Gradle downloads' steps.
+# reclaim space on '/' by deleting everything under $HOME that the build no longer needs.
+# The only things we must keep are the two post-job cache sources: $HOME/android-archives
+# (saved by 'cache Android toolchain archives') and $HOME/.gradle (saved by 'cache Gradle
+# downloads'). Everything else is disposable here, most importantly $HOME/android-toolchain
+# (the extracted SDK/NDK/JDK, ~9 GB) and the NuGet global packages cache.
 # Public-only: the 1ES pipeline runs on agents that do not have this small-disk problem.
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
   - bash: |
@@ -116,7 +118,7 @@ steps:
       df -h
       echo "=== Largest entries under HOME ($HOME) on the small '/' disk ==="
       du -xhd1 "$HOME" 2>/dev/null | sort -h | tail -20 || true
-      for d in "${NUGET_PACKAGES:-$HOME/.nuget/packages}" "$HOME/.dotnet" "$HOME/.local/share/NuGet" "$HOME/.cache"; do
+      for d in "$HOME/android-toolchain" "${NUGET_PACKAGES:-$HOME/.nuget/packages}" "$HOME/.dotnet" "$HOME/.local/share/NuGet" "$HOME/.cache"; do
         echo "Removing $d"
         rm -rf "$d" || true
       done

--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -100,20 +100,27 @@ steps:
   parameters:
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
-# Public dnceng-public agents are sometimes provisioned with very small (~29 GB) OS
-# disks. The build fills the disk to ~94% and the post-job 'cache Android toolchain
-# archives' step then fails writing its tar archive with "No space left". Every build
-# artifact has already been uploaded by this point, so reclaim disk by deleting the
-# build intermediates before the implicit post-job Cache@2 save runs.
-# Public-only: the 1ES pipeline uploads 'bin/Build*/nuget-linux*' at post-job via
-# template 'outputs', so its 'bin' must NOT be deleted here.
+# Public dnceng-public agents are sometimes provisioned with a very small (~29 GB) OS
+# disk mounted at '/'. The build fills '/' to ~94% via caches under $HOME, and the
+# implicit post-job 'cache Android toolchain archives' step then fails writing its tar
+# archive to '/' with a "No space left on device" error, failing the whole job. Note the
+# repo working tree (bin/obj) lives on the large /mnt volume, NOT on '/', so deleting it
+# does not help. Every pipeline artifact has already been uploaded by this point, so
+# reclaim space on '/' by deleting caches that are not needed post-build. We must keep
+# $HOME/android-archives and $HOME/.gradle: those are the sources saved by the post-job
+# 'cache Android toolchain archives' and 'cache Gradle downloads' steps.
+# Public-only: the 1ES pipeline runs on agents that do not have this small-disk problem.
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
   - bash: |
-      echo "Disk usage before freeing build intermediates:"
-      df -h /
-      rm -rf "${{ parameters.xaSourcePath }}/bin"
-      find "${{ parameters.xaSourcePath }}" -type d -name obj -prune -exec rm -rf {} +
-      echo "Disk usage after freeing build intermediates:"
-      df -h /
+      echo "=== Disk usage (all mounts) before freeing space ==="
+      df -h
+      echo "=== Largest entries under HOME ($HOME) on the small '/' disk ==="
+      du -xhd1 "$HOME" 2>/dev/null | sort -h | tail -20 || true
+      for d in "${NUGET_PACKAGES:-$HOME/.nuget/packages}" "$HOME/.dotnet" "$HOME/.local/share/NuGet" "$HOME/.cache"; do
+        echo "Removing $d"
+        rm -rf "$d" || true
+      done
+      echo "=== Disk usage (all mounts) after freeing space ==="
+      df -h
     displayName: Free disk space before post-job cache save
     condition: always()

--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -114,13 +114,20 @@ steps:
 # Public-only: the 1ES pipeline runs on agents that do not have this small-disk problem.
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
   - bash: |
+      set -euo pipefail
       echo "=== Disk usage (all mounts) before freeing space ==="
       df -h
+      # Guard against an unset/empty/root $HOME so the 'rm -rf' below can never target
+      # a system directory (e.g. "/android-toolchain" or "/.dotnet").
+      if [ -z "${HOME:-}" ] || [ "$HOME" = "/" ] || [ ! -d "$HOME" ]; then
+        echo "##vso[task.logissue type=warning]HOME ('${HOME:-}') is not a valid directory; skipping cleanup."
+        exit 0
+      fi
       echo "=== Largest entries under HOME ($HOME) on the small '/' disk ==="
       du -xhd1 "$HOME" 2>/dev/null | sort -h | tail -20 || true
       for d in "$HOME/android-toolchain" "${NUGET_PACKAGES:-$HOME/.nuget/packages}" "$HOME/.dotnet" "$HOME/.local/share/NuGet" "$HOME/.cache"; do
         echo "Removing $d"
-        rm -rf "$d" || true
+        rm -rf -- "$d" || true
       done
       echo "=== Disk usage (all mounts) after freeing space ==="
       df -h


### PR DESCRIPTION
## Problem

`Linux > Build` jobs on the public `dotnet-android` pipeline (dnceng-public, def 333) fail intermittently. The failure is **100% determined by which agent VM the job lands on**: `NetCore-Public` agents provisioned with a small ~29 GB OS disk fail, while agents with a large (248 GB) disk pass.

The build fills the small `/` disk to ~94%. The build itself *completes*, but the implicit **post-job `cache Android toolchain archives`** step then fails writing its tar archive to `/` (only ~1.9 GB free), which fails the whole job:

```
##[warning]Free disk space on / is lower than 5%; Currently used: 96.79%
tar: <hash>_archive.tar: Wrote only 6144 of 10240 bytes
tar: Error is not recoverable: exiting now
##[error]Process returned non-zero exit code: 2
```

## Disk layout on the failing agents

The key detail (from build 1489571, agent `NetCore-Public 66`):

```
/dev/root   29G   28G  1.9G  94%  /      <- tiny OS disk that fills up; the cache tar writes here
/dev/sda1   69G  6.4G   59G  10%  /mnt   <- 59 GB free; holds /mnt/vss/_work (repo, bin/obj)
```

- The repo working tree (`bin/obj`) lives on **`/mnt`** (59 GB free) — it is **not** what fills `/`.
- The **`/`** disk is filled by caches under `$HOME` (NuGet global packages, `.dotnet`, `~/android-archives`).
- The post-job cache `tar` writes its archive on `/`, so when `/` is full it fails.

## Change

Add a **public-pipeline-only** step at the end of `build-linux-steps.yaml` that reclaims space **on `/`** before the implicit post-job `Cache@2` save runs. Once every pipeline artifact has been uploaded, it deletes caches that are no longer needed (`~/.nuget/packages`, `~/.dotnet`, `~/.local/share/NuGet`, `~/.cache`), and logs `df -h` + a `du` of `$HOME` so the effect is visible in the build log.

### Why it's safe

- Preserves `~/android-archives` and `~/.gradle` — those are the sources archived by the post-job `cache Android toolchain archives` and `cache Gradle downloads` steps.
- By the end of the job, all pipeline artifacts have already been published via regular `PublishPipelineArtifact` steps; tests run in separate jobs that download the artifacts.
- Deleted directories (NuGet global packages, the `dotnet` install, misc caches) are not needed by any post-job step.
- **Scoped to `use1ESTemplate != true`**: the 1ES/private pipeline runs on agents that don't have this small-disk problem.
- `condition: always()` so disk is freed even when the build failed (the post-job cache save still runs).

## Caveats

- This is a **stopgap** for the cache-save failure. The build still peaks at ~94% on `/` *during* the build, so this doesn't add headroom for the build itself — only for the cache save afterwards.
- I can't run `du` on the agent from here, so the deletions target the highest-confidence consumers on `/`. The added `df`/`du` diagnostics will confirm what's actually large and whether the reclaim is sufficient; if `~/android-archives` itself is the dominant multi-GB chunk, a follow-up may need to redirect the cache tar's temp to `/mnt` or skip saving that cache on small agents.
- The durable fix is larger agent OS disks — tracked in #11837.

### History
- v1 (reverted approach): deleted the repo `bin/obj`, which had **zero** effect because they live on `/mnt`, not `/`.
- v2 (current): targets the `/` disk by removing `$HOME` caches.
