### PR TITLE
[ci] Fix Java.Interop test lanes on internal 1ES pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -419,6 +419,7 @@ stages:
       name: $(NetCorePublicPoolName)
       demands:
       - ImageOverride -equals $(WindowsPoolImageNetCorePublic)
+      os: windows
     macPool:
       name: AcesShared
       demands:

--- a/build-tools/automation/azure-pipelines.yaml
+++ b/build-tools/automation/azure-pipelines.yaml
@@ -100,6 +100,15 @@ extends:
         usesCleanImages: ${{ parameters.macTestAgentsUseCleanImages }}
 
     - template: /build-tools/automation/yaml-templates/stage-java-interop-tests.yaml@self
+      parameters:
+        # The internal Xamarin.Android pipeline uses 1ES Pipeline Templates, which
+        # require Windows jobs to run on a 1ES-hosted pool. macOS is fine on the
+        # hosted Azure Pipelines pool as long as `os: macOS` is set (which is now
+        # the template default).
+        windowsPool:
+          name: MAUI-1ESPT
+          image: $(WindowsPoolImage1ESPT)
+          os: windows
 
     - stage: maui_tests
       displayName: MAUI Tests

--- a/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
@@ -22,6 +22,10 @@ parameters:
   default: succeeded()
 - name: windowsPool
   type: object
+  # NOTE: This default is a Microsoft-hosted Azure Pipelines pool, which is NOT
+  # allowed by 1ES Pipeline Templates in Official mode. Callers that extend the
+  # 1ES Official template (e.g. build-tools/automation/azure-pipelines.yaml) must
+  # override this with a 1ES-hosted pool like `MAUI-1ESPT`.
   default:
     name: Azure Pipelines
     vmImage: $(HostedWinImage)

--- a/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
@@ -51,6 +51,12 @@ stages:
     NetCoreTargetFrameworkPathSuffix: -$(DotNetStableTargetFramework)
     Build.Configuration: Release
     RunningOnCI: true
+    # Cap the JDK that external/Java.Interop's Prepare.targets picks when it
+    # calls the JdkInfo bootstrap task. Recent hosted agent images ship Java 25
+    # as the default JDK, and Gradle 8.12 (used by java-source-utils and the
+    # Bytecode-Tests kotlin-gradle project) crashes with "Unsupported class
+    # file major version 69" on it. JdkInfo reads JI_MAX_JDK from the env.
+    JI_MAX_JDK: 21
   jobs:
 
   # Check - "Xamarin.Android (Java.Interop Tests Windows - .NET)"
@@ -66,15 +72,6 @@ stages:
       clean: true
 
     - template: /external/Java.Interop/build-tools/automation/templates/install-dependencies.yaml@self
-
-    # Point JAVA_HOME at the agent's preinstalled JDK $(LatestJavaSdkMajorVersion).
-    # Otherwise Gradle 8.12 (used by java-source-utils and the Bytecode-Tests
-    # kotlin-gradle project) runs on the agent's default JDK, which on the
-    # macOS-15-arm64 and other newer hosted images is Java 25 - unsupported by
-    # Gradle 8.12 ("Unsupported class file major version 69").
-    - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
-      parameters:
-        jdkMajorVersion: $(LatestJavaSdkMajorVersion)
 
     - template: /external/Java.Interop/build-tools/automation/templates/core-build.yaml@self
 
@@ -108,12 +105,6 @@ stages:
       displayName: Ensure cmake is installed
 
     - template: /external/Java.Interop/build-tools/automation/templates/install-dependencies.yaml@self
-
-    # Point JAVA_HOME at the agent's preinstalled JDK $(LatestJavaSdkMajorVersion) -
-    # see the equivalent comment on the Windows job above.
-    - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
-      parameters:
-        jdkMajorVersion: $(LatestJavaSdkMajorVersion)
 
     - template: /external/Java.Interop/build-tools/automation/templates/core-build.yaml@self
 

--- a/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
@@ -67,6 +67,15 @@ stages:
 
     - template: /external/Java.Interop/build-tools/automation/templates/install-dependencies.yaml@self
 
+    # Point JAVA_HOME at the agent's preinstalled JDK $(LatestJavaSdkMajorVersion).
+    # Otherwise Gradle 8.12 (used by java-source-utils and the Bytecode-Tests
+    # kotlin-gradle project) runs on the agent's default JDK, which on the
+    # macOS-15-arm64 and other newer hosted images is Java 25 - unsupported by
+    # Gradle 8.12 ("Unsupported class file major version 69").
+    - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
+      parameters:
+        jdkMajorVersion: $(LatestJavaSdkMajorVersion)
+
     - template: /external/Java.Interop/build-tools/automation/templates/core-build.yaml@self
 
     - template: /external/Java.Interop/build-tools/automation/templates/core-tests.yaml@self
@@ -99,6 +108,12 @@ stages:
       displayName: Ensure cmake is installed
 
     - template: /external/Java.Interop/build-tools/automation/templates/install-dependencies.yaml@self
+
+    # Point JAVA_HOME at the agent's preinstalled JDK $(LatestJavaSdkMajorVersion) -
+    # see the equivalent comment on the Windows job above.
+    - template: /build-tools/automation/yaml-templates/setup-jdk-variables.yaml@self
+      parameters:
+        jdkMajorVersion: $(LatestJavaSdkMajorVersion)
 
     - template: /external/Java.Interop/build-tools/automation/templates/core-build.yaml@self
 

--- a/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
@@ -25,11 +25,13 @@ parameters:
   default:
     name: Azure Pipelines
     vmImage: $(HostedWinImage)
+    os: windows
 - name: macPool
   type: object
   default:
     name: Azure Pipelines
     vmImage: $(HostedMacImage)
+    os: macOS
 
 stages:
 - stage: ${{ parameters.stageName }}

--- a/external/Java.Interop/build-tools/automation/templates/core-tests.yaml
+++ b/external/Java.Interop/build-tools/automation/templates/core-tests.yaml
@@ -1,6 +1,7 @@
 parameters:
   condition: succeeded()
   runNativeTests: false
+  runNativeDotnetTests: false
   platformName:
   nativeAotRid:
 

--- a/external/Java.Interop/build-tools/scripts/Prepare.targets
+++ b/external/Java.Interop/build-tools/scripts/Prepare.targets
@@ -17,6 +17,13 @@
       <_MaxJdk Condition=" '$(_MaxJdk)' == '' ">$(JI_MAX_JDK)</_MaxJdk>
       <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_17_X64)' != '' And Exists($(JAVA_HOME_17_X64)) ">$(JAVA_HOME_17_X64)</JdksRoot>
       <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME_11_X64)' != '' And Exists($(JAVA_HOME_11_X64)) ">$(JAVA_HOME_11_X64)</JdksRoot>
+      <!--
+        Fall back to $JAVA_HOME. The JAVA_HOME_*_X64 env vars are set by
+        Azure Pipelines on x64 hosted images only, so on arm64 macOS/Linux
+        agents JdksRoot would otherwise remain empty and JdkInfo would pick
+        the newest system JDK - which may be too new for our Gradle version.
+      -->
+      <JdksRoot Condition=" '$(JdksRoot)' == '' And '$(JAVA_HOME)' != '' And Exists('$(JAVA_HOME)') ">$(JAVA_HOME)</JdksRoot>
     </PropertyGroup>
     <JdkInfo
         JdksRoot="$(JdksRoot)"


### PR DESCRIPTION
### Why

After merging `external/Java.Interop` in-tree, the new `Java.Interop Tests` stage started failing on the internal DevDiv `Xamarin.Android` pipeline (e.g. [build 14551960](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14551960)) with:

> 1ES PT Error: Using a non 1ESHostedPool with 1ES PT is not allowed.

Both the `Windows - .NET` and `Mac - .NET` jobs failed in `1ES PT Pre-Job` before doing any real work.

### Root cause

The internal pipeline extends `MicroBuild.1ES.Official.yml`, which requires Windows jobs to run on a 1ES-hosted pool. `stage-java-interop-tests.yaml` was called with no parameters, so both jobs fell back to the template defaults - `name: Azure Pipelines` with no `os:` field. 1ES PT's `validateHostedPool.ps1` defaults to `-OS windows` when the pool has no `os:`, then rejects the hosted `Azure Pipelines` pool as non-1ES - so even the Mac job was validated as Windows and rejected.

### What changed

- `stage-java-interop-tests.yaml`: set `os: windows` / `os: macOS` on the default pools so callers who omit the parameter still land on a valid setup, with a comment noting the Windows default is not Official-1ES compliant and must be overridden by Official callers.
- `azure-pipelines.yaml` (internal): override `windowsPool` to `MAUI-1ESPT` + `$(WindowsPoolImage1ESPT)` + `os: windows`, matching the other internal Windows jobs. The Mac lane stays on hosted `Azure Pipelines` + `os: macOS` because 1ES has no macOS-hosted pool.
- `azure-pipelines-public.yaml`: add `os: windows` on `windowsPool` for parity.
- `external/Java.Interop/build-tools/automation/templates/core-tests.yaml`: declare `runNativeDotnetTests` as an actual parameter. It was referenced from the `Java.Interop-Tests` step's `condition:` but never declared, so it evaluated to `''` at template expansion and that test step was silently skipped on Windows. Declaring the parameter lets the Windows lane's `runNativeDotnetTests: true` value take effect.

### Testing

No new automated tests; the pipeline itself is the test. Once merged, the next internal run should show `Java.Interop Tests` reaching real build/test steps instead of failing in `1ES PT Pre-Job`, and the Windows `Java.Interop-Tests` test step should actually execute.