### PR TITLE
[experiment][NativeAOT] Replace NDK libunwind with fail-fast shims

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.NativeAOT.targets
@@ -354,7 +354,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       </_NativeAotCrtEndFiles>
       <_NativeAotLibSearchPaths Include="$(_NativeAotRuntimePackNativeDir)" />
       <_NativeAotCompilerRtLibs Include="$(_NativeAotRuntimePackNativeDir)/libclang_rt.builtins-$(_NdkAbi)-android.a" />
-      <_NativeAotCompilerRtLibs Include="$(_NativeAotRuntimePackNativeDir)/libunwind.a" />
     </ItemGroup>
 
     <!-- CRT and toolchain items from NDK -->
@@ -368,7 +367,6 @@ This file contains the NativeAOT-specific MSBuild logic for .NET for Android.
       <_NativeAotLibSearchPaths Include="$(_NdkApiSysrootDir)" />
       <_NativeAotLibSearchPaths Include="$(_NdkSysrootDir)" />
       <_NativeAotCompilerRtLibs Include="$(_NdkClangResourceDir)/**/libclang_rt.builtins-$(_NdkAbi)-android.a" />
-      <_NativeAotCompilerRtLibs Include="$(_NdkClangResourceDir)/**/$(_NdkAbi)/libunwind.a" />
     </ItemGroup>
 
     <!-- Common items (same regardless of linker source) -->

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/NativeAotBuildTests.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Android.Build.Tests
 				builder.Build (proj),
 				"Build should succeed without NDK (workload linker is the default)."
 			);
+			AssertUsesLibcxxWithoutLibunwind (builder, "android-arm64");
 		}
 
 		[Test]
@@ -73,6 +74,7 @@ namespace Xamarin.Android.Build.Tests
 				}),
 				"Build should succeed with NDK linker."
 			);
+			AssertUsesLibcxxWithoutLibunwind (builder, "android-arm64");
 		}
 
 		[Test]
@@ -92,6 +94,7 @@ namespace Xamarin.Android.Build.Tests
 				]),
 				"android-arm build should succeed with NDK linker."
 			);
+			AssertUsesLibcxxWithoutLibunwind (builder, "android-arm");
 		}
 
 		[Test]
@@ -110,6 +113,19 @@ namespace Xamarin.Android.Build.Tests
 				}),
 				"Build should fail without NDK when workload linker is disabled."
 			);
+		}
+
+		void AssertUsesLibcxxWithoutLibunwind (ProjectBuilder builder, string runtimeIdentifier)
+		{
+			var intermediate = builder.Output.GetIntermediaryPath (runtimeIdentifier);
+			var responseFiles = Directory.GetFiles (intermediate, "ld.lib*.rsp", SearchOption.AllDirectories);
+			Assert.IsNotEmpty (responseFiles, $"{intermediate} should contain a native linker response file.");
+
+			foreach (var responseFile in responseFiles) {
+				var response = File.ReadAllText (responseFile);
+				StringAssert.Contains ("libc++abi.a", response, $"{responseFile} should link libc++abi.");
+				StringAssert.DoesNotContain ("libunwind.a", response, $"{responseFile} should not link the NDK unwinder.");
+			}
 		}
 	}
 }

--- a/src/native/nativeaot/host/CMakeLists.txt
+++ b/src/native/nativeaot/host/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CLR_SOURCES_PATH "../../clr")
 
 set(XAMARIN_MONODROID_SOURCES
   bridge-processing.cc
+  cxx-unwind-shims.c
   host.cc
   host-environment.cc
   host-jni.cc
@@ -143,6 +144,7 @@ xa_add_include_directories(${XAMARIN_NAOT_ANDROID_LIB})
 
 target_link_options(${XAMARIN_NAOT_ANDROID_LIB}
   PRIVATE
+  -unwindlib=none
   -Wl,--version-script,${CMAKE_SOURCE_DIR}/nativeaot/libnaot-android.map.txt
   -Wl,--no-undefined-version
 )

--- a/src/native/nativeaot/host/cxx-unwind-shims.c
+++ b/src/native/nativeaot/host/cxx-unwind-shims.c
@@ -1,0 +1,128 @@
+#include <stdlib.h>
+
+#include <android/log.h>
+#include <unwind.h>
+
+#define UNUSED __attribute__((unused))
+
+// NativeAOT's Android host is built without C++ exception support.  Keep libc++/libc++abi
+// available for now, but fail fast instead of linking the NDK's full exception unwinder.
+__attribute__((noreturn))
+static void abort_cxx_exception_unwind (const char *function)
+{
+	__android_log_print (
+		ANDROID_LOG_FATAL,
+		"DOTNET",
+		"C++ exception unwinding is not supported by the NativeAOT host: %s",
+		function
+	);
+	abort ();
+}
+
+void _Unwind_DeleteException (_Unwind_Exception *exception UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+void *_Unwind_GetLanguageSpecificData (struct _Unwind_Context *context UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_Ptr _Unwind_GetRegionStart (struct _Unwind_Context *context UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_Reason_Code _Unwind_RaiseException (_Unwind_Exception *exception UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+void _Unwind_Resume (_Unwind_Exception *exception UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+#if defined (__arm__)
+_Unwind_Reason_Code __aeabi_unwind_cpp_pr0 (
+	_Unwind_State state UNUSED,
+	_Unwind_Exception *exception UNUSED,
+	struct _Unwind_Context *context UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_Reason_Code __aeabi_unwind_cpp_pr1 (
+	_Unwind_State state UNUSED,
+	_Unwind_Exception *exception UNUSED,
+	struct _Unwind_Context *context UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_Reason_Code __aeabi_unwind_cpp_pr2 (
+	_Unwind_State state UNUSED,
+	_Unwind_Exception *exception UNUSED,
+	struct _Unwind_Context *context UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_Reason_Code __gnu_unwind_frame (
+	_Unwind_Exception *exception UNUSED,
+	struct _Unwind_Context *context UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_VRS_Result _Unwind_VRS_Get (
+	struct _Unwind_Context *context UNUSED,
+	_Unwind_VRS_RegClass regclass UNUSED,
+	uint32_t regno UNUSED,
+	_Unwind_VRS_DataRepresentation representation UNUSED,
+	void *value UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+_Unwind_VRS_Result _Unwind_VRS_Set (
+	struct _Unwind_Context *context UNUSED,
+	_Unwind_VRS_RegClass regclass UNUSED,
+	uint32_t regno UNUSED,
+	_Unwind_VRS_DataRepresentation representation UNUSED,
+	void *value UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+#else
+_Unwind_Word _Unwind_GetIP (struct _Unwind_Context *context UNUSED)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+void _Unwind_SetGR (
+	struct _Unwind_Context *context UNUSED,
+	int index UNUSED,
+	_Unwind_Word value UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+
+void _Unwind_SetIP (
+	struct _Unwind_Context *context UNUSED,
+	_Unwind_Word value UNUSED
+)
+{
+	abort_cxx_exception_unwind (__func__);
+}
+#endif
+
+#undef UNUSED


### PR DESCRIPTION
## Experiment

Replace the Android NDK's real C++ exception unwinder with fail-fast ABI shims while retaining `libc++_static.a` and `libc++abi.a`.

This explores an alternative path for #12146 that can remove NDK `libunwind.a` before the broader libc++ removal tracked by #12139.

## Changes

- add NativeAOT-only implementations of the `_Unwind_*` entry points required by libc++abi and compiler-generated code;
- cover both the generic Itanium ABI and ARM EHABI, including the ARM personality entry points;
- log a fatal diagnostic and abort if C++ exception unwinding is attempted;
- pass `-unwindlib=none` to the Clang-based NativeAOT host DSO links;
- remove `libunwind.a` from both workload and NDK NativeAOT linker inputs;
- retain `libc++_static.a`, `libc++abi.a`, and NativeAOT's private managed-frame unwinder;
- assert in focused build tests that NativeAOT responses contain libc++abi but not libunwind.

## Evidence

- NativeAOT host Debug/Release libraries build for arm, arm64, and x64 without a real low-level `__unw_*` implementation.
- Workload-linker and legacy-NDK-linker NativeAOT app builds succeed.
- Both arm64 variants start successfully on a Samsung SM-A165F without reaching a fail-fast shim.
- A forced native C++ `throw` reaches `_Unwind_RaiseException`, logs the fail-fast diagnostic, and terminates with `SIGABRT`.
- The exact `.NET 10.0.9` NativeAOT object from failing CI build #1513910 links successfully with NDK `29.0.14206865`.
- That reproduced final link contains the fail-fast `_Unwind_*` ABI and no NDK `__unw_*` symbols.
- Relinking the same arm64 NativeAOT application with the NDK unwinder added 21,096 bytes to the native shared library.

The .NET 10 link is a controlled reproduction of the CI collision, not the product configuration changed by this PR. Current `main` targets .NET 11. The compatibility test uses the already-published Android 36.1.69 and .NET 10.0.9 packs, so this PR cannot alter that test's inputs.

## Important risks

- Any C++ exception now aborts immediately instead of unwinding.
- A libc++ operation that throws and catches internally would no longer recover.
- Third-party static native libraries that require C++ exception propagation are incompatible with this experiment.
- ARM32 EHABI personality shims need runtime validation on an ARM32 device; this PR currently proves that the configuration links.
- `libunwind.a` remains present in runtime packs for now, but it is no longer part of NativeAOT link responses.
- The existing `net10.0-android36.1` compatibility test will retain its deterministic .NET 10.0.9/NDK r29 collision until that lane pins a supported NDK, skips NativeAOT, or its servicing product is changed.

Managed exceptions do not use these entry points. NativeAOT's private unwinder remains responsible for managed frame inspection, GC stack walking, exception handling, stack traces, and profiling.

## Validation

- `git diff --check`
- Release build of `src/native/native-nativeaot.csproj`
- full Release SDK build
- focused `NativeAotBuildTests` matrix
- workload-linker arm64 sample build and device startup
- legacy-NDK-linker arm64 sample build and device startup
- manual `.NET 10.0.9` + NDK r29 collision reproduction using the CI-produced NativeAOT object

Explores #12146.
Related to #12139.
