### PR TITLE
[TrimmableTypeMap] Bump WorkManager test's AndroidX to post-KMP-split versions

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/BuildTest.cs
@@ -1376,6 +1376,13 @@ public class MyWorker : Worker
 			});
 			proj.PackageReferences.Add (KnownPackages.AndroidXWorkRuntime);
 			proj.PackageReferences.Add (KnownPackages.AndroidXLifecycleLiveData);
+			// Xamarin.Forms 5.0.0.2622 transitively pulls old Xamarin.AndroidX.Fragment (1.5.5) and
+			// Xamarin.Google.Android.Material (1.4.0.2) that were compiled before the AndroidX.Collection
+			// KMP split and carry dangling type references to AndroidX.Collection.SimpleArrayMap in the now
+			// type-less Xamarin.AndroidX.Collection facade. NativeAOT/ILC resolves those references eagerly
+			// while building vtables and fails to load the type. Reference a current Material (which depends
+			// on Fragment 1.6.2.1) so both resolve to Xamarin.AndroidX.Collection.Jvm.
+			proj.PackageReferences.Add (KnownPackages.XamarinGoogleAndroidMaterial);
 			using (var b = CreateApkBuilder ()) {
 				Assert.IsTrue (b.Build (proj), "Build should have succeeded.");
 			}


### PR DESCRIPTION
### Summary

`BuildTest.WorkManager` fails on the trimmable/NativeAOT path with:

```
ilc: error: Failed to load type 'AndroidX.Collection.SimpleArrayMap' from assembly 'Xamarin.AndroidX.Collection'
```

### Root cause

The test uses `XamarinFormsAndroidApplicationProject`, whose `Xamarin.Forms 5.0.0.2622` transitively pulls **`Xamarin.AndroidX.Fragment 1.5.5`** and **`Xamarin.Google.Android.Material 1.4.0.2`**. Both were built **before** the `androidx.collection` Kotlin-Multiplatform split: the types (`SimpleArrayMap`, `ArrayMap`, …) later moved out of `Xamarin.AndroidX.Collection` into `Xamarin.AndroidX.Collection.Jvm`, and the old facade `Xamarin.AndroidX.Collection.dll` was emptied (**0 types, 0 type-forwards**) **without** a `[TypeForwardedTo]` being added.

So those older assemblies carry a **dangling** `TypeRef` `[Xamarin.AndroidX.Collection]AndroidX.Collection.SimpleArrayMap` that now points at an empty assembly.

- **MonoVM / CoreCLR (JIT)** never notice: type references resolve **lazily**, only when a type is actually used, and this path is never exercised (real usages reach `SimpleArrayMap` through the correct `.Jvm` reference from newer assemblies).
- **NativeAOT / ILC** does whole-program compilation and resolves the reference **eagerly** while building vtables for constructed types, so it trips over the dangling reference and fails the build.

### Fix

Reference a current `Xamarin.Google.Android.Material` (`1.10.0.2`, already `KnownPackages.XamarinGoogleAndroidMaterial`). It references `Xamarin.AndroidX.Collection.Jvm` and depends on `Xamarin.AndroidX.Fragment 1.6.2.1`, so both stale Forms-transitive packages resolve to post-split versions and the dangling reference disappears.

This is a test-only change (no product change) — the underlying binding-packaging issue (missing type-forward on the emptied `Xamarin.AndroidX.Collection` facade) lives in the AndroidX bindings, not this repo.
