### PR TITLE
[Java.Interop] Keep transitive System.IO.Hashing out of tool output

### DIFF
--- a/external/Java.Interop/Directory.Build.targets
+++ b/external/Java.Interop/Directory.Build.targets
@@ -34,7 +34,18 @@
     <PackageReference Update="Microsoft.CSharp"                             Version="4.7.0" />
     <PackageReference Update="Microsoft.DotNet.GenAPI"                      Version="8.0.0-beta.26301.3" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                       Version="18.6.0" />
-    <PackageReference Update="Microsoft.SourceLink.GitHub"                  Version="10.0.300" />
+    <!--
+      Microsoft.SourceLink.GitHub is a build-time only package (PrivateAssets="All"), but its
+      dependency Microsoft.Build.Tasks.Git 10.0.300 pulls System.IO.Hashing 10.0.8 in as a *runtime*
+      asset. Projects that only reference System.IO.Hashing transitively (e.g. class-parse, jcw-gen,
+      generator) therefore ship a System.IO.Hashing 10.0.8 assembly, which collides in the shared
+      .NET for Android SDK pack `tools/` directory with the 10.0.9 assembly the build tasks are
+      compiled against (System.IO.Hashing bumps its AssemblyVersion every patch: 10.0.0.8 vs 10.0.0.9),
+      producing a MissingMethodException on System.IO.Hashing.Crc64.Hash at build time. These tools do
+      not use System.IO.Hashing themselves, so exclude SourceLink's runtime assets to keep the unused
+      assembly out of their output. Source linking is unaffected (it runs via SourceLink's build assets).
+    -->
+    <PackageReference Update="Microsoft.SourceLink.GitHub"                  Version="10.0.300" ExcludeAssets="runtime" />
     <PackageReference Update="Microsoft.Xml.SgmlReader"                     Version="1.8.30" />
     <PackageReference Update="Mono.CSharp"                                  Version="4.0.0.143" />
     <PackageReference Update="Mono.Linq.Expressions"                        Version="2.0.0" />


### PR DESCRIPTION
## Problem

`Microsoft.SourceLink.GitHub` 10.0.300 is a build-time-only package (referenced with `PrivateAssets="All"`), but its dependency `Microsoft.Build.Tasks.Git` 10.0.300 pulls **`System.IO.Hashing` 10.0.8** in as a **runtime** asset.

JI tools/libraries that reference `System.IO.Hashing` only *transitively* (via SourceLink) therefore ship a `System.IO.Hashing` **10.0.8** assembly:

- `class-parse`, `generator`, `jcw-gen`, `logcat-parse`, `param-name-importer`
- `Java.Interop.Tools.Generator`, `Java.Interop.Tools.Maven`

These are staged into the **shared** .NET for Android SDK pack `tools/` directory alongside the build tasks (`Xamarin.Android.Build.Tasks`, `Microsoft.Android.Build.BaseTasks`), which reference `System.IO.Hashing` **10.0.9** *directly*. `System.IO.Hashing` bumps its **AssemblyVersion every patch** (`10.0.0.8` vs `10.0.0.9`), so the single `System.IO.Hashing.dll` that wins in `tools/` can mismatch what the build tasks were compiled against, producing at build time:

```
error XACRP7000: System.MissingMethodException: Method not found:
  'Int32 System.IO.Hashing.Crc64.Hash(ReadOnlySpan<Byte>, Span<Byte>)'.
   at Microsoft.Android.Build.Tasks.Files.HashBytes(Byte[])
   at Xamarin.Android.Tasks.AndroidComputeResPaths.RunTask()
```

Because `AndroidComputeResPaths` runs in **every** app build, this breaks the affected builds (observed intermittently on Windows CI lanes — the failure depends on which `System.IO.Hashing.dll` copy wins in the shared `tools/` directory).

The existing `<PackageReference Update="System.IO.Hashing" Version="10.0.9" />` pins do **not** cover these projects, because `Update=` only applies to packages a project references **directly** — these projects reference it only transitively.

## Fix

These tools do not use `System.IO.Hashing` themselves — it only rides in as an unused *runtime* asset of build-time SourceLink. Exclude SourceLink's runtime assets so the unused assembly is never emitted:

```xml
<PackageReference Update="Microsoft.SourceLink.GitHub" Version="10.0.300" ExcludeAssets="runtime" />
```

Verified locally: with this change, `System.IO.Hashing` resolves to the empty `lib/**/_._` placeholder (no runtime DLL) for the affected exes and libraries (both `net10.0` and `netstandard2.0`).

- **Source linking is unaffected** — it runs via SourceLink's `build`/`buildTransitive` assets, not `runtime` assets.
- **The build tasks that legitimately use `System.IO.Hashing` are unaffected** — `Microsoft.Android.Build.BaseTasks` has a *direct* `<PackageReference Include="System.IO.Hashing" />` (→ 10.0.9), which an `ExcludeAssets` on SourceLink does not touch.

## Follow-up

`external/xamarin-android-tools` needs the **same** change for `Xamarin.Android.Tools.AndroidSdk`, which floats to `System.IO.Hashing` 10.0.8 by the identical transitive-SourceLink path. That is a separate upstream (`dotnet/xamarin-android-tools`) change + submodule bump.

## Notes

This is a pre-existing, latent issue on `main` (not specific to any feature branch); the version-pin files are unchanged. It surfaces intermittently depending on `tools/`-directory copy order.
