### PR TITLE
Fix build warnings in jnienv-gen project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,7 +68,6 @@
       
       This can be opted into locally with $(_AndroidTreatWarningsAsErrors) = true.
     -->
-    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'jnienv-gen.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Mono.Android.NET-Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'MSBuildDeviceIntegration.csproj' ">true</_AllowProjectWarnings>

--- a/build-tools/jnienv-gen/Generator.cs
+++ b/build-tools/jnienv-gen/Generator.cs
@@ -120,15 +120,6 @@ namespace Xamarin.Android.JniEnv
 			o.WriteLine ("\t\tpublic unsafe JniNativeInterfaceInvoker (JniNativeInterfaceStruct* p)");
 			o.WriteLine ("\t\t{");
 			o.WriteLine ("\t\t\tJniEnv = *p;");
-
-			foreach (var e in JNIEnvEntries) {
-				if (e.Delegate == null)
-					continue;
-				if (!e.Prebind)
-					continue;
-				o.WriteLine ("\t\t\t{0}", Initialize (e, ""));
-			}
-
 			o.WriteLine ("\t\t}");
 			o.WriteLine ();
 
@@ -136,16 +127,12 @@ namespace Xamarin.Android.JniEnv
 				if (e.Delegate == null)
 					continue;
 				o.WriteLine ();
-				if (e.Prebind)
-					o.WriteLine ("\t\tpublic readonly {0} {1};\n", e.Delegate, e.Name);
-				else {
-					o.WriteLine ("\t\t{0} _{1};", e.Delegate, e.Name);
-					o.WriteLine ("\t\tpublic {0} {1} {{", e.Delegate, e.Name);
-					o.WriteLine ("\t\t\tget {");
-					o.WriteLine ("\t\t\t\tif (_{0} == null)\n\t\t\t\t\t{1}", e.Name, Initialize (e, "_"));
-					o.WriteLine ("\t\t\t\treturn _{0};\n\t\t\t}}", e.Name);
-					o.WriteLine ("\t\t}");
-				}
+				o.WriteLine ("\t\t{0} _{1};", e.Delegate, e.Name);
+				o.WriteLine ("\t\tpublic {0} {1} {{", e.Delegate, e.Name);
+				o.WriteLine ("\t\t\tget {");
+				o.WriteLine ("\t\t\t\tif (_{0} == null)\n\t\t\t\t\t{1}", e.Name, Initialize (e, "_"));
+				o.WriteLine ("\t\t\t\treturn _{0};\n\t\t\t}}", e.Name);
+				o.WriteLine ("\t\t}");
 			}
 
 			o.WriteLine ("\t}");
@@ -519,9 +506,6 @@ namespace Xamarin.Android.JniEnv
 
 		public TypeInfo ReturnType;
 		public ParamInfo [] Parameters;
-
-		// If true, then we initialize the binding on the static ctor, we dont lazy-define it
-		public bool Prebind;
 
 		// If there is a custom wrapper in JNIEnv (so an automatic one shouldn't be generated)
 		public bool CustomWrapper;


### PR DESCRIPTION
This change removes the following build warning:

```
jnienv-gen net10.0 succeeded with 1 warning(s) (3.1s) → bin/BuildDebug/jnienv-gen.dll
    /.../build-tools/jnienv-gen/Generator.cs(524,15): warning CS0649: Field 'JniFunction.Prebind' is never assigned to, and will always have its default value false
```

----

Pull Request
[title](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-summary) and
[description](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md#commit-body)
should follow the
[`commit-messages.md` workflow documentation](https://github.com/xamarin/xamarin-android/blob/main/Documentation/workflow/commit-messages.md), and in particular should include:

- [x] Useful description of *why the change is necessary*.
- [ ] Links to issues fixed
- [ ] Unit tests
