### PR TITLE
[TrimmableTypeMap] Remove InvokerType from JavaPeerProxy

### DIFF
--- a/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniTypeManagerTests.cs
+++ b/external/Java.Interop/tests/Java.Interop-Tests/Java.Interop/JniRuntime.JniTypeManagerTests.cs
@@ -10,6 +10,7 @@ namespace Java.InteropTests {
 	public class JniRuntimeJniTypeManagerTests : JavaVMFixture {
 
 		[Test]
+		[Category ("TrimmableTypeMapUnsupported")]
 		[RequiresDynamicCode ("This test uses ReflectionJniTypeManager, which is reflection-based and not NativeAOT-compatible.")]
 		[RequiresUnreferencedCode ("This test uses ReflectionJniTypeManager, which is reflection-based and not trimming-compatible.")]
 		public void GetInvokerType ()

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -760,7 +760,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
 
-		// .ctor — pass the resolved JNI name and (for generic-definition base) target type
+		// .ctor — pass the resolved JNI name and (for proxies using the non-generic
+		// base, i.e. open generic definitions and interfaces) the target type
 		// to the base proxy constructor.
 		var selfAttrCtorDef = _pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Android.Sdk.TrimmableTypeMap;
 ///         // or: null;                                                // no activation
 ///         // or: throw new NotSupportedException(...);                // open generic
 ///
-///     // JniName / TargetType / InvokerType are supplied by the base JavaPeerProxy constructor.
+///     // JniName / TargetType are supplied by the base JavaPeerProxy constructor.
 ///
 ///     // UCO wrappers — [UnmanagedCallersOnly] entry points for JNI native methods (ACWs only):
 ///     public static void n_OnCreate_uco_0(IntPtr jnienv, IntPtr self, IntPtr p0)
@@ -731,22 +731,20 @@ sealed class TypeMapAssemblyEmitter
 		if (useNonGenericBase) {
 			proxyBaseType = _javaPeerProxyNonGenericRef;
 			baseCtorRef = _pe.AddMemberRef (_javaPeerProxyNonGenericRef, ".ctor",
-				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (3,
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
 					rt => rt.Void (),
 					p => {
 						p.AddParameter ().Type ().String ();
-						p.AddParameter ().Type ().Type (_systemTypeRef, false);
 						p.AddParameter ().Type ().Type (_systemTypeRef, false);
 					}));
 		} else {
 			var genericProxyBase = _pe.MakeGenericTypeSpec (_javaPeerProxyRef, targetTypeRef);
 			proxyBaseType = genericProxyBase;
 			baseCtorRef = _pe.AddMemberRef (genericProxyBase, ".ctor",
-				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (2,
+				sig => sig.MethodSignature (isInstanceMethod: true).Parameters (1,
 					rt => rt.Void (),
 					p => {
 						p.AddParameter ().Type ().String ();
-						p.AddParameter ().Type ().Type (_systemTypeRef, false);
 					}));
 		}
 
@@ -762,8 +760,8 @@ sealed class TypeMapAssemblyEmitter
 			metadata.AddInterfaceImplementation (typeDefHandle, _iAndroidCallableWrapperRef);
 		}
 
-		// .ctor — pass the resolved JNI name, (for generic-definition base) target type, and
-		// optional invoker type to the base proxy constructor.
+		// .ctor — pass the resolved JNI name and (for generic-definition base) target type
+		// to the base proxy constructor.
 		var selfAttrCtorDef = _pe.EmitBody (".ctor",
 			MethodAttributes.Public | MethodAttributes.HideBySig | MethodAttributes.SpecialName | MethodAttributes.RTSpecialName,
 			sig => sig.MethodSignature (isInstanceMethod: true).Parameters (0, rt => rt.Void (), p => { }),
@@ -771,18 +769,12 @@ sealed class TypeMapAssemblyEmitter
 				encoder.OpCode (ILOpCode.Ldarg_0);
 				encoder.LoadString (metadata.GetOrAddUserString (proxy.JniName));
 				if (useNonGenericBase) {
-					// Non-generic base ctor signature: (string, Type, Type?). Push the
+					// Non-generic base ctor signature: (string, Type). Push the
 					// target type (open-generic definition or interface) as the second argument.
 					encoder.LoadToken (targetTypeRef);
 					encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
 				}
-				if (proxy.InvokerType != null) {
-					encoder.LoadToken (_pe.ResolveTypeRef (proxy.InvokerType));
-					encoder.Call (_getTypeFromHandleRef, parameterCount: 1, returnsValue: true);
-				} else {
-					encoder.OpCode (ILOpCode.Ldnull);
-				}
-				encoder.Call (baseCtorRef, parameterCount: useNonGenericBase ? 3 : 2, isInstance: true);
+				encoder.Call (baseCtorRef, parameterCount: useNonGenericBase ? 2 : 1, isInstance: true);
 				encoder.Return ();
 			});
 

--- a/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
+++ b/src/Mono.Android/Java.Interop/JavaPeerProxy.cs
@@ -42,14 +42,13 @@ namespace Java.Interop
 	[AttributeUsage (AttributeTargets.Class | AttributeTargets.Interface, Inherited = false, AllowMultiple = false)]
 	public abstract class JavaPeerProxy : Attribute
 	{
-		private protected JavaPeerProxy (string jniName, Type targetType, Type? invokerType)
+		private protected JavaPeerProxy (string jniName, Type targetType)
 		{
 			ArgumentNullException.ThrowIfNull (jniName);
 			ArgumentNullException.ThrowIfNull (targetType);
 
 			JniName = jniName;
 			TargetType = targetType;
-			InvokerType = invokerType;
 		}
 
 		/// <summary>
@@ -70,12 +69,6 @@ namespace Java.Interop
 		/// Gets the target .NET type that this proxy represents.
 		/// </summary>
 		public Type TargetType { get; }
-
-		/// <summary>
-		/// Gets the invoker type for interfaces and abstract classes.
-		/// Returns null for concrete types that can be directly instantiated.
-		/// </summary>
-		public Type? InvokerType { get; }
 
 		/// <summary>
 		/// Gets a factory for creating containers (arrays, collections) of the target type.
@@ -144,8 +137,8 @@ namespace Java.Interop
 	{
 		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
-		protected JavaPeerProxy (string jniName, Type? invokerType)
-			: base (jniName, typeof (T), invokerType)
+		protected JavaPeerProxy (string jniName)
+			: base (jniName, typeof (T))
 		{
 		}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -494,7 +494,6 @@ public class TrimmableTypeMap
 	}
 
 	/// <summary>
-	/// <summary>
 	/// Gets the container factory for a type from its proxy attribute.
 	/// Used for AOT-safe array/collection/dictionary creation.
 	/// </summary>
@@ -605,7 +604,7 @@ public class TrimmableTypeMap
 
 	sealed class MissingJavaPeerProxy : JavaPeerProxy
 	{
-		public MissingJavaPeerProxy () : base ("<missing>", typeof (Java.Lang.Object), null)
+		public MissingJavaPeerProxy () : base ("<missing>", typeof (Java.Lang.Object))
 		{
 		}
 

--- a/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/TrimmableTypeMap.cs
@@ -494,13 +494,6 @@ public class TrimmableTypeMap
 	}
 
 	/// <summary>
-	/// Gets the invoker type for an interface or abstract class from the proxy attribute.
-	/// </summary>
-	internal Type? GetInvokerType (Type type)
-	{
-		return GetProxyForManagedType (type)?.InvokerType;
-	}
-
 	/// <summary>
 	/// Gets the container factory for a type from its proxy attribute.
 	/// Used for AOT-safe array/collection/dictionary creation.

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapAssemblyGeneratorTests.cs
@@ -248,6 +248,60 @@ public class TypeMapAssemblyGeneratorTests : FixtureTestBase
 		Assert.Equal ("JavaPeerProxy", reader.GetString (baseTypeRef.Name));
 	}
 
+	// Regression test: decode the emitted proxy `.ctor` *body* (not just member presence)
+	// and verify it chains to the correct base constructor. Concrete (constructible) proxies
+	// derive from `JavaPeerProxy<T>` and call the single-arg base ctor `(string)`; interface
+	// and open-generic proxies derive from the non-generic `JavaPeerProxy` and call the
+	// two-arg base ctor `(string, Type)` — pushing the target type via `Type.GetTypeFromHandle`.
+	// A base-ctor arity/token mismatch here would pass metadata inspection but blow up as an
+	// InvalidProgramException/TypeLoadException on the CoreCLR device legs, so assert it directly.
+	[Theory]
+	[InlineData ("Java_Lang_Object_Proxy", 1, false)]              // concrete class -> generic base (string)
+	[InlineData ("Android_Views_IOnClickListener_Proxy", 2, true)] // interface -> non-generic base (string, Type)
+	[InlineData ("MyApp_Generic_GenericHolder_1_Proxy", 2, true)]  // open generic -> non-generic base (string, Type)
+	public void Generate_ProxyCtor_ChainsToExpectedBaseConstructor (string proxyTypeName, int expectedBaseCtorArity, bool expectsGetTypeFromHandle)
+	{
+		var peers = ScanFixtures ();
+		using var stream = GenerateAssembly (peers);
+		using var pe = new PEReader (stream);
+		var reader = pe.GetMetadataReader ();
+
+		var proxyTypeHandle = reader.TypeDefinitions.First (h => {
+			var type = reader.GetTypeDefinition (h);
+			return reader.GetString (type.Namespace) == "_TypeMap.Proxies" &&
+				reader.GetString (type.Name) == proxyTypeName;
+		});
+		var proxyType = reader.GetTypeDefinition (proxyTypeHandle);
+		var ctorHandle = proxyType.GetMethods ().First (h =>
+			reader.GetString (reader.GetMethodDefinition (h).Name) == ".ctor");
+		var ctor = reader.GetMethodDefinition (ctorHandle);
+		var body = pe.GetMethodBody (ctor.RelativeVirtualAddress);
+		Assert.NotNull (body);
+		var ilBytes = body.GetILBytes ();
+		Assert.NotNull (ilBytes);
+
+		var decoder = new TypeNameSignatureDecoder (reader);
+		int? baseCtorArity = null;
+		bool sawGetTypeFromHandle = false;
+		foreach (var token in ReadCallTokens (ilBytes!)) {
+			var handle = MetadataTokens.EntityHandle (token);
+			if (handle.Kind != HandleKind.MemberReference)
+				continue;
+			var mref = reader.GetMemberReference ((MemberReferenceHandle) handle);
+			var name = reader.GetString (mref.Name);
+			if (name == "GetTypeFromHandle") {
+				sawGetTypeFromHandle = true;
+			} else if (name == ".ctor") {
+				var sig = mref.DecodeMethodSignature (decoder, genericContext: null);
+				baseCtorArity = sig.RequiredParameterCount;
+			}
+		}
+
+		Assert.True (baseCtorArity.HasValue, $"Proxy '{proxyTypeName}' .ctor must chain to a base ctor");
+		Assert.Equal (expectedBaseCtorArity, baseCtorArity!.Value);
+		Assert.Equal (expectsGetTypeFromHandle, sawGetTypeFromHandle);
+	}
+
 	// Regression test: every generated proxy type must carry a custom attribute whose
 	// constructor points at the proxy's own TypeDefinitionHandle (either as a MemberRef
 	// parented on the TypeDef, or as a MethodDefinition on the TypeDef). This is how

--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Java.Interop/JavaPeerProxyTests.cs
@@ -18,17 +18,15 @@ namespace Java.InteropTests
 
 			Assert.AreEqual ("custom/ExplicitName", proxy.JniName);
 			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
-			Assert.IsNull (proxy.InvokerType);
 		}
 
 		[Test]
-		public void Constructor_StoresInvokerType ()
+		public void GenericConstructor_StoresJniNameAndTargetType ()
 		{
-			var proxy = new InvokerProxy ();
+			var proxy = new GenericProxy ();
 
-			Assert.AreEqual ("custom/InvokerProxy", proxy.JniName);
+			Assert.AreEqual ("custom/GenericProxy", proxy.JniName);
 			Assert.AreEqual (typeof (ProxyTestPeer), proxy.TargetType);
-			Assert.AreEqual (typeof (ProxyTestPeerInvoker), proxy.InvokerType);
 		}
 	}
 
@@ -45,32 +43,20 @@ namespace Java.InteropTests
 		}
 	}
 
-	sealed class ProxyTestPeerInvoker : Java.Lang.Object
-	{
-		public ProxyTestPeerInvoker ()
-		{
-		}
-
-		public ProxyTestPeerInvoker (IntPtr handle, JniHandleOwnership transfer)
-			: base (handle, transfer)
-		{
-		}
-	}
-
 	sealed class ExplicitNameProxy : JavaPeerProxy
 	{
 		public ExplicitNameProxy ()
-			: base ("custom/ExplicitName", typeof (ProxyTestPeer), invokerType: null)
+			: base ("custom/ExplicitName", typeof (ProxyTestPeer))
 		{
 		}
 
 		public override IJavaPeerable? CreateInstance (IntPtr handle, JniHandleOwnership transfer) => null;
 	}
 
-	sealed class InvokerProxy : JavaPeerProxy<ProxyTestPeer>
+	sealed class GenericProxy : JavaPeerProxy<ProxyTestPeer>
 	{
-		public InvokerProxy ()
-			: base ("custom/InvokerProxy", typeof (ProxyTestPeerInvoker))
+		public GenericProxy ()
+			: base ("custom/GenericProxy")
 		{
 		}
 


### PR DESCRIPTION
Replaces #11970 (moved off the fork so PR CI runs on the `dotnet-android` public pipeline; branch now lives on `dotnet/android`).

## Summary

The trimmable typemap activates managed peers exclusively through the generated `JavaPeerProxy.CreateInstance`, so the `InvokerType` exposed on the `JavaPeerProxy` attribute is never consumed at runtime. `JavaMarshalValueManager.CreatePeer` calls `TrimmableTypeMap.CreateInstance` and never falls back to invoker-type reflection.

This PR removes `InvokerType` from `JavaPeerProxy` and everything that fed it.

## Changes

**Runtime (`src/Mono.Android`)**
- `JavaPeerProxy` / `JavaPeerProxy<T>`: dropped the `invokerType` constructor parameter and the `InvokerType` property.
- `TrimmableTypeMap`: removed the now-dead `GetInvokerType`.
- `TrimmableTypeMapTypeManager.GetInvokerTypeCore`: throws in the trimmable path (peers are activated via `JavaPeerProxy.CreateInstance`).

**Generator (`src/Microsoft.Android.Sdk.TrimmableTypeMap`)**
- `TypeMapAssemblyEmitter`: the generated proxy `.ctor` no longer passes an invoker `Type`/`ldnull` to the base constructor; base ctor refs are now `(string, Type)` (non-generic) and `(string)` (generic). The model's `InvokerType` is retained where genuinely required — emitting `CreateInstance` and UCO constructor activation for interfaces/abstract classes.

**Tests**
- `JavaPeerProxyTests`: dropped the `InvokerType` assertions/fixture; added coverage for the generic `JavaPeerProxy<T>` constructor.
- `JniRuntimeJniTypeManagerTests.GetInvokerType`: tagged `[Category ("TrimmableTypeMapUnsupported")]` (the trimmable type manager throws from `GetInvokerTypeCore`, so this reflection-based test only applies to the other typemap implementations).

## Test plan
- `Microsoft.Android.Sdk.TrimmableTypeMap.Tests`: 604/604 passing.
- Device test legs (CoreCLR trimmable) via CI.
