### PR TITLE
[external/Java.Interop] Drop nested xamarin-android-tools submodule

### DIFF
--- a/.github/skills/tests/references/test-catalog.md
+++ b/.github/skills/tests/references/test-catalog.md
@@ -33,8 +33,8 @@ These tests can be run immediately with `dotnet test` on the `.csproj`, even if 
 | **generator tools** | `external/Java.Interop/tests/Java.Interop.Tools.Generator-Tests/` | `dotnet test external/Java.Interop/tests/Java.Interop.Tools.Generator-Tests/Java.Interop.Tools.Generator-Tests.csproj -v minimal` |
 | **generator** | `external/Java.Interop/tests/generator-Tests/` | `dotnet test external/Java.Interop/tests/generator-Tests/generator-Tests.csproj -v minimal` |
 | **bytecode** | `external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/` | `dotnet test external/Java.Interop/tests/Xamarin.Android.Tools.Bytecode-Tests/Xamarin.Android.Tools.Bytecode-Tests.csproj -v minimal` ⚠️ Requires `javac` |
-| **base tasks** | `external/.../tests/Microsoft.Android.Build.BaseTasks-Tests/` | `dotnet test external/Java.Interop/external/xamarin-android-tools/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj -v minimal` |
-| **android sdk tools** | `external/.../tests/Xamarin.Android.Tools.AndroidSdk-Tests/` | `dotnet test external/Java.Interop/external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj -v minimal` |
+| **base tasks** | `external/.../tests/Microsoft.Android.Build.BaseTasks-Tests/` | `dotnet test external/xamarin-android-tools/tests/Microsoft.Android.Build.BaseTasks-Tests/Microsoft.Android.Build.BaseTasks-Tests.csproj -v minimal` |
+| **android sdk tools** | `external/.../tests/Xamarin.Android.Tools.AndroidSdk-Tests/` | `dotnet test external/xamarin-android-tools/tests/Xamarin.Android.Tools.AndroidSdk-Tests/Xamarin.Android.Tools.AndroidSdk-Tests.csproj -v minimal` |
 
 ---
 
@@ -208,4 +208,4 @@ Run these tests with `dotnet test` from each test project directory listed above
 |-----------|------|--------------------|-------|
 | **aidl** | **Standalone** | `tests/Xamarin.Android.Tools.Aidl-Tests/` | AIDL compiler tests — `dotnet test` on `.csproj` |
 | **api compatibility** | N/A | `tests/api-compatibility/` | Not a test runner — reference data for API surface checks |
-| **android sdk tools** | **Standalone** | `external/Java.Interop/external/xamarin-android-tools/tests/` | Android SDK helper tooling tests — `dotnet test` on `.csproj` |
+| **android sdk tools** | **Standalone** | `external/xamarin-android-tools/tests/` | Android SDK helper tooling tests — `dotnet test` on `.csproj` |

--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,3 @@
 [submodule "external/termux-elf-cleaner"]
 	path = external/termux-elf-cleaner
 	url = https://github.com/termux/termux-elf-cleaner
-[submodule "external/Java.Interop/external/xamarin-android-tools"]
-	path = external/Java.Interop/external/xamarin-android-tools
-	url = https://github.com/xamarin/xamarin-android-tools.git
-	branch = main

--- a/external/Java.Interop/Directory.Build.props
+++ b/external/Java.Interop/Directory.Build.props
@@ -51,7 +51,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)external\xamarin-android-tools</XamarinAndroidToolsDirectory>
+    <XamarinAndroidToolsDirectory   Condition=" '$(XamarinAndroidToolsDirectory)' == '' ">$(MSBuildThisFileDirectory)..\xamarin-android-tools</XamarinAndroidToolsDirectory>
     <!-- Points at the top-level dotnet/android product.snk after the Java.Interop merge. -->
     <ProductSnkPath                 Condition=" '$(ProductSnkPath)' == '' ">$(MSBuildThisFileDirectory)..\..\product.snk</ProductSnkPath>
   </PropertyGroup>

--- a/external/Java.Interop/Java.Interop.sln
+++ b/external/Java.Interop/Java.Interop.sln
@@ -57,7 +57,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "jcw-gen", "tools\jcw-gen\jc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.JavaCallableWrappers-Tests", "tests\Java.Interop.Tools.JavaCallableWrappers-Tests\Java.Interop.Tools.JavaCallableWrappers-Tests.csproj", "{58B564A1-570D-4DA2-B02D-25BDDB1A9F4F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.AndroidSdk", "external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj", "{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.AndroidSdk", "..\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj", "{E34BCFA0-CAA4-412C-AA1C-75DB8D67D157}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.Tools.JavaSource-Tests", "tests\Java.Interop.Tools.JavaSource-Tests\Java.Interop.Tools.JavaSource-Tests.csproj", "{093B5E94-7FB7-499F-9C11-30944BAFEE25}"
 EndProject

--- a/external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.sln
+++ b/external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 17.1.32104.313
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Java.Interop.BootstrapTasks", "Java.Interop.BootstrapTasks.csproj", "{47C54705-71BA-455D-9F72-780487DE861C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.AndroidSdk", "..\..\external\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj", "{2F8744CF-C265-440A-B976-DEC021324A3E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Android.Tools.AndroidSdk", "..\..\..\xamarin-android-tools\src\Xamarin.Android.Tools.AndroidSdk\Xamarin.Android.Tools.AndroidSdk.csproj", "{2F8744CF-C265-440A-B976-DEC021324A3E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/external/Java.Interop/tools/generator/generator.slnf
+++ b/external/Java.Interop/tools/generator/generator.slnf
@@ -2,7 +2,7 @@
   "solution": {
     "path": "..\\..\\Java.Interop.sln",
     "projects": [
-      "external\\xamarin-android-tools\\src\\Xamarin.Android.Tools.AndroidSdk\\Xamarin.Android.Tools.AndroidSdk.csproj",
+      "..\\xamarin-android-tools\\src\\Xamarin.Android.Tools.AndroidSdk\\Xamarin.Android.Tools.AndroidSdk.csproj",
       "src\\Java.Interop.Localization\\Java.Interop.Localization.csproj",
       "src\\Java.Interop.Tools.Cecil\\Java.Interop.Tools.Cecil.csproj",
       "src\\Java.Interop.Tools.Diagnostics\\Java.Interop.Tools.Diagnostics.csproj",


### PR DESCRIPTION
## Why

After the Java.Interop history was merged into `dotnet/android` in #11942, we ended up with **two** submodules pointing at the same repo:

| Submodule path | Points to |
| --- | --- |
| `external/xamarin-android-tools` | `dotnet/android-tools` (top-level, canonical) |
| `external/Java.Interop/external/xamarin-android-tools` | `xamarin/xamarin-android-tools` (nested, redundant) |

Both check out the same code. Keeping both wastes ~30 MB per fresh clone, doubles the "am I up to date?" surface area, and creates two places where the pinned commit can drift out of sync. This PR removes the nested one and retargets every Java.Interop consumer at the top-level checkout.

This is pure de-duplication — no functional change to `Xamarin.Android.Tools.AndroidSdk` or anything that depends on it.

Follows the earlier `.github/` merge in #11942 and complements the parallel cleanup of other stale files under `external/Java.Interop/` (`product.snk`, `CODE-OF-CONDUCT.md`, `SECURITY.md`, top-level `Makefile`, code-workspace, `.gitmodules`) that a sibling session is opening separately.

## What changed

Submodule removal:

- Deleted the `external/Java.Interop/external/xamarin-android-tools` submodule entry.
- Removed the `[submodule "external/Java.Interop/external/xamarin-android-tools"]` block from the top-level `.gitmodules`.
- Deleted `external/Java.Interop/.gitmodules` (the nested submodule was its only entry).

Consumer updates (everything now points at `external/xamarin-android-tools/`):

- `external/Java.Interop/Directory.Build.props`: `$(XamarinAndroidToolsDirectory)` → `$(MSBuildThisFileDirectory)..\xamarin-android-tools`
- `external/Java.Interop/Java.Interop.sln`: project path → `..\xamarin-android-tools\src\...`
- `external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.sln`: project path → `..\..\..\xamarin-android-tools\src\...`
- `external/Java.Interop/Makefile`: `PREPARE_EXTERNAL_FILES` → `../xamarin-android-tools/src/...`
- `external/Java.Interop/tools/generator/generator.slnf`: project path → `..\\xamarin-android-tools\\src\\...`
- `.github/skills/tests/references/test-catalog.md`: doc paths updated.

## Verification

```
dotnet restore external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.sln
  Restored .../Java.Interop.BootstrapTasks.csproj
  Restored .../external/xamarin-android-tools/src/Xamarin.Android.Tools.AndroidSdk/Xamarin.Android.Tools.AndroidSdk.csproj

dotnet build   external/Java.Interop/build-tools/Java.Interop.BootstrapTasks/Java.Interop.BootstrapTasks.sln
  Xamarin.Android.Tools.AndroidSdk -> .../external/xamarin-android-tools/bin/Debug/netstandard2.0/Xamarin.Android.Tools.AndroidSdk.dll
  Java.Interop.BootstrapTasks     -> .../external/Java.Interop/bin/BuildDebug/Java.Interop.BootstrapTasks.dll
  Build succeeded.  0 Warning(s)  0 Error(s)

dotnet restore external/Java.Interop/Java.Interop.sln
  Restored (all 37 projects, including Xamarin.Android.Tools.AndroidSdk at the retargeted path)
```

`git submodule status` after the change no longer lists `external/Java.Interop/external/xamarin-android-tools`, and still lists `external/xamarin-android-tools`.

## Local checkout impact

⚠️ This is potentially breaking for anyone with an existing local clone that has the nested submodule initialized. After pulling this PR, run:

```
git submodule sync
git submodule update --init --recursive
```

Git will then deinit the nested submodule cleanly. If you have local edits under `external/Java.Interop/external/xamarin-android-tools/`, back them up first — that directory is going away.

- [x] Useful description of *why the change is necessary*.
- [x] Links to issues fixed — follow-up to #11942.
- [x] Unit tests — n/a (submodule consolidation, verified via `dotnet build`/`restore`).