### PR TITLE
[tests] Fail fast when the emulator package manager service is wedged

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/DeviceTest.cs
@@ -69,6 +69,59 @@ namespace Xamarin.Android.Build.Tests
 			}
 		}
 
+		/// <summary>
+		/// Probes the Android package manager service the same way `bundletool build-apks
+		/// --connected-device` (which runs `pm list features`) and `adb install` do. On CI the
+		/// emulator's system_server sometimes wedges while `adb shell echo OK` still succeeds, so
+		/// <see cref="IsDeviceAttached"/> reports the device as healthy even though every subsequent
+		/// build/install fails deep inside a test with a cryptic
+		/// "Failure calling service package: Broken pipe" (XABAS0000). Retries a few times so a
+		/// momentary hiccup does not trigger an unnecessary emulator restart.
+		/// </summary>
+		protected static bool IsPackageManagerResponsive (out string diagnostic)
+		{
+			string output = "";
+			for (int attempt = 0; attempt < 3; attempt++) {
+				output = (RunAdbCommand ("shell pm list features", timeout: 30) ?? "").Trim ();
+				bool broken = output.Contains ("Failure calling service", StringComparison.OrdinalIgnoreCase) ||
+					output.Contains ("Broken pipe", StringComparison.OrdinalIgnoreCase) ||
+					output.Contains ("Can't find service", StringComparison.OrdinalIgnoreCase);
+				// A responsive package service always lists the framework's own features.
+				if (!broken && output.Contains ("feature:", StringComparison.OrdinalIgnoreCase)) {
+					diagnostic = output;
+					return true;
+				}
+				WaitFor ((int) TimeSpan.FromSeconds (2).TotalMilliseconds);
+			}
+			diagnostic = output;
+			return false;
+		}
+
+		/// <summary>
+		/// Fails fast, with a clear reason, when the emulator's package manager service is
+		/// unusable — instead of letting the app build/install fail cryptically later and
+		/// reporting an emulator crash as N unrelated test failures. Attempts one emulator
+		/// restart first; if the service is still broken the run is marked inconclusive
+		/// (an infrastructure problem, not a product regression).
+		/// </summary>
+		protected void AssertPackageManagerResponsive ()
+		{
+			if (IsPackageManagerResponsive (out _)) {
+				return;
+			}
+
+			TestContext.Out.WriteLine ("Android package manager service is unresponsive; restarting the emulator.");
+			RestartDevice ();
+			AssertHasDevices ();
+
+			if (!IsPackageManagerResponsive (out string diagnostic)) {
+				Assert.Inconclusive (
+					"Android package manager service is unresponsive even after restarting the emulator " +
+					"(system_server likely crashed). Skipping so an emulator failure is not reported as a test failure. " +
+					$"Last 'adb shell pm list features' output: {diagnostic}");
+			}
+		}
+
 		[OneTimeSetUp]
 		public void DeviceSetup ()
 		{
@@ -125,6 +178,11 @@ namespace Xamarin.Android.Build.Tests
 				RestartDevice ();
 				AssertHasDevices ();
 			}
+
+			// `adb shell echo OK` can succeed while the package manager service is wedged, so
+			// verify it is responsive before a test wastes time building/installing an app that
+			// would otherwise fail with a cryptic "Failure calling service package" error.
+			AssertPackageManagerResponsive ();
 
 			// We want to start with a clean logcat buffer for each test
 			ClearAdbLogcat ();


### PR DESCRIPTION
### Problem

Device integration tests (`DeviceTest`) gate on `adb shell echo OK` in the shared `[SetUp]` before running. That check succeeds even when the emulator's `system_server` / package manager service has crashed or wedged. As a result the health check passes, the test proceeds to build and install an app, and then fails **deep inside the build** with a cryptic error:

```
[BT:1.18.3] error: Unexpected output of 'pm list features' command:
    'cmd: Failure calling service package: Broken pipe (32)'
error XABAS0000: com.android.tools.build.bundletool...AdbOutputParseException
   at ...DeviceFeaturesParser.parse
   at ...DeviceAnalyzer.getDeviceSpec
```

Because these tests run a combined `/t:Build,Install` target, an emulator/service failure surfaces as a misleading `FailedBuildException: "Build failure"` — reported as **N unrelated per-test failures** long after the emulator actually died, instead of a single clear "emulator unusable" signal up front.

Observed in the wild: a single macOS emulator lane failed 8 diverse tests (BundleTool, Debugging, InstallAndRun, StoreKey) while every other build/test lane stayed green — the classic signature of a wedged package service, not a product regression.

### Fix

Probe the package manager service — the same `pm list features` binder path that `bundletool build-apks --connected-device` and `adb install` rely on — in the shared `SetUp`:

- **`IsPackageManagerResponsive(out diagnostic)`** — retries a few times so a momentary hiccup doesn't trigger an unnecessary emulator restart.
- **`AssertPackageManagerResponsive()`** — if the service is wedged, restart the emulator once; if it's still broken, `Assert.Inconclusive` with a clear *"package manager service is unresponsive (system_server likely crashed)"* message.

This surfaces the failure **before** building/installing the app, once, with a real reason — and marks it inconclusive (an infrastructure problem) rather than turning an emulator crash into product-test failures, consistent with the existing `RestartDevice` transient-failure handling.
