### PR TITLE
[docs] Reword terms flagged by PoliCheck

### DIFF
--- a/external/Java.Interop/Documentation/Architecture.md
+++ b/external/Java.Interop/Documentation/Architecture.md
@@ -70,7 +70,7 @@ code generation. It would be nice to remove this requirement.
 e.g. translating `java.io.InputStream` to `System.IO.Stream` (and back),
 and there's no facility for additional types to participate in *any* of this.
 
-It's a big, monolithic, ball of mud.
+It's a big, monolithic, tangled mess.
 
 ## Proposed Java.Interop Architecture
 

--- a/external/Java.Interop/Documentation/EnumMappingFile.md
+++ b/external/Java.Interop/Documentation/EnumMappingFile.md
@@ -58,7 +58,7 @@ Over time we have found some limitations to the format, such as being able
 to specify if the Java constant field should be removed. Additionally, since the
 format only specifies constants that *SHOULD* be mapped, we cannot use this
 to track constants that we have examined and determined *SHOULD NOT* be mapped.
-This has led to various blacklists and tooling of varying success to prevent
+This has led to various block lists and tooling of varying success to prevent
 us from needing to continually re-audit those constants.
 
 There is now a "v2" version of defining constants. This is a line-level change


### PR DESCRIPTION
After merging Java.Interop into this repo, its docs are now scanned under dotnet/android's PoliCheck rules for the first time, which surfaced three flagged terms. These are prose-only hits, so rewording is the cleanest fix (it's also the outcome PoliCheck itself recommends for "blacklist") and avoids adding suppression signatures for documentation text.

Changes:

- `external/Java.Interop/Documentation/Architecture.md`: "ball of mud" -> "tangled mess"
- `external/Java.Interop/Documentation/EnumMappingFile.md`: "blacklists" -> "block lists"

This clears all three active PoliCheck results (both `blacklist`/`blacklists` hits were on the same line).