### PR TITLE
[Xamarin.Android.Build.Tests] Fix build warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -74,7 +74,6 @@
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'MSBuildDeviceIntegration.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'NativeAOT.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'TestRunner.Core.NET.csproj' ">true</_AllowProjectWarnings>
-    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.Build.Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.JcwGen-Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Installer.AndroidSDK.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Installer.Common.csproj' ">true</_AllowProjectWarnings>

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BindingBuildTest.cs
@@ -125,20 +125,6 @@ namespace Xamarin.Android.Build.Tests
 					Assert.IsNotNull (type, $"{assemblyPath} should contain {typeName}");
 				}
 
-				//TODO: see https://github.com/dotnet/msbuild/issues/6609
-				if (false) {
-					//A list of properties we check exist in binding projects
-					var properties = new [] {
-						"AndroidSdkBuildToolsVersion",
-						"AndroidSdkPlatformToolsVersion",
-						"AndroidSdkToolsVersion",
-						"AndroidNdkVersion",
-					};
-					foreach (var property in properties) {
-						Assert.IsTrue (StringAssertEx.ContainsText (b.LastBuildOutput, property + " = "), $"$({property}) should be set!");
-					}
-				}
-
 				Assert.IsTrue (b.Build (proj, doNotCleanupOnUpdate: true, saveProject: false), "second build should succeed");
 				foreach (var target in targets) {
 					Assert.IsTrue (b.Output.IsTargetSkipped (target, defaultIfNotUsed: true), $"`{target}` should be skipped on second build!");

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/BootAndroidEmulatorTests.cs
@@ -217,10 +217,10 @@ public class BootAndroidEmulatorTests : BaseTest
 		Assert.AreEqual ("emulator-5554", task.ResolvedDevice);
 		var bootOptions = task.LastBootOptions;
 		Assert.IsNotNull (bootOptions, "Boot options should be captured");
-		Assert.IsNotNull (bootOptions.AdditionalArgs, "AdditionalArgs should not be null");
+		Assert.IsNotNull (bootOptions?.AdditionalArgs, "AdditionalArgs should not be null");
 		CollectionAssert.AreEqual (
 			new[] { "-no-snapshot-load", "-gpu", "auto" },
-			bootOptions.AdditionalArgs,
+			bootOptions?.AdditionalArgs,
 			"Extra arguments should be parsed and passed to options");
 	}
 
@@ -291,8 +291,8 @@ public class BootAndroidEmulatorTests : BaseTest
 		Assert.IsFalse (task.Execute (), "Task should fail");
 		var error = errors.FirstOrDefault (e => e.Code == "XA0144");
 		Assert.IsNotNull (error, "Unknown errors should map to XA0144");
-		StringAssert.Contains ("Unknown", error.Message, "Error kind should be included in the message");
-		StringAssert.Contains ("Some unexpected error occurred", error.Message, "Error message should be included");
+		StringAssert.Contains ("Unknown", error?.Message, "Error kind should be included in the message");
+		StringAssert.Contains ("Some unexpected error occurred", error?.Message, "Error message should be included");
 	}
 
 	[Test]

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/LinkerTests.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Android.Build.Tests
 				assm.MainModule.Types.Add (iface);
 
 				// Create implementing class
-				var jlo = assm.MainModule.Import (android.MainModule.GetType ("Java.Lang.Object"));
+				var jlo = assm.MainModule.ImportReference (android.MainModule.GetType ("Java.Lang.Object"));
 				var impl = new TypeDefinition ("MyNamespace", "MyClass", TypeAttributes.Public, jlo);
 				impl.Interfaces.Add (new InterfaceImplementation (iface));
 
@@ -131,7 +131,7 @@ namespace Xamarin.Android.Build.Tests
 				assm.MainModule.Types.Add (iface);
 
 				// Create implementing class
-				var jlo = assm.MainModule.Import (android.MainModule.GetType ("Java.Lang.Object"));
+				var jlo = assm.MainModule.ImportReference (android.MainModule.GetType ("Java.Lang.Object"));
 				var impl = new TypeDefinition ("MyNamespace", "MyClass", TypeAttributes.Public, jlo);
 				impl.Interfaces.Add (new InterfaceImplementation (iface));
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/InlineData.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Globalization;
 using Xamarin.ProjectTools;
 
 namespace Xamarin.Android.Build.Tests


### PR DESCRIPTION
Cleans up a few compiler warnings in the build-tasks test project:

- `BindingBuildTest`: remove the dead `if (false) { … }` block (unreachable code / CS0162) that was disabled pending dotnet/msbuild#6609.
- `BootAndroidEmulatorTests`: add `?.` null-guards to silence CS8602 possible-null-dereference warnings.
- `LinkerTests`: use `ModuleDefinition.ImportReference` instead of the obsolete `Import` (CS0618).
- `InlineData`: drop the duplicate `using System.Globalization;` (CS0105).