### PR TITLE
[xaprepare] Move Configuration.OperatingSystem.props JDK values to JdkInfo.props

### DIFF
--- a/Configuration.props
+++ b/Configuration.props
@@ -8,6 +8,10 @@
       Condition=" Exists('$(MSBuildThisFileDirectory)Configuration.OperatingSystem.props') And '$(DoNotLoadOSProperties)' != 'True' "
   />
   <Import
+      Project="$(MSBuildThisFileDirectory)external\Java.Interop\bin\Build$(Configuration)\JdkInfo.props"
+      Condition=" Exists('$(MSBuildThisFileDirectory)external\Java.Interop\bin\Build$(Configuration)\JdkInfo.props') And '$(DoNotLoadOSProperties)' != 'True' "
+  />
+  <Import
       Project="$(MSBuildThisFileDirectory)Configuration.Override.props"
       Condition="Exists('$(MSBuildThisFileDirectory)Configuration.Override.props')"
   />
@@ -143,6 +147,8 @@
     <MicrosoftOpenJDKVersion Condition="'$(MicrosoftOpenJDKVersion)' == ''">21.0.8</MicrosoftOpenJDKVersion>
     <MicrosoftOpenJDKFolder Condition="'$(MicrosoftOpenJDKFolder)' == ''">jdk-21</MicrosoftOpenJDKFolder>
     <MicrosoftOpenJDKRootDirName Condition="'$(MicrosoftOpenJDKRootDirName)' == ''">jdk-21.0.8+9</MicrosoftOpenJDKRootDirName>
+    <JavaSdkVersion Condition=" '$(JavaSdkVersion)' == '' ">$(MicrosoftOpenJDKVersion)</JavaSdkVersion>
+    <MinimumSupportedJavaSdkVersion Condition=" '$(MinimumSupportedJavaSdkVersion)' == '' ">17.0</MinimumSupportedJavaSdkVersion>
     <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\$(MicrosoftOpenJDKFolder)</JavaSdkDirectory>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>

--- a/Configuration.props
+++ b/Configuration.props
@@ -150,6 +150,10 @@
     <JavaSdkVersion Condition=" '$(JavaSdkVersion)' == '' ">$(MicrosoftOpenJDKVersion)</JavaSdkVersion>
     <MinimumSupportedJavaSdkVersion Condition=" '$(MinimumSupportedJavaSdkVersion)' == '' ">17.0</MinimumSupportedJavaSdkVersion>
     <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">$(AndroidToolchainDirectory)\$(MicrosoftOpenJDKFolder)</JavaSdkDirectory>
+    <_JdkExeExtension Condition=" '$(_JdkExeExtension)' == '' And '$(HostOS)' == 'Windows' ">.exe</_JdkExeExtension>
+    <JavaPath Condition=" '$(JavaPath)' == '' ">$(JavaSdkDirectory)\bin\java$(_JdkExeExtension)</JavaPath>
+    <JavaCPath Condition=" '$(JavaCPath)' == '' ">$(JavaSdkDirectory)\bin\javac$(_JdkExeExtension)</JavaCPath>
+    <JarPath Condition=" '$(JarPath)' == '' ">$(JavaSdkDirectory)\bin\jar$(_JdkExeExtension)</JarPath>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(NUGET_PACKAGES)' != ''">$(NUGET_PACKAGES)</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' == 'Windows'">$(userprofile)\.nuget\packages</XAPackagesDir>
     <XAPackagesDir Condition=" '$(XAPackagesDir)' == '' And '$(HostOS)' != 'Windows'">$(HOME)/.nuget/packages</XAPackagesDir>

--- a/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
+++ b/build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs
@@ -15,8 +15,6 @@ namespace Xamarin.Android.Prepare
 	//
 	partial class Configurables
 	{
-		const string MicrosoftOpenJDKVersion        = "21.0.8";
-
 		static Context ctx => Context.Instance;
 
 		public static partial class Urls
@@ -32,9 +30,6 @@ namespace Xamarin.Android.Prepare
 			public static readonly char[] PropertyListSeparator            = new [] { ':' };
 
 			public static readonly string JdkFolder                        = "jdk-21";
-
-			public static readonly Version MicrosoftMinOpenJDKVersion      = new Version (17, 0);
-			public static readonly Version MicrosoftOpenJDKVersion         = new Version (Configurables.MicrosoftOpenJDKVersion);
 
 			public const string DotNetTestRuntimeVersion                   = "3.1.11";
 

--- a/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
+++ b/build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in
@@ -6,12 +6,6 @@
         <HostOsRelease Condition=" '$(HostOsRelease)' == '' ">@OS_RELEASE@</HostOsRelease>
         <HostCpuCount Condition=" '$(HostCpuCount)' == '' ">@HOST_CPUS@</HostCpuCount>
         <HostBits Condition=" '$(HostBits)' == '' ">@ARCHITECTURE_BITS@</HostBits>
-        <JavaSdkVersion>@JAVA_SDK_VERSION@</JavaSdkVersion>
-        <MinimumSupportedJavaSdkVersion>@MIN_SUPPORTED_JDK_VERSION@</MinimumSupportedJavaSdkVersion>
-        <JavaSdkDirectory Condition=" '$(JavaSdkDirectory)' == '' ">@JavaSdkDirectory@</JavaSdkDirectory>
-        <JavaCPath Condition=" '$(JavaCPath)' == '' ">@javac@</JavaCPath>
-        <JarPath Condition=" '$(JarPath)' == '' ">@jar@</JarPath>
-        <JavaPath Condition=" '$(JavaPath)' == '' ">@java@</JavaPath>
         <NdkLlvmTag Condition=" '$(NdkLlvmTag)' == '' ">@NDK_LLVM_TAG@</NdkLlvmTag>
     </PropertyGroup>
 </Project>

--- a/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
+++ b/build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs
@@ -62,13 +62,7 @@ namespace Xamarin.Android.Prepare
 				{ "@OS_RELEASE@",           context.OS.Release ?? String.Empty },
 				{ "@HOST_CPUS@",            context.OS.CPUCount.ToString () },
 				{ "@ARCHITECTURE_BITS@",    context.OS.Is64Bit ? "64" : "32" },
-				{ "@JAVA_SDK_VERSION@",     Configurables.Defaults.MicrosoftOpenJDKVersion.ToString () },
-				{ "@JavaSdkDirectory@",     context.OS.JavaHome },
-				{ "@javac@",                context.OS.JavaCPath },
-				{ "@java@",                 context.OS.JavaPath },
-				{ "@jar@",                  context.OS.JarPath },
 				{ "@NDK_LLVM_TAG@",         $"{context.OS.Type.ToLowerInvariant ()}-x86_64" },
-				{ "@MIN_SUPPORTED_JDK_VERSION@",    $"{Configurables.Defaults.MicrosoftMinOpenJDKVersion.Major}.0" },
 			};
 
 			return new GeneratedPlaceholdersFile (


### PR DESCRIPTION
## Summary

JDK-related properties are now sourced from Java.Interop's `JdkInfo` MSBuild task (in-tree since #11744) plus `Configuration.props`. The `Configuration.OperatingSystem.props` generator in xaprepare no longer writes any JDK values — only the NDK/OS-info half remains, which will be removed in a follow-up slice.

## Changes

- **`Configuration.props`**
  - Imports `external\Java.Interop\bin\Build$(Configuration)\JdkInfo.props` immediately after `Configuration.OperatingSystem.props`. Java.Interop supplies `JavaSdkDirectory`, `JavaPath`, `JavaCPath`, `JarPath` (plus additional JDK metadata) once Prepare has run.
  - Sets `JavaSdkVersion` (= `$(MicrosoftOpenJDKVersion)`) and `MinimumSupportedJavaSdkVersion` (= `17.0`) directly, since `JdkInfo.props` does not emit those two policy constants.
  - Adds conditional `JavaPath`, `JavaCPath`, `JarPath` fallbacks derived from `$(JavaSdkDirectory)\bin\{tool}{.exe on Windows}` — mirroring what xaprepare's `OS.cs` computed pre-slice. This ensures those properties are always defined for consumers that read them directly (e.g. `src/Mono.Android/Mono.Android.targets`, `build-tools/scripts/JavaCallableWrappers.targets`, `src/java-runtime/java-runtime.targets`, `build-tools/create-android-api/create-android-api.csproj`) even before `PrepareJavaInterop` has generated `JdkInfo.props`. When `JdkInfo.props` is imported, its conditional values win.
- **`build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in`** — removes `JavaSdkVersion`, `MinimumSupportedJavaSdkVersion`, `JavaSdkDirectory`, `JavaCPath`, `JarPath`, `JavaPath`.
- **`build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs`** — removes the six matching entries from the `replacements` dictionary.
- **`build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs`** — deletes now-dead `MicrosoftOpenJDKVersion` (const string + `Version` field) and `MicrosoftMinOpenJDKVersion`. Grep confirms zero remaining consumers under `build-tools/xaprepare`.

`OS.JavaHome`/`JavaCPath`/`JavaPath`/`JarPath` are intentionally left in place — `Windows.cs` still uses `JavaHome` for the `JAVA_HOME` env var. Removing those OS discovery paths is deferred to the next slice.

## Verification

**xaprepare build**: `dotnet build build-tools\xaprepare\xaprepare\xaprepare.csproj -c Debug` → 0 warnings, 0 errors.

**Effective-value verification** — three states via a probe project that imports `Configuration.props` with `AndroidToolchainDirectory=C:\android-toolchain`:

Pre-slice equivalent (simulated `Configuration.OperatingSystem.props` present, no `JdkInfo.props`):
```
JavaSdkVersion=21.0.8
MinimumSupportedJavaSdkVersion=17.0
JavaSdkDirectory=C:\jdk-21
JavaCPath=C:\jdk-21\bin\javac.exe
JarPath=C:\jdk-21\bin\jar.exe
JavaPath=C:\jdk-21\bin\java.exe
```

Post-slice, fresh clone (no `Configuration.OperatingSystem.props`, no `JdkInfo.props` — fallbacks fire):
```
JavaSdkVersion=21.0.8
MinimumSupportedJavaSdkVersion=17.0
JavaSdkDirectory=C:\android-toolchain\jdk-21
JavaCPath=C:\android-toolchain\jdk-21\bin\javac.exe
JarPath=C:\android-toolchain\jdk-21\bin\jar.exe
JavaPath=C:\android-toolchain\jdk-21\bin\java.exe
```

Post-slice, post-Prepare (with `JdkInfo.props` supplying real paths):
```
JavaSdkVersion=21.0.8
MinimumSupportedJavaSdkVersion=17.0
JavaSdkDirectory=D:\real-jdk\jdk-21
JavaCPath=D:\real-jdk\jdk-21\bin\javac.exe
JarPath=D:\real-jdk\jdk-21\bin\jar.exe
JavaPath=D:\real-jdk\jdk-21\bin\java.exe
```

**Grep audit** under `build-tools/xaprepare/`: zero references to `@JAVA_SDK_VERSION@`, `@MIN_SUPPORTED_JDK_VERSION@`, `@javac@`, `@java@`, `@jar@`, `MicrosoftOpenJDKVersion`, or `MicrosoftMinOpenJDKVersion` remain. `@JavaSdkDirectory@` still appears in `xaprepare.targets` / `Properties.Defaults.cs.in` — that's the unrelated compile-time replacement in `Properties.Defaults.cs`, intentionally left alone.

Cold `-t:Prepare` was not run in this environment (no Android toolchain / network); the fallback logic above ensures behavior is well-defined in every state along the Prepare pipeline.

## File list

| File | +/- |
| --- | --- |
| `Configuration.props` | +10 |
| `build-tools/xaprepare/xaprepare/ConfigAndData/Configurables.cs` | −5 |
| `build-tools/xaprepare/xaprepare/Resources/Configuration.OperatingSystem.props.in` | −6 |
| `build-tools/xaprepare/xaprepare/Steps/Step_GenerateFiles.cs` | −6 |

Net: +10 / −17 (−7 LOC).

## Precedent

Continues the incremental xaprepare removal in #11568, #11580, #11608, #11613, #11631, #11731, #11732, #11733, #11737, #11740, #11760, #11803, #11821, #11825, #11826, #11945, #11946.