### PR TITLE
[tests] Re-enable AndroidMessageHandler ServerCertificateCustomValidationCallback tests

### DIFF
--- a/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
+++ b/tests/Mono.Android-Tests/Mono.Android-Tests/Xamarin.Android.Net/AndroidMessageHandlerTests.cs
@@ -137,7 +137,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApproveRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -164,7 +163,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_RejectRequest ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -183,7 +181,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_ApprovesRequestWithInvalidCertificate ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -211,7 +208,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_IgnoresCertificateHostnameMismatch ()
 		{
 			bool callbackHasBeenCalled = false;
@@ -233,7 +229,6 @@ namespace Xamarin.Android.NetTests
 		}
 
 		[Test]
-		[Ignore ("Crashes the test process with a native SIGSEGV: https://github.com/dotnet/android/issues/8608")]
 		public async Task ServerCertificateCustomValidationCallback_Redirects ()
 		{
 			int callbackCounter = 0;


### PR DESCRIPTION
## Summary

Re-enables the five `AndroidMessageHandler.ServerCertificateCustomValidationCallback_*` device tests that were `[Ignore]`d in #11801.

They were disabled because a boolean-returning SSL validation callback crashed the test process with a native **SIGSEGV** under the **trimmable typemap** (CoreCLR/NativeAOT) mid-handshake:

- `ServerCertificateCustomValidationCallback_ApproveRequest`
- `ServerCertificateCustomValidationCallback_RejectRequest`
- `ServerCertificateCustomValidationCallback_ApprovesRequestWithInvalidCertificate`
- `ServerCertificateCustomValidationCallback_IgnoresCertificateHostnameMismatch`
- `ServerCertificateCustomValidationCallback_Redirects`

## Why they pass now

The root cause was fixed in #11802: the trimmable typemap generator now matches each `n_*` callback `MemberRef` to its binding's real boolean/char signature, so the `[UnmanagedCallersOnly]` forwarder no longer "will always throw" and the SSL validation callback dispatches correctly.

## Verification

Built the local SDK on top of current `main` (which includes both #11802 and the reflection-free trimmable managers from #11801) and ran the `SSL`-category device tests on an arm64 emulator with `-p:_AndroidTypeMapImplementation=trimmable -p:UseMonoRuntime=false`.

All five re-enabled tests pass (as does the never-ignored `NoServerCertificateCustomValidationCallback_ThrowsWhenThereIsCertificateHostnameMismatch`); overall SSL run: **0 failed**. CI validates the full runtime matrix (CoreCLR / Mono / CoreCLRTrimmable / NativeAOT).
