### PR TITLE
[TrimmableTypeMap] Merge library .aar manifests on the legacy merger path

### DIFF
--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/AssemblyLevelElementBuilder.cs
@@ -176,7 +176,7 @@ static class AssemblyLevelElementBuilder
 		XElement app,
 		Dictionary<string, object?> properties,
 		IReadOnlyList<JavaPeerInfo> allPeers,
-		Action<string>? warn = null)
+		Action<int, string>? warn = null)
 	{
 		PropertyMapper.ApplyMappings (app, properties, PropertyMapper.ApplicationPropertyMappings, skipExisting: true);
 
@@ -191,7 +191,7 @@ static class AssemblyLevelElementBuilder
 		IReadOnlyList<JavaPeerInfo> allPeers,
 		string propertyName,
 		string xmlAttrName,
-		Action<string>? warn)
+		Action<int, string>? warn)
 	{
 		if (app.Attribute (AndroidNs + xmlAttrName) is not null) {
 			return;
@@ -213,7 +213,8 @@ static class AssemblyLevelElementBuilder
 			}
 		}
 
-		warn?.Invoke ($"Could not resolve {propertyName} type '{managedName}' to a Java peer for android:{xmlAttrName}.");
+		// Code 0 = no XA code assigned; the caller may silently ignore it.
+		warn?.Invoke (0, $"Could not resolve {propertyName} type '{managedName}' to a Java peer for android:{xmlAttrName}.");
 	}
 
 	internal static void AddInternetPermission (XElement manifest)

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/Generator/ManifestGenerator.cs
@@ -25,6 +25,9 @@ class ManifestGenerator
 		"provider",
 	};
 
+	/// <summary>Warning code for library-manifest merge failures (maps to XA4302).</summary>
+	internal const int LibraryManifestMergeWarningCode = 4302;
+
 	int appInitOrder = 2000000000;
 
 	public string PackageName { get; set; } = "";
@@ -41,7 +44,7 @@ class ManifestGenerator
 	public bool ForceExtractNativeLibs { get; set; }
 	public string? ManifestPlaceholders { get; set; }
 	public string? ApplicationJavaClass { get; set; }
-	public Action<string>? Warn { get; set; }
+	public Action<int, string>? Warn { get; set; }
 	public Action<string>? WarnInvalidPlaceholder { get; set; }
 
 	/// <summary>
@@ -194,7 +197,7 @@ class ManifestGenerator
 			try {
 				libDoc = XDocument.Load (path);
 			} catch (Exception ex) {
-				Warn?.Invoke ($"Unable to merge library manifest '{path}': {ex.Message}");
+				Warn?.Invoke (LibraryManifestMergeWarningCode, $"Unable to merge library manifest '{path}': {ex.Message}");
 				continue;
 			}
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/ITrimmableTypeMapLogger.cs
@@ -12,6 +12,7 @@ public interface ITrimmableTypeMapLogger
 	void LogGeneratedJcwFilesInfo (int sourceCount);
 	void LogRootingManifestReferencedTypeInfo (string javaTypeName, string managedTypeName);
 	void LogManifestReferencedTypeNotFoundWarning (string javaTypeName);
+	void LogLibraryManifestMergeWarning (string message);
 	void LogUnresolvableJavaPeerSkippedWarning (
 		string managedTypeName,
 		string assemblyName,

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -149,6 +149,8 @@ public class TrimmableTypeMapGenerator
 			ForceExtractNativeLibs = forceDebuggable,
 			ManifestPlaceholders = config.ManifestPlaceholders,
 			ApplicationJavaClass = config.ApplicationJavaClass,
+			Warn = message => logger.LogLibraryManifestMergeWarning (message),
+			LibraryManifests = config.LibraryManifests ?? [],
 		};
 
 		var (doc, providerNames) = generator.Generate (manifestTemplate, allPeers, assemblyManifestInfo);

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapGenerator.cs
@@ -149,7 +149,12 @@ public class TrimmableTypeMapGenerator
 			ForceExtractNativeLibs = forceDebuggable,
 			ManifestPlaceholders = config.ManifestPlaceholders,
 			ApplicationJavaClass = config.ApplicationJavaClass,
-			Warn = message => logger.LogLibraryManifestMergeWarning (message),
+			Warn = (code, message) => {
+				if (code == ManifestGenerator.LibraryManifestMergeWarningCode)
+					logger.LogLibraryManifestMergeWarning (message);
+				// Other codes (e.g. unresolvable type properties) are not yet assigned XA codes
+				// and are intentionally not surfaced here.
+			},
 			LibraryManifests = config.LibraryManifests ?? [],
 		};
 

--- a/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
+++ b/src/Microsoft.Android.Sdk.TrimmableTypeMap/TrimmableTypeMapTypes.cs
@@ -46,4 +46,5 @@ public record ManifestConfig (
 	bool EmbedAssemblies = false,
 	string? ManifestPlaceholders = null,
 	string? CheckedBuild = null,
-	string? ApplicationJavaClass = null);
+	string? ApplicationJavaClass = null,
+	IReadOnlyList<string>? LibraryManifests = null);

--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.TypeMap.Trimmable.targets
@@ -98,7 +98,8 @@
   <Target Name="_GenerateTrimmableTypeMap"
       Condition=" '$(_AndroidTypeMapImplementation)' == 'trimmable' and '$(DesignTimeBuild)' != 'true' and '@(ReferencePath->Count())' != '0' and '$(_OuterIntermediateOutputPath)' == '' "
       AfterTargets="CoreCompile"
-      Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
+      DependsOnTargets="_GetLibraryImports"
+      Inputs="@(ReferencePath);@(PrivateSdkAssemblies);@(FrameworkAssemblies);@(ExtractedManifestDocuments);$(IntermediateOutputPath)$(TargetFileName);$(_AndroidManifestAbs);$(_AndroidBuildPropertiesCache)"
       Outputs="$(_TrimmableTypeMapOutputStamp)">
 
     <ItemGroup>
@@ -112,6 +113,9 @@
       <_TypeMapFrameworkAssemblies Include="@(FrameworkAssemblies)" />
       <_TypeMapInputAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)"
           Condition="Exists('$(IntermediateOutputPath)$(TargetFileName)')" />
+      <!-- Library (.aar) manifests to merge into the app manifest. Only on the legacy manifest
+           merger path; manifestmerger.jar merges these downstream in the _ManifestMerger target. -->
+      <_MergedManifestDocuments Condition=" '$(AndroidManifestMerger)' == 'legacy' " Include="@(ExtractedManifestDocuments)" />
     </ItemGroup>
 
     <GenerateTrimmableTypeMap
@@ -123,6 +127,7 @@
         TargetFrameworkVersion="$(TargetFrameworkVersion)"
         ManifestTemplate="$(_AndroidManifestAbs)"
         MergedAndroidManifestOutput="$(_TypeMapBaseOutputDir)AndroidManifest.xml"
+        MergedManifestDocuments="@(_MergedManifestDocuments)"
         PackageName="$(_AndroidPackage)"
         ApplicationLabel="$(_ApplicationLabel)"
         VersionCode="$(_AndroidVersionCode)"

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateTrimmableTypeMap.cs
@@ -44,6 +44,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 			log.LogMessage (MessageImportance.Low, $"Rooting manifest-referenced type '{javaTypeName}' ({managedTypeName}) as unconditional.");
 		public void LogManifestReferencedTypeNotFoundWarning (string javaTypeName) =>
 			log.LogCodedWarning ("XA4250", Properties.Resources.XA4250, javaTypeName);
+		public void LogLibraryManifestMergeWarning (string message) =>
+			log.LogCodedWarning ("XA4302", Properties.Resources.XA4302, message);
 		public void LogUnresolvableJavaPeerSkippedWarning (
 			string managedTypeName,
 			string assemblyName,
@@ -78,6 +80,13 @@ public class GenerateTrimmableTypeMap : AndroidTask
 	public string? ManifestTemplate { get; set; }
 
 	public string? MergedAndroidManifestOutput { get; set; }
+
+	/// <summary>
+	/// Absolute paths to extracted library (.aar) <c>AndroidManifest.xml</c> documents that must be
+	/// merged into the application manifest. Only populated on the legacy manifest-merger path;
+	/// <c>manifestmerger.jar</c> handles this downstream in the <c>_ManifestMerger</c> target.
+	/// </summary>
+	public string []? MergedManifestDocuments { get; set; }
 
 	public string? PackageName { get; set; }
 	public string? ApplicationLabel { get; set; }
@@ -184,7 +193,8 @@ public class GenerateTrimmableTypeMap : AndroidTask
 					EmbedAssemblies: EmbedAssemblies,
 					ManifestPlaceholders: ManifestPlaceholders,
 					CheckedBuild: CheckedBuild,
-					ApplicationJavaClass: ApplicationJavaClass);
+					ApplicationJavaClass: ApplicationJavaClass,
+					LibraryManifests: MergedManifestDocuments);
 			}
 
 			var generator = new TrimmableTypeMapGenerator (new MSBuildTrimmableTypeMapLogger (Log));

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/ManifestGeneratorTests.cs
@@ -1436,4 +1436,89 @@ public class ManifestGeneratorTests
 		Assert.NotNull (app);
 		Assert.Equal ("com.example.app.ManageActivity", (string?)app?.Attribute (AndroidNs + "manageSpaceActivity"));
 	}
+
+	[Fact]
+	public void LibraryManifests_MergedWithApplicationIdAndRelativeNamesResolved ()
+	{
+		// Mirrors ManifestTest.MergeLibraryManifest: a library (.aar) manifest is merged into the
+		// app manifest, ${applicationId} resolves to the app package, and relative component names
+		// (".Type") are qualified with the library's own package attribute.
+		var libManifest = Path.Combine (Path.GetTempPath (), $"lib-manifest-{Path.GetRandomFileName ()}.xml");
+		File.WriteAllText (libManifest, """
+			<?xml version='1.0'?>
+			<manifest xmlns:android='http://schemas.android.com/apk/res/android' package='com.xamarin.test'>
+			    <uses-sdk android:minSdkVersion='16'/>
+			    <permission android:name='${applicationId}.permission.C2D_MESSAGE' android:protectionLevel='signature' />
+			    <application>
+			        <activity android:name='.signin.internal.SignInHubActivity' />
+			        <provider
+			            android:authorities='${applicationId}.FacebookInitProvider'
+			            android:name='.internal.FacebookInitProvider'
+			            android:exported='false' />
+			        <meta-data android:name='android.support.VERSION' android:value='25.4.0' />
+			        <meta-data android:name='android.support.VERSION' android:value='25.4.0' />
+			    </application>
+			</manifest>
+			""");
+		try {
+			var gen = CreateDefaultGenerator ();
+			gen.PackageName = "com.xamarin.manifest";
+			gen.LibraryManifests = [libManifest];
+			var template = ParseTemplate ("""
+				<?xml version="1.0" encoding="utf-8"?>
+				<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.xamarin.manifest">
+				  <uses-sdk />
+				  <application android:label="App" />
+				</manifest>
+				""");
+
+			var doc = GenerateAndLoad (gen, template: template);
+
+			// ${applicationId} resolves to the app package on the merged permission.
+			var permission = doc.Root?.Elements ("permission")
+				.FirstOrDefault (e => (string?) e.Attribute (AttName) == "com.xamarin.manifest.permission.C2D_MESSAGE");
+			Assert.NotNull (permission);
+
+			var app = doc.Root?.Element ("application");
+			Assert.NotNull (app);
+
+			// Relative ".Type" names are qualified with the library package (com.xamarin.test).
+			var activity = app?.Elements ("activity")
+				.FirstOrDefault (e => (string?) e.Attribute (AttName) == "com.xamarin.test.signin.internal.SignInHubActivity");
+			Assert.NotNull (activity);
+
+			var provider = app?.Elements ("provider")
+				.FirstOrDefault (e => (string?) e.Attribute (AttName) == "com.xamarin.test.internal.FacebookInitProvider");
+			Assert.NotNull (provider);
+			// authorities uses ${applicationId} -> app package.
+			Assert.Equal ("com.xamarin.manifest.FacebookInitProvider", (string?) provider?.Attribute (AndroidNs + "authorities"));
+
+			// The two identical meta-data elements collapse to a single element.
+			var versionMeta = app?.Elements ("meta-data")
+				.Where (e => (string?) e.Attribute (AttName) == "android.support.VERSION")
+				.ToList ();
+			Assert.NotNull (versionMeta);
+			Assert.Single (versionMeta);
+		} finally {
+			File.Delete (libManifest);
+		}
+	}
+
+	[Fact]
+	public void LibraryManifests_MissingFileIgnored ()
+	{
+		// A non-existent library manifest path is skipped without throwing.
+		var gen = CreateDefaultGenerator ();
+		gen.LibraryManifests = [Path.Combine (Path.GetTempPath (), $"does-not-exist-{Path.GetRandomFileName ()}.xml")];
+		var template = ParseTemplate ("""
+			<?xml version="1.0" encoding="utf-8"?>
+			<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.example.app">
+			  <uses-sdk />
+			  <application android:label="App" />
+			</manifest>
+			""");
+
+		var doc = GenerateAndLoad (gen, template: template);
+		Assert.NotNull (doc.Root?.Element ("application"));
+	}
 }

--- a/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
+++ b/tests/Microsoft.Android.Sdk.TrimmableTypeMap.Tests/Generator/TrimmableTypeMapGeneratorTests.cs
@@ -36,6 +36,8 @@ public class TrimmableTypeMapGeneratorTests : FixtureTestBase
 			logMessages.Add ($"Rooting manifest-referenced type '{javaTypeName}' ({managedTypeName}) as unconditional.");
 		public void LogManifestReferencedTypeNotFoundWarning (string javaTypeName) =>
 			warnings?.Add ($"Manifest-referenced type '{javaTypeName}' was not found in any scanned assembly. It may be a framework type.");
+		public void LogLibraryManifestMergeWarning (string message) =>
+			warnings?.Add (message);
 		public void LogUnresolvableJavaPeerSkippedWarning (
 			string managedTypeName,
 			string assemblyName,


### PR DESCRIPTION
### Summary

On the trimmable typemap path, the app `AndroidManifest.xml` was missing content declared by referenced library `.aar` manifests (permissions, activities, providers, meta-data) **when `AndroidManifestMerger=legacy`**. The `manifestmerger.jar` path was unaffected because it merges library manifests downstream in `_ManifestMerger`.

The trimmable `ManifestGenerator` already contained the merge logic (`MergeLibraryManifests` + `FixupNameElements` + `${applicationId}`/placeholder substitution + duplicate-element removal), but it was **never fed the extracted library manifests**, so on the legacy path nothing was merged.

### Fix

Wire the extracted library manifests through to the generator:

`@(ExtractedManifestDocuments)` → `GenerateTrimmableTypeMap.MergedManifestDocuments` → `ManifestConfig.LibraryManifests` → `ManifestGenerator.LibraryManifests`.

- `_GenerateTrimmableTypeMap` now depends on `_GetLibraryImports` (which populates `@(ExtractedManifestDocuments)`) and includes those documents in its `Inputs` for incrementality.
- The library manifests are only passed on the legacy merger path (`AndroidManifestMerger == 'legacy'`).
- Merge failures now surface as an `XA4302` warning via a new `LogLibraryManifestMergeWarning` logger method, matching the legacy `ManifestDocument` behavior.

### Tests

Adds two `ManifestGeneratorTests`:
- `LibraryManifests_MergedWithApplicationIdAndRelativeNamesResolved` — verifies `${applicationId}` resolves to the app package, relative `.Type` component names are qualified with the library's own package, and duplicate `meta-data` collapses to one element (mirrors `ManifestTest.MergeLibraryManifest`).
- `LibraryManifests_MissingFileIgnored` — a non-existent library manifest path is skipped without throwing.

This fixes `ManifestTest.MergeLibraryManifest` on the trimmable/NativeAOT path.
