### PR TITLE
[ci] Fix macOS hosted image label on internal pipeline

### DIFF
--- a/build-tools/automation/azure-pipelines-public.yaml
+++ b/build-tools/automation/azure-pipelines-public.yaml
@@ -45,8 +45,6 @@ variables:
 - name: DefaultJavaSdkMajorVersion
   value: 21
 # Override pool images for public Microsoft-hosted agents
-- name: HostedMacImage
-  value: macOS-15
 - name: LinuxPoolImage
   value: ubuntu-22.04
 - name: NetCorePublicPoolName

--- a/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
+++ b/build-tools/automation/yaml-templates/stage-java-interop-tests.yaml
@@ -104,6 +104,18 @@ stages:
         fi
       displayName: Ensure cmake is installed
 
+    # The hosted macOS pool architecture can change between Intel (osx-x64) and
+    # Apple Silicon (osx-arm64), so detect it at runtime and publish/run the
+    # NativeAOT sample for the matching RID. Otherwise the produced .dylib fails
+    # to dlopen with an "incompatible architecture" error.
+    - bash: |
+        if [ "$(Agent.OSArchitecture)" = "ARM64" ]; then
+          echo "##vso[task.setvariable variable=NativeAOTRid]osx-arm64"
+        else
+          echo "##vso[task.setvariable variable=NativeAOTRid]osx-x64"
+        fi
+      displayName: Determine NativeAOT RID
+
     - template: /external/Java.Interop/build-tools/automation/templates/install-dependencies.yaml@self
 
     - template: /external/Java.Interop/build-tools/automation/templates/core-build.yaml@self
@@ -111,7 +123,7 @@ stages:
     - template: /external/Java.Interop/build-tools/automation/templates/core-tests.yaml@self
       parameters:
         runNativeTests: true
-        nativeAotRid: osx-arm64
+        nativeAotRid: $(NativeAOTRid)
         platformName: .NET - MacOS
 
     - template: /external/Java.Interop/build-tools/automation/templates/fail-on-dirty-tree.yaml@self

--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -30,7 +30,7 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-15-arm64
+  value: macOS-15
 - name: HostedMacImageWithEmulator
   value: macOS-15
 - name: SharedMacPool


### PR DESCRIPTION
## Why

Builds on the internal DevDiv pipeline started failing on the macOS MSBuild test jobs with:

```
No image label found to route agent pool Azure Pipelines.
```

PR #11708 bumped `HostedMacImage` from `macOS-14-arm64` to `macOS-15-arm64`. However, Microsoft has [paused the macOS-15 ARM64 hosted-agent limited public preview](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml) on the `Azure Pipelines` pool:

> The macOS 15 Sequoia ARM64 limited public preview has been paused. Any Azure DevOps organization currently using it can continue to do so.

DevDiv was not already onboarded to the `macOS-15-arm64` preview (it had been on `macOS-14-arm64`), so that label no longer routes to any agent, and the internal builds fail. The only valid macOS labels on the hosted `Azure Pipelines` pool are now `macOS-14`, `macOS-15`, and `macOS-26` (no ARM64 variant).

## What

- `variables.yaml`: point `HostedMacImage` at `macOS-15` (Intel) instead of the paused `macOS-15-arm64`. This matches the label the public pipeline was already using, which is why `dnceng-public` stayed green.
- `azure-pipelines-public.yaml`: drop the now-redundant `HostedMacImage: macOS-15` override, since it is identical to the new default. The public-only `LinuxPoolImage` override stays, as it has no default.

`HostedMacImageWithEmulator` was already `macOS-15` (never had the `-arm64` suffix), so no change was needed there.

## Follow-on: Java.Interop Mac lane

Switching the hosted Mac pool from ARM64 to Intel also broke the Java.Interop Mac lane, which had hard-coded `nativeAotRid: osx-arm64`. Publishing/running the `Hello-NativeAOTFromJNI` NativeAOT sample for `osx-arm64` on an x64 agent produces a `.dylib` the x64 JDK cannot `dlopen`:

```
incompatible architecture (have 'arm64', need 'x86_64')
```

That run step is `continueOnError: true`, but it still records an error that the trailing `fail-on-issue` step turns into a lane failure.

- `stage-java-interop-tests.yaml`: detect the agent architecture at runtime via `Agent.OSArchitecture` and publish/run the sample for the matching RID (`osx-arm64` on Apple Silicon, `osx-x64` on Intel), so the lane stays correct regardless of the hosted pool's architecture.

### Why not just omit the RID and let the CLI pick the default?

The lane targets `net10.0` on a .NET 10 SDK, so you might expect `PublishAot` to infer the host RID automatically. It does, but only for `publish`, and the lane runs two commands:

```
dotnet publish -r <rid> samples/Hello-NativeAOTFromJNI/...
dotnet build   -r <rid> -t:RunJavaSample samples/Hello-NativeAOTFromJNI/...
```

- The `dotnet publish` step would be fine without `-r`: `PublishAot=true` triggers an [automatic `RuntimeIdentifier`](https://learn.microsoft.com/dotnet/core/compatibility/sdk/7.0/automatic-rid), so it infers the host RID and writes to `bin/Release/<host-rid>/publish/`.
- The `RunJavaSample` step would break: that automatic-RID behavior is **restricted to `dotnet publish`** ([publish-only note](https://learn.microsoft.com/dotnet/core/compatibility/sdk/7.0/automatic-rid-publish-only)). The run step is a `dotnet build`, so without `-r` its `RuntimeIdentifier` stays empty.

`RunJavaSample` executes from the publish output directory:

```xml
<Exec Command="&quot;$(JavaPath)&quot; -classpath ..."
      WorkingDirectory="$(MSBuildThisFileDirectory)$(PublishDir)" />
```

`$(PublishDir)` defaults to `bin/$(Configuration)/$(TargetFramework)/$(RuntimeIdentifier)/publish/`. If we omit the RID, `publish` writes to `.../osx-x64/publish/` (inferred RID) while the `build`/run step looks in `.../net10.0/publish/` (no RID) - so the `.dylib` and jars aren't found and the run fails. Passing an explicit RID to **both** commands keeps their `$(PublishDir)` aligned, which is why runtime arch detection (rather than omitting the RID) is the correct fix.
