### PR TITLE
[ci] Make Android SDK test setup downloads more resilient

### DIFF
--- a/build-tools/automation/yaml-templates/cache-android-archives.yaml
+++ b/build-tools/automation/yaml-templates/cache-android-archives.yaml
@@ -18,17 +18,18 @@
 
 parameters:
   xaSourcePath: $(System.DefaultWorkingDirectory)/android
+  condition: succeeded()
 
 steps:
 - script: echo "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]$HOME/android-archives"
   displayName: prepare android-archives cache variables
-  condition: ne(variables['Agent.OS'], 'Windows_NT')
+  condition: and(${{ parameters.condition }}, ne(variables['Agent.OS'], 'Windows_NT'))
 
 - pwsh: |
     $dir = Join-Path $env:USERPROFILE 'android-archives'
     Write-Host "##vso[task.setvariable variable=ANDROID_ARCHIVES_DIR]$dir"
   displayName: prepare android-archives cache variables
-  condition: eq(variables['Agent.OS'], 'Windows_NT')
+  condition: and(${{ parameters.condition }}, eq(variables['Agent.OS'], 'Windows_NT'))
 
 # Key off every file that defines what gets downloaded or its expected hash.
 # Bumping a version or hash in any of these invalidates the cache; the
@@ -36,6 +37,7 @@ steps:
 # a subset changes (e.g. a single component bump).
 - task: Cache@2
   displayName: cache Android toolchain archives
+  condition: ${{ parameters.condition }}
   inputs:
     key: '"android-archives" | "v1" | "$(Agent.OS)" | ${{ parameters.xaSourcePath }}/Configuration.props | ${{ parameters.xaSourcePath }}/src/androidsdk/androidsdk.targets | ${{ parameters.xaSourcePath }}/src/openjdk/openjdk.targets | ${{ parameters.xaSourcePath }}/src/binutils/binutils.targets | ${{ parameters.xaSourcePath }}/src/aapt2/aapt2.targets | ${{ parameters.xaSourcePath }}/src/bundletool/bundletool.targets'
     restoreKeys: |

--- a/build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
+++ b/build-tools/automation/yaml-templates/setup-test-environment-steps.yaml
@@ -49,6 +49,11 @@ steps:
     displayName: Install p7zip on macOS
     condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
 
+- template: /build-tools/automation/yaml-templates/cache-android-archives.yaml
+  parameters:
+    xaSourcePath: ${{ parameters.xaSourcePath }}
+    condition: and(succeeded(), eq(variables['agent.os'], 'Darwin'))
+
 - pwsh: |
     & "${{ parameters.xaSourcePath }}/eng/install-dotnet.ps1" -configuration ${{ parameters.configuration }}
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
@@ -82,6 +87,7 @@ steps:
     project: ${{ parameters.xaSourcePath }}/src/androidsdk/androidsdk.csproj
     arguments: -c ${{ parameters.configuration }} -bl:${{ parameters.xaSourcePath }}/bin/Test${{ parameters.configuration }}/androidsdk.binlog
     continueOnError: false
+    retryCountOnTaskFailure: 2
     env:
       AndroidSdkPlatforms: ${{ parameters.androidSdkPlatforms }}
 


### PR DESCRIPTION
## Summary

This is another incremental hardening PR for the recurring `install OpenJDK and accept Android SDK licenses` CI failure where large Android SDK archives from `dl.google.com` fail with:

```text
MSB3923: Failed to download file "https://dl.google.com/android/repository/...".
The response ended prematurely. (ResponseEnded)
```

The specific recent failure already had the newer retry/backoff behavior: the log shows retries waiting 30s, 60s, 90s, and 120s before ultimately exhausting `x86_64-29_r08-darwin.zip`. So this PR does **not** replace the existing download retry work; it builds on it and covers the next failure mode.

## Prior work this builds on

- [#11348](https://github.com/dotnet/android/pull/11348) moved OpenJDK installation into an MSBuild NoTargets project.
- [#11440](https://github.com/dotnet/android/pull/11440) moved Android SDK/NDK component downloads into `src/androidsdk/androidsdk.targets`, which is what this setup step builds.
- [#11618](https://github.com/dotnet/android/pull/11618) added the shared `android-archives` pipeline cache for build jobs and bumped the built-in `DownloadFile` retries.
- [#11647](https://github.com/dotnet/android/pull/11647) added the shared `DownloadFileWithRetry` wrapper because `ResponseEnded` is a top-level `HttpIOException` that MSBuild's built-in `DownloadFile` retry logic does not catch.
- [#11693](https://github.com/dotnet/android/pull/11693) made `DownloadOneFileWithRetry` skip cleanly on no-op builds using per-file stamps, which makes whole-step retries less wasteful once some archives already succeeded.
- [#11817](https://github.com/dotnet/android/pull/11817) added escalating outer backoff between retry attempts, so transient CDN hiccups get several minutes to recover instead of burning through attempts immediately.

## Remaining gap

Those PRs made individual downloads much more resilient, but the failing path is the **test environment setup** template, not the main build template:

- `build-{linux,macos,windows}-steps.yaml` already uses `cache-android-archives.yaml`.
- `setup-test-environment-steps.yaml` did **not** use that cache before running `src/androidsdk/androidsdk.csproj`.
- The `install OpenJDK and accept Android SDK licenses` `run-dotnet-preview.yaml` invocation also had `retryCountOnTaskFailure: 0` through the template default.

That means a macOS test setup job could still cold-download several large archives concurrently and fail the entire job if one archive exhausted the per-file retry/backoff loop.

## Change

This PR hardens that remaining test-setup path by:

- adding a `condition` parameter to `cache-android-archives.yaml`, preserving the existing default behavior for build jobs
- invoking the Android archive cache from `setup-test-environment-steps.yaml` for macOS test setup before SDK downloads run
- setting `retryCountOnTaskFailure: 2` on the `install OpenJDK and accept Android SDK licenses` step

The cache is intentionally limited to macOS test setup for now. Linux archive caching already has a separate disk-pressure concern tracked by [#11837](https://github.com/dotnet/android/issues/11837), so this PR avoids expanding Linux cache usage while still targeting the observed macOS `ResponseEnded` failure.

## Why step retry helps

The per-file retry wrapper is still the first line of defense. The task-level retry is a second line of defense for the case where a specific archive exhausts all per-file attempts.

On a second task attempt, successfully downloaded archives should be reused/skipped by the existing cache/stamp logic, so the retry mostly focuses on the archive that failed rather than restarting all work from scratch.

## Validation

- `git diff --check`
