### PR TITLE
[release/10.0.1xx] [ci] Fix macOS hosted image label on internal pipeline

### DIFF
--- a/build-tools/automation/yaml-templates/variables.yaml
+++ b/build-tools/automation/yaml-templates/variables.yaml
@@ -34,9 +34,9 @@ variables:
 - name: GitHub.Token
   value: $(github--pat--vs-mobiletools-engineering-service2)
 - name: HostedMacImage
-  value: macOS-14-arm64
+  value: macOS-15
 - name: HostedMacImageWithEmulator
-  value: macOS-14
+  value: macOS-15
 - name: SharedMacPool
   value: VSEng-VSMac-Xamarin-Shared
 - name: SharedMacName


### PR DESCRIPTION
Backport of #12005

## Why

Internal DevDiv pipeline builds fail on the macOS MSBuild test jobs with:

> `No image label found to route agent pool Azure Pipelines.`

Microsoft paused the macOS-15 ARM64 hosted-agent limited public preview on the `Azure Pipelines` pool, and DevDiv is not onboarded to it, so any `*-arm64` macOS label no longer routes. The only valid macOS labels on the hosted `Azure Pipelines` pool are now `macOS-14`, `macOS-15`, and `macOS-26` (no ARM64 variant). See the [Microsoft-hosted agents documentation](https://learn.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml).

The `main` branch already moved to macOS-15 in an earlier PR; `release/10.0.1xx` still had the arm64 label.

## What

In `build-tools/automation/yaml-templates/variables.yaml`:

- `HostedMacImage`: `macOS-14-arm64` → `macOS-15`
- `HostedMacImageWithEmulator`: `macOS-14` → `macOS-15`

This matches `main`'s end state. No redundant `HostedMacImage` overrides exist elsewhere under `build-tools/automation` on this branch, so no other changes are needed.