### PR TITLE
[typemap] Fix trimmable primitive and alias arrays

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/Model/TypeMapAssemblyData.cs
@@ -119,7 +119,7 @@ sealed record ArrayProxyData
 /// </summary>
 sealed record PrimitiveArrayProxyData
 {
-	public required TypeRefData ConcreteArrayType { get; init; }
+	public IReadOnlyList<TypeRefData> ConcreteArrayTypes { get; init; } = [];
 }
 
 /// <summary>

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ModelBuilder.cs
@@ -17,14 +17,18 @@ static class ModelBuilder
 	const string ProxyTypeSuffix = "_Proxy";
 
 	static readonly PrimitiveArrayProxyInfo [] PrimitiveArrayProxies = [
-		new ("Z", "Boolean", "System.Boolean", "Java.Interop.JavaBooleanArray"),
-		new ("B", "SByte", "System.SByte", "Java.Interop.JavaSByteArray"),
-		new ("C", "Char", "System.Char", "Java.Interop.JavaCharArray"),
-		new ("S", "Int16", "System.Int16", "Java.Interop.JavaInt16Array"),
-		new ("I", "Int32", "System.Int32", "Java.Interop.JavaInt32Array"),
-		new ("J", "Int64", "System.Int64", "Java.Interop.JavaInt64Array"),
-		new ("F", "Single", "System.Single", "Java.Interop.JavaSingleArray"),
-		new ("D", "Double", "System.Double", "Java.Interop.JavaDoubleArray"),
+		new ("Z", "Boolean", "System.Boolean", ["Java.Interop.JavaBooleanArray"]),
+		new ("B", "SByte", "System.SByte", ["Java.Interop.JavaSByteArray"]),
+		new ("B", "Byte", "System.Byte", []),
+		new ("C", "Char", "System.Char", ["Java.Interop.JavaCharArray"]),
+		new ("S", "Int16", "System.Int16", ["Java.Interop.JavaInt16Array"]),
+		new ("S", "UInt16", "System.UInt16", []),
+		new ("I", "Int32", "System.Int32", ["Java.Interop.JavaInt32Array"]),
+		new ("I", "UInt32", "System.UInt32", []),
+		new ("J", "Int64", "System.Int64", ["Java.Interop.JavaInt64Array"]),
+		new ("J", "UInt64", "System.UInt64", []),
+		new ("F", "Single", "System.Single", ["Java.Interop.JavaSingleArray"]),
+		new ("D", "Double", "System.Double", ["Java.Interop.JavaDoubleArray"]),
 	];
 
 	static readonly HashSet<string> EssentialRuntimeTypes = new (StringComparer.Ordinal) {
@@ -575,12 +579,14 @@ static class ModelBuilder
 			return ExpandRankOneTypes (rankOneTypes, proxy.Rank);
 		}
 
-		var rankOnePrimitiveTypes = new [] {
+		List<string> rankOnePrimitiveTypes = [
 			AddArrayRank (elementType, 1),
 			MakeGenericTypeReference ("Java.Interop.JavaArray`1", "Java.Interop", elementType),
 			MakeGenericTypeReference ("Java.Interop.JavaPrimitiveArray`1", "Java.Interop", elementType),
-			AssemblyQualify (proxy.Primitive.ConcreteArrayType.ManagedTypeName, proxy.Primitive.ConcreteArrayType.AssemblyName),
-		};
+		];
+		foreach (var concreteArrayType in proxy.Primitive.ConcreteArrayTypes) {
+			rankOnePrimitiveTypes.Add (AssemblyQualify (concreteArrayType.ManagedTypeName, concreteArrayType.AssemblyName));
+		}
 		return ExpandRankOneTypes (rankOnePrimitiveTypes, proxy.Rank);
 	}
 
@@ -615,22 +621,25 @@ static class ModelBuilder
 	/// <summary>
 	/// Emits per-rank array TypeMap entries for one peer, anchored to the per-assembly
 	/// <c>__ArrayMapRank{N}</c> sentinels. Keys are managed element type names (rank is encoded
-	/// by the sentinel anchor, not by JNI array prefixes). Skips open generics and alias groups.
+	/// by the sentinel anchor, not by JNI array prefixes). Skips open generics.
 	/// </summary>
 	static void EmitArrayEntries (TypeMapAssemblyData model, string jniName, List<JavaPeerInfo> peersForName, int maxArrayRank)
 	{
-		if (peersForName.Count != 1) {
+		if (jniName.Length == 1 && IsJniPrimitiveKeyword (jniName [0])) {
 			return;
 		}
 
-		var peer = peersForName [0];
+		foreach (var peer in peersForName) {
+			EmitArrayEntriesForPeer (model, peer, maxArrayRank);
+		}
+	}
+
+	static void EmitArrayEntriesForPeer (TypeMapAssemblyData model, JavaPeerInfo peer, int maxArrayRank)
+	{
 		if (!peer.GenerateArrayEntries) {
 			return;
 		}
 		if (peer.IsGenericDefinition) {
-			return;
-		}
-		if (jniName.Length == 1 && IsJniPrimitiveKeyword (jniName [0])) {
 			return;
 		}
 
@@ -668,10 +677,10 @@ static class ModelBuilder
 					},
 					Rank = rank,
 					Primitive = new PrimitiveArrayProxyData {
-						ConcreteArrayType = new TypeRefData {
-							ManagedTypeName = primitive.ConcreteArrayTypeName,
+						ConcreteArrayTypes = primitive.ConcreteArrayTypeNames.Select (name => new TypeRefData {
+							ManagedTypeName = name,
 							AssemblyName = "Java.Interop",
-						},
+						}).ToList (),
 					},
 				};
 				model.ArrayProxyTypes.Add (proxy);
@@ -711,5 +720,5 @@ static class ModelBuilder
 		string JniName,
 		string Name,
 		string ManagedTypeName,
-		string ConcreteArrayTypeName);
+		IReadOnlyList<string> ConcreteArrayTypeNames);
 }

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/TypeMapAssemblyEmitter.cs
@@ -1636,12 +1636,14 @@ sealed class TypeMapAssemblyEmitter
 			return ExpandRankOneTypes (rankOneObjectTypes, proxy.Rank);
 		}
 
-		var rankOneTypes = new RuntimeTypeSpec [] {
+		List<RuntimeTypeSpec> rankOneTypes = [
 			AddSzArrayRank (elementType, 1),
 			new GenericRuntimeTypeSpec (_javaArrayOpenRef, elementType),
 			new GenericRuntimeTypeSpec (_javaPrimitiveArrayOpenRef, elementType),
-			new NamedRuntimeTypeSpec (proxy.Primitive.ConcreteArrayType),
-		};
+		];
+		foreach (var concreteArrayType in proxy.Primitive.ConcreteArrayTypes) {
+			rankOneTypes.Add (new NamedRuntimeTypeSpec (concreteArrayType));
+		}
 
 		return ExpandRankOneTypes (rankOneTypes, proxy.Rank);
 	}

--- a/src/Mono.Android/Android.Runtime/JNIEnv.cs
+++ b/src/Mono.Android/Android.Runtime/JNIEnv.cs
@@ -41,9 +41,11 @@ namespace Android.Runtime {
 					}
 				}
 
+				int arrayRank = GetArrayRank (elementType, out var leafElementType);
 				throw new NotSupportedException (
-					$"No TrimmableTypeMap array proxy entry for element type '{elementType}'. " +
-					$"Array lookups use the element type within the per-rank __ArrayMapRank{GetArrayRank (elementType)} typemap group; " +
+					$"No TrimmableTypeMap array proxy entry for element type '{elementType}' " +
+					$"(leaf element type '{leafElementType}', rank {arrayRank}). " +
+					$"Array lookups use the leaf element type within the per-rank __ArrayMapRank{arrayRank} typemap group; " +
 					$"ensure the mapping is emitted for that rank (for example by increasing _AndroidTrimmableTypeMapMaxArrayRank) or report an issue.");
 			}
 
@@ -52,7 +54,7 @@ namespace Android.Runtime {
 			#pragma warning restore IL3050
 		}
 
-		static int GetArrayRank (Type elementType)
+		static int GetArrayRank (Type elementType, out Type leafElementType)
 		{
 			int rank = 1;
 			while (elementType.IsSZArray) {
@@ -63,6 +65,7 @@ namespace Android.Runtime {
 				}
 				elementType = nestedElementType;
 			}
+			leafElementType = elementType;
 			return rank;
 		}
 

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TypeMapModelBuilderTests.cs
@@ -1128,17 +1128,27 @@ public class ModelBuilderTests : FixtureTestBase
 		}
 
 		[Fact]
-		public void Build_EmitArrayEntries_AliasGroup_Skipped ()
+		public void Build_EmitArrayEntries_AliasGroup_EmitsPerManagedType ()
 		{
-			// Alias groups (multiple peers sharing one JNI name) would produce duplicate
-			// JNI array keys; deferred pending an alias-aware design.
 			var peers = new List<JavaPeerInfo> {
-				MakeMcwPeer ("test/Dup", "Test.First", "App"),
-				MakeMcwPeer ("test/Dup", "Test.Second", "App"),
+				MakeMcwPeer ("java/lang/Object", "Java.Interop.JavaObject", "Java.Interop")
+					with { IsFrameworkAssembly = true, GenerateArrayEntries = false },
+				MakeMcwPeer ("java/lang/Object", "Java.Lang.Object", "Mono.Android")
+					with { IsFrameworkAssembly = true, GenerateArrayEntries = true },
 			};
 			var model = BuildModelWithArrays (peers);
 
-			Assert.DoesNotContain (model.Entries, e => e.AnchorRank is not null);
+			var arrayEntries = model.Entries.Where (e => e.AnchorRank is not null).ToList ();
+			Assert.Equal (3, arrayEntries.Count);
+			Assert.Contains (arrayEntries, e =>
+				e.MapKey == "Java.Lang.Object, Mono.Android" &&
+				e.AnchorRank == 1 &&
+				e.ProxyTypeReference == "_TypeMap.ArrayProxies.Java_Lang_Object_ArrayProxy1, TestTypeMap");
+			Assert.Contains (arrayEntries, e =>
+				e.MapKey == "Java.Lang.Object, Mono.Android" &&
+				e.AnchorRank == 2 &&
+				e.ProxyTypeReference == "_TypeMap.ArrayProxies.Java_Lang_Object_ArrayProxy2, TestTypeMap");
+			Assert.DoesNotContain (arrayEntries, e => e.MapKey == "Java.Interop.JavaObject, Java.Interop");
 		}
 
 		[Theory]
@@ -1170,7 +1180,7 @@ public class ModelBuilderTests : FixtureTestBase
 			var primitiveEntries = model.Entries
 				.Where (e => e.MapKey.StartsWith ("System.", StringComparison.Ordinal) && e.AnchorRank is not null)
 				.ToList ();
-			Assert.Equal (24, primitiveEntries.Count); // 8 primitive keywords × 3 ranks
+			Assert.Equal (36, primitiveEntries.Count);
 
 			var sbyteRank1 = primitiveEntries.Single (e => e.MapKey == "System.SByte, System.Runtime" && e.AnchorRank == 1);
 			Assert.Equal ("_TypeMap.ArrayProxies.Primitive_SByte_ArrayProxy1, _Java.Interop.TypeMap", sbyteRank1.ProxyTypeReference);
@@ -1188,6 +1198,24 @@ public class ModelBuilderTests : FixtureTestBase
 			Assert.Contains (model.Associations, a =>
 				a.SourceTypeReference == "Java.Interop.JavaSByteArray, Java.Interop" &&
 				a.AliasProxyTypeReference == sbyteRank1.ProxyTypeReference);
+
+			foreach (var (mapKey, proxyName, arrayTypeReference, concreteArrayTypeReference) in new [] {
+				("System.Byte, System.Runtime", "Byte", "System.Byte[], System.Runtime", "Java.Interop.JavaSByteArray, Java.Interop"),
+				("System.UInt16, System.Runtime", "UInt16", "System.UInt16[], System.Runtime", "Java.Interop.JavaInt16Array, Java.Interop"),
+				("System.UInt32, System.Runtime", "UInt32", "System.UInt32[], System.Runtime", "Java.Interop.JavaInt32Array, Java.Interop"),
+				("System.UInt64, System.Runtime", "UInt64", "System.UInt64[], System.Runtime", "Java.Interop.JavaInt64Array, Java.Interop"),
+			}) {
+				var rank1 = primitiveEntries.Single (e => e.MapKey == mapKey && e.AnchorRank == 1);
+				Assert.Equal ($"_TypeMap.ArrayProxies.Primitive_{proxyName}_ArrayProxy1, _Java.Interop.TypeMap", rank1.ProxyTypeReference);
+				var rank2 = primitiveEntries.Single (e => e.MapKey == mapKey && e.AnchorRank == 2);
+				Assert.Equal ($"_TypeMap.ArrayProxies.Primitive_{proxyName}_ArrayProxy2, _Java.Interop.TypeMap", rank2.TargetTypeReference);
+				Assert.Contains (model.Associations, a =>
+					a.SourceTypeReference == arrayTypeReference &&
+					a.AliasProxyTypeReference == rank1.ProxyTypeReference);
+				Assert.DoesNotContain (model.Associations, a =>
+					a.SourceTypeReference == concreteArrayTypeReference &&
+					a.AliasProxyTypeReference == rank1.ProxyTypeReference);
+			}
 		}
 
 		[Fact]
@@ -1277,6 +1305,34 @@ public class ModelBuilderTests : FixtureTestBase
 				Assert.DoesNotContain ("__ArrayMapRank1", typeRefNames);
 				Assert.DoesNotContain ("__ArrayMapRank2", typeRefNames);
 				Assert.DoesNotContain ("__ArrayMapRank3", typeRefNames);
+			});
+		}
+
+		[Fact]
+		public void FullPipeline_PrimitiveAliasArrayEntries_EmitWithoutConcreteArrayType ()
+		{
+			var peer = MakeMcwPeer ("java/lang/Object", "Java.Lang.Object", "Java.Interop");
+			var model = BuildModelWithArrays (new [] { peer }, assemblyName: "_Java.Interop.TypeMap");
+
+			EmitAndVerify (model, "_Java.Interop.TypeMap", (pe, reader) => {
+				var typeDefNames = reader.TypeDefinitions
+					.Select (h => reader.GetString (reader.GetTypeDefinition (h).Name))
+					.ToHashSet (StringComparer.Ordinal);
+				Assert.Contains ("Primitive_Byte_ArrayProxy1", typeDefNames);
+				Assert.Contains ("Primitive_Byte_ArrayProxy2", typeDefNames);
+				Assert.Contains ("Primitive_UInt32_ArrayProxy1", typeDefNames);
+
+				var assocAttrs = ReadAllTypeMapAssociationAttributeBlobs (reader);
+				Assert.Contains (assocAttrs, a =>
+					a.sourceRef == "System.Byte[], System.Runtime" &&
+					a.proxyRef == "_TypeMap.ArrayProxies.Primitive_Byte_ArrayProxy1, _Java.Interop.TypeMap");
+				Assert.Contains (assocAttrs, a =>
+					a.sourceRef == "System.UInt32[], System.Runtime" &&
+					a.proxyRef == "_TypeMap.ArrayProxies.Primitive_UInt32_ArrayProxy1, _Java.Interop.TypeMap");
+				Assert.DoesNotContain (assocAttrs, a =>
+					a.sourceRef == "Java.Interop.JavaSByteArray, Java.Interop" &&
+					a.proxyRef is not null &&
+					a.proxyRef.Contains ("Primitive_Byte", StringComparison.Ordinal));
 			});
 		}
 


### PR DESCRIPTION
Fix trimmable typemap array proxy emission for NativeAOT array lookups.

Changes:
- Emit primitive array proxies for Mono.Android primitive aliases: byte, ushort, uint, and ulong.
- Emit array entries for alias-group peers such as Java.Lang.Object instead of skipping the whole group.
- Allow primitive proxy metadata to model zero or more Java.Interop concrete array wrappers.
- Improve the NativeAOT missing-array-proxy diagnostic with leaf element type and rank.

Validation:
- dotnet test tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests.csproj --filter 'FullyQualifiedName~ModelBuilderTests+ArrayEntries' --verbosity normal