### PR TITLE
[tests] Fix BuildArtifactsOutputPaths Directory.Build.props flake

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidGradleProjectTests.cs
@@ -316,21 +316,23 @@ namespace Xamarin.Android.Build.Tests
 						},
 					},
 				},
-				Imports = {
-					new Import ("Directory.Build.props") {
-						TextContent = () =>
-$@"<Project>
-	<PropertyGroup>
-		<UseArtifactsOutput>true</UseArtifactsOutput>
-		<ArtifactsPath>{customOutputPathsRoot}</ArtifactsPath>
-	</PropertyGroup>
-</Project>"
-					},
-				},
 				OutputPath = "",
 				IntermediateOutputPath = "",
 			};
 			proj.SetRuntime (runtime);
+
+			// Augment the base `Directory.Build.props` import instead of adding a second one for
+			// the same file. Two imports writing the same path overwrite each other on save, which
+			// intermittently dropped these properties and left the build using the default output
+			// paths (observed as a Windows-only flake in this test).
+			var directoryBuildProps = proj.GetImport ("Directory.Build.props");
+			var baseContent = directoryBuildProps.TextContent;
+			directoryBuildProps.TextContent = () => baseContent ().Replace ("</Project>",
+$@"	<PropertyGroup>
+		<UseArtifactsOutput>true</UseArtifactsOutput>
+		<ArtifactsPath>{customOutputPathsRoot}</ArtifactsPath>
+	</PropertyGroup>
+</Project>");
 
 			Assert.IsTrue (builder.Build (proj), "Build should have succeeded.");
 


### PR DESCRIPTION
## Description

`AndroidGradleProjectTests.BuildArtifactsOutputPaths` intermittently fails (observed as a Windows-only lane failure) with:

```
Expected: file exists
But was:  "...\customout\bin\UnnamedProject\debug\TestModule-release.aar"
```

### Root cause

The test sets `UseArtifactsOutput`/`ArtifactsPath` by adding a **second** `Import("Directory.Build.props")`:

```csharp
Imports = {
    new Import ("Directory.Build.props") { TextContent = () => /* UseArtifactsOutput + ArtifactsPath */ },
},
```

But the base `XamarinProject` constructor **already** adds an `Import("Directory.Build.props")` (with `Configuration` + `DisableTransitiveFrameworkReferenceDownloads`). Both imports resolve to the **same file path**, and `XamarinProject.Save` writes each import in list order via `File.WriteAllText` — so the two writes overwrite each other. Depending on save/update timing, the base content wins and the test's `UseArtifactsOutput`/`ArtifactsPath` are silently dropped. The build then uses the default `bin/Debug` output, no `customout/` tree is produced, and the assertion fails.

This is why the same test case passes on macOS but failed on the Windows lane in the same build — a nondeterministic file-write collision, unrelated to product code.

### Fix

Augment the **existing** `Directory.Build.props` import (via `GetImport`) instead of adding a colliding second one, so only one file is written and all four properties are applied deterministically. The base content is preserved by wrapping the original `TextContent`.

### Testing

- `Xamarin.Android.Build.Tests` compiles cleanly.
- Local build of the test project succeeds; the change only affects how the test's `Directory.Build.props` is generated.

### Where this was observed

- PR dotnet/android#11804, AzDO build [#1489305](https://dev.azure.com/dnceng-public/public/_build/results?buildId=1489305) — check `dotnet-android (MSBuild Tests Windows > Tests > MSBuild 7)`.
- `AndroidGradleProjectTests.BuildArtifactsOutputPaths(CoreCLR)` failed only on the `Windows-7` lane, while the identical case passed on `macOS-1` in the same build — confirming a nondeterministic file-write collision rather than a product regression.
