### PR TITLE
[Xamarin.Android.Build.Tasks] memoize LlvmIrGenerator basic type writes

### DIFF
--- a/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
+++ b/src/Xamarin.Android.Build.Tasks/Utilities/LlvmIrGenerator/LlvmIrGenerator.cs
@@ -93,6 +93,24 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			}
 		}
 
+		/// <summary>
+		/// Everything <see cref="WriteType(GeneratorWriteContext, Type, object?, out LlvmTypeInfo, LlvmIrGlobalVariable?)" />
+		/// needs in order to emit a basic scalar type.  Both members depend only on the managed type and
+		/// on <see cref="target" />, which is fixed for the lifetime of a generator instance, so they can
+		/// be computed once per type instead of once per written value.
+		/// </summary>
+		sealed class BasicTypeWriteInfo
+		{
+			public readonly string IRType;
+			public readonly LlvmTypeInfo TypeInfo;
+
+			public BasicTypeWriteInfo (string irType, LlvmTypeInfo typeInfo)
+			{
+				IRType = irType;
+				TypeInfo = typeInfo;
+			}
+		}
+
 		sealed class BasicType
 		{
 			public readonly string Name;
@@ -162,6 +180,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 		public bool EmitComments         { get; set; }
 
 		LlvmIrModuleTarget target;
+		readonly Dictionary<Type, BasicTypeWriteInfo> basicTypeWriteCache = new Dictionary<Type, BasicTypeWriteInfo> ();
 
 		protected LlvmIrGenerator (string filePath, LlvmIrModuleTarget target)
 		{
@@ -492,6 +511,14 @@ namespace Xamarin.Android.Tasks.LLVMIR
 			// an array or a string blob, so skip the reflection-heavy probing below.  Arrays and string
 			// blobs write one element at a time, so this runs millions of times for a typical
 			// application and `Type.IsPrimitive`/`Type.IsArray` dominate the generator otherwise.
+			// The IR type name and the `LlvmTypeInfo` are the same for every value of a given type,
+			// so they are computed once and memoized - a single dictionary lookup per written value.
+			if (basicTypeWriteCache.TryGetValue (type, out BasicTypeWriteInfo cachedBasicType)) {
+				typeInfo = cachedBasicType.TypeInfo;
+				context.Output.Write (cachedBasicType.IRType);
+				return;
+			}
+
 			if (basicTypeMap.ContainsKey (type)) {
 				string basicIRType = GetIRType (context, type, out ulong basicSize, out bool basicIsPointer);
 				typeInfo = new LlvmTypeInfo (
@@ -501,6 +528,7 @@ namespace Xamarin.Android.Tasks.LLVMIR
 					size: basicSize,
 					maxFieldAlignment: basicSize
 				);
+				basicTypeWriteCache.Add (type, new BasicTypeWriteInfo (basicIRType, typeInfo));
 				context.Output.Write (basicIRType);
 				return;
 			}


### PR DESCRIPTION
Memoizes the basic-scalar fast path in `LlvmIrGenerator.WriteType`. The method's own comment says it "runs millions of times for a typical application" — a MAUI app's `typemaps.arm64-v8a.ll` is 7.6 MB / 232k lines with 16,567 typemap entries, and every scalar member of every array entry lands here.

Each call did 3 dictionary lookups (`basicTypeMap.ContainsKey` → `MapToIRType` → `IsNativePointer` + `basicTypeMap.TryGetValue`) plus an `LlvmTypeInfo` allocation. All of it is a pure function of the `Type`: `MapToIRType` is documented as target-independent, and a generator instance has a fixed `target`, so the `(IRType, LlvmTypeInfo)` pair is cached per generator instance. Steady state: 1 lookup, 0 allocations.

### Structural evidence — `dotnet-trace`, MAUI source-change rebuild, matched pair

Inclusive ms inside `GenerateTypeMappings`:

| frame | before | after |
| --- | --- | --- |
| `GetActualType` | 303.9 | **frame absent** |
| `MapToIRType` | 307.9 | 3.8 |
| `WriteType (context, Type, …)` | 305.9 | 58.2 |
| `WriteStructureValue` | 313.6 | 183.3 |
| `LlvmIrGenerator.Generate` | 379.9 | 286.8 |
| `TypeMapGenerator.GenerateNativeAssembly` | 429.8 | 330.5 |

`GetActualType` no longer appears in the trace's frame table at all — proof the call was eliminated, independent of timing.

### Wall clock — honest read: below the noise floor

Interleaved A/B, 6 pairs, source-change rebuild of a `dotnet new maui -sc` app, `-nodeReuse:false`. `GenerateTypeMappings` task, raw ms:

| pair | before | after | delta |
| --- | --- | --- | --- |
| 1 | 743.4 | 725.1 | −18.3 |
| 2 | 736.6 | 787.3 | +50.7 |
| 3 | 783.2 | 749.3 | −33.9 |
| 4 | 746.8 | 686.3 | −60.5 |
| 5 | 737.6 | 1301.2 | +563.6 |
| 6 | 1488.0 | 1302.7 | −185.3 |

Pairs 5–6 were hit by unrelated machine load. **The ranges fully overlap; I am not claiming a wall-clock win.** The trace numbers are inclusive time under a profiler and overstate the real saving. The defensible claim is the structural one: ~200k dictionary lookups and ~200k allocations removed per build.

### Correctness

446 generated outputs hashed (SHA256), sorted, diffed against a matched baseline captured immediately before the binary swap: **all identical**.
- 368 `.java` Java Callable Wrappers
- 10 `.ll` (both `typemaps.*`, `environment.*`, `jni_remap.*`, `marshal_methods.*`, `compressed_assemblies.*`)
- `AndroidManifest.xml` ×2, `acw-map.txt`

Tests: `Microsoft.Android.Build.BaseTasks-Tests` 129/129 pass; `Xamarin.Android.Build.Tests --filter LlvmIr` 9/9 pass.

Squash on merge.
