### PR TITLE
[build] Don't store Windows binutils in the macOS/Linux SDK pack

### DIFF
--- a/build-tools/automation/yaml-templates/build-macos-steps.yaml
+++ b/build-tools/automation/yaml-templates/build-macos-steps.yaml
@@ -45,7 +45,7 @@ steps:
     xaSourcePath: ${{ parameters.xaSourcePath }}
 
 # Prepare and Build everything
-- script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
+- script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }} /p:ArchiveWindowsToolchainPdbFiles=true'
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
   retryCountOnTaskFailure: 1

--- a/build-tools/automation/yaml-templates/commercial-build.yaml
+++ b/build-tools/automation/yaml-templates/commercial-build.yaml
@@ -31,7 +31,7 @@ steps:
   condition: and(succeeded(), eq(variables['Codeql.Enabled'], 'true'), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
 
 # Prepare and Build everything
-- script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }}'
+- script: make jenkins CONFIGURATION=$(XA.Build.Configuration) PREPARE_CI=1 MSBUILD_ARGS='${{ parameters.makeMSBuildArgs }} /p:ArchiveWindowsToolchainPdbFiles=true'
   workingDirectory: ${{ parameters.xaSourcePath }}
   displayName: make jenkins
 

--- a/src/binutils/binutils.targets
+++ b/src/binutils/binutils.targets
@@ -10,6 +10,12 @@
     <_WindowsBinutilsInstallDir>$(MicrosoftAndroidSdkOutDir)binutils</_WindowsBinutilsInstallDir>
     <_7zaPath Condition=" '$(HostOS)' == 'Windows' ">$(Pkg7-Zip_CommandLine)\tools\x64\7za.exe</_7zaPath>
     <_7zaPath Condition=" '$(_7zaPath)' == '' ">7za</_7zaPath>
+    <!--
+      The Windows toolchain PDBs (and their matching EXEs) are only needed by CI to publish a
+      symbol archive; they are never consumed by a local build and are not shipped in any NuGet.
+      They add ~1.4 GB to the SDK pack, so only install them when a symbol archive is requested.
+    -->
+    <ArchiveWindowsToolchainPdbFiles Condition=" '$(ArchiveWindowsToolchainPdbFiles)' == '' ">false</ArchiveWindowsToolchainPdbFiles>
   </PropertyGroup>
 
   <Target Name="_DownloadBinutils"
@@ -59,27 +65,34 @@
         SkipUnchangedFiles="true"
         Condition=" '@(_HostBinutilsLibFiles)' != '' "
     />
-    <!-- Install Windows binutils -->
-    <MakeDir Directories="$(_WindowsBinutilsInstallDir)\bin" />
+    <!-- Install Windows binutils: only needed on a Windows host, where the SDK's linker path is
+         tools\binutils\bin. On macOS/Linux the SDK uses tools\<HostOS>\binutils\bin instead, so
+         these Windows binaries are never used and would only waste ~105 MB in the pack. -->
+    <MakeDir Directories="$(_WindowsBinutilsInstallDir)\bin" Condition=" '$(HostOS)' == 'Windows' " />
     <Copy
         SourceFiles="@(_WindowsBinutilsBinFiles)"
         DestinationFolder="$(_WindowsBinutilsInstallDir)\bin"
         SkipUnchangedFiles="true"
+        Condition=" '$(HostOS)' == 'Windows' "
     />
-    <!-- Copy PDBs and their corresponding EXEs for symbol archiving -->
-    <MakeDir Directories="$(_WindowsBinutilsInstallDir)\windows-toolchain-pdb" Condition=" '@(_WindowsBinutilsPdbFiles)' != '' " />
+    <!-- Copy PDBs and their corresponding EXEs for symbol archiving (CI only, opt-in) -->
+    <MakeDir Directories="$(_WindowsBinutilsInstallDir)\windows-toolchain-pdb" Condition=" '@(_WindowsBinutilsPdbFiles)' != '' and '$(ArchiveWindowsToolchainPdbFiles)' == 'true' " />
     <Copy
         SourceFiles="@(_WindowsBinutilsPdbFiles)"
         DestinationFolder="$(_WindowsBinutilsInstallDir)\windows-toolchain-pdb"
         SkipUnchangedFiles="true"
-        Condition=" '@(_WindowsBinutilsPdbFiles)' != '' "
+        Condition=" '@(_WindowsBinutilsPdbFiles)' != '' and '$(ArchiveWindowsToolchainPdbFiles)' == 'true' "
     />
     <Copy
         SourceFiles="@(_WindowsBinutilsExeForPdb)"
         DestinationFolder="$(_WindowsBinutilsInstallDir)\windows-toolchain-pdb"
         SkipUnchangedFiles="true"
-        Condition=" '@(_WindowsBinutilsExeForPdb)' != '' "
+        Condition=" '@(_WindowsBinutilsExeForPdb)' != '' and '$(ArchiveWindowsToolchainPdbFiles)' == 'true' "
     />
+    <!-- Remove any Windows binutils left over from a previous build that no longer apply, so
+         incremental builds reclaim the space without requiring a full Clean. -->
+    <RemoveDir Directories="$(_WindowsBinutilsInstallDir)\bin" Condition=" '$(HostOS)' != 'Windows' " />
+    <RemoveDir Directories="$(_WindowsBinutilsInstallDir)\windows-toolchain-pdb" Condition=" '$(ArchiveWindowsToolchainPdbFiles)' != 'true' " />
   </Target>
 
   <Target Name="_CleanBinutils" BeforeTargets="Clean">


### PR DESCRIPTION
## Summary

`_InstallBinutils` (`src/binutils/binutils.targets`) copied the Windows binutils binaries and the Windows toolchain PDBs into the SDK pack on **every** host. On macOS/Linux this wastes **~1.5 GB per build** for files that are never used locally:

- **`tools/binutils/windows-toolchain-pdb` (~1.4 GB)** — consumed only by the macOS CI leg, which zips it into a `windows-toolchain-pdb` artifact for symbol archival. Never used by a local build and not shipped in any NuGet.
- **`tools/binutils/bin` (~105 MB of Windows `.exe`)** — only the linker path on a **Windows** host. `MonoAndroidHelper.GetOSBinPath()` returns the tools root on Windows, but `tools/<HostOS>/binutils/bin` on Unix, so the Windows binaries are never referenced on macOS/Linux.

## Changes

- Install `tools/binutils/bin` only when `$(HostOS) == Windows`.
- Install `windows-toolchain-pdb` only when the new opt-in property **`$(ArchiveWindowsToolchainPdbFiles)`** is `true`. The macOS CI legs (`build-macos-steps.yaml`, `commercial-build.yaml`) set it so symbol archival is unchanged.
- Remove any stale Windows binutils left by a previous build, so incremental builds reclaim the space without a full `Clean`.

## Verification (macOS, local)

| build | pack `tools/` |
| --- | --- |
| before | 1.8 GB |
| after (default) | **345 MB** (−1.5 GB); host `Darwin/binutils` intact |
| `-p:ArchiveWindowsToolchainPdbFiles=true` | PDBs restored (1.4 GB, 7 `.pdb`) → CI zip step still works |

## Notes

This is the "don't **store** it" step. The toolchain archive is still downloaded/extracted in full (it's a single combined `.7z`); reducing the download/extract would require per-platform archives in `dotnet/android-native-tools` and is left as a follow-up.
