### PR TITLE
Cache managed-to-Java type signatures

### DIFF
--- a/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
+++ b/src/Mono.Android/Android.Runtime/AndroidRuntime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
@@ -319,12 +320,23 @@ namespace Android.Runtime {
 	[RequiresUnreferencedCode ("This type manager is reflection-backed and is not trimming-compatible.")]
 	class AndroidTypeManager : JniRuntime.ReflectionJniTypeManager {
 		bool jniAddNativeMethodRegistrationAttributePresent;
+		readonly ConcurrentDictionary<Type, JniTypeSignature> typeSignatures = new ();
 
 		const DynamicallyAccessedMemberTypes Constructors = DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.NonPublicConstructors;
 
 		public AndroidTypeManager (bool jniAddNativeMethodRegistrationAttributePresent)
 		{
 			this.jniAddNativeMethodRegistrationAttributePresent = jniAddNativeMethodRegistrationAttributePresent;
+		}
+
+		protected override JniTypeSignature GetTypeSignatureCore (Type type)
+		{
+			if (typeSignatures.TryGetValue (type, out var signature)) {
+				return signature;
+			}
+
+			signature = base.GetTypeSignatureCore (type);
+			return typeSignatures.GetOrAdd (type, signature);
 		}
 
 		protected override IEnumerable<Type> GetTypesForSimpleReference (string jniSimpleReference)


### PR DESCRIPTION
## Summary

Cache `Type` to `JniTypeSignature` results in the reflection-backed `AndroidTypeManager`, including negative results.

The non-trimmable typemap previously repeated MVID extraction, native typemap lookup, P/Invoke, and string marshaling every time peer creation requested the same managed type. The trimmable typemap already has an equivalent cache.

The cache is populated lazily, so it does not move unused typemap work onto the startup path.

## Startup evidence

Runtime typemap diagnostics from a cold .NET MAUI launch on a Pixel 10 recorded **637 managed-to-Java lookups for 158 unique types**. **479 lookups (75%) were repeats**.

Frequently repeated types included:

| Managed type | Lookups |
| --- | ---: |
| `Java.Lang.Object` | 81 |
| `Android.Content.Res.ColorStateList` | 51 |
| `AndroidX.Core.Graphics.Insets` | 47 |
| `Android.Graphics.Drawables.Drawable` | 39 |
| `AndroidX.Core.View.WindowInsetsCompat` | 37 |

## Device benchmark

Measured on a Pixel 10 using Release, CoreCLR, and the LLVM-IR typemap. JIT, P/Invoke resolution, and native typemap pages were warmed before measuring. Cold measurements used a fresh manager for each pass; warm measurements reused a populated manager.

| Run | Cold signature | Cached signature | Improvement |
| ---: | ---: | ---: | ---: |
| 1 | 6.684 us/op | 0.166 us/op | 40.3x |
| 2 | 32.532 us/op | 0.948 us/op | 34.3x |
| 3 | 13.952 us/op | 0.356 us/op | 39.2x |
| 4 | 10.303 us/op | 0.287 us/op | 35.9x |
| 5 | 25.449 us/op | 0.626 us/op | 40.7x |

The median changed from **13.952 us/op to 0.356 us/op**, approximately **39x faster** or **97.4% less lookup time**.

Applying the median saving to the 479 repeated lookups observed during startup gives an expected improvement of approximately **6.5 ms** for that launch. Unique cold misses remain unchanged.

<details>
<summary>Benchmark example</summary>

```csharp
Type [] types = [
    typeof (Java.Lang.Object),
    typeof (Android.Content.Res.ColorStateList),
    typeof (Android.Graphics.Drawables.Drawable),
    typeof (Android.Views.View),
    typeof (Android.Graphics.Canvas),
    typeof (Android.Graphics.Rect),
    typeof (Android.Views.ViewGroup.LayoutParams),
    typeof (Android.Graphics.Typeface),
];

// Warm JIT, P/Invoke resolution, and native typemap pages.
using (var manager = new AndroidTypeManager (false)) {
    foreach (var type in types) {
        manager.GetTypeSignature (type);
    }
}

long coldTicks = 0;
for (int i = 0; i < 50; i++) {
    using var manager = new AndroidTypeManager (false);
    long start = Stopwatch.GetTimestamp ();
    foreach (var type in types) {
        manager.GetTypeSignature (type);
    }
    coldTicks += Stopwatch.GetTimestamp () - start;
}

long warmTicks;
using (var manager = new AndroidTypeManager (false)) {
    foreach (var type in types) {
        manager.GetTypeSignature (type);
    }

    long start = Stopwatch.GetTimestamp ();
    for (int i = 0; i < 1000; i++) {
        foreach (var type in types) {
            manager.GetTypeSignature (type);
        }
    }
    warmTicks = Stopwatch.GetTimestamp () - start;
}
```

A device test also verified that both mapped and unmapped types invoke the underlying lookup only once.

</details>

## Validation

- Built `src/Mono.Android/Mono.Android.csproj` with the local .NET Android SDK.
- Ran the cache correctness test on a Pixel 10 with Release/CoreCLR/LLVM-IR.
- Ran the benchmark repeatedly on the same device configuration.