### PR TITLE
[EXPERIMENT] Zero-copy, mmap-able assembly store (CoreCLR)

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssemblyStore.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/CreateAssemblyStore.cs
@@ -38,7 +38,17 @@ public class CreateAssemblyStore : AndroidTask
 	[Output]
 	public ITaskItem [] AssembliesToAddToArchive { get; set; } = [];
 
+	// EXPERIMENT (assemblystore-mmap hybrid): ReadyToRun composite native images (*.r2r.dll) are
+	// architecture-specific, so they must NOT go into the shared (architecture-independent) assembly
+	// store asset. They are emitted here separately (tagged with their ABI) so they can be packaged
+	// per-ABI under lib/<abi>/ where an AAB can split them by architecture.
+	[Output]
+	public ITaskItem [] R2RCompositeAssemblies { get; set; } = [];
+
 	AndroidRuntime targetRuntime;
+
+	static bool IsR2RComposite (ITaskItem asm) =>
+		System.IO.Path.GetFileName (asm.ItemSpec).EndsWith (".r2r.dll", StringComparison.OrdinalIgnoreCase);
 
 	public override bool RunTask ()
 	{
@@ -54,17 +64,27 @@ public class CreateAssemblyStore : AndroidTask
 
 		var store_builder = new AssemblyStoreBuilder (Log, targetRuntime);
 		var per_arch_assemblies = MonoAndroidHelper.GetPerArchAssemblies (assemblies, SupportedAbis, true);
+		var composites = new List<ITaskItem> ();
 
 		foreach (var kvp in per_arch_assemblies) {
+			string abi = MonoAndroidHelper.ArchToAbi (kvp.Key);
 			Log.LogDebugMessage ($"Adding assemblies for architecture '{kvp.Key}'");
 
 			foreach (var assembly in kvp.Value.Values) {
+				if (IsR2RComposite (assembly)) {
+					composites.Add (new TaskItem (assembly.ItemSpec, new Dictionary<string, string> { { "Abi", abi } }));
+					Log.LogDebugMessage ($"Routing R2R composite '{assembly.ItemSpec}' to lib/{abi}/ instead of the shared assembly store.");
+					continue;
+				}
+
 				var sourcePath = assembly.GetMetadataOrDefault ("CompressedAssembly", assembly.ItemSpec);
 				store_builder.AddAssembly (sourcePath, assembly, includeDebugSymbols: IncludeDebugSymbols);
 
 				Log.LogDebugMessage ($"Added '{sourcePath}' to assembly store.");
 			}
 		}
+
+		R2RCompositeAssemblies = composites.ToArray ();
 
 		var assembly_store_paths = store_builder.Generate (AppSharedLibrariesDir);
 

--- a/src/Xamarin.Android.Build.Tasks/Tasks/WrapAssembliesAsSharedLibraries.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/WrapAssembliesAsSharedLibraries.cs
@@ -33,6 +33,11 @@ public class WrapAssembliesAsSharedLibraries : AndroidTask
 
 	public bool UseAssemblyStore { get; set; }
 
+	// EXPERIMENT (assemblystore-mmap hybrid): architecture-specific ReadyToRun composite images,
+	// peeled out of the shared assembly store by CreateAssemblyStore, to be packaged per-ABI under
+	// lib/<abi>/ (DSO-wrapped, stored uncompressed) so an AAB can split them by architecture.
+	public ITaskItem [] R2RCompositeAssemblies { get; set; } = [];
+
 	[Required]
 	public ITaskItem [] ResolvedAssemblies { get; set; } = [];
 
@@ -52,9 +57,31 @@ public class WrapAssembliesAsSharedLibraries : AndroidTask
 		else
 			AssemblyPackagingHelper.AddAssembliesFromCollection (Log, SupportedAbis, ResolvedAssemblies, (TaskLoggingHelper log, AndroidTargetArch arch, ITaskItem assembly) => WrapAssembly (log, arch, assembly, wrapper_config, files));
 
+		WrapR2RComposites (wrapper_config, files);
+
 		WrappedAssemblies = files.ToArray ();
 
 		return !Log.HasLoggedErrors;
+	}
+
+	// EXPERIMENT (assemblystore-mmap hybrid): DSO-wrap each architecture-specific R2R composite image
+	// and place it under lib/<abi>/ (as a `.so`, which is stored uncompressed and can be ABI-split by
+	// an AAB), keeping the shared assembly store free of architecture-specific content.
+	void WrapR2RComposites (DSOWrapperGenerator.Config dsoWrapperConfig, PackageFileListBuilder files)
+	{
+		foreach (var composite in R2RCompositeAssemblies) {
+			var abi = composite.GetMetadata ("Abi");
+			if (abi.IsNullOrEmpty ()) {
+				Log.LogError ($"Internal error: R2R composite '{composite.ItemSpec}' lacks the required 'Abi' metadata");
+				return;
+			}
+
+			var arch = MonoAndroidHelper.AbiToTargetArch (abi);
+			var archive_path = MakeArchiveLibPath (abi, "lib" + Path.GetFileName (composite.ItemSpec) + ".so");
+			var wrapped_source_path = DSOWrapperGenerator.WrapIt (Log, dsoWrapperConfig, arch, composite.ItemSpec, Path.GetFileName (archive_path));
+			files.AddItem (wrapped_source_path, archive_path);
+			Log.LogDebugMessage ($"Packaged R2R composite '{composite.ItemSpec}' as '{archive_path}'");
+		}
 	}
 
 	void WrapAssemblyStores (DSOWrapperGenerator.Config dsoWrapperConfig, PackageFileListBuilder files)
@@ -67,11 +94,14 @@ public class WrapAssembliesAsSharedLibraries : AndroidTask
 			if (abi is null)
 				return;
 
-			var arch = MonoAndroidHelper.AbiToTargetArch (abi);
-			var archive_path = MakeArchiveLibPath (abi, "lib" + Path.GetFileName (store_path));
-			var wrapped_source_path = DSOWrapperGenerator.WrapIt (Log, dsoWrapperConfig, arch, store_path, Path.GetFileName (archive_path));
-
-			files.AddItem (wrapped_source_path, archive_path);
+			// EXPERIMENT (assemblystore-mmap): instead of disguising the assembly store as a
+			// native library (`lib/{ABI}/libassembly-store.so`, which Google Play force-stores
+			// uncompressed for AAB delivery on API 26+), emit the raw store blob as a plain
+			// APK asset. Assets are DEFLATE-compressed by the packager and are *not* force-stored
+			// uncompressed by Play (small download), and the runtime extracts the store once to the
+			// app's files dir and mmaps it without any per-assembly decompression.
+			var archive_path = MonoAndroidHelper.MakeZipArchivePath ("assets", "libassembly-store.assemblystore");
+			files.AddItem (store_path, archive_path);
 		}
 	}
 

--- a/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/AssemblyStoreGenerator.cs
@@ -127,6 +127,20 @@ partial class AssemblyStoreGenerator
 
 		uint mappingIndex = 0;
 		foreach (AssemblyStoreAssemblyInfo info in infos) {
+			// EXPERIMENT (assemblystore-mmap zero-copy): page-align each assembly's data so the
+			// runtime can hand CoreCLR a direct pointer into a writable (MAP_PRIVATE COW) mapping of
+			// the store. Alignment guarantees (a) the PE image starts on a page boundary, and (b) no
+			// two assemblies (or the store metadata) share a page, so CoreCLR's in-place writes to one
+			// image cannot corrupt a neighbour via copy-on-write.
+			const ulong AssemblyAlignment = 16384;
+			if (!info.Ignored) {
+				ulong aligned = (curPos + (AssemblyAlignment - 1)) & ~(AssemblyAlignment - 1);
+				if (aligned != curPos) {
+					fs.Seek ((long)aligned, SeekOrigin.Begin);
+					curPos = aligned;
+				}
+			}
+
 			(AssemblyStoreEntryDescriptor desc, curPos) = MakeDescriptor (info, curPos);
 			if (info.Ignored) {
 				desc.mapping_index = 0;

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -2224,6 +2224,7 @@ because xbuild doesn't support framework reference assemblies.
       SupportedAbis="@(_BuildTargetAbis)"
       UseAssemblyStore="$(_AndroidUseAssemblyStore)">
     <Output TaskParameter="AssembliesToAddToArchive" ItemName="_BuildApkAssembliesToAddToArchive" />
+    <Output TaskParameter="R2RCompositeAssemblies" ItemName="_BuildApkR2RCompositeAssemblies" />
   </CreateAssemblyStore>
 
   <WrapAssembliesAsSharedLibraries
@@ -2232,6 +2233,7 @@ because xbuild doesn't support framework reference assemblies.
       IncludeDebugSymbols="$(AndroidIncludeDebugSymbols)"
       IntermediateOutputPath="$(IntermediateOutputPath)"
       ResolvedAssemblies="@(_BuildApkAssembliesToAddToArchive)"
+      R2RCompositeAssemblies="@(_BuildApkR2RCompositeAssemblies)"
       SupportedAbis="@(_BuildTargetAbis)"
       UseAssemblyStore="$(_AndroidUseAssemblyStore)"
       RuntimePackLibraryDirectories="@(_RuntimePackLibraryDirectory)">

--- a/src/native/clr/host/CMakeLists.txt
+++ b/src/native/clr/host/CMakeLists.txt
@@ -158,6 +158,7 @@ macro(lib_target_options TARGET_NAME)
     xa::lz4
     -landroid
     -llog
+    -lz
     -lcoreclr
   )
 endmacro ()

--- a/src/native/clr/host/assembly-store.cc
+++ b/src/native/clr/host/assembly-store.cc
@@ -1,11 +1,23 @@
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
 #include <string>
+#include <vector>
 
 #if defined (HAVE_LZ4)
 #include <lz4.h>
 #endif
 
+#include <zlib.h>
+
 #include <xamarin-app.hh>
+#include <constants.hh>
 #include <host/assembly-store.hh>
+#include <startup/zip.hh>
 #include <runtime-base/util.hh>
 #include <runtime-base/search.hh>
 #include <runtime-base/startup-aware-lock.hh>
@@ -149,32 +161,28 @@ auto AssemblyStore::get_assembly_data (AssemblyStoreSingleAssemblyRuntimeData co
 	} else
 #endif // def HAVE_LZ4 && def RELEASE
 	{
-		log_debug (LOG_ASSEMBLY, "Assembly '{}' is not compressed in the assembly store"sv, name);
-
-		// HACK! START
-		// Currently, MAUI crashes when we return a pointer to read-only data, so we must copy
-		// the assembly data to a read-write area.
-		log_debug (LOG_ASSEMBLY, "Copying assembly data to an r/w memory area"sv);
+		// EXPERIMENT (assemblystore-mmap zero-copy): the assembly is stored uncompressed in a store
+		// mmap'd MAP_PRIVATE, PROT_READ|PROT_WRITE. Hand CoreCLR a pointer straight into the mapping
+		// with no decompression and no memcpy: in-place writes to the PE image fault in copy-on-write
+		// pages (only the touched ones), everything else stays demand-paged and shared with the file's
+		// page cache. Requires the store to page-align each assembly (see AssemblyStoreGenerator) so
+		// one image's writes cannot corrupt a neighbour sharing a page.
+		log_debug (LOG_ASSEMBLY, "assemblystore-mmap: zero-copy mapping assembly '{}' ({} bytes)"sv, name, e.descriptor->data_size);
 
 		if (FastTiming::enabled ()) [[unlikely]] {
 			internal_timing.start_event (TimingEventKind::AssemblyLoad);
 		}
 
-		uint8_t *rw_pointer = static_cast<uint8_t*>(malloc (e.descriptor->data_size));
-		memcpy (rw_pointer, e.image_data, e.descriptor->data_size);
+		set_assembly_data_and_size (e.image_data, e.descriptor->data_size, assembly_data, assembly_data_size);
 
 		if (FastTiming::enabled ()) [[unlikely]] {
 			internal_timing.end_event (true /* uses more info */);
 
 			dynamic_local_string<SENSIBLE_TYPE_NAME_LENGTH> msg;
 			msg.append (name);
-			msg.append (" (memcpy to r/w area, part of assembly load time)"sv);
+			msg.append (" (zero-copy mmap COW pointer)"sv);
 			internal_timing.add_more_info (msg);
 		}
-
-		set_assembly_data_and_size (rw_pointer, e.descriptor->data_size, assembly_data, assembly_data_size);
-		// HACK! END
-		// 	set_assembly_data_and_size (e.image_data, e.descriptor->data_size, assembly_data, assembly_data_size);
 	}
 
 	return {assembly_data, assembly_data_size};
@@ -192,9 +200,39 @@ auto AssemblyStore::find_assembly_store_entry (hash_t hash, const AssemblyStoreI
 	return nullptr;
 }
 
+void AssemblyStore::register_extra_assembly (std::string_view const& name, int fd, std::string_view const& apk_path, uint32_t offset, uint32_t size) noexcept
+{
+	detail::mmap_info map = Util::mmap_file (fd, offset, size, apk_path);
+	auto [payload_start, payload_size] = Util::get_wrapper_dso_payload_pointer_and_size (map, apk_path);
+
+	// CoreCLR needs a writable image (see the get_assembly_data HACK), so copy the payload into a
+	// read-write buffer that lives for the process lifetime.
+	uint8_t *rw = static_cast<uint8_t*>(malloc (payload_size));
+	memcpy (rw, payload_start, payload_size);
+
+	hash_t name_hash = xxhash::hash (name.data (), name.length ());
+	extra_assemblies.push_back (ExtraAssembly { name_hash, rw, static_cast<uint32_t>(payload_size) });
+
+	log_debug (
+		LOG_ASSEMBLY,
+		"assemblystore-mmap: registered extra assembly '{}' (hash 0x{:x}, {} bytes) from '{}'"sv,
+		name, name_hash, payload_size, apk_path
+	);
+}
+
 auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*
 {
 	hash_t name_hash = xxhash::hash (name.data (), name.length ());
+
+	// EXPERIMENT (assemblystore-mmap hybrid): out-of-store assemblies (R2R composites) live in
+	// per-ABI lib/<abi>/*.so entries instead of the shared store; serve them here.
+	for (ExtraAssembly const& extra : extra_assemblies) {
+		if (extra.name_hash == name_hash) {
+			size = extra.size;
+			log_debug (LOG_ASSEMBLY, "assemblystore-mmap: serving extra assembly '{}' ({} bytes)"sv, name, extra.size);
+			return extra.data;
+		}
+	}
 
 	if constexpr (Constants::is_debug_build) {
 		// In fastdev mode we might not have any assembly store.
@@ -259,9 +297,9 @@ auto AssemblyStore::open_assembly (std::string_view const& name, int64_t &size) 
 	return assembly_data;
 }
 
-void AssemblyStore::map (int fd, std::string_view const& apk_path, std::string_view const& store_path, uint32_t offset, uint32_t size) noexcept
+void AssemblyStore::map (int fd, std::string_view const& apk_path, std::string_view const& store_path, uint32_t offset, uint32_t size, bool writable) noexcept
 {
-	detail::mmap_info assembly_store_map = Util::mmap_file (fd, offset, size, store_path);
+	detail::mmap_info assembly_store_map = Util::mmap_file (fd, offset, size, store_path, writable);
 
 	auto [payload_start, payload_size] = Util::get_wrapper_dso_payload_pointer_and_size (assembly_store_map, store_path);
 	log_debug (LOG_ASSEMBLY, "Adjusted assembly store pointer: {:p}; size: {}"sv, payload_start, payload_size);
@@ -313,4 +351,156 @@ void AssemblyStore::map (int fd, std::string_view const& apk_path, std::string_v
 	assembly_store_hashes = reinterpret_cast<AssemblyStoreIndexEntry*>(assembly_store.data_start + header_size);
 
 	log_debug (LOG_ASSEMBLY, "Mapped assembly store {}"sv, get_full_store_path ());
+}
+
+// EXPERIMENT (assemblystore-mmap): the assembly store is shipped as a plain, DEFLATE-compressed
+// APK asset (`assemblies/<abi>/libassembly-store.assemblystore`) rather than a native library, so
+// that Google Play keeps it compressed for AAB delivery. It cannot be mmap'd straight from the APK
+// (compressed ZIP entries are not contiguous uncompressed bytes), so on the first launch we inflate
+// it once into the app's files dir and, on every launch, mmap that uncompressed on-disk copy with
+// no per-assembly decompression.
+bool AssemblyStore::try_extract_and_map (std::string_view const& apk_path, std::string_view const& override_dir) noexcept
+{
+	int apk_fd = open (apk_path.data (), O_RDONLY);
+	if (apk_fd < 0) {
+		log_warn (LOG_ASSEMBLY, "assemblystore-mmap: unable to open APK '{}': {}"sv, apk_path, std::strerror (errno));
+		return false;
+	}
+
+	std::string entry_name;
+	entry_name.append ("assets/"sv);
+	entry_name.append (Constants::assembly_store_asset_file_name);
+
+	Zip::zip_entry_info info {};
+	if (!Zip::find_entry (apk_fd, apk_path, entry_name, info)) {
+		close (apk_fd);
+		return false;
+	}
+
+	log_debug (
+		LOG_ASSEMBLY,
+		"assemblystore-mmap: found store asset '{}' (offset {}, {} compressed, {} uncompressed, method {})"sv,
+		entry_name, info.data_offset, info.compressed_size, info.uncompressed_size, info.compression_method
+	);
+
+	std::string dest;
+	dest.append (override_dir);
+	dest.append ("/"sv);
+	dest.append (Constants::assembly_store_asset_file_name);
+
+	// Extract once: reuse an already-extracted copy of the expected size.
+	struct stat st;
+	bool need_extract = !(stat (dest.c_str (), &st) == 0 && static_cast<uint32_t>(st.st_size) == info.uncompressed_size);
+
+	if (need_extract) {
+		if (FastTiming::enabled ()) [[unlikely]] {
+			internal_timing.start_event (TimingEventKind::AssemblyDecompression);
+		}
+
+		// The override/files sub-directory may not exist yet; create it recursively.
+		{
+			std::string partial;
+			for (char c : dest) {
+				if (c == '/' && !partial.empty ()) {
+					mkdir (partial.c_str (), 0700); // best-effort; EEXIST is fine
+				}
+				partial += c;
+			}
+		}
+
+		std::vector<uint8_t> compressed (info.compressed_size);
+		size_t total = 0;
+		while (total < info.compressed_size) {
+			ssize_t n = pread (apk_fd, compressed.data () + total, info.compressed_size - total, static_cast<off_t>(info.data_offset + total));
+			if (n < 0) {
+				if (errno == EINTR) {
+					continue;
+				}
+				Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: failed to read store data from APK: {}", std::strerror (errno)));
+			}
+			if (n == 0) {
+				break;
+			}
+			total += static_cast<size_t>(n);
+		}
+
+		std::string tmp = dest;
+		tmp.append (".tmp"sv);
+		int out_fd = open (tmp.c_str (), O_WRONLY | O_CREAT | O_TRUNC, 0600);
+		if (out_fd < 0) {
+			Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: unable to create '{}': {}", tmp, std::strerror (errno)));
+		}
+
+		auto write_all = [](int fd, const uint8_t *data, size_t len) -> bool {
+			size_t off = 0;
+			while (off < len) {
+				ssize_t w = write (fd, data + off, len - off);
+				if (w < 0) {
+					if (errno == EINTR) {
+						continue;
+					}
+					return false;
+				}
+				off += static_cast<size_t>(w);
+			}
+			return true;
+		};
+
+		bool ok = true;
+		if (info.compression_method == 0) {
+			ok = write_all (out_fd, compressed.data (), info.compressed_size);
+		} else {
+			z_stream zs {};
+			if (inflateInit2 (&zs, -MAX_WBITS) != Z_OK) {
+				Helpers::abort_application (LOG_ASSEMBLY, "assemblystore-mmap: inflateInit2 failed"sv);
+			}
+			zs.next_in = compressed.data ();
+			zs.avail_in = info.compressed_size;
+			std::vector<uint8_t> outbuf (256uz * 1024uz);
+			int ret;
+			do {
+				zs.next_out = outbuf.data ();
+				zs.avail_out = static_cast<uInt>(outbuf.size ());
+				ret = inflate (&zs, Z_NO_FLUSH);
+				if (ret != Z_OK && ret != Z_STREAM_END) {
+					inflateEnd (&zs);
+					Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: inflate failed with code {}", ret));
+				}
+				size_t have = outbuf.size () - zs.avail_out;
+				if (!write_all (out_fd, outbuf.data (), have)) {
+					ok = false;
+					break;
+				}
+			} while (ret != Z_STREAM_END);
+			inflateEnd (&zs);
+		}
+
+		if (!ok) {
+			Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: failed to write '{}': {}", tmp, std::strerror (errno)));
+		}
+
+		fsync (out_fd);
+		close (out_fd);
+		if (rename (tmp.c_str (), dest.c_str ()) != 0) {
+			Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: failed to rename '{}' to '{}': {}", tmp, dest, std::strerror (errno)));
+		}
+
+		if (FastTiming::enabled ()) [[unlikely]] {
+			internal_timing.end_event (true /* uses_more_info */);
+			internal_timing.add_more_info ("assemblystore-mmap extract"sv);
+		}
+		log_debug (LOG_ASSEMBLY, "assemblystore-mmap: extracted store to '{}' ({} bytes)"sv, dest, info.uncompressed_size);
+	} else {
+		log_debug (LOG_ASSEMBLY, "assemblystore-mmap: reusing extracted store '{}'"sv, dest);
+	}
+
+	close (apk_fd);
+
+	int store_fd = open (dest.c_str (), O_RDONLY);
+	if (store_fd < 0) {
+		Helpers::abort_application (LOG_ASSEMBLY, std::format ("assemblystore-mmap: unable to open extracted store '{}': {}", dest, std::strerror (errno)));
+	}
+	AssemblyStore::map (store_fd, dest, 0, info.uncompressed_size, /* writable */ true);
+	close (store_fd);
+	return true;
 }

--- a/src/native/clr/host/host.cc
+++ b/src/native/clr/host/host.cc
@@ -148,6 +148,21 @@ auto Host::zip_scan_callback (std::string_view const& apk_path, int apk_fd, dyna
 		}
 	}
 
+	// EXPERIMENT (assemblystore-mmap hybrid): a per-ABI ReadyToRun composite image, shipped as a
+	// DSO-wrapped `lib/<abi>/lib<Name>.so`, is served from memory by AssemblyStore (it lives outside
+	// the shared, architecture-independent assembly store).
+	if (entry_name.ends_with (".r2r.dll.so"sv)) {
+		std::string_view full { entry_name.get (), entry_name.length () };
+		auto slash = full.rfind ('/');
+		std::string_view base = (slash == std::string_view::npos) ? full : full.substr (slash + 1);
+		if (base.length () > 6) { // "lib" + name + ".so"
+			std::string_view asm_name = base.substr (3, base.length () - 6);
+			log_debug (LOG_ASSEMBLY, "assemblystore-mmap: found R2R composite '{}' -> assembly '{}'"sv, entry_name.get (), asm_name);
+			AssemblyStore::register_extra_assembly (asm_name, apk_fd, apk_path, offset, size);
+		}
+		return false; // keep the APK open
+	}
+
 	if (!AndroidSystem::is_embedded_dso_mode_enabled () || !entry_name.starts_with (Zip::lib_prefix) || !entry_name.ends_with (Constants::dso_suffix)) {
 		return false;
 	}
@@ -265,6 +280,19 @@ void Host::gather_assemblies_and_libraries (jstring_array_wrapper& runtimeApks, 
 	int64_t apk_count = static_cast<int64_t>(runtimeApks.get_length ());
 	bool got_split_config_abi_apk = false;
 	std::string_view base_apk{};
+
+	// EXPERIMENT (assemblystore-mmap): the assembly store ships as a DEFLATE-compressed, non-.so
+	// APK asset. Extract it once into the app's files dir and mmap that uncompressed copy before we
+	// scan the APK(s) for shared libraries, so the regular scan below skips the store lookup.
+	{
+		std::string const& override_dir = AndroidSystem::get_primary_override_dir ();
+		for (int64_t i = 0; i < apk_count && !found_assembly_store; i++) {
+			std::string_view apk_file = runtimeApks [static_cast<size_t>(i)].get_string_view ();
+			if (AssemblyStore::try_extract_and_map (apk_file, override_dir)) {
+				found_assembly_store = true;
+			}
+		}
+	}
 
 	for (int64_t i = 0; i < apk_count; i++) {
 		std::string_view apk_file = runtimeApks [static_cast<size_t>(i)].get_string_view ();

--- a/src/native/clr/include/constants.hh
+++ b/src/native/clr/include/constants.hh
@@ -105,6 +105,11 @@ namespace xamarin::android {
 	public:
 		static constexpr std::string_view assembly_store_file_name { "libassembly-store.so" };
 
+		// EXPERIMENT (assemblystore-mmap): name of the raw assembly store when shipped as a
+		// plain, DEFLATE-compressed APK asset (not a native library) and of the copy the
+		// runtime extracts once into the app's files dir before mmap'ing it.
+		static constexpr std::string_view assembly_store_asset_file_name { "libassembly-store.assemblystore" };
+
 		static constexpr auto split_config_abi_apk_name = concat_string_views<split_config_abi_apk_name_size> (split_config_prefix, android_abi, split_config_extension);
 		static constexpr std::string_view base_apk_name = { "/base.apk" };
 

--- a/src/native/clr/include/host/assembly-store.hh
+++ b/src/native/clr/include/host/assembly-store.hh
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string_view>
 #include <tuple>
+#include <vector>
 
 #include <xamarin-app.hh>
 #include <runtime-base/strings.hh>
@@ -15,12 +16,22 @@ namespace xamarin::android {
 	public:
 		static auto open_assembly (std::string_view const& name, int64_t &size) noexcept -> void*;
 
-		static void map (int fd, std::string_view const& apk_path, std::string_view const& store_path, uint32_t offset, uint32_t size) noexcept;
+		static void map (int fd, std::string_view const& apk_path, std::string_view const& store_path, uint32_t offset, uint32_t size, bool writable = false) noexcept;
 
-		static void map (int fd, std::string_view const& file_path, uint32_t offset, uint32_t size) noexcept
+		static void map (int fd, std::string_view const& file_path, uint32_t offset, uint32_t size, bool writable = false) noexcept
 		{
-			map (fd, {}, file_path, offset, size);
+			map (fd, {}, file_path, offset, size, writable);
 		}
+
+		// EXPERIMENT (assemblystore-mmap): find the DEFLATE-compressed assembly store asset in
+		// the given APK, extract it once (uncompressed) into `override_dir`, and mmap it from
+		// disk. Returns `true` if the store was found and mapped.
+		static bool try_extract_and_map (std::string_view const& apk_path, std::string_view const& override_dir) noexcept;
+
+		// EXPERIMENT (assemblystore-mmap hybrid): register an assembly (e.g. a per-ABI ReadyToRun
+		// composite image) that lives outside the shared assembly store, mmap'd from a DSO-wrapped
+		// `lib/<abi>/*.so` entry in the APK, so `open_assembly` can serve it by name.
+		static void register_extra_assembly (std::string_view const& name, int fd, std::string_view const& apk_path, uint32_t offset, uint32_t size) noexcept;
 
 	private:
 		static void set_assembly_data_and_size (uint8_t* source_assembly_data, uint32_t source_assembly_data_size, uint8_t*& dest_assembly_data, uint32_t& dest_assembly_data_size) noexcept;
@@ -32,5 +43,14 @@ namespace xamarin::android {
 	private:
 		static inline AssemblyStoreIndexEntry *assembly_store_hashes = nullptr;
 		static inline std::mutex  assembly_decompress_mutex {};
+
+		// EXPERIMENT (assemblystore-mmap hybrid): out-of-store assemblies (ReadyToRun composites)
+		// keyed by name hash, each an in-memory pointer + size.
+		struct ExtraAssembly {
+			hash_t   name_hash;
+			uint8_t *data;
+			uint32_t size;
+		};
+		static inline std::vector<ExtraAssembly> extra_assemblies {};
 	};
 }

--- a/src/native/clr/include/runtime-base/util.hh
+++ b/src/native/clr/include/runtime-base/util.hh
@@ -195,7 +195,7 @@ namespace xamarin::android {
 			return page_size;
 		}
 
-		static detail::mmap_info mmap_file (int fd, uint32_t offset, size_t size, std::string_view const& filename) noexcept
+		static detail::mmap_info mmap_file (int fd, uint32_t offset, size_t size, std::string_view const& filename, bool writable = false) noexcept
 		{
 			detail::mmap_info file_info;
 			detail::mmap_info mmap_info;
@@ -205,7 +205,13 @@ namespace xamarin::android {
 			size_t offsetPage     = offset - offsetFromPage;
 			size_t offsetSize     = size + offsetFromPage;
 
-			mmap_info.area		  = mmap (nullptr, offsetSize, PROT_READ, MAP_PRIVATE, fd, static_cast<off_t>(offsetPage));
+			// EXPERIMENT (assemblystore-mmap zero-copy): when `writable` is set we map the file
+			// MAP_PRIVATE with PROT_READ|PROT_WRITE so callers can hand the mapped bytes straight to
+			// a consumer that writes into them (e.g. CoreCLR patching a PE image in place). Writes
+			// are copy-on-write: only the touched pages are privately copied, untouched pages stay
+			// demand-paged and shared with the file's page cache, and the backing file is unchanged.
+			int prot = writable ? (PROT_READ | PROT_WRITE) : PROT_READ;
+			mmap_info.area		  = mmap (nullptr, offsetSize, prot, MAP_PRIVATE, fd, static_cast<off_t>(offsetPage));
 
 			if (mmap_info.area == MAP_FAILED) {
 				Helpers::abort_application (
@@ -222,6 +228,15 @@ namespace xamarin::android {
 			mmap_info.size = offsetSize;
 			file_info.area = pointer_add (mmap_info.area, offsetFromPage);
 			file_info.size = size;
+
+			// EXPERIMENT (assemblystore-mmap zero-copy): when we intend to hand these bytes to CoreCLR
+			// directly (writable path), advise the kernel to read the whole region ahead sequentially.
+			// This turns the many small, random demand-fault reads that CoreCLR would otherwise trigger
+			// while loading assemblies into one efficient prefetch, which matters because startup ends
+			// up touching almost every page anyway.
+			if (writable) {
+				madvise (mmap_info.area, offsetSize, MADV_WILLNEED);
+			}
 
 			log_info (
 				LOG_ASSEMBLY,
@@ -250,16 +265,16 @@ namespace xamarin::android {
 			auto elf_bytes = static_cast<const uint8_t* const>(mapped_elf);
 			auto elf_header = reinterpret_cast<const Elf_Header*const>(mapped_elf);
 
-			if constexpr (Constants::is_debug_build) {
-				// In debug mode we might be dealing with plain data, without DSO wrapper
-				if (elf_header->e_ident[EI_MAG0] != ELFMAG0 ||
-					elf_header->e_ident[EI_MAG1] != ELFMAG1 ||
-					elf_header->e_ident[EI_MAG2] != ELFMAG2 ||
-					elf_header->e_ident[EI_MAG3] != ELFMAG3) {
-						log_debug (LOG_ASSEMBLY, "Not an ELF image: {}", file_name);
-						// Not an ELF image, just return what we mmapped before
-						return { map_info.area, map_info.size };
-				}
+			// EXPERIMENT (assemblystore-mmap): the assembly store may be a raw (non-ELF) blob that
+			// was extracted from the APK rather than a DSO-wrapped native library, so always check
+			// the ELF magic and return the mapping as-is when it is not an ELF image.
+			if (elf_header->e_ident[EI_MAG0] != ELFMAG0 ||
+				elf_header->e_ident[EI_MAG1] != ELFMAG1 ||
+				elf_header->e_ident[EI_MAG2] != ELFMAG2 ||
+				elf_header->e_ident[EI_MAG3] != ELFMAG3) {
+					log_debug (LOG_ASSEMBLY, "Not an ELF image: {}", file_name);
+					// Not an ELF image, just return what we mmapped before
+					return { map_info.area, map_info.size };
 			}
 
 			auto section_header = reinterpret_cast<const Elf_SHeader*const>(elf_bytes + elf_header->e_shoff);

--- a/src/native/clr/include/startup/zip.hh
+++ b/src/native/clr/include/startup/zip.hh
@@ -36,9 +36,20 @@ namespace xamarin::android {
 			uint32_t			    local_header_offset;
 			uint32_t			    data_offset;
 			uint32_t			    file_size;
+			uint32_t			    compressed_size;
 			bool				    bundled_assemblies_slow_path;
 			uint32_t			    max_assembly_name_size;
 			uint32_t			    max_assembly_file_name_size;
+		};
+
+		// EXPERIMENT (assemblystore-mmap): information about a single ZIP entry located by name,
+		// used to extract the DEFLATE-compressed assembly store asset from the APK.
+		struct zip_entry_info
+		{
+			uint32_t data_offset;        // offset of the entry's file data within the APK
+			uint32_t compressed_size;    // size of the (possibly compressed) data in the APK
+			uint32_t uncompressed_size;  // size of the data once decompressed
+			uint16_t compression_method; // 0 == stored, 8 == deflate
 		};
 
 	private:
@@ -74,6 +85,11 @@ namespace xamarin::android {
 		// was interesting/useful), then the APK file descriptor is closed. Otherwise, the descriptor is
 		// kept open since we will need it later on.
 		static void scan_archive (std::string_view const& apk_path, ScanCallbackFn entry_cb) noexcept;
+
+		// EXPERIMENT (assemblystore-mmap): locate a single ZIP entry by its exact name, without
+		// the `lib/{ABI}/` prefix filtering or the "must be stored uncompressed" requirement that
+		// `scan_archive` imposes. Returns `true` and fills `out` when the entry is found.
+		static bool find_entry (int apk_fd, std::string_view const& apk_path, std::string_view const& entry_name, zip_entry_info& out) noexcept;
 
 	private:
 		static std::tuple<const char*, uint32_t> get_assemblies_prefix_and_length () noexcept;

--- a/src/native/clr/startup/zip.cc
+++ b/src/native/clr/startup/zip.cc
@@ -77,6 +77,7 @@ bool Zip::zip_adjust_data_offset (int fd, zip_scan_state &state) noexcept
 bool Zip::zip_read_entry_info (std::vector<uint8_t> const& buf, dynamic_local_string<SENSIBLE_PATH_MAX>& file_name, zip_scan_state &state) noexcept
 {
 	constexpr size_t CD_COMPRESSION_METHOD_OFFSET = 10uz;
+	constexpr size_t CD_COMPRESSED_SIZE_OFFSET    = 20uz;
 	constexpr size_t CD_UNCOMPRESSED_SIZE_OFFSET  = 24uz;
 	constexpr size_t CD_FILENAME_LENGTH_OFFSET	  = 28uz;
 	constexpr size_t CD_EXTRA_LENGTH_OFFSET		  = 30uz;
@@ -106,6 +107,12 @@ bool Zip::zip_read_entry_info (std::vector<uint8_t> const& buf, dynamic_local_st
 	index = state.buf_offset + CD_UNCOMPRESSED_SIZE_OFFSET;;
 	if (!zip_read_field (buf, index, state.file_size)) {
 		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'uncompressed size' field"sv);
+		return false;
+	}
+
+	index = state.buf_offset + CD_COMPRESSED_SIZE_OFFSET;
+	if (!zip_read_field (buf, index, state.compressed_size)) {
+		log_error (LOG_ASSEMBLY, "Failed to read Central Directory entry 'compressed size' field"sv);
 		return false;
 	}
 
@@ -418,6 +425,7 @@ bool Zip::zip_scan_entries (int apk_fd, std::string_view const& apk_path, ScanCa
 		.local_header_offset = 0u,
 		.data_offset		 = 0u,
 		.file_size			 = 0u,
+		.compressed_size	 = 0u,
 		.bundled_assemblies_slow_path = false,
 		.max_assembly_name_size = 0u,
 		.max_assembly_file_name_size = 0u,
@@ -454,6 +462,75 @@ bool Zip::zip_scan_entries (int apk_fd, std::string_view const& apk_path, ScanCa
 	}
 
 	return keep_archive_open;
+}
+
+bool Zip::find_entry (int apk_fd, std::string_view const& apk_path, std::string_view const& entry_name, zip_entry_info& out) noexcept
+{
+	uint32_t cd_offset;
+	uint32_t cd_size;
+	uint16_t cd_entries;
+
+	if (!zip_read_cd_info (apk_fd, cd_offset, cd_size, cd_entries)) {
+		log_error (LOG_ASSEMBLY, "Failed to read the EOCD record from APK file {}", apk_path);
+		return false;
+	}
+
+	if (::lseek (apk_fd, static_cast<off_t>(cd_offset), SEEK_SET) < 0) {
+		log_error (LOG_ASSEMBLY, "Failed to seek to central directory in APK {}: {}", apk_path, std::strerror (errno));
+		return false;
+	}
+
+	std::vector<uint8_t> buf (cd_size);
+	ssize_t nread;
+	do {
+		nread = read (apk_fd, buf.data (), buf.size ());
+	} while (nread < 0 && errno == EINTR);
+
+	if (static_cast<size_t>(nread) != cd_size) {
+		log_error (LOG_ASSEMBLY, "Failed to read Central Directory from APK {}: {}", apk_path, std::strerror (errno));
+		return false;
+	}
+
+	zip_scan_state state {
+		.file_fd			 = apk_fd,
+		.file_name			 = apk_path,
+		.prefix				 = "",
+		.prefix_len			 = 0u,
+		.buf_offset			 = 0uz,
+		.compression_method	 = 0u,
+		.local_header_offset = 0u,
+		.data_offset		 = 0u,
+		.file_size			 = 0u,
+		.compressed_size	 = 0u,
+		.bundled_assemblies_slow_path = false,
+		.max_assembly_name_size = 0u,
+		.max_assembly_file_name_size = 0u,
+	};
+
+	dynamic_local_string<SENSIBLE_PATH_MAX> cur_name;
+	for (size_t i = 0uz; i < cd_entries; i++) {
+		if (!zip_read_entry_info (buf, cur_name, state)) {
+			log_error (LOG_ASSEMBLY, "Failed to read Central Directory info for entry {} in APK {}", i, apk_path);
+			return false;
+		}
+
+		if (cur_name.length () != entry_name.length () || memcmp (cur_name.get (), entry_name.data (), entry_name.length ()) != 0) {
+			continue;
+		}
+
+		if (!zip_adjust_data_offset (apk_fd, state)) {
+			log_error (LOG_ASSEMBLY, "Failed to adjust data offset for entry {} in APK {}", i, apk_path);
+			return false;
+		}
+
+		out.data_offset        = state.data_offset;
+		out.compressed_size    = state.compressed_size;
+		out.uncompressed_size  = state.file_size;
+		out.compression_method = state.compression_method;
+		return true;
+	}
+
+	return false;
 }
 
 void Zip::scan_archive (std::string_view const& apk_path, ScanCallbackFn entry_cb) noexcept


### PR DESCRIPTION
> **Draft / experiment — not for merge.** Opened for review and to weigh the feasibility of two directions for the assembly store, related to #11668 and #11729. Measured on a single low-end device; numbers are directional.

## What this explores

An alternative to manually LZ4-compressing the assembly store: ship the store **uncompressed** and load assemblies via a **copy-on-write `mmap`** with **no per-assembly decompression and no memcpy**.

- Store ships as a plain, DEFLATE-compressed APK asset (`assets/libassembly-store.assemblystore`) rather than a DSO-wrapped `lib/<abi>/libassembly-store.so`. Assets stay zip-compressed (small download) and Play does **not** force them uncompressed the way it does native libs.
- The runtime inflates the store **once** into the app's files dir (system `libz`) and `mmap`s the uncompressed copy `MAP_PRIVATE, PROT_READ|PROT_WRITE`, then hands CoreCLR **pointers straight into the mapping**. Writes fault in copy-on-write (only touched pages); everything else stays demand-paged and shared with the page cache.
- Each assembly is **16 KB page-aligned** in the store so one image's in-place writes can't corrupt a page-sharing neighbour (without this, CoreCLR crashes with a managed stack overflow during init).
- **Hybrid R2R:** the architecture-specific ReadyToRun **composite** (`*.r2r.dll`) is peeled out of the (architecture-independent) store and packaged per-ABI under `lib/<abi>/`, so an AAB can ABI-split it.

## Results (Samsung Galaxy A16, arm64, Release, R2R MAUI app, interleaved cold starts)

| metric | LZ4 baseline | this experiment | Δ |
|---|---|---|---|
| Cold start (median) | 1301 ms | 1286 ms | −15 ms (noise) |
| PSS (steady) | ~119.3 MB | ~114.1 MB | **−5.2 MB** |
| RSS (steady) | ~218 MB | ~213 MB | −5.2 MB |
| Signed APK (single-arch) | 25.84 MB | 26.74 MB | **+0.9 MB** |

- **Startup:** on par with LZ4 (assembly loading is a small slice of startup; JIT/R2R dominates).
- **Memory:** consistent ~5 MB less, and the store's pages are **private-clean** (file-backed, evictable) instead of private-dirty — the advantage grows under memory pressure.
- **Size:** single-APK is +0.9 MB because the R2R composite ships **uncompressed** in `lib/`. **Non-R2R** builds are *smaller* than baseline (the whole store DEFLATEs).

## The two variants to weigh

**Variant A — this PR (uncompressed store + zero-copy mmap).** Removes the entire manual-compression subsystem (~820 lines of our code + the `.bss` decompression buffer) **and the vendored `external/lz4` fork (~28k lines)**, using OS `libz` only for a one-time extraction. Adds ~450 lines of new machinery (extract-once, zip scan, alignment, COW mapping, R2R composite split). Wins on RAM; startup-neutral.

**Variant B — codec swap to Zstd (see #11729 / the Zstd PR).** Keeps the proven compress-at-build / decompress-at-load architecture and the `.bss` buffer, swaps `LZ4`→`ZSTD` from `libSystem.IO.Compression.Native` (already in the runtime pack). ~18 lines. Also removes the `external/lz4` fork. Smaller download; ~2% slower start; far less code churn.

Both delete the `external/lz4` fork (the bulk of the maintenance burden). Variant B is the minimal-risk maintainability win; Variant A is only worth its added complexity if the zero-copy RAM behaviour (and the compressed-download-of-uncompressed-store story) is desirable.

## Known limitations (why this is a draft)

- The shared store still holds **per-arch R2R *component* assemblies**, so it is **not yet arch-neutral** — a single shared base-module store is incorrect for a real multi-arch AAB. Correct multi-arch needs **pre-crossgen IL** in the shared store (composite carries all native code per-ABI). arm64 and x64 stores currently differ byte-for-byte.
- The per-ABI R2R composite is **memcpy-served**, not zero-copy (costs back ~4 MB RAM).
- Verified on **arm64 only** — x86_64 can't be executed on an Apple-Silicon dev host; it packages symmetrically and multi-arch builds cleanly, but x64 runtime is unverified.
- CoreCLR-only.

## Commit
Files: 12 changed, ~453 insertions. See the commit message for the per-file rationale.
