### PR TITLE
[Tests] Retry flaky InstallAndroidDependenciesTest download

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/AndroidDependenciesTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Xml;
 using System.Xml.Linq;
 using NUnit.Framework;
@@ -43,11 +44,6 @@ namespace Xamarin.Android.Build.Tests
 				string jdkPath = Path.Combine (Root, "temp", TestName, "android-jdk");
 				Environment.SetEnvironmentVariable ("TEST_ANDROID_SDK_PATH", sdkPath);
 				Environment.SetEnvironmentVariable ("TEST_ANDROID_JDK_PATH", jdkPath);
-				foreach (var path in new [] { sdkPath, jdkPath }) {
-					if (Directory.Exists (path))
-						Directory.Delete (path, recursive: true);
-					Directory.CreateDirectory (path);
-				}
 
 				var proj = new XamarinAndroidApplicationProject {
 					IsRelease = isRelease,
@@ -69,7 +65,30 @@ namespace Xamarin.Android.Build.Tests
 					string defaultTarget = b.Target;
 					b.Target = "InstallAndroidDependencies";
 					b.BuildLogFile = "install-deps.log";
-					Assert.IsTrue (b.Build (proj, parameters: buildArgs.ToArray ()), "InstallAndroidDependencies should have succeeded.");
+
+					// InstallAndroidDependencies downloads the Android SDK and JDK over the network, which
+					// can fail intermittently in CI. Retry a few times before giving up, starting from a
+					// clean SDK/JDK directory each attempt so a partial download does not affect the next.
+					// See https://github.com/dotnet/android/issues/11973
+					const int maxInstallAttempts = 3;
+					bool installSucceeded = false;
+					for (int attempt = 1; attempt <= maxInstallAttempts; attempt++) {
+						foreach (var path in new [] { sdkPath, jdkPath }) {
+							if (Directory.Exists (path))
+								Directory.Delete (path, recursive: true);
+							Directory.CreateDirectory (path);
+						}
+
+						if (b.Build (proj, parameters: buildArgs.ToArray ())) {
+							installSucceeded = true;
+							break;
+						}
+
+						TestContext.WriteLine ($"InstallAndroidDependencies attempt {attempt} of {maxInstallAttempts} failed. Please check the task output in 'install-deps.log'.");
+						if (attempt < maxInstallAttempts)
+							Thread.Sleep (TimeSpan.FromSeconds (10));
+					}
+					Assert.IsTrue (installSucceeded, $"InstallAndroidDependencies should have succeeded within {maxInstallAttempts} attempts.");
 
 					// When dependencies can not be resolved/installed a warning will be present in build output:
 					//    Dependency `platform-tools` should have been installed but could not be resolved.


### PR DESCRIPTION
### Description

`InstallAndroidDependenciesTest` exercises the `InstallAndroidDependencies` target, which downloads the Android SDK and JDK over the network. Because there is no caching (the test wipes and recreates the SDK/JDK directories on every run), these downloads fail intermittently in CI — causing the `("GoogleV2", CoreCLR)` and `("Xamarin", CoreCLR)` cases to fail randomly across unrelated PRs.

Typical failure (a short 2–4s `FailedBuildException`, with the real error hidden in the per-test `install-deps.log` artifact):

```
Failed InstallAndroidDependenciesTest("GoogleV2",CoreCLR) [4 s]
  Xamarin.ProjectTools.FailedBuildException : Build failure: UnnamedProject.csproj
```

### Change

Retry the `InstallAndroidDependencies` build up to **3 times**:

- Wait **10 seconds** between attempts.
- Start from a **clean SDK/JDK directory** on each attempt, so a partial/corrupt download from a failed attempt cannot poison the next one.
- Only fail after all 3 attempts are exhausted, logging each failed attempt for triage.

### Notes

This is a mitigation for the CI flakiness, not a confirmed root-cause fix — the underlying network failure still needs to be characterized from `install-deps.log`. The tracking issue is intentionally left open for that investigation.

Mitigates #11973
