### PR TITLE
[ci] Relocate Linux caches/toolchain to /mnt (alternative to #11838)

### DIFF
--- a/build-tools/automation/yaml-templates/build-linux-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-linux-steps.yaml
@@ -11,6 +11,27 @@ parameters:
 steps:
 - template: /build-tools/automation/yaml-templates/log-disk-space.yaml
 
+# Public dnceng-public agents have a tiny (~29 GB) OS disk mounted at '/', but the work
+# volume /mnt (~69 GB) has plenty of room. Point every large cache/tooling directory at a
+# folder on /mnt next to the checked-out repo so '/' never fills up (which otherwise makes
+# the post-job cache-save 'tar' fail with "No space left on device"). This must run before
+# 'setup-jdk-variables' (JAVA_HOME lives inside the toolchain dir) and 'make prepare'.
+# The overrides are honored downstream: NuGet via NUGET_PACKAGES, Gradle via
+# GRADLE_USER_HOME, and the Android toolchain via the AndroidToolchain*Directory MSBuild
+# properties (Configuration.props only defaults them when empty, and MSBuild reads env
+# vars as properties). Job-scoped, so the separate test-stage agents are unaffected.
+# Public-only: the 1ES pipeline runs on agents that do not have this small-disk problem.
+- ${{ if ne(parameters.use1ESTemplate, true) }}:
+  - bash: |
+      set -euo pipefail
+      root="$(Pipeline.Workspace)/xa-caches"
+      echo "Relocating caches and toolchain under $root (on the large /mnt work volume)"
+      echo "##vso[task.setvariable variable=NUGET_PACKAGES]$root/nuget"
+      echo "##vso[task.setvariable variable=GRADLE_USER_HOME]$root/gradle"
+      echo "##vso[task.setvariable variable=AndroidToolchainDirectory]$root/android-toolchain"
+      echo "##vso[task.setvariable variable=AndroidToolchainCacheDirectory]$root/android-archives"
+    displayName: Relocate caches to the large /mnt volume
+
 - ${{ if ne(parameters.use1ESTemplate, true) }}:
   - bash: |
       set -e

--- a/build-tools/automation/yaml-templates/cache-android-archives.yaml
+++ b/build-tools/automation/yaml-templates/cache-android-archives.yaml
@@ -20,7 +20,9 @@ parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)/android
 
 steps:
-- script: echo "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]$HOME/android-archives"
+# Honor a relocated AndroidToolchainCacheDirectory (set as a job variable -> env var
+# ANDROIDTOOLCHAINCACHEDIRECTORY); default to the usual $HOME location otherwise.
+- script: echo "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]${ANDROIDTOOLCHAINCACHEDIRECTORY:-$HOME/android-archives}"
   displayName: prepare android-archives cache variables
   condition: ne(variables['Agent.OS'], 'Windows_NT')
 

--- a/build-tools/automation/yaml-templates/cache-gradle.yaml
+++ b/build-tools/automation/yaml-templates/cache-gradle.yaml
@@ -10,7 +10,8 @@ parameters:
 steps:
 - script: |
     git submodule status --cached external/Java.Interop > $(Agent.TempDirectory)/java-interop-submodule-hash.txt
-    echo "##vso[task.setvariable variable=GRADLE_CACHE_DIR]$HOME/.gradle/caches"
+    # Honor a relocated GRADLE_USER_HOME; default to the usual $HOME/.gradle otherwise.
+    echo "##vso[task.setvariable variable=GRADLE_CACHE_DIR]${GRADLE_USER_HOME:-$HOME/.gradle}/caches"
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: prepare Gradle cache variables
   condition: ne(variables['Agent.OS'], 'Windows_NT')

--- a/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
+++ b/build-tools/automation/yaml-templates/setup-jdk-variables.yaml
@@ -7,9 +7,13 @@ steps:
     $agentOS="$(Agent.OS)"
     $agentArch="$(Agent.OSArchitecture)" -eq "ARM64" ? "arm64" : "$(Agent.OSArchitecture)"
     $jdkMajorVersion="${{ parameters.jdkMajorVersion }}"
-    $xaPrepareJdkPath="$env:HOME/android-toolchain/jdk-$jdkMajorVersion"
+    # Honor a relocated AndroidToolchainDirectory (set as a job variable -> env var
+    # ANDROIDTOOLCHAINDIRECTORY); the JDK is unpacked under it. Default to the usual $HOME.
+    $toolchainDir = if ($env:ANDROIDTOOLCHAINDIRECTORY) { $env:ANDROIDTOOLCHAINDIRECTORY } else { "$env:HOME/android-toolchain" }
+    $xaPrepareJdkPath="$toolchainDir/jdk-$jdkMajorVersion"
     if ("$agentOS" -eq "Windows_NT") {
-      $xaPrepareJdkPath="$env:USERPROFILE\android-toolchain\jdk-$jdkMajorVersion"
+      $toolchainDirWin = if ($env:ANDROIDTOOLCHAINDIRECTORY) { $env:ANDROIDTOOLCHAINDIRECTORY } else { "$env:USERPROFILE\android-toolchain" }
+      $xaPrepareJdkPath="$toolchainDirWin\jdk-$jdkMajorVersion"
     }
     $jdkHomePath=$xaPrepareJdkPath
     if ("${{ parameters.useAgentJdkPath }}" -eq "true") {


### PR DESCRIPTION
## Alternative approach to #11838 (side-by-side experiment)

#11838 fixes the small-disk cache-save failure **reactively** — it deletes caches from the full `/` disk right before the post-job cache save. This PR takes the **proactive** approach instead: point every large cache/tooling directory at the big `/mnt` work volume so `/` never fills up in the first place.

Opening this separately so we can compare both in CI before deciding which to keep.

## The problem (recap)

Public dnceng-public Linux agents are sometimes provisioned with a tiny ~29 GB OS disk at `/`, while the work volume `/mnt` has ~69 GB (59 GB free). The build fills `/` to ~94% via caches under `$HOME`, and the post-job `cache Android toolchain archives` step then fails writing its tar on `/`:

```
tar: <hash>_archive.tar: Wrote only 6144 of 10240 bytes
tar: Error is not recoverable: exiting now
```

Ground truth from a failing agent:

```
/dev/root   29G   28G  1.9G  94%  /      <- fills up; the cache tar writes here
/dev/sda1   69G  6.4G   59G  10%  /mnt   <- holds /mnt/vss/_work (repo), lots of room
```

`du` of `$HOME` (all on `/`): `android-toolchain` 8.7G · `android-archives` 5.0G · `.nuget` 2.8G · `.gradle` 1.1G · `.dotnet` 0.6G.

## Change

A new **public-Linux-only**, job-scoped step redirects the big consumers to `$(Pipeline.Workspace)/xa-caches` (on `/mnt`, next to the checked-out repo), **before** `setup-jdk-variables` and `make prepare`:

| Consumer | Override |
| --- | --- |
| NuGet global packages | `NUGET_PACKAGES` |
| Gradle user home | `GRADLE_USER_HOME` |
| Android toolchain + downloaded archives | `AndroidToolchainDirectory` / `AndroidToolchainCacheDirectory` (MSBuild props) |

Three shared consumer templates now honor these, **defaulting to the existing `$HOME` locations** so macOS/Windows/1ES/test-stage callers are byte-for-byte unchanged:

- `setup-jdk-variables.yaml` — `JAVA_HOME` lives inside the toolchain dir, so it must follow the relocation.
- `cache-android-archives.yaml` — cache `path` follows `AndroidToolchainCacheDirectory`.
- `cache-gradle.yaml` — cache `path` follows `GRADLE_USER_HOME`.

## Why it works

- `Configuration.props` defaults `AndroidToolchain*Directory` only `Condition="== ''"`, and MSBuild imports env vars as properties, so the exported values win. xaprepare's generated `Properties.Defaults.cs` picks them up when it's compiled during `make prepare` (after the redirect step runs).
- No `nuget.config` pins `globalPackagesFolder`/`RestorePackagesPath`, so `NUGET_PACKAGES` is honored.
- Gradle honors `GRADLE_USER_HOME` natively.
- The redirect is set via `task.setvariable` (job-scoped), so the separate test-stage agents keep using `$HOME/android-toolchain` (see `stage-linux-tests.yaml`).

## Expected result

`/` stays around its ~8 GB baseline throughout the build (instead of ~94%), giving both the build and the post-job cache save ~19 GB of headroom — fixing the root cause rather than the symptom.

## Trade-offs vs #11838

| | This PR (relocate) | #11838 (delete) |
| --- | --- | --- |
| Fixes cache-save OOM | ✅ | ✅ (validated) |
| Fixes build peaking at 94% during build | ✅ | ❌ |
| Files touched | 4 shared templates | 1 (public-only) |
| Blast radius | larger — needs a green run to trust | small |

Durable infra fix is still tracked in #11837.
