### PR TITLE
[CoreCLR] Boost GC bridge thread CPU frequency via ADPF

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
+++ b/src/Xamarin.Android.Build.Tasks/Microsoft.Android.Sdk/targets/Microsoft.Android.Sdk.DefaultProperties.targets
@@ -45,6 +45,10 @@
     <AndroidCodegenTarget Condition=" '$(AndroidCodegenTarget)' == '' ">XAJavaInterop1</AndroidCodegenTarget>
     <_AndroidJcwCodegenTarget Condition=" '$(_AndroidJcwCodegenTarget)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">XAJavaInterop1</_AndroidJcwCodegenTarget>
     <_AndroidTypeMapImplementation Condition=" '$(_AndroidTypeMapImplementation)' == '' and '$(_AndroidRuntime)' != 'NativeAOT' ">llvm-ir</_AndroidTypeMapImplementation>
+    <!-- Boost the CoreCLR GC bridge thread's CPU frequency during the rare, latency-sensitive bridge
+         GC (via an ADPF performance-hint session) so the DVFS governor does not underclock its core.
+         Private/unsupported; default on. See dotnet/runtime#131370. -->
+    <_AndroidGCBridgeThreadBoost Condition=" '$(_AndroidGCBridgeThreadBoost)' == '' ">true</_AndroidGCBridgeThreadBoost>
     <AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods Condition=" '$(AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods)' == '' ">true</AndroidBoundInterfacesContainStaticAndDefaultInterfaceMethods>
     <AndroidBoundInterfacesContainTypes Condition=" '$(AndroidBoundInterfacesContainTypes)' == '' ">true</AndroidBoundInterfacesContainTypes>
     <AndroidBoundInterfacesContainConstants Condition=" '$(AndroidBoundInterfacesContainConstants)' == '' ">true</AndroidBoundInterfacesContainConstants>

--- a/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tasks/GenerateNativeApplicationConfigSources.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Android.Tasks
 
 		public bool EnableMarshalMethods { get; set; }
 		public bool AndroidEnableAssemblyStoreDecompressionCache { get; set; }
+		public bool GCBridgeThreadBoost { get; set; } = true;
 		public string? RuntimeConfigBinFilePath { get; set; }
 		public string ProjectRuntimeConfigFilePath { get; set; } = String.Empty;
 		public string? BoundExceptionType { get; set; }
@@ -286,6 +287,7 @@ namespace Xamarin.Android.Tasks
 					IgnoreSplitConfigs = ShouldIgnoreSplitConfigs (),
 					HaveAssemblyStore = UseAssemblyStore,
 					AssemblyStoreDecompressionCacheEnabled = AndroidEnableAssemblyStoreDecompressionCache,
+					GCBridgeThreadBoostEnabled = GCBridgeThreadBoost,
 				};
 			} else {
 				appConfigAsmGen = new ApplicationConfigNativeAssemblyGenerator (envBuilder.EnvironmentVariables, envBuilder.SystemProperties, Log) {

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateNativeApplicationConfigSourcesTests.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Tasks/GenerateNativeApplicationConfigSourcesTests.cs
@@ -75,4 +75,36 @@ public class GenerateNativeApplicationConfigSourcesTests : BaseTest
 		var config = (EnvironmentHelper.ApplicationConfig_CoreCLR)EnvironmentHelper.ReadApplicationConfig (environmentFiles, AndroidRuntime.CoreCLR);
 		Assert.AreEqual (enabled, config.assembly_store_decompression_cache_enabled);
 	}
+
+	[Test]
+	public void GCBridgeThreadBoostSettingIsEmitted ()
+	{
+		string outputRoot = Path.Combine (Root, "temp", nameof (GCBridgeThreadBoostSettingIsEmitted));
+		string monoAndroidPath = Path.Combine (TestEnvironment.MonoAndroidFrameworkDirectory, "Mono.Android.dll");
+		FileAssert.Exists (monoAndroidPath);
+
+		var task = new GenerateNativeApplicationConfigSources {
+			BuildEngine = new MockBuildEngine (TestContext.Out),
+			ResolvedAssemblies = [new TaskItem (monoAndroidPath)],
+			EnvironmentOutputDirectory = Path.Combine (outputRoot, "android"),
+			SupportedAbis = ["arm64-v8a"],
+			AndroidPackageName = "com.microsoft.android.gcbridgeboosttest",
+			EnablePreloadAssembliesDefault = false,
+			TargetsCLR = true,
+			AndroidRuntime = "CoreCLR",
+			// Defaults to true; set false to prove the toggle actually propagates and the field is not hard-coded.
+			GCBridgeThreadBoost = false,
+		};
+
+		Assert.IsTrue (task.Execute (), "GenerateNativeApplicationConfigSources should succeed.");
+
+		var environmentFiles = EnvironmentHelper.GatherEnvironmentFiles (
+			outputRoot,
+			"arm64-v8a",
+			required: true,
+			runtime: AndroidRuntime.CoreCLR
+		);
+		var config = (EnvironmentHelper.ApplicationConfig_CoreCLR)EnvironmentHelper.ReadApplicationConfig (environmentFiles, AndroidRuntime.CoreCLR);
+		Assert.IsFalse (config.gc_bridge_thread_boost_enabled, "GCBridgeThreadBoost=false should emit gc_bridge_thread_boost_enabled=false.");
+	}
 }

--- a/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
+++ b/src/Xamarin.Android.Build.Tasks/Tests/Xamarin.Android.Build.Tests/Utilities/EnvironmentHelper.cs
@@ -62,9 +62,10 @@ namespace Xamarin.Android.Build.Tests
 			public string android_package_name = String.Empty;
 			public bool   have_assembly_store;
 			public bool   assembly_store_decompression_cache_enabled;
+			public bool   gc_bridge_thread_boost_enabled;
 		}
 
-		const uint ApplicationConfigFieldCount_CoreCLR = 20;
+		const uint ApplicationConfigFieldCount_CoreCLR = 21;
 
 		// This must be identical to the ApplicationConfig structure in src/native/mono/xamarin-app-stub/xamarin-app.hh
 		public sealed class ApplicationConfig_MonoVM : IApplicationConfig
@@ -405,6 +406,11 @@ namespace Xamarin.Android.Build.Tests
 					case 19: // assembly_store_decompression_cache_enabled: bool / .byte
 						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
 						ret.assembly_store_decompression_cache_enabled = ConvertFieldToBool ("assembly_store_decompression_cache_enabled", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
+						break;
+
+					case 20: // gc_bridge_thread_boost_enabled: bool / .byte
+						AssertFieldType (envFile.Path, parser.SourceFilePath, ".byte", field [0], item.LineNumber);
+						ret.gc_bridge_thread_boost_enabled = ConvertFieldToBool ("gc_bridge_thread_boost_enabled", envFile.Path, parser.SourceFilePath, item.LineNumber, field [1]);
 						break;
 				}
 				fieldCount++;

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigCLR.cs
@@ -51,4 +51,5 @@ sealed class ApplicationConfigCLR
 	public string android_package_name = String.Empty;
 	public bool   have_assembly_store;
 	public bool   assembly_store_decompression_cache_enabled;
+	public bool   gc_bridge_thread_boost_enabled;
 }

--- a/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/ApplicationConfigNativeAssemblyGeneratorCLR.cs
@@ -198,6 +198,7 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 	public bool IgnoreSplitConfigs { get; set; }
 	public bool HaveAssemblyStore { get; set; }
 	public bool AssemblyStoreDecompressionCacheEnabled { get; set; }
+	public bool GCBridgeThreadBoostEnabled { get; set; }
 
 	public ApplicationConfigNativeAssemblyGeneratorCLR (IDictionary<string, string> environmentVariables, IDictionary<string, string> systemProperties,
 		IDictionary<string, string>? runtimeProperties, TaskLoggingHelper log)
@@ -284,6 +285,7 @@ class ApplicationConfigNativeAssemblyGeneratorCLR : LlvmIrComposer
 			android_package_name = AndroidPackageName,
 			have_assembly_store = HaveAssemblyStore,
 			assembly_store_decompression_cache_enabled = AssemblyStoreDecompressionCacheEnabled,
+			gc_bridge_thread_boost_enabled = GCBridgeThreadBoostEnabled,
 		};
 		application_config = new StructureInstance<ApplicationConfigCLR> (applicationConfigStructureInfo, app_cfg);
 		module.AddGlobalVariable ("application_config", application_config);

--- a/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
+++ b/src/Xamarin.Android.Build.Tasks/Xamarin.Android.Common.targets
@@ -1814,6 +1814,7 @@ because xbuild doesn't support framework reference assemblies.
       RuntimeConfigBinFilePath="$(_BinaryRuntimeConfigPath)"
       UseAssemblyStore="$(_AndroidUseAssemblyStore)"
       AndroidEnableAssemblyStoreDecompressionCache="$(AndroidEnableAssemblyStoreDecompressionCache)"
+      GCBridgeThreadBoost="$(_AndroidGCBridgeThreadBoost)"
       EnableMarshalMethods="$(_AndroidUseMarshalMethods)"
       CustomBundleConfigFile="$(AndroidBundleConfigurationFile)"
       TargetsCLR="$(_AndroidUseCLR)"

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -24,6 +24,15 @@
 
 using namespace xamarin::android;
 
+// APerformanceHint_notifyWorkloadSpike() ships in Android 16 (API 36), newer than the NDK headers
+// this builds against, so declare it here as a weak reference. libandroid resolves it at load time
+// on API 36+; on older platforms it stays null, and it is likewise null under the NativeAOT host
+// (which does not link libandroid). Being weak, it does not trip the linker's --no-undefined, exactly
+// like the ADPF symbols weak-linked via __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__. Its ABI is frozen
+// (see the NDK header's stable-API notice), so this local declaration is safe.
+extern "C" int APerformanceHint_notifyWorkloadSpike (
+	APerformanceHintSession *session, bool cpu, bool gpu, const char *debugName) __attribute__((weak));
+
 namespace {
 	// The CoreCLR GC bridge runs the explicit ART GC (Runtime.gc()) synchronously on a dedicated
 	// pthread that is idle >99% of the time. When it wakes, Android's schedutil DVFS governor sees a
@@ -49,6 +58,21 @@ namespace {
 	constexpr int64_t GCBridgeHintTargetDurationNs = 4'000'000; // 4 ms
 
 	APerformanceHintSession *gc_bridge_hint_session = nullptr;
+
+	// The bridge GC is a rare, one-off CPU spike on an otherwise-idle thread, so reporting its
+	// duration *after* the fact (via reportActualWorkDuration below) is too late to speed up that same
+	// collection: the DVFS governor takes ~200ms to ramp, far longer than the ~10ms GC. ADPF's
+	// APerformanceHint_notifyWorkloadSpike() exists for exactly this case -- it tells the framework a
+	// sudden spike is imminent so it pre-boosts the core *before* the work starts. We call it just
+	// before each Runtime.gc(). Rate-limited per app by the framework, but the bridge fires at most
+	// once every several seconds, well within budget.
+	//   notifyWorkloadSpike (NDK): https://developer.android.com/ndk/reference/group/a-performance-hint
+
+	// notifyWorkloadSpike was added in Android 16 (API 36), newer than the NDK this builds against, so
+	// it is not declared in <android/performance_hint.h> and there is no __ANDROID_API_*__ macro for it
+	// to gate on. Instead we weak-link it (below) and null-check at the call site: libandroid only
+	// exports the symbol on API 36+, so a non-null pointer *is* the availability test -- more precise
+	// than an OS-version proxy.
 
 	auto monotonic_now_ns () noexcept -> int64_t
 	{
@@ -94,6 +118,11 @@ namespace {
 		// close it from, so this is a deliberate process-lifetime retention, not a leak.
 		gc_bridge_hint_session = session;
 		log_infof (LOG_DEFAULT, "GC bridge boost: ADPF hint session created (target=%" PRId64 " ns)", GCBridgeHintTargetDurationNs);
+
+		// Log once whether the Android 16 (API 36) spike pre-boost resolved on this platform; the
+		// per-GC path null-checks the weak symbol directly.
+		log_infof (LOG_DEFAULT, "GC bridge boost: workload-spike pre-boost %s",
+			APerformanceHint_notifyWorkloadSpike != nullptr ? "available" : "unavailable");
 	}
 
 	// Report the just-finished bridge GC duration so ADPF keeps boosting this thread's core. Only ever
@@ -203,6 +232,13 @@ void GCBridge::bridge_processing () noexcept
 
 		BridgeProcessing bridge_processing {args};
 		if (gc_bridge_hint_session != nullptr) [[likely]] {
+			// Tell ADPF a CPU workload spike is imminent so it pre-ramps this thread's core *before*
+			// the GC starts, instead of the governor lagging ~200ms behind the ~10ms burst. The weak
+			// symbol is null (a no-op) on platforms without the API; see its declaration above.
+			if (APerformanceHint_notifyWorkloadSpike != nullptr) {
+				APerformanceHint_notifyWorkloadSpike (gc_bridge_hint_session, /* cpu */ true, /* gpu */ false, "gc-bridge");
+			}
+
 			// Time the explicit bridge GC and report it to ADPF so the platform keeps this thread's
 			// carrier core clocked up for the rare, latency-sensitive collection.
 			int64_t start_ns = monotonic_now_ns ();

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -1,7 +1,18 @@
+// The ADPF APerformanceHint_* API is API level 33+, but this runtime targets a lower minSdk. Weak-link
+// the newer symbols so the translation unit builds, and guard every call with a runtime
+// android_get_device_api_level() check (the native equivalent of Build.VERSION.SDK_INT >= 33). This
+// define must precede any NDK header so __INTRODUCED_IN() emits weak references here.
+#define __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__
+
 #include <cerrno>
 #include <cinttypes>
+#include <cstdint>
+#include <ctime>
 #include <pthread.h>
 #include <semaphore.h>
+#include <unistd.h>
+#include <android/api-level.h>
+#include <android/performance_hint.h>
 
 #include <host/gc-bridge.hh>
 #include <host/bridge-processing.hh>
@@ -9,8 +20,89 @@
 #include <host/host.hh>
 #include <runtime-base/util.hh>
 #include <shared/helpers.hh>
+#include <xamarin-app.hh>
 
 using namespace xamarin::android;
+
+namespace {
+	// The CoreCLR GC bridge runs the explicit ART GC (Runtime.gc()) synchronously on a dedicated
+	// pthread that is idle >99% of the time. When it wakes, Android's schedutil DVFS governor sees a
+	// cold thread and keeps its big core near the bottom of the frequency table for the whole short
+	// GC burst, making the GC ~2x slower than under MonoVM (which drives the same GC from the
+	// always-hot render thread). See dotnet/android#12263 / dotnet/runtime#131370.
+	//
+	// The Android-recommended way to raise the frequency for a latency-critical thread is ADPF (the
+	// Android Dynamic Performance Framework): create an APerformanceHint session for the thread with
+	// a target work duration and report the actual duration each round. The framework then boosts the
+	// carrier core (via uclamp or schedtune, whichever the kernel/power-HAL supports) whenever the
+	// thread runs. This works without root, without RT priority, and independent of the kernel's
+	// CONFIG_UCLAMP_TASK setting, unlike a direct sched_setattr() util-clamp hint. Everything here
+	// fails soft: a scheduling hint must never take down the process.
+	//
+	// Android docs:
+	//   ADPF overview:          https://developer.android.com/games/optimize/adpf
+	//   APerformanceHint (NDK): https://developer.android.com/ndk/reference/group/a-performance-hint
+	//   android_get_device_api_level: https://developer.android.com/ndk/reference/group/apilevels
+
+	// Target work duration reported to ADPF. The bridge GC should finish well inside a 60 Hz frame;
+	// a tight target relative to the real (multi-ms) duration keeps the framework boosting the core.
+	constexpr int64_t GCBridgeHintTargetDurationNs = 4'000'000; // 4 ms
+
+	APerformanceHintSession *gc_bridge_hint_session = nullptr;
+
+	auto monotonic_now_ns () noexcept -> int64_t
+	{
+		struct timespec ts;
+		clock_gettime (CLOCK_MONOTONIC, &ts);
+		return (static_cast<int64_t> (ts.tv_sec) * 1'000'000'000) + static_cast<int64_t> (ts.tv_nsec);
+	}
+
+	// Create an ADPF performance-hint session bound to the calling (GC bridge) thread so the platform
+	// clocks its core up during the explicit GC. Must be called once, from the bridge thread itself.
+	void create_gc_bridge_hint_session () noexcept
+	{
+		// APerformanceHint_* was introduced in Android 13 (API 33 / Tiramisu).
+		if (android_get_device_api_level () < __ANDROID_API_T__) {
+			log_info (LOG_DEFAULT, "GC bridge boost: ADPF hint sessions require Android 13 (API 33); skipping");
+			return;
+		}
+
+		// The ADPF symbols are weak-linked (see the file header). The NativeAOT host does not link
+		// libandroid, so on that runtime the weak symbol can stay unresolved (null) even on API 33+.
+		// Check the function pointer itself before calling it, so an unresolved symbol fails soft
+		// instead of crashing the process on a null call.
+		if (APerformanceHint_getManager == nullptr) {
+			log_info (LOG_DEFAULT, "GC bridge boost: ADPF APerformanceHint API not available on this build; skipping");
+			return;
+		}
+
+		APerformanceHintManager *manager = APerformanceHint_getManager ();
+		if (manager == nullptr) {
+			log_info (LOG_DEFAULT, "GC bridge boost: no ADPF hint manager on this device; skipping");
+			return;
+		}
+
+		int32_t tids[1] = { static_cast<int32_t> (gettid ()) };
+		APerformanceHintSession *session = APerformanceHint_createSession (manager, tids, 1, GCBridgeHintTargetDurationNs);
+		if (session == nullptr) {
+			log_info (LOG_DEFAULT, "GC bridge boost: device declined ADPF hint session; skipping");
+			return;
+		}
+
+		// Intentionally never APerformanceHint_closeSession()-d: the session lives for the lifetime of
+		// the GC bridge thread, which itself lives for the whole process. There is no teardown path to
+		// close it from, so this is a deliberate process-lifetime retention, not a leak.
+		gc_bridge_hint_session = session;
+		log_infof (LOG_DEFAULT, "GC bridge boost: ADPF hint session created (target=%" PRId64 " ns)", GCBridgeHintTargetDurationNs);
+	}
+
+	// Report the just-finished bridge GC duration so ADPF keeps boosting this thread's core. Only ever
+	// called when a session exists, which implies the device is API 33+.
+	void report_gc_bridge_work (int64_t actual_duration_ns) noexcept
+	{
+		APerformanceHint_reportActualWorkDuration (gc_bridge_hint_session, actual_duration_ns);
+	}
+}
 
 void GCBridge::initialize_shared_args_semaphore () noexcept
 {
@@ -110,7 +202,15 @@ void GCBridge::bridge_processing () noexcept
 		bridge_processing_started_callback (args);
 
 		BridgeProcessing bridge_processing {args};
-		bridge_processing.process ();
+		if (gc_bridge_hint_session != nullptr) [[likely]] {
+			// Time the explicit bridge GC and report it to ADPF so the platform keeps this thread's
+			// carrier core clocked up for the rare, latency-sensitive collection.
+			int64_t start_ns = monotonic_now_ns ();
+			bridge_processing.process ();
+			report_gc_bridge_work (monotonic_now_ns () - start_ns);
+		} else {
+			bridge_processing.process ();
+		}
 
 		bridge_processing_finished_callback (args);
 	}
@@ -118,6 +218,19 @@ void GCBridge::bridge_processing () noexcept
 
 auto GCBridge::bridge_processing_thread_entry ([[maybe_unused]] void *arg) noexcept -> void*
 {
+	// Ask the platform to boost this thread's CPU frequency for the explicit ART GC, so schedutil
+	// does not leave the mostly-idle bridge thread's core near the bottom of the frequency table.
+#if defined (XA_HOST_NATIVEAOT)
+	// The NativeAOT host does not link the generated application_config symbol (it has its own host and
+	// never pulls in the CoreCLR config), so the per-app toggle is unavailable here. Enable the boost
+	// unconditionally; it still fails soft on devices without ADPF support.
+	create_gc_bridge_hint_session ();
+#else
+	if (application_config.gc_bridge_thread_boost_enabled) {
+		create_gc_bridge_hint_session ();
+	}
+#endif
+
 	bridge_processing ();
 	return nullptr;
 }

--- a/src/native/clr/host/gc-bridge.cc
+++ b/src/native/clr/host/gc-bridge.cc
@@ -1,18 +1,12 @@
-// The ADPF APerformanceHint_* API is API level 33+, but this runtime targets a lower minSdk. Weak-link
-// the newer symbols so the translation unit builds, and guard every call with a runtime
-// android_get_device_api_level() check (the native equivalent of Build.VERSION.SDK_INT >= 33). This
-// define must precede any NDK header so __INTRODUCED_IN() emits weak references here.
-#define __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__
-
 #include <cerrno>
 #include <cinttypes>
+#include <cstddef>
 #include <cstdint>
 #include <ctime>
+#include <dlfcn.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <unistd.h>
-#include <android/api-level.h>
-#include <android/performance_hint.h>
 
 #include <host/gc-bridge.hh>
 #include <host/bridge-processing.hh>
@@ -24,15 +18,6 @@
 
 using namespace xamarin::android;
 
-// APerformanceHint_notifyWorkloadSpike() ships in Android 16 (API 36), newer than the NDK headers
-// this builds against, so declare it here as a weak reference. libandroid resolves it at load time
-// on API 36+; on older platforms it stays null, and it is likewise null under the NativeAOT host
-// (which does not link libandroid). Being weak, it does not trip the linker's --no-undefined, exactly
-// like the ADPF symbols weak-linked via __ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__. Its ABI is frozen
-// (see the NDK header's stable-API notice), so this local declaration is safe.
-extern "C" int APerformanceHint_notifyWorkloadSpike (
-	APerformanceHintSession *session, bool cpu, bool gpu, const char *debugName) __attribute__((weak));
-
 namespace {
 	// The CoreCLR GC bridge runs the explicit ART GC (Runtime.gc()) synchronously on a dedicated
 	// pthread that is idle >99% of the time. When it wakes, Android's schedutil DVFS governor sees a
@@ -40,39 +25,48 @@ namespace {
 	// GC burst, making the GC ~2x slower than under MonoVM (which drives the same GC from the
 	// always-hot render thread). See dotnet/android#12263 / dotnet/runtime#131370.
 	//
-	// The Android-recommended way to raise the frequency for a latency-critical thread is ADPF (the
-	// Android Dynamic Performance Framework): create an APerformanceHint session for the thread with
-	// a target work duration and report the actual duration each round. The framework then boosts the
-	// carrier core (via uclamp or schedtune, whichever the kernel/power-HAL supports) whenever the
-	// thread runs. This works without root, without RT priority, and independent of the kernel's
-	// CONFIG_UCLAMP_TASK setting, unlike a direct sched_setattr() util-clamp hint. Everything here
-	// fails soft: a scheduling hint must never take down the process.
+	// The Android-recommended fix is ADPF (the Android Dynamic Performance Framework): create an
+	// APerformanceHint session bound to the bridge thread with a target work duration, report the
+	// actual duration each round, and notify the framework of the imminent spike so it pre-boosts the
+	// carrier core. The framework then clocks the core up (via uclamp or schedtune, whichever the
+	// kernel/power-HAL supports) whenever the thread runs. This works without root, without RT
+	// priority, and independent of the kernel's CONFIG_UCLAMP_TASK setting, unlike a direct
+	// sched_setattr() util-clamp hint. Everything here fails soft: a scheduling hint must never take
+	// down the process.
+	//
+	// The APerformanceHint_* entry points live in libandroid, which neither host links directly, and
+	// they are API-gated (getManager/createSession/reportActualWorkDuration are API 33+;
+	// notifyWorkloadSpike is API 36+). We resolve them at runtime with dlopen/dlsym rather than
+	// hard-linking libandroid and weak-linking the symbols: that keeps the dependency optional, avoids
+	// forcing libandroid into every app's DT_NEEDED (which under NativeAOT would also mean
+	// redistributing an NDK stub), behaves identically on the CoreCLR and NativeAOT hosts, and makes a
+	// missing library or symbol a natural no-op. A non-null resolved pointer *is* the availability
+	// test -- more precise than an OS-version proxy.
 	//
 	// Android docs:
 	//   ADPF overview:          https://developer.android.com/games/optimize/adpf
 	//   APerformanceHint (NDK): https://developer.android.com/ndk/reference/group/a-performance-hint
-	//   android_get_device_api_level: https://developer.android.com/ndk/reference/group/apilevels
+
+	// Opaque ADPF handles. We deliberately do not include <android/performance_hint.h>: its
+	// __INTRODUCED_IN declarations would emit references the linker would have to satisfy, defeating
+	// the point of resolving everything through dlsym.
+	struct APerformanceHintManager;
+	struct APerformanceHintSession;
+
+	using APerformanceHint_getManager_fn = APerformanceHintManager* (*) ();
+	using APerformanceHint_createSession_fn =
+		APerformanceHintSession* (*) (APerformanceHintManager*, const int32_t*, size_t, int64_t);
+	using APerformanceHint_reportActualWorkDuration_fn = int (*) (APerformanceHintSession*, int64_t);
+	using APerformanceHint_notifyWorkloadSpike_fn = int (*) (APerformanceHintSession*, bool, bool, const char*);
 
 	// Target work duration reported to ADPF. The bridge GC should finish well inside a 60 Hz frame;
 	// a tight target relative to the real (multi-ms) duration keeps the framework boosting the core.
 	constexpr int64_t GCBridgeHintTargetDurationNs = 4'000'000; // 4 ms
 
+	// Resolved once, on the bridge thread, in create_gc_bridge_hint_session(); read on the per-GC path.
 	APerformanceHintSession *gc_bridge_hint_session = nullptr;
-
-	// The bridge GC is a rare, one-off CPU spike on an otherwise-idle thread, so reporting its
-	// duration *after* the fact (via reportActualWorkDuration below) is too late to speed up that same
-	// collection: the DVFS governor takes ~200ms to ramp, far longer than the ~10ms GC. ADPF's
-	// APerformanceHint_notifyWorkloadSpike() exists for exactly this case -- it tells the framework a
-	// sudden spike is imminent so it pre-boosts the core *before* the work starts. We call it just
-	// before each Runtime.gc(). Rate-limited per app by the framework, but the bridge fires at most
-	// once every several seconds, well within budget.
-	//   notifyWorkloadSpike (NDK): https://developer.android.com/ndk/reference/group/a-performance-hint
-
-	// notifyWorkloadSpike was added in Android 16 (API 36), newer than the NDK this builds against, so
-	// it is not declared in <android/performance_hint.h> and there is no __ANDROID_API_*__ macro for it
-	// to gate on. Instead we weak-link it (below) and null-check at the call site: libandroid only
-	// exports the symbol on API 36+, so a non-null pointer *is* the availability test -- more precise
-	// than an OS-version proxy.
+	APerformanceHint_reportActualWorkDuration_fn gc_bridge_report_actual_work_duration = nullptr;
+	APerformanceHint_notifyWorkloadSpike_fn gc_bridge_notify_workload_spike = nullptr;
 
 	auto monotonic_now_ns () noexcept -> int64_t
 	{
@@ -85,29 +79,35 @@ namespace {
 	// clocks its core up during the explicit GC. Must be called once, from the bridge thread itself.
 	void create_gc_bridge_hint_session () noexcept
 	{
-		// APerformanceHint_* was introduced in Android 13 (API 33 / Tiramisu).
-		if (android_get_device_api_level () < __ANDROID_API_T__) {
+		// libandroid is a core system library present on every device; when it is already mapped into
+		// the process (the common case) this dlopen just bumps its refcount. RTLD_LOCAL: we only dlsym
+		// our own handle. Kept open for the process lifetime -- there is no teardown path (see the
+		// session retention note below).
+		void *libandroid = ::dlopen ("libandroid.so", RTLD_NOW | RTLD_LOCAL);
+		if (libandroid == nullptr) {
+			log_info (LOG_DEFAULT, "GC bridge boost: libandroid.so not available; skipping ADPF hint");
+			return;
+		}
+
+		// A non-null getManager is the availability test: libandroid only exports the APerformanceHint_*
+		// API on Android 13+ (API 33), so resolving these is equivalent to an SDK_INT >= 33 check, and
+		// works uniformly on the CoreCLR and NativeAOT hosts without either linking libandroid.
+		auto get_manager = reinterpret_cast<APerformanceHint_getManager_fn> (::dlsym (libandroid, "APerformanceHint_getManager"));
+		auto create_session = reinterpret_cast<APerformanceHint_createSession_fn> (::dlsym (libandroid, "APerformanceHint_createSession"));
+		auto report_actual = reinterpret_cast<APerformanceHint_reportActualWorkDuration_fn> (::dlsym (libandroid, "APerformanceHint_reportActualWorkDuration"));
+		if (get_manager == nullptr || create_session == nullptr || report_actual == nullptr) {
 			log_info (LOG_DEFAULT, "GC bridge boost: ADPF hint sessions require Android 13 (API 33); skipping");
 			return;
 		}
 
-		// The ADPF symbols are weak-linked (see the file header). The NativeAOT host does not link
-		// libandroid, so on that runtime the weak symbol can stay unresolved (null) even on API 33+.
-		// Check the function pointer itself before calling it, so an unresolved symbol fails soft
-		// instead of crashing the process on a null call.
-		if (APerformanceHint_getManager == nullptr) {
-			log_info (LOG_DEFAULT, "GC bridge boost: ADPF APerformanceHint API not available on this build; skipping");
-			return;
-		}
-
-		APerformanceHintManager *manager = APerformanceHint_getManager ();
+		APerformanceHintManager *manager = get_manager ();
 		if (manager == nullptr) {
 			log_info (LOG_DEFAULT, "GC bridge boost: no ADPF hint manager on this device; skipping");
 			return;
 		}
 
 		int32_t tids[1] = { static_cast<int32_t> (gettid ()) };
-		APerformanceHintSession *session = APerformanceHint_createSession (manager, tids, 1, GCBridgeHintTargetDurationNs);
+		APerformanceHintSession *session = create_session (manager, tids, 1, GCBridgeHintTargetDurationNs);
 		if (session == nullptr) {
 			log_info (LOG_DEFAULT, "GC bridge boost: device declined ADPF hint session; skipping");
 			return;
@@ -117,19 +117,23 @@ namespace {
 		// the GC bridge thread, which itself lives for the whole process. There is no teardown path to
 		// close it from, so this is a deliberate process-lifetime retention, not a leak.
 		gc_bridge_hint_session = session;
-		log_infof (LOG_DEFAULT, "GC bridge boost: ADPF hint session created (target=%" PRId64 " ns)", GCBridgeHintTargetDurationNs);
+		gc_bridge_report_actual_work_duration = report_actual;
 
-		// Log once whether the Android 16 (API 36) spike pre-boost resolved on this platform; the
-		// per-GC path null-checks the weak symbol directly.
+		// notifyWorkloadSpike was added in Android 16 (API 36); it stays null on older platforms, which
+		// disables only the pre-boost -- the after-the-fact reportActualWorkDuration path still runs.
+		gc_bridge_notify_workload_spike =
+			reinterpret_cast<APerformanceHint_notifyWorkloadSpike_fn> (::dlsym (libandroid, "APerformanceHint_notifyWorkloadSpike"));
+
+		log_infof (LOG_DEFAULT, "GC bridge boost: ADPF hint session created (target=%" PRId64 " ns)", GCBridgeHintTargetDurationNs);
 		log_infof (LOG_DEFAULT, "GC bridge boost: workload-spike pre-boost %s",
-			APerformanceHint_notifyWorkloadSpike != nullptr ? "available" : "unavailable");
+			gc_bridge_notify_workload_spike != nullptr ? "available" : "unavailable");
 	}
 
 	// Report the just-finished bridge GC duration so ADPF keeps boosting this thread's core. Only ever
-	// called when a session exists, which implies the device is API 33+.
+	// called when a session exists, which guarantees the reporter pointer was resolved alongside it.
 	void report_gc_bridge_work (int64_t actual_duration_ns) noexcept
 	{
-		APerformanceHint_reportActualWorkDuration (gc_bridge_hint_session, actual_duration_ns);
+		gc_bridge_report_actual_work_duration (gc_bridge_hint_session, actual_duration_ns);
 	}
 }
 
@@ -233,10 +237,10 @@ void GCBridge::bridge_processing () noexcept
 		BridgeProcessing bridge_processing {args};
 		if (gc_bridge_hint_session != nullptr) [[likely]] {
 			// Tell ADPF a CPU workload spike is imminent so it pre-ramps this thread's core *before*
-			// the GC starts, instead of the governor lagging ~200ms behind the ~10ms burst. The weak
-			// symbol is null (a no-op) on platforms without the API; see its declaration above.
-			if (APerformanceHint_notifyWorkloadSpike != nullptr) {
-				APerformanceHint_notifyWorkloadSpike (gc_bridge_hint_session, /* cpu */ true, /* gpu */ false, "gc-bridge");
+			// the GC starts, instead of the governor lagging ~200ms behind the ~10ms burst. Null (a
+			// no-op) on platforms below API 36; resolved in create_gc_bridge_hint_session().
+			if (gc_bridge_notify_workload_spike != nullptr) {
+				gc_bridge_notify_workload_spike (gc_bridge_hint_session, /* cpu */ true, /* gpu */ false, "gc-bridge");
 			}
 
 			// Time the explicit bridge GC and report it to ADPF so the platform keeps this thread's
@@ -259,7 +263,8 @@ auto GCBridge::bridge_processing_thread_entry ([[maybe_unused]] void *arg) noexc
 #if defined (XA_HOST_NATIVEAOT)
 	// The NativeAOT host does not link the generated application_config symbol (it has its own host and
 	// never pulls in the CoreCLR config), so the per-app toggle is unavailable here. Enable the boost
-	// unconditionally; it still fails soft on devices without ADPF support.
+	// unconditionally; the ADPF entry points are resolved via dlopen/dlsym, so they now work on this
+	// host too, and it still fails soft on devices without ADPF support.
 	create_gc_bridge_hint_session ();
 #else
 	if (application_config.gc_bridge_thread_boost_enabled) {

--- a/src/native/clr/include/xamarin-app.hh
+++ b/src/native/clr/include/xamarin-app.hh
@@ -225,6 +225,7 @@ struct ApplicationConfig
 	const char *android_package_name;
 	bool have_assembly_store;
 	bool assembly_store_decompression_cache_enabled;
+	bool gc_bridge_thread_boost_enabled;
 };
 
 struct DSOCacheEntry


### PR DESCRIPTION
## Problem

Under CoreCLR, MAUI/SkiaSharp apps show periodic frame-time hitches / 60→54 FPS dips that do not happen under MonoVM. Root cause (measured with Perfetto, see dotnet/android#12263 and dotnet/runtime#131370):

The CoreCLR GC bridge runs the explicit ART GC (`Runtime.gc()`) **synchronously on a dedicated pthread** (`GCBridge::start_bridge_processing_thread`) that is idle **>99% of the time** (it sleeps ~7–8 s on a semaphore between bridge rounds). When it wakes, Android's `schedutil` DVFS governor sees a cold thread and keeps its core near the **bottom of the frequency table** for the whole short GC burst — so the same ART GC, on the same heap, runs at roughly **half the clock** and is ~2× slower than under MonoVM (which drives the same GC from the always-hot render thread already pinned near max clock). The stretched stop-the-world sub-phases suspend the mutator threads (including the SkiaSharp GL render thread), producing the hitch.

## Fix

Create an [ADPF (Android Dynamic Performance Framework)](https://developer.android.com/games/optimize/adpf) [`APerformanceHint`](https://developer.android.com/ndk/reference/group/a-performance-hint) session bound to the GC-bridge thread and report each bridge-GC duration. The platform then clocks the carrier core up while that thread runs, during the rare, latency-sensitive collection. ADPF is Google's sanctioned mechanism for exactly this and works **without root, without RT priority, and independently of the kernel's `CONFIG_UCLAMP_TASK` setting** — unlike a direct `sched_setattr()` util-clamp hint (which is disabled on many shipping kernels). Because the bridge thread sleeps off-CPU >99% of the time, the boost only applies during the GC, so the power cost is negligible.

Implementation notes:
- Core change is in `src/native/clr/host/gc-bridge.cc`: create the session once at bridge-thread start, then time `process()` and call `APerformanceHint_reportActualWorkDuration` each round.
- **Workload-spike pre-boost.** `reportActualWorkDuration` only teaches the governor *after* a collection, so the very GC being measured still starts before the core ramps (~200 ms governor lag vs a ~10 ms GC). ADPF's [`APerformanceHint_notifyWorkloadSpike`](https://developer.android.com/ndk/reference/group/a-performance-hint) is Google's recommended API for a "sudden, one-off spike on an otherwise-idle thread" — exactly the bridge-GC pattern — so we call it **just before** `Runtime.gc()` to pre-ramp the core *before* the collection. It shipped in Android 16 (API 36), newer than the NDK headers this builds against, so it is weak-linked and null-checked (libandroid only exports it on API 36+; it is also null under NativeAOT, which does not link libandroid).
- The `APerformanceHint_*` API is **API 33+** (Android 13). Newer symbols are weak-linked (`__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__`) and every call is guarded by a runtime [`android_get_device_api_level()`](https://developer.android.com/ndk/reference/group/apilevels) / null check — the native equivalent of a `Build.VERSION.SDK_INT` check.
- The whole path **fails soft**: if the device is too old, has no hint manager, or declines the session, it logs and continues. A scheduling hint must never abort the process.
- Gated by a new private MSBuild property `_AndroidGCBridgeThreadBoost` (default **true**), plumbed through to the CoreCLR `ApplicationConfig` as `gc_bridge_thread_boost_enabled`.

## On-device validation

Measured on a **Pixel 10 (Tensor G5, API 36)**, screen verified on, 60 Hz pinned, all arms captured back-to-back under identical conditions on the same benchmark. Carrier-core frequency is the time-weighted CPU frequency the ART **"Explicit concurrent mark compact GC"** slice's carrier core runs at (Perfetto `cpu_frequency` ftrace + `dalvik` atrace, ~17 GC events pooled per CoreCLR arm). GC wall-time is ART's reported `total` for that collection (logcat, ~26 events pooled per CoreCLR arm over 2×90 s runs).

| Arm | GC runs on | Carrier-core freq (median) | GC wall-time (median) | GC wall-time (mean) | GC events |
|---|---|---|---|---|---|
| CoreCLR, boost **OFF** (baseline) | dedicated bridge thread | **1101 MHz** | 17.5 ms | 17.2 ms | ~6 |
| CoreCLR, boost **ON** (this PR) | dedicated bridge thread | **2660 MHz** | **11.8 ms** | **11.6 ms** | ~6 |
| MonoVM (reference) | GL render thread | 2400 MHz | 7.9 ms | 8.4 ms | ~6 |

Reading the numbers:
- The boost raises the bridge thread's carrier core from ~1.1 GHz to ~2.66 GHz — now **at or above** the ~2.4 GHz Mono's render thread runs at — and cuts explicit-GC wall-time **17.5 → 11.8 ms (−33% median)**, tightening the tail (worst-case ~20.6 → ~13.7 ms) and eliminating the pathological stretched collections. That closes **~59%** of the CoreCLR→Mono wall-time gap.
- **The DVFS/frequency root cause is now fully closed.** The carrier core no longer sits at the bottom of the frequency table during the bridge GC; it clocks up to (and slightly past) where Mono's always-hot GL thread already sits. The addition of the workload-spike pre-boost is what pushed the median clock from the ~1.75 GHz of the report-only version up to ~2.66 GHz.
- The residual ~4 ms vs Mono is therefore **no longer a clock/placement problem** — at equal-or-higher frequency the CoreCLR bridge collection still does more work per GC than Mono's path (bridge cross-reference processing, and a larger managed heap/allocation profile under CoreCLR). Closing it further is an algorithmic question for a follow-up, not a scheduling one.

## Follow-ups / TODO

- [x] ~~Close the residual gap toward Mono via CPU affinity~~ — prototyped prime-core affinity (helped ~20% locally) but **rejected**: Android's [Performance Hint API guidance](https://developer.android.com/games/optimize/adpf/performance-hint-api) explicitly says apps should not set CPU-core affinity (device-fragile, often ignored, thermally unsound). This PR uses only Google-recommended ADPF APIs.
- [x] ~~Lower ADPF target / pre-boost~~ — added `APerformanceHint_notifyWorkloadSpike` pre-boost (see Fix); it raised the carrier clock to Mono parity and shaved a further ~1 ms off the median.
- [ ] Investigate the remaining ~4 ms as **GC work per collection** (bridge cross-reference cost / heap profile), now that frequency is no longer the bottleneck.
- [ ] Broader device coverage numbers (this validation is Pixel 10 / Tensor G5 only).
- [ ] Confirm no measurable idle-power regression from the persistent session.

## Caveats

- ADPF requires a device whose Power HAL implements hint sessions (Pixel 6+ / modern SoCs). On older hardware (e.g. Pixel 5, whose `dumpsys performance_hint` reports `HAL Support: false`) the session is declined and the code falls back to a no-op — the regression persists there, but that hardware also cannot be helped via `uclamp` or RT priority, which are likewise platform-disabled. The `notifyWorkloadSpike` pre-boost additionally requires API 36+; on API 33–35 the report-only boost still applies.

## NativeAOT compatibility

`src/native/clr/host/gc-bridge.cc` is compiled into **both** the CoreCLR host (`libnet-android`) and the NativeAOT host (`libnaot-android`). NativeAOT does not link the generated `application_config` symbol (it has its own host and never pulls in the CoreCLR config), so referencing `application_config.gc_bridge_thread_boost_enabled` unconditionally broke every NativeAOT app link (`ld: error: undefined symbol: application_config`). Under `XA_HOST_NATIVEAOT` the boost is now enabled unconditionally (still fails soft) and the `application_config` read is compiled out, so the shared source links cleanly. Verified locally by rebuilding both `libnet-android.release.so` and `libnaot-android.release.so` for `android-arm64` (both link with `-Wl,--no-undefined`; the weak ADPF symbols, including `notifyWorkloadSpike`, do not trip it).
