### PR TITLE
[release/11.0.1xx-preview6] Bump external/Java.Interop from `7049364` to `c24a8e9b`

### DIFF
--- a/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
+++ b/src/Mono.Android/Microsoft.Android.Runtime/ManagedTypeManager.cs
@@ -65,6 +65,7 @@ class ManagedTypeManager : JniRuntime.ReflectionJniTypeManager {
 	[UnconditionalSuppressMessage ("Trimming", "IL2057", Justification = "Type.GetType() can never statically know the string value parsed from parameter 'methods'.")]
 	[UnconditionalSuppressMessage ("Trimming", "IL2067", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
 	[UnconditionalSuppressMessage ("Trimming", "IL2072", Justification = "Delegate.CreateDelegate() can never statically know the string value parsed from parameter 'methods'.")]
+	[UnconditionalSuppressMessage ("AOT", "IL3050", Justification = "JniNativeMethodRegistration[] registration path will be migrated to the blittable RegisterNatives overload in a future change.")]
 	public override void RegisterNativeMembers (
 			JniType nativeClass,
 			[DynamicallyAccessedMembers (MethodsAndPrivateNested)]


### PR DESCRIPTION
Bumps `external/Java.Interop` from `7049364` to `c24a8e9b` (tip of `dotnet/java-interop/release/11.0.1xx-preview6`).

### Why

preview.6 **Release** builds of MAUI apps crash on startup:

```
System.TypeInitializationException: ... Java.Interop.ManagedPeer
 ---> Java.Lang.IncompatibleClassChangeError: no static or non-static method "Lnet/dot/jni/ManagedPeer;.????"
   at Java.Interop.JniEnvironment.Types._RegisterNatives(...)
   at Java.Interop.JniType.RegisterNativeMethods(...)
   at Java.Interop.ManagedPeer..cctor()
```

`Debug` and `dotnet new android` are unaffected; only MAUI **Release** (composite ReadyToRun + startup MIBC/PGO) reproduces.

### Root cause

The default registration path passed a **non-blittable** `JniNativeMethodRegistration[]` (`string Name; string Signature; Delegate Marshaler`) through a `delegate* unmanaged<>` call. [dotnet/runtime#126911](https://github.com/dotnet/runtime/pull/126911) moved array-of-struct marshalling into a managed `StructureMarshaler<T>` whose blittable-only fallback is miscompiled by crossgen2 when the marshaller is precompiled hot under composite R2R + MIBC. It emits a raw `Memmove` that blits a managed `string` reference straight into the native `char* name`, so JNI receives garbage method names (`????`) and registration fails with `NoSuchMethodError`.

### Fix

Picks up [dotnet/java-interop#1474](https://github.com/dotnet/java-interop/pull/1474) — *Register JNI natives via blittable `JniNativeMethod`*. It reworks the single `RegisterNatives` chokepoint to marshal names/signatures to UTF-8 ourselves and dispatch through the blittable `RegisterNatives(ReadOnlySpan<JniNativeMethod>)` overload, so there is no `StructureMarshaler<T>` involved and it is correct regardless of the crossgen2 bug. This fixes `ManagedPeer`, `AndroidTypeManager`, and `ManagedTypeManager` together.

Submodule fast-forward, exactly one commit, all in Java.Interop:

```
c24a8e9b Register JNI natives via blittable JniNativeMethod (#1474)
```

### Companion change: suppress new IL3050 warning

`#1474` adds `[RequiresDynamicCode]` to `RegisterNatives(.., JniNativeMethodRegistration[], int)`, which surfaces a new `IL3050` AOT analysis warning at `ManagedTypeManager.RegisterNativeMembers` under NativeAOT and breaks `BuildHasNoWarnings(True,False,"apk",NativeAOT)` (exact-count assertion, 10 → 12).

This PR adds the same one-line `[UnconditionalSuppressMessage("AOT", "IL3050", ...)]` that main carries (companion to the JI bump in #11782). The `JniNativeMethodRegistration[]` path will be migrated to the blittable `RegisterNatives(ReadOnlySpan<JniNativeMethod>)` overload in a future change.

(main's #11782 also removed the `Java.Runtime.Environment` project from the solution, but that came from an unrelated upstream PR, dotnet/java-interop#1447, which is *not* part of this narrow #1474-only bump, so it is intentionally omitted here.)

Fixes #11633