### PR TITLE
[tests] Improve trimmer warning diagnostics

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -562,6 +562,8 @@ namespace Xamarin.Android.Build.Tests
 		[TestCaseSource (nameof (Get_BuildHasTrimmerWarningsData))]
 		public void BuildHasTrimmerWarnings (AndroidRuntime runtime, string properties, string [] codes, bool isRelease, int? totalWarnings = null)
 		{
+			const int maxWarningLinesToShow = 25;
+
 			if (IgnoreUnsupportedConfiguration (runtime, release: isRelease)) {
 				return;
 			}
@@ -601,10 +603,38 @@ namespace Xamarin.Android.Build.Tests
 				b.AssertHasNoWarnings ();
 			} else {
 				totalWarnings ??= codes.Length;
-				Assert.True (StringAssertEx.ContainsText (b.LastBuildOutput, $"{totalWarnings} Warning(s)"), $"Should receive {totalWarnings} warnings");
+
+				string warningSummaryLine = b.LastBuildOutput.LastOrDefault (line => line.Contains ("Warning(s)", StringComparison.Ordinal)) ?? "";
+				var actualWarnings = GetWarningCount (warningSummaryLine);
+
+				var allWarningLines = b.LastBuildOutput
+					.Where (line => line.Contains (": warning ", StringComparison.OrdinalIgnoreCase))
+					.Take (maxWarningLinesToShow)
+					.ToArray ();
+				Assert.AreEqual (
+					totalWarnings.Value,
+					actualWarnings,
+					$"{b.BuildLogFile} should have {totalWarnings} warnings. Summary line: '{warningSummaryLine}'. " +
+					$"Warnings found ({allWarningLines.Length} shown):{Environment.NewLine}{string.Join (Environment.NewLine, allWarningLines)}"
+				);
 				foreach (var code in codes) {
-					Assert.True (StringAssertEx.ContainsText (b.LastBuildOutput, code), $"Should receive {code} warning");
+					Assert.True (
+						StringAssertEx.ContainsText (b.LastBuildOutput, code),
+						$"{b.BuildLogFile} should contain warning {code}. Summary line: '{warningSummaryLine}'. " +
+						$"Warnings found ({allWarningLines.Length} shown):{Environment.NewLine}{string.Join (Environment.NewLine, allWarningLines)}"
+					);
 				}
+			}
+
+			static int GetWarningCount (string warningSummaryLine)
+			{
+				string [] tokens = warningSummaryLine.Split (new [] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+				for (int i = 1; i < tokens.Length; i++) {
+					if (tokens [i] == "Warning(s)" && int.TryParse (tokens [i - 1], out var warningCount)) {
+						return warningCount;
+					}
+				}
+				return -1;
 			}
 		}
 

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest2.cs
@@ -604,10 +604,11 @@ namespace Xamarin.Android.Build.Tests
 			} else {
 				totalWarnings ??= codes.Length;
 
-				string warningSummaryLine = b.LastBuildOutput.LastOrDefault (line => line.Contains ("Warning(s)", StringComparison.Ordinal)) ?? "";
+				string [] buildOutput = b.LastBuildOutput.ToArray ();
+				string warningSummaryLine = buildOutput.LastOrDefault (line => line.Contains ("Warning(s)", StringComparison.Ordinal)) ?? "";
 				var actualWarnings = GetWarningCount (warningSummaryLine);
 
-				var allWarningLines = b.LastBuildOutput
+				var allWarningLines = buildOutput
 					.Where (line => line.Contains (": warning ", StringComparison.OrdinalIgnoreCase))
 					.Take (maxWarningLinesToShow)
 					.ToArray ();
@@ -619,7 +620,7 @@ namespace Xamarin.Android.Build.Tests
 				);
 				foreach (var code in codes) {
 					Assert.True (
-						StringAssertEx.ContainsText (b.LastBuildOutput, code),
+						StringAssertEx.ContainsText (buildOutput, code),
 						$"{b.BuildLogFile} should contain warning {code}. Summary line: '{warningSummaryLine}'. " +
 						$"Warnings found ({allWarningLines.Length} shown):{Environment.NewLine}{string.Join (Environment.NewLine, allWarningLines)}"
 					);


### PR DESCRIPTION
Improve the failure message in BuildHasTrimmerWarnings by parsing the warning summary and printing the warning lines found when the expected count does not match.

Split out from #11669 so the RuntimeFeature PR stays focused.