### PR TITLE
Fix build warnings in Xamarin.ProjectTools

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -78,7 +78,6 @@
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Android.JcwGen-Tests.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Installer.AndroidSDK.csproj' ">true</_AllowProjectWarnings>
     <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.Installer.Common.csproj' ">true</_AllowProjectWarnings>
-    <_AllowProjectWarnings Condition=" '$(MSBuildProjectFile)' == 'Xamarin.ProjectTools.csproj' ">true</_AllowProjectWarnings>
     <TreatWarningsAsErrors Condition=" ('$(RunningOnCI)' == 'true' OR '$(_AndroidTreatWarningsAsErrors)' == 'true') AND '$(_AllowProjectWarnings)' != 'true' ">true</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs
@@ -15,7 +15,7 @@ namespace Xamarin.ProjectTools
 
 		static string GetPathFromRegistry (string valueName)
 		{
-			if (TestEnvironment.IsWindows) {
+			if (OperatingSystem.IsWindows ()) {
 				return (string) Microsoft.Win32.Registry.GetValue ("HKEY_CURRENT_USER\\SOFTWARE\\Novell\\Mono for Android", valueName, null);
 			}
 			return null;


### PR DESCRIPTION
This PR fixes the following build warning:
```
 Xamarin.ProjectTools net10.0 succeeded with 1 warning(s) (2.6s) → src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/bin/Debug/net10.0/Xamarin.ProjectTools.dll
   /.../src/Xamarin.Android.Build.Tasks/Tests/Xamarin.ProjectTools/Android/AndroidSdkResolver.cs(19,21): warning CA1416: This call site is reachable on all platforms. 'Registry.GetValue(string, string?, object?)' is only supported on: 'windows'. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1416)
```
